### PR TITLE
Fix specification of bors checks

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,7 +5,10 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 status = [
-  "github/linux/%",
+  "github/linux/debug/fast",
+  "github/linux/fetchcontent/fast",
+  "github/linux/hip/fast",
+  "github/linux/sanitizers/fast",
   "ci/circleci: check_circular_deps",
   "ci/circleci: check_module_cmakelists",
   "ci/circleci: clang_format",


### PR DESCRIPTION
The catchall `%` means that when _any_ (one) matching build has succeeded bors will decide to merge. What we're looking for is all matching builds to succeed. This changes the list to an explicit list of the required builds.