### PR TITLE
Remove spellcheck from required bors checks

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -16,7 +16,6 @@ status = [
   "ci/circleci: configure",
   "ci/circleci: configure_test_combinations",
   "ci/circleci: inspect",
-  "ci/circleci: spellcheck",
   "ci/circleci: core",
 ]
 required_approvals = 0


### PR DESCRIPTION
It's a guideline and can be broken in certain cases (and it sometimes reports false positives). This removes it as a requirement when bors merging.