### PR TITLE
Require Jenkins jobs for bors merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,17 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+branch_filter: &branch_filter
+    filters:
+      branches:
+        only:
+          # Development and release branches
+          - main
+          - /release.*/
+          # Bors branches
+          - trying
+          - staging
+
 working_dir_default: &working_dir_default
     working_directory: /pika/build
 
@@ -539,23 +550,32 @@ workflows:
             - core
             - configure
       - core:
+          <<: *branch_filter
           requires:
             - configure
       - tests.examples:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.unit.algorithms:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.unit.container_algorithms:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.unit:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.regressions:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.performance:
+          <<: *branch_filter
           <<: *core_dependency
       - tests.headers:
+          <<: *branch_filter
           <<: *core_dependency
       - install:
+          <<: *branch_filter
           requires:
             - core
             - tests.examples

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -12,15 +12,24 @@ status = [
   "github/linux/sanitizers/fast",
   "github/macos/debug",
 
-  # CircleCI
+  # CircleCI static checks
   "ci/circleci: check_circular_deps",
   "ci/circleci: check_module_cmakelists",
   "ci/circleci: clang_format",
   "ci/circleci: cmake_format",
-  "ci/circleci: configure",
-  "ci/circleci: configure_test_combinations",
   "ci/circleci: inspect",
+
+  # CircleCI build and test
+  "ci/circleci: configure_test_combinations",
+  "ci/circleci: configure",
   "ci/circleci: core",
+  "ci/circleci: tests.examples",
+  "ci/circleci: tests.headers",
+  "ci/circleci: tests.performance",
+  "ci/circleci: tests.regressions",
+  "ci/circleci: tests.unit",
+  "ci/circleci: tests.unit.algorithms",
+  "ci/circleci: tests.unit.container_algorithms",
 
   # Jenkins
   "jenkins/cscs/clang-13-debug",

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -27,7 +27,7 @@ status = [
   "ci/circleci: tests.headers",
   "ci/circleci: tests.performance",
   "ci/circleci: tests.regressions",
-  "ci/circleci: tests.unit",
+  # "ci/circleci: tests.unit", # Some tests still occasionally fail here
   "ci/circleci: tests.unit.algorithms",
   "ci/circleci: tests.unit.container_algorithms",
 

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -10,6 +10,7 @@ status = [
   "github/linux/fetchcontent/fast",
   "github/linux/hip/fast",
   "github/linux/sanitizers/fast",
+  "github/macos/debug",
 
   # CircleCI
   "ci/circleci: check_circular_deps",

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,10 +5,13 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 status = [
+  # GitHub actions
   "github/linux/debug/fast",
   "github/linux/fetchcontent/fast",
   "github/linux/hip/fast",
   "github/linux/sanitizers/fast",
+
+  # CircleCI
   "ci/circleci: check_circular_deps",
   "ci/circleci: check_module_cmakelists",
   "ci/circleci: clang_format",
@@ -17,6 +20,15 @@ status = [
   "ci/circleci: configure_test_combinations",
   "ci/circleci: inspect",
   "ci/circleci: core",
+
+  # Jenkins
+  "jenkins/cscs/clang-13-debug",
+  "jenkins/cscs/clang-7-debug",
+  "jenkins/cscs/clang-cuda-debug",
+  "jenkins/cscs/clang-apex-debug",
+  "jenkins/cscs/gcc-11-debug",
+  "jenkins/cscs/gcc-7-debug",
+  "jenkins/cscs/gcc-cuda-debug",
 ]
 required_approvals = 0
 delete_merged_branches = true

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -43,3 +43,5 @@ status = [
 required_approvals = 0
 delete_merged_branches = true
 use_squash_merge = false
+# Three hours to account for queueing delays
+timeout_sec = 10800

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -33,11 +33,11 @@ status = [
 
   # Jenkins
   "jenkins/cscs/clang-13-debug",
-  "jenkins/cscs/clang-7-debug",
+  "jenkins/cscs/clang-9-debug",
   "jenkins/cscs/clang-cuda-debug",
-  "jenkins/cscs/clang-apex-debug",
   "jenkins/cscs/gcc-11-debug",
-  "jenkins/cscs/gcc-7-debug",
+  "jenkins/cscs/gcc-10-apex-spack-debug",
+  "jenkins/cscs/gcc-9-debug",
   "jenkins/cscs/gcc-cuda-debug",
 ]
 required_approvals = 0

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -27,7 +27,8 @@ status = [
   "ci/circleci: tests.headers",
   "ci/circleci: tests.performance",
   "ci/circleci: tests.regressions",
-  # "ci/circleci: tests.unit", # Some tests still occasionally fail here
+  # Some tests still occasionally fail here
+  # "ci/circleci: tests.unit",
   "ci/circleci: tests.unit.algorithms",
   "ci/circleci: tests.unit.container_algorithms",
 
@@ -36,7 +37,8 @@ status = [
   "jenkins/cscs/clang-9-debug",
   "jenkins/cscs/clang-cuda-debug",
   "jenkins/cscs/gcc-11-debug",
-  "jenkins/cscs/gcc-10-apex-spack-debug",
+  # This regularly fails
+  # "jenkins/cscs/gcc-10-apex-spack-debug",
   "jenkins/cscs/gcc-9-debug",
   "jenkins/cscs/gcc-cuda-debug",
 ]

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -9,8 +9,12 @@ name: Linux CI (Debug)
 on:
   push:
     branches:
-      - staging
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
       - trying
+      - staging
   pull_request:
 
 jobs:

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -9,9 +9,12 @@ name: Linux HIP CI (Debug)
 on:
   push:
     branches:
-      - staging
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
       - trying
-  pull_request:
+      - staging
 
 jobs:
   build:

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -9,9 +9,12 @@ name: Linux CI (Release, FetchContent)
 on:
   push:
     branches:
-      - staging
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
       - trying
-  pull_request:
+      - staging
 
 jobs:
   build:

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -9,9 +9,12 @@ name: Linux CI - Using Address and Undefined behavior sanitizer
 on:
   push:
     branches:
-      - staging
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
       - trying
-  pull_request:
+      - staging
 
 jobs:
   build:

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -6,7 +6,15 @@
 
 name: macOS CI (Debug)
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
 
 jobs:
   build:


### PR DESCRIPTION
Draft. Requires #23 before this makes sense. Testing that the Jenkins commit statuses etc. work correctly.

Fixes #31.