### PR TITLE
Rename `PIKA_WITH_ASYNC_MPI` to `PIKA_WITH_MPI`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,14 +794,14 @@ pika_option(
 )
 
 pika_option(
-  PIKA_WITH_ASYNC_MPI
+  PIKA_WITH_MPI
   BOOL
   "Enable support for returning futures from MPI asynchronous calls (default: ON)"
   OFF
   CATEGORY "MPI"
 )
 
-if(PIKA_WITH_ASYNC_MPI)
+if(PIKA_WITH_MPI)
   # mpi parcelport settings
   pika_option(
     PIKA_WITH_PARCELPORT_MPI_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,37 +802,30 @@ pika_option(
 )
 
 if(PIKA_WITH_MPI)
-  # mpi parcelport settings
+  # mpi settings
   pika_option(
-    PIKA_WITH_PARCELPORT_MPI_ENV
+    PIKA_WITH_MPI_ENV
     STRING
     "List of environment variables checked to detect MPI (default: MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK;PALS_NODEID)."
     "MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK;PALS_NODEID"
-    CATEGORY "Parcelport"
+    CATEGORY "MPI"
     ADVANCED
   )
 
-  # This list is to detect whether we run inside an mpi environment. If one of
-  # those environment variables is set, the MPI parcelport is enabled by
-  # default. PMI_RANK: Intel MPI and MVAPICH2 OMPI_COMM_WORLD_SIZE: OpenMPI
-  # starting at version 1.3
-  if(PIKA_WITH_PARCELPORT_MPI_ENV)
-    string(REPLACE ";" "," pika_parcelport_mpi_env_
-                   "${PIKA_WITH_PARCELPORT_MPI_ENV}"
-    )
-    pika_add_config_define(
-      PIKA_HAVE_PARCELPORT_MPI_ENV "\"${pika_parcelport_mpi_env_}\""
-    )
+  # This list is to detect whether we run inside an mpi environment.
+  if(PIKA_WITH_MPI_ENV)
+    string(REPLACE ";" "," pika_mpi_env_ "${PIKA_WITH_MPI_ENV}")
+    pika_add_config_define(PIKA_HAVE_MPI_ENV "\"${pika_mpi_env_}\"")
   endif()
 
   pika_option(
-    PIKA_WITH_PARCELPORT_MPI_MULTITHREADED BOOL
+    PIKA_WITH_MPI_MULTITHREADED BOOL
     "Turn on MPI multithreading support (default: ON)." ON
-    CATEGORY "Parcelport"
+    CATEGORY "MPI"
     ADVANCED
   )
-  if(PIKA_WITH_PARCELPORT_MPI_MULTITHREADED)
-    pika_add_config_define(PIKA_HAVE_PARCELPORT_MPI_MULTITHREADED)
+  if(PIKA_WITH_MPI_MULTITHREADED)
+    pika_add_config_define(PIKA_HAVE_MPI_MULTITHREADED)
   endif()
 
   if(MSVC)

--- a/cmake/pika_setup_mpi.cmake
+++ b/cmake/pika_setup_mpi.cmake
@@ -45,6 +45,6 @@ macro(pika_setup_mpi)
   endif()
 endmacro()
 
-if(PIKA_WITH_ASYNC_MPI)
+if(PIKA_WITH_MPI)
   pika_setup_mpi()
 endif()

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -4,11 +4,11 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# Note: PIKA_WITH_ASYNC_MPI is handled in the main CMakeLists.txt
+# Note: PIKA_WITH_MPI is handled in the main CMakeLists.txt
 
 # if the user does not want mpi async futures, quit - the module will not be
 # enabled
-if(NOT ${PIKA_WITH_ASYNC_MPI})
+if(NOT ${PIKA_WITH_MPI})
   return()
 endif()
 

--- a/libs/pika/mpi_base/CMakeLists.txt
+++ b/libs/pika/mpi_base/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-if(NOT PIKA_WITH_ASYNC_MPI)
+if(NOT PIKA_WITH_MPI)
   return()
 endif()
 

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -118,15 +118,11 @@ namespace pika { namespace util {
         int this_rank = -1;
         has_called_init_ = false;
 
-        // We assume to use the MPI parcelport if it is not explicitly disabled
         enabled_ = check_mpi_environment(rtcfg);
         if (!enabled_)
         {
-            rtcfg.add_entry("pika.parcel.mpi.enable", "0");
             return;
         }
-
-        rtcfg.add_entry("pika.parcel.bootstrap", "mpi");
 
         int required = MPI_THREAD_SINGLE;
         int minimal = MPI_THREAD_SINGLE;
@@ -147,9 +143,6 @@ namespace pika { namespace util {
             init(argc, argv, required, minimal, provided_threading_flag_);
         if (MPI_SUCCESS != retval && MPI_ERR_OTHER != retval)
         {
-            // explicitly disable mpi if not run by mpirun
-            rtcfg.add_entry("pika.parcel.mpi.enable", "0");
-
             enabled_ = false;
 
             int msglen = 0;

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -60,8 +60,7 @@ namespace pika { namespace util {
         util::runtime_configuration const& cfg)
     {
         // log message was already generated
-        return detail::detect_mpi_environment(
-            cfg, PIKA_HAVE_PARCELPORT_MPI_ENV);
+        return detail::detect_mpi_environment(cfg, PIKA_HAVE_MPI_ENV);
     }
 }}    // namespace pika::util
 
@@ -131,7 +130,7 @@ namespace pika { namespace util {
 
         int required = MPI_THREAD_SINGLE;
         int minimal = MPI_THREAD_SINGLE;
-#if defined(PIKA_HAVE_PARCELPORT_MPI_MULTITHREADED)
+#if defined(PIKA_HAVE_MPI_MULTITHREADED)
         required =
             (get_entry_as(rtcfg, "pika.parcel.mpi.multithreaded", 1) != 0) ?
             MPI_THREAD_MULTIPLE :

--- a/libs/pika/version/CMakeLists.txt
+++ b/libs/pika/version/CMakeLists.txt
@@ -10,7 +10,7 @@ set(version_headers pika/version.hpp)
 
 set(version_sources version.cpp)
 
-if(PIKA_WITH_ASYNC_MPI)
+if(PIKA_WITH_MPI)
   include(pika_setup_mpi)
   set(mpi_dependencies Mpi::mpi)
 endif()


### PR DESCRIPTION
Fixes #5.

Renames `PIKA_WITH_ASYNC_MPI` to `PIKA_WITH_MPI`, `PIKA_WITH_PARCELPORT_MPI_X` to `PIKA_WITH_MPI_X` and removes a few unnecessary config options. I'm keeping the setting of the other MPI-related config options (e.g. `pika.parcel.mpi.multithreaded`) for now as they may be useful at some point. They should probably be renamed eventually though.