### PR TITLE
Fix spellcheck branch comparison

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
               if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
                   cd /pika/source
                   codespell --version
-                  codespell --ignore-words tools/.codespell_whitelist --skip='*.h5,*.png' $(git diff --name-only origin/master...) > /tmp/spelling_suggestions.txt
+                  codespell --ignore-words tools/.codespell_whitelist --skip='*.h5,*.png' $(git diff --name-only origin/main...) > /tmp/spelling_suggestions.txt
                   if [ -s /tmp/spelling_suggestions.txt ]; then exit 1; fi
               else
                   echo "skipping spellcheck on non-PR build"


### PR DESCRIPTION
Should be against `main`, not `master`.