### PR TITLE
Fix missing inline for `pika::mpi::experimental::detail::error_message`

### DIFF
--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -25,7 +25,7 @@ set(async_mpi_headers
 )
 
 # Default location is $PIKA_ROOT/libs/mpi/src
-set(mpi_sources mpi_future.cpp)
+set(mpi_sources mpi_exception.cpp mpi_future.cpp)
 
 include(pika_add_module)
 pika_add_module(

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_exception.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_exception.hpp
@@ -8,46 +8,19 @@
 
 #include <pika/config.hpp>
 #include <pika/errors/exception.hpp>
-#include <pika/mpi_base/mpi.hpp>
 
-#include <cstddef>
-#include <memory>
 #include <string>
 
 namespace pika::mpi::experimental {
-
     namespace detail {
-
-        // extract MPI error message
-        std::string error_message(int code)
-        {
-            int N = 1023;
-            std::unique_ptr<char[]> err_buff(new char[std::size_t(N) + 1]);
-            err_buff[0] = '\0';
-
-            MPI_Error_string(code, err_buff.get(), &N);
-
-            return err_buff.get();
-        }
-
+        PIKA_EXPORT std::string error_message(int code);
     }    // namespace detail
 
-    // -------------------------------------------------------------------------
-    // exception type for failed launch of MPI functions
     struct mpi_exception : pika::exception
     {
-        explicit mpi_exception(int err_code, const std::string& msg = "")
-          : err_code_(err_code)
-        {
-            pika::exception(pika::bad_function_call,
-                msg + std::string(" MPI returned with error: ") +
-                    detail::error_message(err_code));
-        }
-
-        int get_mpi_errorcode()
-        {
-            return err_code_;
-        }
+        PIKA_EXPORT explicit mpi_exception(
+            int err_code, const std::string& msg = "");
+        PIKA_EXPORT int get_mpi_errorcode() const noexcept;
 
     protected:
         int err_code_;

--- a/libs/pika/async_mpi/src/mpi_exception.cpp
+++ b/libs/pika/async_mpi/src/mpi_exception.cpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2020 John Biddiscombe
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/config.hpp>
+#include <pika/async_mpi/mpi_exception.hpp>
+#include <pika/errors/exception.hpp>
+#include <pika/mpi_base/mpi.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace pika::mpi::experimental {
+    namespace detail {
+        std::string error_message(int code)
+        {
+            int N = 1023;
+            std::unique_ptr<char[]> err_buff(new char[std::size_t(N) + 1]);
+            err_buff[0] = '\0';
+
+            MPI_Error_string(code, err_buff.get(), &N);
+
+            return err_buff.get();
+        }
+
+    }    // namespace detail
+
+    // -------------------------------------------------------------------------
+    // exception type for failed launch of MPI functions
+    mpi_exception::mpi_exception(int err_code, const std::string& msg)
+      : pika::exception(pika::bad_function_call,
+            msg + std::string(" MPI returned with error: ") +
+                detail::error_message(err_code))
+      , err_code_(err_code)
+    {
+    }
+
+    int mpi_exception::get_mpi_errorcode() const noexcept
+    {
+        return err_code_;
+    }
+}    // namespace pika::mpi::experimental


### PR DESCRIPTION
An inline keyword would fix it as well, but this moves the function into a
source file and `PIKA_EXPORT`s the function instead. I've also moved the other functions in `mpi_exception` to the source file.