### PR TITLE
Rename inspect_local to inspect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Running Inspect Tool
           command: |
-              ./bin/inspect_local --all --output=./pika_inspect_report.html /pika/source
+              ./bin/inspect --all --output=./pika_inspect_report.html /pika/source
       - run:
           name: Convert inspect HTML output to XML
           command: |
@@ -262,7 +262,7 @@ jobs:
       - persist_to_workspace:
           root: /pika
           paths:
-            - ./build/bin/inspect_local
+            - ./build/bin/inspect
 
   spellcheck:
     <<: *defaults

--- a/tools/inspect/CMakeLists.txt
+++ b/tools/inspect/CMakeLists.txt
@@ -9,7 +9,7 @@
 include(pika_setup_boost_regex)
 
 pika_add_executable(
-  inspect_local INTERNAL_FLAGS AUTOGLOB NOLIBS FOLDER "Tools/Local/Inspect"
+  inspect INTERNAL_FLAGS AUTOGLOB NOLIBS FOLDER "Tools/Local/Inspect"
 )
 
 if(NOT Boost_REGEX_FOUND)
@@ -17,9 +17,7 @@ if(NOT Boost_REGEX_FOUND)
 endif()
 
 # Set the basic search paths for the generated pika headers
-target_link_libraries(
-  inspect_local PRIVATE Boost::regex pika_dependencies_boost pika
-)
+target_link_libraries(inspect PRIVATE Boost::regex pika_dependencies_boost pika)
 
 # add dependencies to pseudo-target
-pika_add_pseudo_dependencies(tools.inspect inspect_local)
+pika_add_pseudo_dependencies(tools.inspect inspect)


### PR DESCRIPTION
This only renames the binary/target. Folder names still contain `Local`, see #50.