### PR TITLE
Fix missing include in parse_affinity_options.cpp

### DIFF
--- a/libs/pika/affinity/src/parse_affinity_options.cpp
+++ b/libs/pika/affinity/src/parse_affinity_options.cpp
@@ -13,6 +13,7 @@
 #include <hwloc.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
On the `gcc-11` builder `std::round` was not visible due to the missing include.