### PR TITLE
Don't try to take lock when getting work counts from MPI/CUDA polling

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_executor.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_executor.hpp
@@ -60,7 +60,7 @@ namespace pika { namespace mpi { namespace experimental {
 
         std::size_t in_flight_estimate() const
         {
-            return detail::get_mpi_info().requests_vector_size_ +
+            return detail::get_mpi_info().active_requests_vector_size_ +
                 detail::get_mpi_info().requests_queue_size_;
         }
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
@@ -116,8 +116,10 @@ namespace pika { namespace mpi { namespace experimental {
             bool error_handler_initialized_ = false;
             int rank_ = -1;
             int size_ = -1;
-            // requests vector holds the requests that are checked
-            std::atomic<std::uint32_t> requests_vector_size_{0};
+            // requests vector holds the requests that are checked; this
+            // represents the number of active requests in the vector, not the
+            // size of the vector
+            std::atomic<std::uint32_t> active_requests_vector_size_{0};
             // requests queue holds the requests recently added
             std::atomic<std::uint32_t> requests_queue_size_{0};
         };
@@ -212,7 +214,7 @@ namespace pika { namespace mpi { namespace experimental {
             {
                 return true;
             }
-            return (detail::get_mpi_info().requests_vector_size_ > 0);
+            return (detail::get_mpi_info().active_requests_vector_size_ > 0);
         });
     }
 
@@ -226,7 +228,8 @@ namespace pika { namespace mpi { namespace experimental {
             {
                 return true;
             }
-            return (detail::get_mpi_info().requests_vector_size_ > 0) || f();
+            return (detail::get_mpi_info().active_requests_vector_size_ > 0) ||
+                f();
         });
     }
 


### PR DESCRIPTION
Fixes #41. Instead uses atomic counts for the vector/queue sizes. This means that `get_work_count` will never accidentally return zero if it can't take the lock. Related to https://github.com/eth-cscs/DLA-Future/issues/448.

Still waiting for some DLA-Future runs, but this at least improves (not necessarily fixes) the shutdown behaviour in miniapps.