### PR TITLE
Document dependencies in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,62 @@ pika is a C++ library for concurrency and parallelism. It implements
 senders/receivers (as proposed in `P2300 <https://wg21.link/p2300>`_) for CPU
 thread pools, MPI, and CUDA.
 
+Dependencies
+============
+
+pika requires:
+
+* a C++17-capable compiler:
+
+  * `GCC <https://gcc.gnu.org>`_ 7 or greater
+  * `clang <https://clang.llvm.org>`_ 7 or greater
+  * MSVC is likely to work but is not regularly tested
+
+* `CMake <https://cmake.org>`_ 3.18.0 or greater
+* `header-only Boost <https://boost.org>`_ 1.71.0 or greater
+* `hwloc <https://www-lb.open-mpi.org/projects/hwloc/>`_ 1.11.5 or greater
+
+pika optionally requires:
+
+* `gperftools/tcmalloc <https://github.com/gperftools/gperftools>`_, `jemalloc
+  <http://jemalloc.net/>`_, or `mimalloc
+  <https://github.com/microsoft/mimalloc>`_
+* `CUDA <https://docs.nvidia.com/cuda/>`_ 11.0 or greater
+* `HIP <https://rocmdocs.amd.com/en/latest/index.html>`_ 4.3.0 or greater
+* `MPI <https://www.mpi-forum.org/>`_
+* `Boost.Context, Thread, and Chrono <https://boost.org>`_ on macOS
+* `Boost.Regex <https://boost.org>`_ when building pika tools
+
+Building
+========
+
+pika is built using CMake. Please see the documentation of
+CMake for help on how to use it. Dependencies are usually available in
+distribution repositories. Alternatively, pika can be built using `spack
+<https://spack.readthedocs.io>`_ (`pika spack package
+<https://spack.readthedocs.io/en/latest/package_list.html#pika>`_). The pika
+repository also includes a ``shell.nix`` file for use with `nix
+<https://nixos.org/download.html#download-nix>`_. The file includes dependencies
+for regular development. It is provided for convenience only and is not
+comprehensive or guaranteed to be up to date. It may require the nixos unstable
+channel.
+
+pika is configured using CMake variables. The most important variables are:
+
+* ``PIKA_WITH_MALLOC``: This defaults to ``tcmalloc`` which requires gperftools.
+  Can be set to ``tcmalloc``, ``jemalloc``, ``mimalloc``, or ``system``. Setting
+  it to ``system`` can be useful in debug builds.
+* ``PIKA_WITH_CUDA``: Enable CUDA support.
+* ``PIKA_WITH_HIP``: Enable HIP support. To enabled this set the compiler to
+  ``hipcc`` instead of setting the variable explicitly.
+* ``PIKA_WITH_MPI``: Enable MPI support.
+* ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enables the use of Boost.Context for
+  fiber context switching. This has to be enabled on non-Linux and non-x86
+  platforms.
+
+Tests and examples are disabled by default and can be enabled with
+``PIKA_WITH_TESTS``, ``PIKA_WITH_TESTS_*``, and ``PIKA_WITH_EXAMPLES``.
+
 Acknowledgements
 ================
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell.override { stdenv = pkgs.gcc11Stdenv; } {
+  buildInputs = with pkgs; [
+    boost177
+    ccache
+    cmake-format
+    cmakeCurses
+    gperftools
+    hwloc
+    mpich
+    ninja
+    pkgconfig
+  ];
+
+  hardeningDisable = [ "fortify" ];
+
+  CMAKE_GENERATOR = "Ninja";
+  CMAKE_CXX_COMPILER_LAUNCHER = "ccache";
+  CXXFLAGS = "-ftemplate-backtrace-limit=0 -fdiagnostics-color=always";
+}


### PR DESCRIPTION
Fixes #65, fixes #54.

@aurianer do you remember what version of HIP we require? If not, I suppose we just document the version that we test, which I think is 4.4 on GitHub actions. What are you using on ault?

Note, I've also included a `shell.nix` file. It's quite convenient for getting a development shell without the rebuilding hell that spack comes with. Once nix is installed you can get a development shell with all the dependencies installed with `nix-shell <path-to-repo>`.