### PR TITLE
Add ADL isolation to P2300 CPOs

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -19,104 +19,109 @@
 #include <utility>
 
 namespace pika { namespace execution { namespace experimental {
-    namespace detail {
+    namespace just_detail {
         template <typename Is, typename... Ts>
-        struct just_sender;
+        struct just_sender_impl;
 
         template <typename std::size_t... Is, typename... Ts>
-        struct just_sender<pika::util::index_pack<Is...>, Ts...>
+        struct just_sender_impl<pika::util::index_pack<Is...>, Ts...>
         {
-            pika::util::member_pack_for<std::decay_t<Ts>...> ts;
-
-            constexpr just_sender() = default;
-
-            template <typename T,
-                typename = std::enable_if_t<
-                    !std::is_same_v<std::decay_t<T>, just_sender>>>
-            explicit constexpr just_sender(T&& t)
-              : ts(std::piecewise_construct, PIKA_FORWARD(T, t))
+            struct type
             {
-            }
-
-            template <typename T0, typename T1, typename... Ts_>
-            explicit constexpr just_sender(T0&& t0, T1&& t1, Ts_&&... ts)
-              : ts(std::piecewise_construct, PIKA_FORWARD(T0, t0),
-                    PIKA_FORWARD(T1, t1), PIKA_FORWARD(Ts_, ts)...)
-            {
-            }
-
-            just_sender(just_sender&&) = default;
-            just_sender(just_sender const&) = default;
-            just_sender& operator=(just_sender&&) = default;
-            just_sender& operator=(just_sender const&) = default;
-
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = Variant<Tuple<std::decay_t<Ts>...>>;
-
-            template <template <typename...> class Variant>
-            using error_types = Variant<std::exception_ptr>;
-
-            static constexpr bool sends_done = false;
-
-            template <typename Receiver>
-            struct operation_state
-            {
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
                 pika::util::member_pack_for<std::decay_t<Ts>...> ts;
 
-                template <typename Receiver_>
-                operation_state(Receiver_&& receiver,
-                    pika::util::member_pack_for<std::decay_t<Ts>...> ts)
-                  : receiver(PIKA_FORWARD(Receiver_, receiver))
-                  , ts(PIKA_MOVE(ts))
+                constexpr type() = default;
+
+                template <typename T,
+                    typename = std::enable_if_t<
+                        !std::is_same_v<std::decay_t<T>, type>>>
+                explicit constexpr type(T&& t)
+                  : ts(std::piecewise_construct, PIKA_FORWARD(T, t))
                 {
                 }
 
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
+                template <typename T0, typename T1, typename... Ts_>
+                explicit constexpr type(T0&& t0, T1&& t1, Ts_&&... ts)
+                  : ts(std::piecewise_construct, PIKA_FORWARD(T0, t0),
+                        PIKA_FORWARD(T1, t1), PIKA_FORWARD(Ts_, ts)...)
                 {
-                    pika::detail::try_catch_exception_ptr(
-                        [&]() {
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(os.receiver),
-                                PIKA_MOVE(os.ts).template get<Is>()...);
-                        },
-                        [&](std::exception_ptr ep) {
-                            pika::execution::experimental::set_error(
-                                PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
-                        });
+                }
+
+                type(type&&) = default;
+                type(type const&) = default;
+                type& operator=(type&&) = default;
+                type& operator=(type const&) = default;
+
+                template <template <typename...> class Tuple,
+                    template <typename...> class Variant>
+                using value_types = Variant<Tuple<std::decay_t<Ts>...>>;
+
+                template <template <typename...> class Variant>
+                using error_types = Variant<std::exception_ptr>;
+
+                static constexpr bool sends_done = false;
+
+                template <typename Receiver>
+                struct operation_state
+                {
+                    PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+                    pika::util::member_pack_for<std::decay_t<Ts>...> ts;
+
+                    template <typename Receiver_>
+                    operation_state(Receiver_&& receiver,
+                        pika::util::member_pack_for<std::decay_t<Ts>...> ts)
+                      : receiver(PIKA_FORWARD(Receiver_, receiver))
+                      , ts(PIKA_MOVE(ts))
+                    {
+                    }
+
+                    operation_state(operation_state&&) = delete;
+                    operation_state& operator=(operation_state&&) = delete;
+                    operation_state(operation_state const&) = delete;
+                    operation_state& operator=(operation_state const&) = delete;
+
+                    friend void tag_invoke(
+                        start_t, operation_state& os) noexcept
+                    {
+                        pika::detail::try_catch_exception_ptr(
+                            [&]() {
+                                pika::execution::experimental::set_value(
+                                    PIKA_MOVE(os.receiver),
+                                    PIKA_MOVE(os.ts).template get<Is>()...);
+                            },
+                            [&](std::exception_ptr ep) {
+                                pika::execution::experimental::set_error(
+                                    PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
+                            });
+                    }
+                };
+
+                template <typename Receiver>
+                friend auto tag_invoke(connect_t, type&& s, Receiver&& receiver)
+                {
+                    return operation_state<Receiver>{
+                        PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.ts)};
+                }
+
+                template <typename Receiver>
+                friend auto tag_invoke(connect_t, type& s, Receiver&& receiver)
+                {
+                    return operation_state<Receiver>{
+                        PIKA_FORWARD(Receiver, receiver), s.ts};
                 }
             };
-
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, just_sender&& s, Receiver&& receiver)
-            {
-                return operation_state<Receiver>{
-                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.ts)};
-            }
-
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, just_sender& s, Receiver&& receiver)
-            {
-                return operation_state<Receiver>{
-                    PIKA_FORWARD(Receiver, receiver), s.ts};
-            }
         };
-    }    // namespace detail
+
+        template <typename Is, typename... Ts>
+        using just_sender = typename just_sender_impl<Is, Ts...>::type;
+    }    // namespace just_detail
 
     inline constexpr struct just_t final
     {
         template <typename... Ts>
         constexpr PIKA_FORCEINLINE auto operator()(Ts&&... ts) const
         {
-            return detail::just_sender<
+            return just_detail::just_sender<
                 typename pika::util::make_index_pack<sizeof...(Ts)>::type,
                 Ts...>{PIKA_FORWARD(Ts, ts)...};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -27,9 +27,19 @@
 #include <utility>
 
 namespace pika { namespace execution { namespace experimental {
-    namespace detail {
+    namespace let_value_detail {
         template <typename PredecessorSender, typename F>
-        struct let_value_sender
+        struct let_value_sender_impl
+        {
+            struct type;
+        };
+
+        template <typename PredecessorSender, typename F>
+        using let_value_sender =
+            typename let_value_sender_impl<PredecessorSender, F>::type;
+
+        template <typename PredecessorSender, typename F>
+        struct let_value_sender_impl<PredecessorSender, F>::type
         {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<PredecessorSender>
                 predecessor_sender;
@@ -73,7 +83,7 @@ namespace pika { namespace execution { namespace experimental {
             using value_types = pika::util::detail::unique_t<
                 pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
                         transform_t<successor_sender_types<Tuple, Variant>,
-                            value_types<Tuple, Variant>::template apply
+                            detail::value_types<Tuple, Variant>::template apply
 #if defined(PIKA_CLANG_VERSION) && PIKA_CLANG_VERSION < 110000
                             >
                     //
@@ -91,7 +101,7 @@ namespace pika { namespace execution { namespace experimental {
                     pika::util::detail::concat_pack_of_packs_t<
                         pika::util::detail::transform_t<
                             successor_sender_types<pika::util::pack, Variant>,
-                            error_types<Variant>::template apply>>,
+                            detail::error_types<Variant>::template apply>>,
                     std::exception_ptr>>;
 
             static constexpr bool sends_done = false;
@@ -304,15 +314,14 @@ namespace pika { namespace execution { namespace experimental {
             };
 
             template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, let_value_sender&& s, Receiver&& receiver)
+            friend auto tag_invoke(connect_t, type&& s, Receiver&& receiver)
             {
                 return operation_state<Receiver>(
                     PIKA_MOVE(s.predecessor_sender),
                     PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
             }
         };
-    }    // namespace detail
+    }    // namespace let_value_detail
 
     inline constexpr struct let_value_t final
       : pika::functional::detail::tag_fallback<let_value_t>
@@ -327,7 +336,7 @@ namespace pika { namespace execution { namespace experimental {
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
             let_value_t, PredecessorSender&& predecessor_sender, F&& f)
         {
-            return detail::let_value_sender<PredecessorSender, F>{
+            return let_value_detail::let_value_sender<PredecessorSender, F>{
                 PIKA_FORWARD(PredecessorSender, predecessor_sender),
                 PIKA_FORWARD(F, f)};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
@@ -45,8 +45,9 @@ namespace pika { namespace execution { namespace experimental {
         // clang-format off
         template <typename Sender, typename Scheduler,
             PIKA_CONCEPT_REQUIRES_(
-                is_sender_v<Sender> &&
-                is_scheduler_v<Scheduler>
+                is_sender_v<Sender>
+                // &&
+                // is_scheduler_v<Scheduler>
             )>
         // clang-format on
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(

--- a/libs/pika/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_bulk.cpp
@@ -230,5 +230,7 @@ int main()
         PIKA_TEST_EQ(custom_bulk_call_count, 3);
     }
 
+    test_adl_isolation(ex::bulk(ex::just(), 1, my_namespace::my_type{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_just.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_just.cpp
@@ -120,5 +120,7 @@ int main()
         PIKA_TEST(set_value_called);
     }
 
+    test_adl_isolation(ex::just(my_namespace::my_type{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_let_error.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_error.cpp
@@ -198,5 +198,7 @@ int main()
         PIKA_TEST(!let_error_callback_called);
     }
 
+    test_adl_isolation(ex::let_error(ex::just(), my_namespace::my_type{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_let_value.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_value.cpp
@@ -175,5 +175,7 @@ int main()
         PIKA_TEST(!let_value_callback_called);
     }
 
+    test_adl_isolation(ex::let_value(ex::just(), my_namespace::my_type{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_split.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_split.cpp
@@ -151,5 +151,7 @@ int main()
         PIKA_TEST(receiver_set_value_called);
     }
 
+    test_adl_isolation(ex::split(my_namespace::my_sender{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_then.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_then.cpp
@@ -201,5 +201,7 @@ int main()
         PIKA_TEST(custom_transformer_call_operator_called);
     }
 
+    test_adl_isolation(ex::then(ex::just(), my_namespace::my_type{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -295,5 +295,7 @@ int main()
         PIKA_TEST(!scheduler_execute_called);
     }
 
+    test_adl_isolation(ex::transfer(ex::just(), my_namespace::my_scheduler{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_transfer_just.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer_just.cpp
@@ -249,5 +249,7 @@ int main()
         PIKA_TEST(!scheduler_execute_called);
     }
 
+    test_adl_isolation(ex::transfer_just(my_namespace::my_scheduler{}));
+
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all.cpp
@@ -217,5 +217,7 @@ int main()
         PIKA_TEST(set_error_called);
     }
 
+    test_adl_isolation(ex::when_all(my_namespace::my_sender{}));
+
     return pika::util::report_errors();
 }


### PR DESCRIPTION
Fixes #75.

See https://brycelelbach.github.io/wg21_p2300_std_execution/std_execution.html#spec-library for details (particularly the part about "arguments are not associated entities").

This does uglify the code quite a bit unfortunately, but is useful. In short, this means that for some e.g. sender type `template <typename... Ts>` any of the types `Ts...` will not contribute to ADL in e.g. a `tag_invoke(tag_t, sender<Ts...>`) call, only the namespace of `sender` itself contributes to ADL.