### PR TITLE
Ignore spack files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ packages
 .clangd
 /out
 .vs
+/spack-*


### PR DESCRIPTION
When using `spack develop` spack creates various `spack-*` files and directories in the root of the repo that can be ignored.