### PR TITLE
Properly handle types of forwarded values

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -84,7 +84,7 @@ namespace pika { namespace execution { namespace experimental {
                         [&]() {
                             pika::execution::experimental::set_value(
                                 PIKA_MOVE(os.receiver),
-                                PIKA_MOVE(os.ts).template get<Is>()...);
+                                PIKA_FORWARD(Ts, os.ts.template get<Is>())...);
                         },
                         [&](std::exception_ptr ep) {
                             pika::execution::experimental::set_error(


### PR DESCRIPTION
This fixes use cases like the following:
```
    {
        namespace ex = pika::execution::experimental;

        std::atomic<bool> set_value_called{false};
        std::string str{"hello"};
        int x = 3;
        auto s = ex::just(str, x);
        auto f = [](std::string& str, int& x) {  // <-- note the reference arguments
            PIKA_TEST_EQ(str, std::string("hello"));
            PIKA_TEST_EQ(x, 3);
        };
        auto r = callback_receiver<decltype(f)>{f, set_value_called};
        auto os = ex::connect(std::move(s), std::move(r));
        ex::start(os);
        PIKA_TEST(set_value_called);
    }
```