### PR TITLE
Add shorter timeouts to GitHub actions tests

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -47,5 +47,6 @@ jobs:
       run: |
           cd build
           ctest \
+            --timeout 120 \
             --output-on-failure \
             --tests-regex tests.examples

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -52,5 +52,6 @@ jobs:
           export UBSAN_OPTIONS=print_stacktrace=1,suppressions=$PWD/tools/ubsan.supp
           cd build
           ctest \
+            --timeout 120 \
             --output-on-failure \
             --tests-regex tests.examples

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
           cd build
           ctest --output-on-failure \
+            --timeout 120 \
             --exclude-regex \
           "tests.unit.modules.algorithms.default_construct|\
           tests.unit.modules.algorithms.destroy|\


### PR DESCRIPTION
Finishes builds faster in case of timeouts (the default is 1500 seconds).