### PR TITLE
Set conservative timeout on build steps in Jenkins

### DIFF
--- a/.jenkins/cscs-perftests/Jenkinsfile
+++ b/.jenkins/cscs-perftests/Jenkinsfile
@@ -40,6 +40,9 @@ pipeline {
             }
         }
         stage('perftests') {
+            options {
+                timeout(time: 2, unit: 'HOURS')
+            }
             matrix {
                 axes {
                     axis {

--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -36,6 +36,9 @@ pipeline {
             }
         }
         stage('build') {
+            options {
+                timeout(time: 2, unit: 'HOURS')
+            }
             matrix {
                 axes {
                     axis {


### PR DESCRIPTION
To avoid jobs like these taking 13 hours: https://lisone.cscs.ch/blue/organizations/jenkins/ssl%2Fpika/detail/pika/26/pipeline.

The underlying problem of the filesystem quota being full should of course also be addressed...