### PR TITLE
Fix unused parameters on macOS

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -36,7 +36,8 @@ jobs:
               -DPIKA_WITH_TESTS=ON \
               -DPIKA_WITH_TESTS_HEADERS=OFF \
               -DPIKA_WITH_TESTS_MAX_THREADS=3 \
-              -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON
+              -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON \
+              -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=On
     - name: Build
       shell: bash
       run: |

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -365,6 +365,9 @@ namespace pika { namespace util {
       , argv0(argv0_)
 #endif
     {
+#if !(defined(__linux) || defined(linux) || defined(__linux__))
+        PIKA_UNUSED(argv0_);
+#endif
         pre_initialize_ini();
 
         // set global config options

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -525,6 +525,8 @@ namespace pika { namespace threads {
         sleep(0);    // Allow the OS to pick up the change.
 #endif
         hwloc_bitmap_free(cpuset);
+#else
+        PIKA_UNUSED(mask);
 #endif    // __APPLE__
 
         if (&ec != &throws)
@@ -1367,6 +1369,10 @@ namespace pika { namespace threads {
                 "hwloc_set_area_membind_nodeset failed : {}", msg);
             return false;
         }
+#else
+        PIKA_UNUSED(addr);
+        PIKA_UNUSED(len);
+        PIKA_UNUSED(nodeset);
 #endif
         return true;
     }


### PR DESCRIPTION
Also enables `PIKA_WITH_COMPILER_WARNINGS_AS_ERRORS` on CI.