### PR TITLE
Set default verbosity to 1, stacktrace, but not all env{vars}

### DIFF
--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -62,7 +62,7 @@ namespace pika {
     std::string diagnostic_information(pika::exception_info const& xi)
     {
         int const verbosity = util::from_string<int>(
-            get_config_entry("pika.exception_verbosity", "2"));
+            get_config_entry("pika.exception_verbosity", "1"));
 
         std::ostringstream strm;
         strm << "\n";

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -72,7 +72,7 @@ namespace pika {
         if (get_config_entry("pika.diagnostics_on_terminate", "1") == "1")
         {
             int const verbosity = util::from_string<int>(
-                get_config_entry("pika.exception_verbosity", "2"));
+                get_config_entry("pika.exception_verbosity", "1"));
 
             if (verbosity >= 2)
             {
@@ -145,7 +145,7 @@ namespace pika {
         if (get_config_entry("pika.diagnostics_on_terminate", "1") == "1")
         {
             int const verbosity = util::from_string<int>(
-                get_config_entry("pika.exception_verbosity", "2"));
+                get_config_entry("pika.exception_verbosity", "1"));
 
             char* reason = strsignal(signum);
 

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -151,7 +151,7 @@ namespace pika { namespace util {
 #else
             "attach_debugger = ${PIKA_ATTACH_DEBUGGER}",
 #endif
-            "exception_verbosity = ${PIKA_EXCEPTION_VERBOSITY:2}",
+            "exception_verbosity = ${PIKA_EXCEPTION_VERBOSITY:1}",
             "trace_depth = ${PIKA_TRACE_DEPTH:" PIKA_PP_STRINGIZE(
                 PIKA_PP_EXPAND(PIKA_HAVE_THREAD_BACKTRACE_DEPTH)) "}",
 


### PR DESCRIPTION
Fixes # too much annoying output on error.
