### PR TITLE
Add P2300 scheduler queries

### DIFF
--- a/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
@@ -18,13 +18,12 @@ inline constexpr bool is_cuda_scheduler_v =
     std::is_same_v<std::decay_t<Scheduler>, cu::cuda_scheduler>;
 
 #define CHECK_CUDA_COMPLETION_SCHEDULER(...)                                   \
-    static_assert(is_cuda_scheduler_v<decltype(                                \
-            ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
+    static_assert(is_cuda_scheduler_v<                                         \
+        decltype(ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
 
 #define CHECK_NOT_CUDA_COMPLETION_SCHEDULER(...)                               \
-    static_assert(                                                             \
-        !is_cuda_scheduler_v<decltype(                                         \
-            ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
+    static_assert(!is_cuda_scheduler_v<decltype(ex::get_completion_scheduler<  \
+                      ex::set_value_t>(__VA_ARGS__))>)
 
 int main()
 {
@@ -112,5 +111,10 @@ int main()
                 .get_next_stream()
                 .get_priority(),
             pika::threads::thread_priority::high);
+    }
+
+    {
+        PIKA_TEST(ex::get_forward_progress_guarantee(sched) ==
+            ex::forward_progress_guarantee::weakly_parallel);
     }
 }

--- a/libs/pika/execution/CMakeLists.txt
+++ b/libs/pika/execution/CMakeLists.txt
@@ -46,6 +46,7 @@ set(execution_headers
     pika/execution/executors/polymorphic_executor.hpp
     pika/execution/executors/rebind_executor.hpp
     pika/execution/executors/static_chunk_size.hpp
+    pika/execution/scheduler_queries.hpp
     pika/execution/traits/detail/simd/vector_pack_alignment_size.hpp
     pika/execution/traits/detail/simd/vector_pack_all_any_none.hpp
     pika/execution/traits/detail/simd/vector_pack_count_bits.hpp

--- a/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
+++ b/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/concepts/concepts.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/functional/tag_invoke.hpp>
+
+namespace pika::execution::experimental {
+    enum class forward_progress_guarantee
+    {
+        concurrent,
+        parallel,
+        weakly_parallel
+    };
+
+    namespace scheduler_queries_detail {
+        struct forwarding_scheduler_query_t
+        {
+            template <typename Query,
+                PIKA_CONCEPT_REQUIRES_(
+                    pika::functional::is_nothrow_tag_invocable_v<
+                        forwarding_scheduler_query_t, Query const&>)>
+            constexpr bool operator()(Query const& query) const noexcept
+            {
+                return pika::functional::tag_invoke(*this, query);
+            }
+
+            template <typename Query,
+                PIKA_CONCEPT_REQUIRES_(
+                    !pika::functional::is_nothrow_tag_invocable_v<
+                        forwarding_scheduler_query_t, Query const&>)>
+            constexpr bool operator()(Query const&) const noexcept
+            {
+                return false;
+            }
+        };
+
+        struct get_forward_progress_guarantee_t
+        {
+            template <typename Scheduler,
+                PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler>&&
+                        pika::functional::is_nothrow_tag_invocable_v<
+                            get_forward_progress_guarantee_t,
+                            Scheduler const&>)>
+            constexpr forward_progress_guarantee operator()(
+                Scheduler const& scheduler) const noexcept
+            {
+                return pika::functional::tag_invoke(*this, scheduler);
+            }
+
+            template <typename Scheduler,
+                PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler> &&
+                    !pika::functional::is_nothrow_tag_invocable_v<
+                        get_forward_progress_guarantee_t, Scheduler const&>)>
+            constexpr forward_progress_guarantee operator()(
+                Scheduler const&) const noexcept
+            {
+                return forward_progress_guarantee::weakly_parallel;
+            }
+        };
+    }    // namespace scheduler_queries_detail
+
+    using scheduler_queries_detail::forwarding_scheduler_query_t;
+    using scheduler_queries_detail::get_forward_progress_guarantee_t;
+
+    inline constexpr forwarding_scheduler_query_t forwarding_scheduler_query{};
+    inline constexpr get_forward_progress_guarantee_t
+        get_forward_progress_guarantee{};
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
     minimal_async_executor
     minimal_sync_executor
     persistent_executor_parameters
+    scheduler_queries
 )
 
 set(future_then_executor_PARAMETERS THREADS 4)

--- a/libs/pika/execution/tests/unit/scheduler_queries.cpp
+++ b/libs/pika/execution/tests/unit/scheduler_queries.cpp
@@ -1,0 +1,105 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/execution/scheduler_queries.hpp>
+#include <pika/modules/testing.hpp>
+
+#include <exception>
+#include <utility>
+
+namespace ex = pika::execution::experimental;
+
+struct uncustomized_scheduler
+{
+    struct sender
+    {
+        template <template <class...> class Tuple,
+            template <class...> class Variant>
+        using value_types = Variant<Tuple<>>;
+
+        template <template <class...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        template <typename R>
+        struct operation_state
+        {
+            std::decay_t<R> r;
+
+            friend void tag_invoke(ex::start_t, operation_state& os) noexcept
+            {
+                ex::set_value(std::move(os.r));
+            };
+        };
+
+        template <typename R>
+        friend auto tag_invoke(ex::connect_t, sender&&, R&& r)
+        {
+            return operation_state<R>{std::forward<R>(r)};
+        }
+    };
+
+    friend sender tag_invoke(ex::schedule_t, uncustomized_scheduler)
+    {
+        return {};
+    }
+
+    bool operator==(uncustomized_scheduler const&) const noexcept
+    {
+        return true;
+    }
+
+    bool operator!=(uncustomized_scheduler const&) const noexcept
+    {
+        return false;
+    }
+};
+
+struct customized_scheduler : uncustomized_scheduler
+{
+    friend ex::forward_progress_guarantee tag_invoke(
+        ex::get_forward_progress_guarantee_t, customized_scheduler) noexcept
+    {
+        return ex::forward_progress_guarantee::concurrent;
+    }
+};
+
+inline constexpr struct custom_scheduler_query_t
+{
+    friend constexpr bool tag_invoke(ex::forwarding_scheduler_query_t,
+        custom_scheduler_query_t const&) noexcept
+    {
+        return true;
+    }
+} custom_scheduler_query{};
+
+int main()
+{
+    // An uncustomized scheduler has weakly_parallel forward progress guarantees
+    {
+        PIKA_TEST(
+            ex::get_forward_progress_guarantee(uncustomized_scheduler{}) ==
+            ex::forward_progress_guarantee::weakly_parallel);
+    }
+
+    // A customized scheduler can have other forward progress guarantees
+    {
+        PIKA_TEST(ex::get_forward_progress_guarantee(customized_scheduler{}) ==
+            ex::forward_progress_guarantee::concurrent);
+    }
+
+    // get_forward_progress_guarantee is not a forwarding query
+    {
+        static_assert(!ex::forwarding_scheduler_query(
+            ex::get_forward_progress_guarantee));
+    }
+
+    // The custom query is a forwarding query
+    {
+        static_assert(ex::forwarding_scheduler_query(custom_scheduler_query));
+    }
+}

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1766,6 +1766,12 @@ void test_completion_scheduler()
     }
 }
 
+void test_scheduler_queries()
+{
+    PIKA_TEST(ex::get_forward_progress_guarantee(ex::thread_pool_scheduler{}) ==
+        ex::forward_progress_guarantee::weakly_parallel);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
@@ -1796,6 +1802,7 @@ int pika_main()
     test_detach();
     test_bulk();
     test_completion_scheduler();
+    test_scheduler_queries();
 
     return pika::finalize();
 }

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -191,7 +191,7 @@ namespace pika { namespace functional {
     };
 #else
     template <typename Tag, typename... Args>
-    struct is_nothrow_tag_invocable : std::true_type
+    struct is_nothrow_tag_invocable : is_tag_invocable<Tag, Args...>
     {
     };
 #endif


### PR DESCRIPTION
Fixes #96 and #80.

Adds
- `forward_progress_guarantee` enum
- `get_forward_progress_guarantee` query
- `forwarding_scheduler_query` query

The last is currently not used anywhere (it's intended for checking generically if a query on a scheduler should be forwarded or not).

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
