### PR TITLE
Use even more specific spec for cmake and ninja in Jenkins CI

### DIFF
--- a/.jenkins/cscs-perftests/env-perftests.sh
+++ b/.jenkins/cscs-perftests/env-perftests.sh
@@ -24,5 +24,5 @@ export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load cray-jemalloc/5.1.0.3
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
+spack load cmake@3.18.6 %gcc@10.3.0
+spack load ninja@1.10.0 %gcc@10.3.0

--- a/.jenkins/cscs/env-clang-10.sh
+++ b/.jenkins/cscs/env-clang-10.sh
@@ -20,8 +20,6 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
 configure_extra_options+=" -DPIKA_WITH_COMPILER_WARNINGS=ON"

--- a/.jenkins/cscs/env-clang-12.sh
+++ b/.jenkins/cscs/env-clang-12.sh
@@ -20,8 +20,6 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"

--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -20,8 +20,6 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"

--- a/.jenkins/cscs/env-clang-9.sh
+++ b/.jenkins/cscs/env-clang-9.sh
@@ -20,8 +20,6 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-apex.sh
+++ b/.jenkins/cscs/env-clang-apex.sh
@@ -21,8 +21,6 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -12,8 +12,6 @@ export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
 module load daint-gpu
 module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
 module load Boost/1.75.0-CrayCCE-20.11
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -7,8 +7,8 @@
 source $SPACK_ROOT/share/spack/setup-env.sh
 
 spack load ccache@3.7.9
-spack load cmake@3.18.6
-spack load ninja@1.10.0
+spack load cmake@3.18.6 %gcc@10.3.0
+spack load ninja@1.10.0 %gcc@10.3.0
 
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 export CMAKE_GENERATOR=Ninja

--- a/.jenkins/cscs/env-gcc-10.sh
+++ b/.jenkins/cscs/env-gcc-10.sh
@@ -19,8 +19,6 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-gcc-11.sh
+++ b/.jenkins/cscs/env-gcc-11.sh
@@ -19,8 +19,6 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-gcc-9.sh
+++ b/.jenkins/cscs/env-gcc-9.sh
@@ -19,8 +19,6 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -12,8 +12,6 @@ module switch PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit/11.0.2_3.38-8.1__g5b73779
 module load Boost/1.75.0-CrayGNU-20.11
 module load hwloc/.2.0.3
-spack load cmake@3.18.6
-spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`


### PR DESCRIPTION
Hopefully fixes Jenkins CI. `ccache` will also be updated separately (#104), but it does not seem to be required right now.