### PR TITLE
Add `when_all_vector` sender adaptor

### DIFF
--- a/libs/pika/execution/CMakeLists.txt
+++ b/libs/pika/execution/CMakeLists.txt
@@ -27,6 +27,7 @@ set(execution_headers
     pika/execution/algorithms/transfer.hpp
     pika/execution/algorithms/transfer_just.hpp
     pika/execution/algorithms/when_all.hpp
+    pika/execution/algorithms/when_all_vector.hpp
     pika/execution/detail/async_launch_policy_dispatch.hpp
     pika/execution/detail/execution_parameter_callbacks.hpp
     pika/execution/detail/future_exec.hpp

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -63,8 +63,7 @@ namespace pika { namespace execution { namespace experimental {
 
             // Constant to indicate if the type of the result from the
             // predecessor sender is void or not
-            static constexpr bool is_void_result =
-                std::is_same_v<result_type, void>;
+            static constexpr bool is_void_result = std::is_void_v<result_type>;
 
             // Dummy type to indicate that set_value with void has been called
             struct void_value_type

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -1,0 +1,342 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+#include <pika/concepts/concepts.hpp>
+#include <pika/datastructures/optional.hpp>
+#include <pika/datastructures/variant.hpp>
+#include <pika/execution/algorithms/detail/single_result.hpp>
+#include <pika/execution_base/operation_state.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/type_support/detail/with_result_of.hpp>
+#include <pika/type_support/pack.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace pika::execution::experimental {
+    namespace when_all_vector_detail {
+        template <typename Sender>
+        struct when_all_vector_sender_impl
+        {
+            struct when_all_vector_sender_type;
+        };
+
+        template <typename Sender>
+        using when_all_vector_sender = typename when_all_vector_sender_impl<
+            Sender>::when_all_vector_sender_type;
+
+        template <typename Sender>
+        struct when_all_vector_sender_impl<Sender>::when_all_vector_sender_type
+        {
+            using senders_type = std::vector<Sender>;
+            senders_type senders;
+
+            explicit constexpr when_all_vector_sender_type(
+                senders_type&& senders)
+              : senders(PIKA_MOVE(senders))
+            {
+            }
+
+            explicit constexpr when_all_vector_sender_type(
+                senders_type const& senders)
+              : senders(senders)
+            {
+            }
+
+            // We expect a single value type or nothing from the predecessor
+            // sender type
+            using element_value_type = detail::single_result_t<
+                typename pika::execution::experimental::sender_traits<Sender>::
+                    template value_types<pika::util::pack, pika::util::pack>>;
+
+            static constexpr bool is_void_value_type =
+                std::is_void_v<element_value_type>;
+
+            // This is a helper empty type for the case that nothing is sent
+            // from the predecessors
+            struct void_value_type
+            {
+            };
+
+            // This sender sends a single vector of the type sent by the
+            // predecessor senders or nothing if the predecessor senders send
+            // nothing
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<std::conditional_t<is_void_value_type,
+                Tuple<>, Tuple<std::vector<element_value_type>>>>;
+
+            // This sender sends any error types sent by the predecessor senders
+            // or std::exception_ptr
+            template <template <typename...> class Variant>
+            using error_types = pika::util::detail::unique_concat_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template error_types<Variant>,
+                Variant<std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename Receiver>
+            struct operation_state
+            {
+                struct when_all_vector_receiver
+                {
+                    operation_state& op_state;
+                    std::size_t const i;
+
+                    template <typename Error>
+                    friend void tag_invoke(set_error_t,
+                        when_all_vector_receiver&& r, Error&& error) noexcept
+                    {
+                        if (!r.op_state.set_done_error_called.exchange(true))
+                        {
+                            try
+                            {
+                                r.op_state.error = PIKA_FORWARD(Error, error);
+                            }
+                            catch (...)
+                            {
+                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                                r.op_state.error = std::current_exception();
+                            }
+                        }
+
+                        r.op_state.finish();
+                    }
+
+                    friend void tag_invoke(
+                        set_done_t, when_all_vector_receiver&& r) noexcept
+                    {
+                        r.op_state.set_done_error_called = true;
+                        r.op_state.finish();
+                    };
+
+                    template <typename... Ts>
+                    friend void tag_invoke(set_value_t,
+                        when_all_vector_receiver&& r, Ts&&... ts) noexcept
+                    {
+                        if (!r.op_state.set_done_error_called)
+                        {
+                            try
+                            {
+                                // We only have something to store if the
+                                // predecessor sends the single value that it
+                                // should send. We have nothing to store for
+                                // predecessor senders that send nothing.
+                                if constexpr (sizeof...(Ts) == 1)
+                                {
+                                    r.op_state.ts[r.i].emplace(
+                                        PIKA_FORWARD(Ts, ts)...);
+                                }
+                            }
+                            catch (...)
+                            {
+                                if (!r.op_state.set_done_error_called.exchange(
+                                        true))
+                                {
+                                    // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                                    r.op_state.error = std::current_exception();
+                                }
+                            }
+                        }
+
+                        r.op_state.finish();
+                    }
+                };
+
+                std::size_t const num_predecessors;
+                std::decay_t<Receiver> receiver;
+
+                // Number of predecessor senders that have not yet called any of
+                // the set signals.
+                std::atomic<std::size_t> predecessors_remaining{
+                    num_predecessors};
+
+                // The values sent by the predecessor senders are stored in a
+                // vector of optional or the dummy type void_value_type if the
+                // predecessor senders send nothing
+                using value_types_storage_type =
+                    std::conditional_t<is_void_value_type, void_value_type,
+                        std::vector<pika::optional<element_value_type>>>;
+                value_types_storage_type ts;
+
+                // The first error sent by any predecessor sender is stored in a
+                // optional of a variant of the error_types
+                using error_types_storage_type =
+                    pika::optional<error_types<pika::variant>>;
+                error_types_storage_type error;
+
+                // Set to true when set_done or set_error has been called
+                std::atomic<bool> set_done_error_called{false};
+
+                // The operation states are stored in an array of optionals of
+                // the operation states to handle the non-movability and
+                // non-copyability of them
+                using operation_state_type =
+                    pika::execution::experimental::connect_result_t<Sender,
+                        when_all_vector_receiver>;
+                using operation_states_storage_type =
+                    std::unique_ptr<pika::optional<operation_state_type>[]>;
+                operation_states_storage_type op_states = nullptr;
+
+                template <typename Receiver_>
+                operation_state(
+                    Receiver_&& receiver, std::vector<Sender>&& senders)
+                  : num_predecessors(senders.size())
+                  , receiver(PIKA_FORWARD(Receiver_, receiver))
+                {
+                    op_states = std::make_unique<
+                        pika::optional<operation_state_type>[]>(
+                        num_predecessors);
+                    std::size_t i = 0;
+                    for (auto&& sender : senders)
+                    {
+                        op_states[i].emplace(
+                            pika::util::detail::with_result_of([&]() {
+                                return pika::execution::experimental::connect(
+                                    PIKA_MOVE(sender),
+                                    when_all_vector_receiver{*this, i});
+                            }));
+                        ++i;
+                    }
+
+                    if constexpr (!is_void_value_type)
+                    {
+                        ts.resize(num_predecessors);
+                    }
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void finish() noexcept
+                {
+                    if (--predecessors_remaining == 0)
+                    {
+                        if (!set_done_error_called)
+                        {
+                            if constexpr (is_void_value_type)
+                            {
+                                pika::execution::experimental::set_value(
+                                    PIKA_MOVE(receiver));
+                            }
+                            else
+                            {
+                                std::vector<element_value_type> values;
+                                values.reserve(num_predecessors);
+                                for (auto&& t : ts)
+                                {
+                                    values.push_back(t.value());
+                                }
+                                pika::execution::experimental::set_value(
+                                    PIKA_MOVE(receiver), PIKA_MOVE(values));
+                            }
+                        }
+                        else if (error)
+                        {
+                            pika::visit(
+                                [this](auto&& error) {
+                                    pika::execution::experimental::set_error(
+                                        PIKA_MOVE(receiver),
+                                        PIKA_FORWARD(decltype(error), error));
+                                },
+                                PIKA_MOVE(error.value()));
+                        }
+                        else
+                        {
+                            pika::execution::experimental::set_done(
+                                PIKA_MOVE(receiver));
+                        }
+                    }
+                }
+
+                friend void tag_invoke(start_t, operation_state& os) noexcept
+                {
+                    // If there are no predecessors we can signal the
+                    // continuation as soon as start is called.
+                    if (os.num_predecessors == 0)
+                    {
+                        // If the predecessor sender type sends nothing, we also
+                        // send nothing to the continuation.
+                        if constexpr (is_void_value_type)
+                        {
+                            pika::execution::experimental::set_value(
+                                PIKA_MOVE(os.receiver));
+                        }
+                        // If the predecessor sender type sends something we
+                        // send an empty vector of that type to the continuation.
+                        else
+                        {
+                            pika::execution::experimental::set_value(
+                                PIKA_MOVE(os.receiver),
+                                std::vector<element_value_type>{});
+                        }
+                    }
+                    // Otherwise we start all the operation states and wait for
+                    // the predecessors to signal completion.
+                    else
+                    {
+                        for (std::size_t i = 0; i < os.num_predecessors; ++i)
+                        {
+                            pika::execution::experimental::start(
+                                os.op_states.get()[i].value());
+                        }
+                    }
+                }
+            };
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, when_all_vector_sender_type&& s, Receiver&& receiver)
+            {
+                return operation_state<Receiver>(
+                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.senders));
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, when_all_vector_sender_type& s, Receiver&& receiver)
+            {
+                return operation_state<Receiver>(receiver, s.senders);
+            }
+        };
+    }    // namespace when_all_vector_detail
+
+    inline constexpr struct when_all_vector_t final
+      : pika::functional::detail::tag_fallback<when_all_vector_t>
+    {
+    private:
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
+            when_all_vector_t, std::vector<Sender>&& senders)
+        {
+            return when_all_vector_detail::when_all_vector_sender<Sender>{
+                PIKA_MOVE(senders)};
+        }
+
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
+            when_all_vector_t, std::vector<Sender> const& senders)
+        {
+            return when_all_vector_detail::when_all_vector_sender<Sender>{
+                senders};
+        }
+    } when_all_vector{};
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/tests/include/algorithm_test_utils.hpp
+++ b/libs/pika/execution/tests/include/algorithm_test_utils.hpp
@@ -196,7 +196,7 @@ struct error_typed_sender
 
     template <typename R>
     friend auto tag_invoke(
-        pika::execution::experimental::connect_t, error_typed_sender&&, R&& r)
+        pika::execution::experimental::connect_t, error_typed_sender, R&& r)
     {
         return operation_state<R>{std::forward<R>(r)};
     }

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     algorithm_transfer
     algorithm_transfer_just
     algorithm_when_all
+    algorithm_when_all_vector
     bulk_async
     executor_parameters
     executor_parameters_dispatching

--- a/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -1,0 +1,279 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/config.hpp>
+#include <pika/modules/execution.hpp>
+#include <pika/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ex = pika::execution::experimental;
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector<decltype(ex::just())>{});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector<decltype(ex::just(42))>{});
+        auto f = [](std::vector<int> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(0));
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector{ex::just(42)});
+        auto f = [](std::vector<int> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(1));
+            PIKA_TEST_EQ(v[0], 42);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(
+            std::vector{ex::just(42), ex::just(43), ex::just(44)});
+        auto f = [](std::vector<int> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(3));
+            PIKA_TEST_EQ(v[0], 42);
+            PIKA_TEST_EQ(v[1], 43);
+            PIKA_TEST_EQ(v[2], 44);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::unique_any_sender<int>> senders;
+        senders.emplace_back(ex::just(42));
+        senders.emplace_back(ex::just(43));
+        senders.emplace_back(ex::just(44));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f = [](std::vector<int> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(3));
+            PIKA_TEST_EQ(v[0], 42);
+            PIKA_TEST_EQ(v[1], 43);
+            PIKA_TEST_EQ(v[2], 44);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::any_sender<double>> senders;
+        senders.emplace_back(ex::just(42.0));
+        senders.emplace_back(ex::just(43.0));
+        senders.emplace_back(ex::just(44.0));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f = [](std::vector<double> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(3));
+            PIKA_TEST_EQ(v[0], 42.0);
+            PIKA_TEST_EQ(v[1], 43.0);
+            PIKA_TEST_EQ(v[2], 44.0);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector{ex::just()});
+        auto f = []() {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(
+            std::vector{ex::just(), ex::just(), ex::just()});
+        auto f = []() {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::unique_any_sender<>> senders;
+        senders.emplace_back(ex::just());
+        senders.emplace_back(ex::just());
+        senders.emplace_back(ex::just());
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f = []() {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::any_sender<>> senders;
+        senders.emplace_back(ex::just());
+        senders.emplace_back(ex::just());
+        senders.emplace_back(ex::just());
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f = []() {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // Test a combination with when_all
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<decltype(ex::just(std::declval<double>()))> senders1;
+        senders1.emplace_back(ex::just(13.0));
+        senders1.emplace_back(ex::just(14.0));
+        senders1.emplace_back(ex::just(15.0));
+
+        std::vector<ex::any_sender<>> senders2;
+        senders2.emplace_back(ex::just());
+        senders2.emplace_back(ex::just());
+
+        std::vector<ex::unique_any_sender<int>> senders3;
+        senders3.emplace_back(ex::just(42));
+        senders3.emplace_back(ex::just(43));
+        senders3.emplace_back(ex::just(44));
+        senders3.emplace_back(ex::just(45));
+
+        auto s = ex::when_all(ex::when_all_vector(std::move(senders1)),
+            ex::when_all_vector(std::move(senders2)),
+            ex::when_all_vector(std::move(senders3)));
+        auto f = [](std::vector<double> v1, std::vector<int> v3) {
+            PIKA_TEST_EQ(v1.size(), std::size_t(3));
+            PIKA_TEST_EQ(v1[0], 13.0);
+            PIKA_TEST_EQ(v1[1], 14.0);
+            PIKA_TEST_EQ(v1[2], 15.0);
+
+            PIKA_TEST_EQ(v3.size(), std::size_t(4));
+            PIKA_TEST_EQ(v3[0], 42);
+            PIKA_TEST_EQ(v3[1], 43);
+            PIKA_TEST_EQ(v3[2], 44);
+            PIKA_TEST_EQ(v3[3], 45);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::when_all_vector(std::vector{error_typed_sender<double>{}});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        std::vector<ex::unique_any_sender<double>> senders;
+        senders.emplace_back(error_typed_sender<double>{});
+        senders.emplace_back(ex::just(42.0));
+        senders.emplace_back(ex::just(43.0));
+        senders.emplace_back(ex::just(44.0));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        std::vector<ex::unique_any_sender<double>> senders;
+        senders.emplace_back(error_typed_sender<double>{});
+        senders.emplace_back(ex::just(42.0));
+        senders.emplace_back(ex::just(43.0));
+        senders.emplace_back(ex::just(44.0));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        std::vector<ex::any_sender<double>> senders;
+        senders.emplace_back(error_typed_sender<double>{});
+        senders.emplace_back(ex::just(42.0));
+        senders.emplace_back(ex::just(43.0));
+        senders.emplace_back(ex::just(44.0));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        std::vector<ex::any_sender<double>> senders;
+        senders.emplace_back(error_typed_sender<double>{});
+        senders.emplace_back(ex::just(42.0));
+        senders.emplace_back(ex::just(43.0));
+        senders.emplace_back(ex::just(44.0));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    test_adl_isolation(
+        ex::when_all_vector(std::vector{my_namespace::my_sender{}}));
+
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
This is an adaptor like when_all, but specialized to take a vector of senders and signal the continuation when all senders in the vector have completed. It requires that the senders send a single type, or none at all. If they send nothing, the sender returned by when_all_vector also sends nothing.

Fixes #86, at least the minimum required case for DLA-Future.

Note that this currently only works with a vector of senders. Open questions for future work are:
1. Can this be optimized to allocate less? There are currently many separate heap allocations within this adaptor which could potentially be unified.
2. Can this be generalized in some reasonable way? It could handle any ranges or iterator/sentinel pairs. What container should it send in that case? It could handle nested senders, like dataflow.

Opening this PR for early CI/review feedback. This has _not_ yet been tested in DLA-Future.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

## To do before merging

- [x] Add `when_all(when_all_vector(x), when_all_vector(y), when_all_vector(z))` test case
- [ ] Rerun tests on Piz Daint (down for maintenance at the time of writing)