### PR TITLE
Reschedule threads on the worker thread where they were suspended again

### DIFF
--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -204,8 +204,11 @@ namespace pika { namespace threads {
     void execution_agent::do_resume(
         const char* /* desc */, pika::threads::thread_restart_state statex)
     {
-        threads::detail::set_thread_state(self_.get_thread_id(),
+        auto thrd = self_.get_thread_id();
+        threads::detail::set_thread_state(PIKA_MOVE(thrd),
             thread_schedule_state::pending, statex, thread_priority::normal,
-            thread_schedule_hint{}, false);
+            thread_schedule_hint{static_cast<std::int16_t>(
+                get_thread_id_data(thrd)->get_last_worker_thread_num())},
+            false);
     }
 }}    // namespace pika::threads

--- a/libs/pika/threading_base/src/set_thread_state.cpp
+++ b/libs/pika/threading_base/src/set_thread_state.cpp
@@ -18,6 +18,7 @@
 #include <pika/threading_base/threading_base_fwd.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>
@@ -57,10 +58,13 @@ namespace pika { namespace threads { namespace detail {
                 thread_schedule_state::terminated, invalid_thread_id);
         }
 
+        thread_schedule_hint schedulehint{static_cast<std::int16_t>(
+            get_thread_id_data(thrd)->get_last_worker_thread_num())};
+
         // just retry, set_state will create new thread if target is still active
         error_code ec(lightweight);    // do not throw
         detail::set_thread_state(thrd.noref(), newstate, newstate_ex, priority,
-            thread_schedule_hint(), true, ec);
+            schedulehint, true, ec);
 
         return thread_result_type(
             thread_schedule_state::terminated, invalid_thread_id);

--- a/libs/pika/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/unit/CMakeLists.txt
@@ -4,7 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests)
+set(tests resume_suspended_same_thread)
+
+set(resume_suspended_same_thread_PARAMETERS THREADS 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -13,7 +15,7 @@ foreach(test ${tests})
 
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS} ${${test}_LIBRARIES}
+    SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Local/ThreadingBase"
   )

--- a/libs/pika/threading_base/tests/unit/resume_suspended_same_thread.cpp
+++ b/libs/pika/threading_base/tests/unit/resume_suspended_same_thread.cpp
@@ -1,0 +1,65 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies that threads that are suspended get rescheduled on the
+// same thread where they were suspended
+
+#include <pika/assert.hpp>
+#include <pika/condition_variable.hpp>
+#include <pika/init.hpp>
+#include <pika/modules/testing.hpp>
+#include <pika/mutex.hpp>
+#include <pika/thread.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+struct test_data
+{
+    pika::mutex mtx{};
+    pika::condition_variable cond{};
+    bool notified{false};
+};
+
+int pika_main()
+{
+    PIKA_ASSERT(pika::get_num_worker_threads() >= 2);
+
+    for (std::size_t i = 0; i < 100; ++i)
+    {
+        std::cerr << i << "\n";
+        std::shared_ptr<test_data> d = std::make_shared<test_data>();
+
+        pika::jthread t1([d] {
+            std::unique_lock l{d->mtx};
+            auto t = pika::get_worker_thread_num();
+            d->cond.wait(l, [&] { return d->notified; });
+            PIKA_TEST_EQ(t, pika::get_worker_thread_num());
+        });
+        pika::jthread t2([d = std::move(d)] {
+            std::unique_lock l{d->mtx};
+            d->notified = true;
+            d->cond.notify_one();
+        });
+    }
+
+    return pika::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    pika::init_params init_args;
+    // We use the static scheduler to ensure that a thread scheduled on a
+    // particular worker thread actually run on that worker thread
+    init_args.cfg = {"pika.scheduler=static"};
+
+    PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);
+
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
This used to work but the changes seem to have been lost at some point. This also adds a test to verify the behaviour with the static scheduler (static since we want to guarantee that a thread runs where it's scheduled).

## Any background context you want to provide?

This is not super critical but I noticed this was missing when working on DLA-Future (https://github.com/eth-cscs/DLA-Future/pull/475).

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
