### PR TITLE
Fix `split`/`ensure_started` shared state reference counting

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -156,23 +156,21 @@ namespace pika { namespace execution { namespace experimental {
 
                 struct split_receiver
                 {
-                    pika::intrusive_ptr<shared_state> state;
+                    shared_state& state;
 
                     template <typename Error>
                     friend void tag_invoke(
                         set_error_t, split_receiver&& r, Error&& error) noexcept
                     {
-                        r.state->v.template emplace<error_type>(
+                        r.state.v.template emplace<error_type>(
                             error_type(PIKA_FORWARD(Error, error)));
-                        r.state->set_predecessor_done();
-                        r.state.reset();
+                        r.state.set_predecessor_done();
                     }
 
                     friend void tag_invoke(
                         set_done_t, split_receiver&& r) noexcept
                     {
-                        r.state->set_predecessor_done();
-                        r.state.reset();
+                        r.state.set_predecessor_done();
                     };
 
                     // This typedef is duplicated from the parent struct. The
@@ -194,11 +192,10 @@ namespace pika { namespace execution { namespace experimental {
                                         PIKA_FORWARD(Ts, ts)...)),
                             void())
                     {
-                        r.state->v.template emplace<value_type>(
+                        r.state.v.template emplace<value_type>(
                             pika::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
 
-                        r.state->set_predecessor_done();
-                        r.state.reset();
+                        r.state.set_predecessor_done();
                     }
                 };
 
@@ -216,9 +213,9 @@ namespace pika { namespace execution { namespace experimental {
                 {
                     PIKA_ASSERT_MSG(start_called,
                         "start was never called on the operation state of "
-                        "split or ensure_started. Did you forget to connect the"
-                        "sender to a receiver, or call start on the operation "
-                        "state?");
+                        "split or ensure_started. Did you forget to connect "
+                        "the sender to a receiver, or call start on the "
+                        "operation state?");
                 }
 
                 template <typename Receiver>

--- a/libs/pika/execution/tests/unit/algorithm_split.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_split.cpp
@@ -151,7 +151,15 @@ int main()
         PIKA_TEST(receiver_set_value_called);
     }
 
-    test_adl_isolation(ex::split(my_namespace::my_sender{}));
+    {
+        auto s = ex::split(my_namespace::my_sender{});
+        test_adl_isolation(s);
+
+        // This is not required by the ADL test, but required by split. The
+        // shared state destructor of the sender returned by split asserts that
+        // the sender has been connected and started before being released.
+        ex::sync_wait(std::move(s));
+    }
 
     return pika::util::report_errors();
 }


### PR DESCRIPTION
Fixes the reference counting for the shared state of `split`/`ensure_started`. It was being held with an additional unnecessary reference count by the `split_receiver` which is connected to the predecessor sender. This made the shared state stay alive longer than necessary.

Additionally it resets the operation state (resulting from connecting the predecessor sender to `split`/`ensure_started` to `split_receiver`) as soon as `set_x` has been called on `split_receiver`. This releases resources as early as possible, since the operation state is no longer needed after `set_x` has been called.

This was triggered by the work in https://github.com/eth-cscs/DLA-Future/pull/475 where the RAII nature of `Tile` revealed deadlocks unless the operation state is released as early as possible.

Note that currently P2300 does not mandate that the operation state has to be released this early. I don't yet know if it should mandate that or not, but if it won't this kind of usage requires a non-standard `ensure_started` which has this guarantee.