### PR TITLE
Don't allow yielding with uncaught exceptions

### DIFF
--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_base.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_base.hpp
@@ -193,6 +193,15 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
         //         resumed.
         void yield()
         {
+            // Misbehaved threads may try to yield while handling an exception.
+            // This is dangerous if the thread can migrate to other worker
+            // threads since the count for std::uncaught_exceptions may become
+            // inconsistent (including negative). If at any point in the future
+            // there is a legitimate use case for yielding with uncaught
+            // exceptions this assertion can be revisited, but until then we
+            // prefer to be strict about it.
+            PIKA_ASSERT(std::uncaught_exceptions() == 0);
+
             //prevent infinite loops
             PIKA_ASSERT(m_exit_state < ctx_exit_signaled);
             PIKA_ASSERT(running());

--- a/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
+++ b/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
@@ -119,9 +119,6 @@ namespace pika {
         PIKA_EXPORT void set_get_full_build_string(
             get_full_build_string_type f);
         PIKA_EXPORT std::string get_full_build_string();
-
-        PIKA_EXPORT std::string trace_on_new_stack(
-            std::size_t frames_no = PIKA_HAVE_THREAD_BACKTRACE_DEPTH);
     }    // namespace detail
 
     namespace detail {

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -161,6 +161,15 @@ namespace pika { namespace threads {
         PIKA_ASSERT(thrd_data);
         thrd_data->interruption_point();
 
+        // Misbehaved threads may try to yield while handling an exception. This
+        // is dangerous if the thread can migrate to other worker threads since
+        // the count for std::uncaught_exceptions may become inconsistent
+        // (including negative). If at any point in the future there is a
+        // legitimate use case for yielding with uncaught exceptions this
+        // assertion can be revisited, but until then we prefer to be strict
+        // about it.
+        PIKA_ASSERT(std::uncaught_exceptions() == 0);
+
         thrd_data->set_last_worker_thread_num(
             pika::get_local_worker_thread_num());
 


### PR DESCRIPTION
This is also related to the work in https://github.com/eth-cscs/DLA-Future/pull/475. The underlying bug is fixed separately, but this fixes a side effect that was revealed by the bug, which I don't see a reason to allow, namely yielding pika threads with uncaught exceptions.

This was triggered by a test:
- throwing an exception
- the destructor for an unsatisfied promise running
- the destructor trying to construct an exception
- the exception construction trying to collect a stacktrace
- the stacktrace collection being launched on another thread
- the exception construction waiting for the completion of the stacktrace by suspending/yielding
- the exception construction thread waking up on another worker thread (this happens sometimes with the stealing schedulers, also see #110)

Since the yield happens with an uncaught exception the value of `std::uncaught_exceptions()` is one on the worker thread where the yield happened. When the thread is resumed and the exception is eventually handled libstdc++ will decrement the count for `std::uncaught_exceptions()`. However, since it's now on another thread and the count is thread local the count will be decremented to `-1` on the new worker thread, while the count remains `1` on the first worker thread. This leads to all kinds of inconsistencies.

This adds assertions that `std::uncaught_exceptions()` is `0` before yielding since I don't see a legitimate use case (at this point) for allowing it.

Additionally, I've made the stacktrace collection happen inline instead of on a new pika thread to make it safe to construct pika exceptions while there are uncaught exceptions. This last part I'm slightly unsure about since I'm guessing there was a reason for putting the stacktrace collection on a separate pika thread. However, so far it seems to be safe. CI may tell me otherwise. @biddisco do you have any memory of why the stacktrace collection might have happened on a separate pika thread?