### PR TITLE
Attempt to fix deadlocks in `condition_variable`

### DIFF
--- a/libs/pika/config/include/pika/config.hpp
+++ b/libs/pika/config/include/pika/config.hpp
@@ -61,7 +61,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// By default, enable minimal thread deadlock detection in debug builds only.
 #if !defined(PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT)
-#  define PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT 1073741823
+#  define PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT 10000000
+#endif
+
+/// Print a warning about potential deadlocks after this many iterations.
+#if !defined(PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT)
+#  define PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT 1000000
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/pika/execution_base/include/pika/execution_base/detail/spinlock_deadlock_detection.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/detail/spinlock_deadlock_detection.hpp
@@ -15,6 +15,8 @@ namespace pika { namespace util { namespace detail {
     PIKA_EXPORT void set_spinlock_break_on_deadlock_enabled(bool enabled);
     PIKA_EXPORT bool get_spinlock_break_on_deadlock_enabled();
     PIKA_EXPORT void set_spinlock_deadlock_detection_limit(std::size_t limit);
+    PIKA_EXPORT void set_spinlock_deadlock_warning_limit(std::size_t limit);
     PIKA_EXPORT std::size_t get_spinlock_deadlock_detection_limit();
+    PIKA_EXPORT std::size_t get_spinlock_deadlock_warning_limit();
 }}}    // namespace pika::util::detail
 #endif

--- a/libs/pika/execution_base/src/spinlock_deadlock_detection.cpp
+++ b/libs/pika/execution_base/src/spinlock_deadlock_detection.cpp
@@ -18,6 +18,8 @@ namespace pika { namespace util { namespace detail {
     static bool spinlock_break_on_deadlock_enabled = false;
     static std::size_t spinlock_deadlock_detection_limit =
         PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT;
+    static std::size_t spinlock_deadlock_warning_limit =
+        PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT;
 
     void set_spinlock_break_on_deadlock_enabled(bool enabled)
     {
@@ -34,9 +36,19 @@ namespace pika { namespace util { namespace detail {
         spinlock_deadlock_detection_limit = limit;
     }
 
+    void set_spinlock_deadlock_warning_limit(std::size_t limit)
+    {
+        spinlock_deadlock_warning_limit = limit;
+    }
+
     std::size_t get_spinlock_deadlock_detection_limit()
     {
         return spinlock_deadlock_detection_limit;
+    }
+
+    std::size_t get_spinlock_deadlock_warning_limit()
+    {
+        return spinlock_deadlock_warning_limit;
     }
 }}}    // namespace pika::util::detail
 #endif

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -12,6 +12,7 @@
 #include <pika/coroutines/detail/context_impl.hpp>
 #include <pika/detail/filesystem.hpp>
 #include <pika/execution/detail/execution_parameter_callbacks.hpp>
+#include <pika/execution_base/detail/spinlock_deadlock_detection.hpp>
 #include <pika/executors/exception_list.hpp>
 #include <pika/functional/bind_front.hpp>
 #include <pika/functional/function.hpp>
@@ -254,6 +255,8 @@ namespace pika {
                 cmdline.rtcfg_.enable_spinlock_deadlock_detection());
             util::detail::set_spinlock_deadlock_detection_limit(
                 cmdline.rtcfg_.get_spinlock_deadlock_detection_limit());
+            util::detail::set_spinlock_deadlock_warning_limit(
+                cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
 #endif
 #if defined(PIKA_HAVE_LOGGING)
             util::detail::init_logging_local(cmdline.rtcfg_);

--- a/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
+++ b/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
@@ -66,6 +66,7 @@ namespace pika { namespace util {
         bool enable_minimal_deadlock_detection() const;
         bool enable_spinlock_deadlock_detection() const;
         std::size_t get_spinlock_deadlock_detection_limit() const;
+        std::size_t get_spinlock_deadlock_warning_limit() const;
 
 #if defined(__linux) || defined(linux) || defined(__linux__) ||                \
     defined(__FreeBSD__)

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -116,6 +116,9 @@ namespace pika { namespace util {
             "spinlock_deadlock_detection_limit = "
             "${PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT:" PIKA_PP_STRINGIZE(
                 PIKA_PP_EXPAND(PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT)) "}",
+            "spinlock_deadlock_warning_limit = "
+            "${PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT:" PIKA_PP_STRINGIZE(
+                PIKA_PP_EXPAND(PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT)) "}",
 #endif
             "expect_connecting_localities = "
             "${PIKA_EXPECT_CONNECTING_LOCALITIES:0}",
@@ -504,6 +507,22 @@ namespace pika { namespace util {
                 PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT);
         }
         return PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT;
+#else
+        return std::size_t(-1);
+#endif
+    }
+
+    std::size_t runtime_configuration::get_spinlock_deadlock_warning_limit()
+        const
+    {
+#ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION
+        if (util::section const* sec = get_section("pika"); nullptr != sec)
+        {
+            return pika::util::get_entry_as<std::size_t>(*sec,
+                "spinlock_deadlock_warning_limit",
+                PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT);
+        }
+        return PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT;
 #else
         return std::size_t(-1);
 #endif

--- a/libs/pika/synchronization/src/stop_token.cpp
+++ b/libs/pika/synchronization/src/stop_token.cpp
@@ -117,6 +117,10 @@ namespace pika { namespace detail {
         if (stop_requested(old_state))
         {
             cb->execute();
+
+            cb->callback_finished_executing_.store(
+                true, std::memory_order_release);
+
             return false;
         }
         else if (!stop_possible(old_state))
@@ -137,6 +141,10 @@ namespace pika { namespace detail {
                 if (stop_requested(old_state))
                 {
                     cb->execute();
+
+                    cb->callback_finished_executing_.store(
+                        true, std::memory_order_release);
+
                     return false;
                 }
                 else if (!stop_possible(old_state))

--- a/libs/pika/synchronization/src/stop_token.cpp
+++ b/libs/pika/synchronization/src/stop_token.cpp
@@ -210,13 +210,12 @@ namespace pika { namespace detail {
         {
             // Callback is currently executing on another thread,
             // block until it finishes executing.
-            for (std::size_t k = 0; !cb->callback_finished_executing_.load(
-                     std::memory_order_relaxed);
-                 ++k)
-            {
-                pika::execution_base::this_thread::yield_k(
-                    k, "stop_state::remove_callback");
-            }
+            pika::util::yield_while(
+                [&]() {
+                    return !cb->callback_finished_executing_.load(
+                        std::memory_order_relaxed);
+                },
+                "stop_state::remove_callback");
         }
     }
 

--- a/libs/pika/threading/tests/unit/condition_variable2.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable2.cpp
@@ -590,8 +590,6 @@ void test_many_cvs(bool call_notify, bool call_interrupt)
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
-
     try
     {
         test_minimal_wait(0);

--- a/libs/pika/threading/tests/unit/condition_variable3.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable3.cpp
@@ -48,7 +48,6 @@ void test_cv_callback()
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
     try
     {
         test_cv_callback();

--- a/libs/pika/threading/tests/unit/condition_variable4.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable4.cpp
@@ -123,8 +123,6 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
-
     try
     {
         producer_consumer(0, 0, false);

--- a/libs/pika/threading/tests/unit/condition_variable4.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable4.cpp
@@ -60,6 +60,7 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
                     if (prod_sec > 0)
                     {
                         std::this_thread::sleep_for(prod_sleep);
+                        pika::this_thread::yield();
                     }
                 }
 
@@ -80,6 +81,7 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
                 if (cons_sec > 0)
                 {
                     std::this_thread::sleep_for(cons_sleep);
+                    pika::this_thread::yield();
                 }
             }
 
@@ -112,6 +114,7 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
         if (prod_sec > 0)
         {
             std::this_thread::sleep_for(prod_sleep * 10);
+            pika::this_thread::yield();
         }
         ssource.request_stop();
     }

--- a/libs/pika/threading/tests/unit/condition_variable_race.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable_race.cpp
@@ -220,7 +220,6 @@ void test_cv_any_mutex()
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
     try
     {
         test_cv_mutex();

--- a/libs/pika/threading/tests/unit/jthread1.cpp
+++ b/libs/pika/threading/tests/unit/jthread1.cpp
@@ -475,8 +475,6 @@ void test_jthread_api()
 ////////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
-
     test_jthread_without_token();
     test_jthread_with_token();
     test_join();

--- a/libs/pika/threading/tests/unit/jthread2.cpp
+++ b/libs/pika/threading/tests/unit/jthread2.cpp
@@ -315,8 +315,6 @@ void test_jthread_move()
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    std::set_terminate([]() { PIKA_TEST(false); });
-
     test_interrupt_by_destructor();
     test_interrupt_started_thread();
     test_interrupt_started_thread_with_subthread();


### PR DESCRIPTION
Attemps to fix the deadlocks that seem to happen occasionally in the `condition_variable2/4` tests. The deadlocks seem related to `stop_token` in the sense that previously if a stop request comes in at a bad moment compared to when a `stop_callback` is created, the `stop_callback` will execute but will not mark itself as executed. While removing the callback it will then wait (in vain) for the callback to first have been executed (which it has, but it has not been marked as executed).

The first three commits of this PR slightly refactor the deadlock detection mechanism we have to first print a warning at a lower iteration count. This also reduces the limit at which an exception is thrown when deadlock detection is enabled. I hope I've not reduced the limit too far but it's still user-configurable, is only enabled by default in debug builds, and we can still increase the default again. The current limit ends up stopping after around 10 seconds (with nothing else in the queues).

The last commit attempts to fix the deadlock itself by marking the callback as executed after executing it.

Part of #23.