### PR TITLE
More sanitizers

### DIFF
--- a/.github/workflows/linux_asan_ubsan.yml
+++ b/.github/workflows/linux_asan_ubsan.yml
@@ -1,0 +1,72 @@
+# Copyright (c) 2020 EXASOL
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (asan/ubsan)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/asan_ubsan/fast
+    # if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:18
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: linux-asan-ubsan
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
+              -DPIKA_WITH_TESTS_HEADERS=OFF \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_COMPILER_WARNINGS=ON \
+              -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
+              -DPIKA_WITH_SANITIZERS=ON \
+              -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer" \
+              -DPIKA_WITH_STACKOVERFLOW_DETECTION=OFF
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target tests.examples
+    - name: Test
+      shell: bash
+      run: |
+          export ASAN_OPTIONS=fast_unwind_on_malloc=0
+          export LSAN_OPTIONS=suppressions=$PWD/tools/asan.supp
+          export UBSAN_OPTIONS=print_stacktrace=1,suppressions=$PWD/tools/ubsan.supp
+          cd build
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.examples

--- a/.github/workflows/linux_msan.yml
+++ b/.github/workflows/linux_msan.yml
@@ -1,0 +1,67 @@
+# Copyright (c) 2022 ETH Zurich
+# Copyright (c) 2020 EXASOL
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (MemorySanitizer)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/msan/fast
+    # if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:18
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: linux-msan
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
+              -DPIKA_WITH_TESTS_HEADERS=OFF \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_SANITIZERS=On \
+              -DCMAKE_CXX_FLAGS="-fsanitize=memory -fno-omit-frame-pointer" \
+              -DPIKA_WITH_STACKOVERFLOW_DETECTION=OFF
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target tests.examples
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.examples

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -1,0 +1,67 @@
+# Copyright (c) 2022 ETH Zurich
+# Copyright (c) 2020 EXASOL
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (ThreadSanitizer)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/tsan/fast
+    # if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:18
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: linux-tsan
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
+              -DPIKA_WITH_TESTS_HEADERS=OFF \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_SANITIZERS=ON \
+              -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
+              -DPIKA_WITH_STACKOVERFLOW_DETECTION=OFF
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target tests.examples
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.examples

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -34,12 +34,14 @@ jobs:
         key: linux-valgrind
     - name: Configure
       shell: bash
+      # -gdwarf-4 because of https://github.com/llvm/llvm-project/issues/56550
       run: |
           cmake \
               . \
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_CXX_FLAGS="-gdwarf-4" \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \
               -DPIKA_WITH_EXAMPLES=ON \

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -1,10 +1,10 @@
-# Copyright (c) 2020 EXASOL
+# Copyright (c) 2022 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-name: Linux CI (asan/ubsan)
+name: Linux CI (Valgrind)
 
 on:
   merge_group:
@@ -20,8 +20,7 @@ on:
 
 jobs:
   build:
-    name: github/linux/sanitizers/fast
-    if: ${{ github.event_name == 'merge_group' }}
+    name: github/linux/msan/fast
     runs-on: ubuntu-latest
     container: pikaorg/pika-ci-base:18
 
@@ -32,7 +31,7 @@ jobs:
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ccache-linux-sanitizers
+        key: linux-valgrind
     - name: Configure
       shell: bash
       run: |
@@ -40,31 +39,27 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \
               -DPIKA_WITH_EXAMPLES=ON \
               -DPIKA_WITH_TESTS=ON \
               -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
+              -DPIKA_WITH_TESTS_HEADERS=OFF \
               -DPIKA_WITH_TESTS_MAX_THREADS=2 \
-              -DPIKA_WITH_COMPILER_WARNINGS=ON \
-              -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
-              -DPIKA_WITH_SANITIZERS=On \
-              -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer" \
+              -DPIKA_WITH_TESTS_VALGRIND=ON \
               -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
               -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
     - name: Build
       shell: bash
       run: |
-          cmake --build build --target all
-          cmake --build build --target examples
+          cmake --build build --target tests.examples
     - name: Test
       shell: bash
       run: |
-          export ASAN_OPTIONS=fast_unwind_on_malloc=0
-          export LSAN_OPTIONS=suppressions=$PWD/tools/asan.supp
-          export UBSAN_OPTIONS=print_stacktrace=1,suppressions=$PWD/tools/ubsan.supp
+          # TODO: Make this part of the image
+          apt update && apt install -y valgrind
           cd build
           ctest \
             --timeout 120 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,6 +835,13 @@ pika_option(
   ADVANCED
 )
 
+pika_option(
+  PIKA_WITH_TESTS_VALGRIND BOOL "Run tests under valgrind."
+  OFF
+  CATEGORY "Debugging"
+  ADVANCED
+)
+
 set(PIKA_WITH_VERIFY_LOCKS_DEFAULT OFF)
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   set(PIKA_WITH_VERIFY_LOCKS_DEFAULT ON)

--- a/cmake/pika_add_test.cmake
+++ b/cmake/pika_add_test.cmake
@@ -70,6 +70,10 @@ function(pika_add_test category name)
 
   set(cmd ${_exe})
 
+  if(PIKA_WITH_TESTS_VALGRIND)
+    list(PREPEND cmd valgrind --leak-check=full --error-exitcode=1)
+  endif()
+
   if(${name}_RUNWRAPPER)
     set(_preflags_list_ ${MPIEXEC_PREFLAGS})
     separate_arguments(_preflags_list_)

--- a/libs/pika/logging/include/pika/logging/format/destinations.hpp
+++ b/libs/pika/logging/include/pika/logging/format/destinations.hpp
@@ -137,12 +137,12 @@ namespace pika::util::logging::destination {
         and @ref dealing_with_flags
     */
         PIKA_EXPORT static std::unique_ptr<file> make(
-            std::string const& file_name, file_settings set = {});
+            std::string_view file_name, file_settings set = {});
 
         PIKA_EXPORT ~file();
 
     protected:
-        file(std::string const& file_name, file_settings set)
+        file(std::string_view file_name, file_settings set)
           : name(file_name)
           , settings(set)
         {

--- a/libs/pika/logging/include/pika/logging/format/named_write.hpp
+++ b/libs/pika/logging/include/pika/logging/format/named_write.hpp
@@ -226,13 +226,14 @@ namespace pika::util::logging::detail {
             return *this;
         }
 
-        void add(std::string const& name, ptr_type p)
+        void add(std::string_view name, ptr_type p)
         {
             auto iter = find_named(destinations, name);
             if (iter != destinations.end())
                 iter->value = PIKA_MOVE(p);
             else
-                destinations.push_back(named<ptr_type>{name, PIKA_MOVE(p)});
+                destinations.push_back(
+                    named<ptr_type>{std::string(name), PIKA_MOVE(p)});
             compute_write_steps();
         }
 
@@ -420,7 +421,7 @@ namespace pika::util::logging::writer {
         }
 
         template <typename Destination, typename... Args>
-        void set_destination(std::string const& name, Args&&... args)
+        void set_destination(std::string_view name, Args&&... args)
         {
             m_destination.add(name, Destination::make(PIKA_FORWARD(Args, args)...));
         }

--- a/libs/pika/logging/src/format/destination/file.cpp
+++ b/libs/pika/logging/src/format/destination/file.cpp
@@ -42,7 +42,7 @@ namespace pika::util::logging::destination {
     {
         using mutex_type = pika::detail::spinlock;
 
-        explicit file_impl(std::string const& file_name, file_settings set)
+        explicit file_impl(std::string_view file_name, file_settings set)
           : file(file_name, set)
         {
         }
@@ -78,7 +78,8 @@ namespace pika::util::logging::destination {
         mutable mutex_type mtx_;
     };
 
-    std::unique_ptr<file> file::make(std::string const& file_name, file_settings set)
+    std::unique_ptr<file> file::make(
+        std::string_view file_name, file_settings set)
     {
         return std::unique_ptr<file>(new file_impl(file_name, set));
     }

--- a/tools/tsan.supp
+++ b/tools/tsan.supp
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+race:boost::lockfree::deque*


### PR DESCRIPTION
This is meant for #63. I have done _zero_ work to attempt to fix any leaks etc. This currently only adds various new CI sanitizer configurations (MemorySanitizer and ThreadSanitizer) as well as one which runs tests inside valgrind. I'm simply opening this as a draft to see how bad the situation is.

We might be able to get these running by heavily suppressing the current errors. That would at least be useful to ensure we don't introduce new errors and would let us gradually fix what is there.