### PR TITLE
Add `pika/cuda.hpp` and `pika/mpi.hpp` API headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,8 @@ pika_option(
 )
 
 if(PIKA_WITH_MPI)
+  pika_add_config_define(PIKA_HAVE_MPI)
+
   # mpi settings
   pika_option(
     PIKA_WITH_MPI_ENV

--- a/libs/pika/async_cuda/tests/performance/cuda_executor_throughput.cpp
+++ b/libs/pika/async_cuda/tests/performance/cuda_executor_throughput.cpp
@@ -26,9 +26,9 @@
 // cudaMalloc/cudaMemcpy etc, so we do not #define PIKA_CUBLAS_DEMO_WITH_ALLOCATOR
 
 #include <pika/algorithm.hpp>
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/modules/timing.hpp>
 #include <pika/parallel/algorithms/copy.hpp>
 #include <pika/parallel/algorithms/for_each.hpp>

--- a/libs/pika/async_cuda/tests/performance/synchronize.cu
+++ b/libs/pika/async_cuda/tests/performance/synchronize.cu
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/chrono.hpp>
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/libs/pika/async_cuda/tests/unit/cublas_handle.cu
+++ b/libs/pika/async_cuda/tests/unit/cublas_handle.cu
@@ -4,10 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/async_cuda/cublas_exception.hpp>
-#include <pika/async_cuda/cublas_handle.hpp>
-#include <pika/async_cuda/cuda_exception.hpp>
-#include <pika/async_cuda/cuda_stream.hpp>
+#include <pika/cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <utility>

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -27,13 +27,11 @@
 
 #include <pika/algorithm.hpp>
 #include <pika/assert.hpp>
-#include <pika/async_cuda/custom_blas_api.hpp>
-#include <pika/async_cuda/custom_gpu_api.hpp>
 #include <pika/chrono.hpp>
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <algorithm>

--- a/libs/pika/async_cuda/tests/unit/cuda_bulk.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_bulk.cu
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/chrono.hpp>
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <cstddef>

--- a/libs/pika/async_cuda/tests/unit/cuda_future.cpp
+++ b/libs/pika/async_cuda/tests/unit/cuda_future.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/algorithm.hpp>
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <algorithm>

--- a/libs/pika/async_cuda/tests/unit/cuda_pool.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_pool.cu
@@ -4,8 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/async_cuda/cuda_exception.hpp>
-#include <pika/async_cuda/cuda_pool.hpp>
+#include <pika/cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <cstddef>

--- a/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <type_traits>

--- a/libs/pika/async_cuda/tests/unit/cuda_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_stream.cu
@@ -4,9 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/async_cuda/cuda_exception.hpp>
-#include <pika/async_cuda/cuda_stream.hpp>
 #include <pika/testing.hpp>
+#include <pika/cuda.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/pika/async_cuda/tests/unit/cusolver_handle.cu
+++ b/libs/pika/async_cuda/tests/unit/cusolver_handle.cu
@@ -4,11 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/async_cuda/cuda_exception.hpp>
-#include <pika/async_cuda/cuda_stream.hpp>
-#include <pika/async_cuda/cusolver_exception.hpp>
-#include <pika/async_cuda/cusolver_handle.hpp>
-#include <pika/async_cuda/custom_lapack_api.hpp>
+#include <pika/cuda.hpp>
 #include <pika/testing.hpp>
 
 #include <iostream>

--- a/libs/pika/async_cuda/tests/unit/saxpy.cu
+++ b/libs/pika/async_cuda/tests/unit/saxpy.cu
@@ -5,9 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/future.hpp>
-
-#include <pika/async_cuda/cuda_executor.hpp>
-#include <pika/async_cuda/custom_gpu_api.hpp>
+#include <pika/cuda.hpp>
 
 #include <cstddef>
 

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -4,10 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/cuda.hpp>
+#include <pika/execution.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
-#include <pika/modules/execution.hpp>
-#include <pika/modules/executors.hpp>
 #include <pika/testing.hpp>
 
 #include <atomic>

--- a/libs/pika/async_cuda/tests/unit/trivial_demo.cu
+++ b/libs/pika/async_cuda/tests/unit/trivial_demo.cu
@@ -4,13 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/preprocessor/seq/for_each.hpp>
-
 #include <pika/config.hpp>
-
 #include <pika/assert.hpp>
-#include <pika/async_cuda/cuda_exception.hpp>
-#include <pika/async_cuda/custom_gpu_api.hpp>
+#include <pika/cuda.hpp>
+
+#include <boost/preprocessor/seq/for_each.hpp>
 
 #include <iostream>
 

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -4,10 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/exception.hpp>
+#include <pika/execution.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_mpi.hpp>
-#include <pika/modules/errors.hpp>
-#include <pika/modules/execution.hpp>
+#include <pika/mpi.hpp>
 #include <pika/testing.hpp>
 
 #include "algorithm_test_utils.hpp"

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -7,7 +7,7 @@
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_mpi.hpp>
+#include <pika/mpi.hpp>
 #include <pika/program_options.hpp>
 #include <pika/testing.hpp>
 

--- a/libs/pika/include/CMakeLists.txt
+++ b/libs/pika/include/CMakeLists.txt
@@ -11,12 +11,14 @@ set(include_headers
     pika/channel.hpp
     pika/chrono.hpp
     pika/condition_variable.hpp
+    pika/cuda.hpp
     pika/exception.hpp
     pika/execution.hpp
     pika/functional.hpp
     pika/future.hpp
     pika/latch.hpp
     pika/memory.hpp
+    pika/mpi.hpp
     pika/mutex.hpp
     pika/numeric.hpp
     pika/optional.hpp
@@ -31,6 +33,16 @@ set(include_headers
     pika/type_traits.hpp
     pika/unwrap.hpp
 )
+
+set(include_additional_module_dependencies)
+
+if(PIKA_WITH_GPU_SUPPORT)
+  list(APPEND include_additional_module_dependencies pika_async_cuda)
+endif()
+
+if(PIKA_WITH_MPI)
+  list(APPEND include_additional_module_dependencies pika_async_cuda)
+endif()
 
 include(pika_add_module)
 pika_add_module(
@@ -48,5 +60,6 @@ pika_add_module(
     pika_futures
     pika_lcos
     pika_runtime
+    ${include_additional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/pika/include/include/pika/cuda.hpp
+++ b/libs/pika/include/include/pika/cuda.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#if defined(PIKA_HAVE_GPU_SUPPORT)
+#include <pika/modules/async_cuda.hpp>
+#endif

--- a/libs/pika/include/include/pika/mpi.hpp
+++ b/libs/pika/include/include/pika/mpi.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#if defined(PIKA_HAVE_MPI)
+#include <pika/modules/async_mpi.hpp>
+#endif


### PR DESCRIPTION
Fixes #57.

Also updates tests and examples to use them.

I'm calling the "GPU" header `pika/cuda.hpp` still at the moment because all the functionality has `cuda` the names or lives in the `cuda` namespace. We should, however, start considering replacing the `cuda` terminology with a more generic `gpu` (as has been started e.g. with `PIKA_WITH_GPU_SUPPORT`). See #116.

As a flyby I've changed some more `pika/modules/x.hpp` includes in the MPI/CUDA tests and examples to use the API headers.