### PR TITLE
Remove unused `hardware_concurrency_tag`

### DIFF
--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -1586,10 +1586,6 @@ namespace pika { namespace threads {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct hardware_concurrency_tag
-    {
-    };
-
     struct hw_concurrency
     {
         hw_concurrency()

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -1586,25 +1586,27 @@ namespace pika { namespace threads {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct hw_concurrency
-    {
-        hw_concurrency()
-#if defined(__ANDROID__) && defined(ANDROID)
-          : num_of_cores_(::android_getCpuCount())
-#else
-          : num_of_cores_(detail::hwloc_hardware_concurrency())
-#endif
+    namespace detail {
+        struct hw_concurrency
         {
-            if (num_of_cores_ == 0)
-                num_of_cores_ = 1;
-        }
+            hw_concurrency()
+#if defined(__ANDROID__) && defined(ANDROID)
+              : num_of_cores_(::android_getCpuCount())
+#else
+              : num_of_cores_(hwloc_hardware_concurrency())
+#endif
+            {
+                if (num_of_cores_ == 0)
+                    num_of_cores_ = 1;
+            }
 
-        std::size_t num_of_cores_;
-    };
+            std::size_t num_of_cores_;
+        };
+    }    // namespace detail
 
     unsigned int hardware_concurrency()
     {
-        static hw_concurrency hwc;
+        static detail::hw_concurrency hwc;
         return static_cast<unsigned int>(hwc.num_of_cores_);
     }
 }}    // namespace pika::threads


### PR DESCRIPTION
The struct is unused (it used to be used for thread-local storage, but that's long gone). I've also moved the helper struct `hw_concurrency` into `detail`.