### PR TITLE
Update jenkins configurations after Piz Daint upgrade

### DIFF
--- a/.jenkins/cscs-perftests/env-perftests.sh
+++ b/.jenkins/cscs-perftests/env-perftests.sh
@@ -5,7 +5,21 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 set -eu
 
-source $SPACK_ROOT/share/spack/setup-env.sh
+module load daint-gpu spack-config
+
+export SPACK_USER_CONFIG_PATH="${SPACK_ROOT}/../spack-user-config"
+export SPACK_USER_CACHE_PATH="/scratch/snx3000/simbergm/spack-user-cache-jenkins"
+source "${SPACK_ROOT}/share/spack/setup-env.sh"
+
+spack load ccache@4.5.1 %gcc@10.3.0
+spack load cmake@3.18.6 %gcc@10.3.0
+spack load ninja@1.10.0 %gcc@10.3.0
+
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+export CMAKE_GENERATOR=Ninja
+export CCACHE_DIR=/scratch/snx3000/simbergm/ccache-jenkins-pika
+export CCACHE_MAXSIZE=100G
+export CCACHE_MAXFILES=50000
 
 export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/pika/packages"
@@ -23,6 +37,3 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load cray-jemalloc/5.1.0.3
-module load daint-mc
-spack load cmake@3.18.6 %gcc@10.3.0
-spack load ninja@1.10.0 %gcc@10.3.0

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -8,10 +8,10 @@ export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/pika/packages"
 export CXX_STD="17"
 export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
+export BOOST_ROOT=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-gpu/software/Boost/1.78.0-CrayGNU-21.09
 
 module load daint-gpu
-module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
-module load Boost/1.75.0-CrayCCE-20.11
+module load cudatoolkit/11.0.2_3.38-8.1__g5b73779
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -6,11 +6,13 @@
 
 export CRAYPE_LINK_TYPE=dynamic
 export CXX_STD="17"
+export BOOST_ROOT=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-gpu/software/Boost/1.78.0-CrayGNU-21.09
+export HWLOC_ROOT=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-gpu/software/hwloc/2.4.1/
 
 module switch PrgEnv-cray PrgEnv-gnu
-module load cudatoolkit/11.0.2_3.38-8.1__g5b73779
-module load Boost/1.75.0-CrayGNU-20.11
-module load hwloc/.2.0.3
+module switch gcc gcc/9.3.0
+module load cudatoolkit/21.5_11.3
+module load CMake/3.22.1
 
 export CXX=`which CC`
 export CC=`which cc`
@@ -22,4 +24,3 @@ configure_extra_options+=" -DPIKA_WITH_EXAMPLES_OPENMP=ON"
 configure_extra_options+=" -DPIKA_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DPIKA_WITH_TESTS_HEADERS=ON"
-configure_extra_options+=" -DHWLOC_ROOT=${EBROOTHWLOC}"

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -136,7 +136,7 @@ namespace pika { namespace execution { namespace experimental {
             {
                 std::unique_lock<mutex_type> l(state.mtx);
                 state.set_called = true;
-                pika::util::ignore_while_checking il(&l);
+                pika::util::ignore_while_checking<decltype(l)> il(&l);
                 PIKA_UNUSED(il);
 
                 state.cond_var.notify_one();


### PR DESCRIPTION
Some of the modules have changed and been removed, so I'm being lazy with Boost and hwloc by just hardcoding their roots for the configurations where they were previously loaded through modules.

This is even more reason to just fully move over to spack environments (#121).