### PR TITLE
Add threadmanager and resource partitioner headers to `pika/runtime.hpp`

### DIFF
--- a/libs/pika/include/include/pika/runtime.hpp
+++ b/libs/pika/include/include/pika/runtime.hpp
@@ -6,4 +6,6 @@
 
 #pragma once
 
+#include <pika/modules/resource_partitioner.hpp>
+#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime/runtime_fwd.hpp>


### PR DESCRIPTION
Fixes #59. This simply adds the headers to `pika/runtime.hpp` as I think they should all be considered one inseparable unit.