### PR TITLE
Thread-local streams in `cuda_pool`

### DIFF
--- a/libs/pika/async_cuda/CMakeLists.txt
+++ b/libs/pika/async_cuda/CMakeLists.txt
@@ -52,6 +52,7 @@ set(async_cuda_sources
     cusolver_exception.cpp
     cusolver_handle.cpp
     get_targets.cpp
+    then_with_stream.cpp
 )
 
 if(PIKA_WITH_HIP AND TARGET roc::hipblas)

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -31,31 +31,33 @@
 #include <utility>
 
 namespace pika::cuda::experimental::detail {
+    PIKA_EXPORT pika::cuda::experimental::cublas_handle const&
+    get_thread_local_cublas_handle(
+        cuda_stream const& stream, cublasPointerMode_t pointer_mode);
+
     template <typename F, typename... Ts>
     auto invoke_with_thread_local_cublas_handle(cuda_stream const& stream,
         cublasPointerMode_t pointer_mode, F&& f, Ts&&... ts)
         -> decltype(PIKA_INVOKE(PIKA_FORWARD(F, f),
             std::declval<cublasHandle_t>(), PIKA_FORWARD(Ts, ts)...))
     {
-        static thread_local pika::cuda::experimental::cublas_handle handle{
-            stream};
-        handle.set_stream(stream);
-        handle.set_pointer_mode(pointer_mode);
-        return PIKA_INVOKE(
-            PIKA_FORWARD(F, f), handle.get(), PIKA_FORWARD(Ts, ts)...);
+        return PIKA_INVOKE(PIKA_FORWARD(F, f),
+            get_thread_local_cublas_handle(stream, pointer_mode).get(),
+            PIKA_FORWARD(Ts, ts)...);
     }
 
 #if defined(PIKA_HAVE_CUDA)
+    PIKA_EXPORT pika::cuda::experimental::cusolver_handle const&
+    get_thread_local_cusolver_handle(cuda_stream const& stream);
+
     template <typename F, typename... Ts>
     auto invoke_with_thread_local_cusolver_handle(cuda_stream const& stream,
         F&& f, Ts&&... ts) -> decltype(PIKA_INVOKE(PIKA_FORWARD(F, f),
         std::declval<cusolverDnHandle_t>(), PIKA_FORWARD(Ts, ts)...))
     {
-        static thread_local pika::cuda::experimental::cusolver_handle handle{
-            stream};
-        handle.set_stream(stream);
-        return PIKA_INVOKE(
-            PIKA_FORWARD(F, f), handle.get(), PIKA_FORWARD(Ts, ts)...);
+        return PIKA_INVOKE(PIKA_FORWARD(F, f),
+            get_thread_local_cusolver_handle(stream).get(),
+            PIKA_FORWARD(Ts, ts)...);
     }
 #endif
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -172,8 +172,8 @@ namespace pika::cuda::experimental::detail {
     template <typename R, typename F>
     struct then_with_cuda_receiver
     {
-        std::decay_t<R> r;
-        std::decay_t<F> f;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<R> r;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
         cuda_scheduler sched;
         pika::optional<std::reference_wrapper<const cuda_stream>> stream;
 
@@ -367,8 +367,8 @@ namespace pika::cuda::experimental::detail {
             std::enable_if_t<is_cuda_stream_invocable_with_sender_v<S, F>>>
     struct then_with_cuda_sender
     {
-        std::decay_t<S> s;
-        std::decay_t<F> f;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<S> s;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
         cuda_scheduler sched;
 
         template <typename S_, typename F_>

--- a/libs/pika/async_cuda/src/then_with_stream.cpp
+++ b/libs/pika/async_cuda/src/then_with_stream.cpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/async_cuda/cublas_handle.hpp>
+#include <pika/async_cuda/cuda_stream.hpp>
+#include <pika/async_cuda/cusolver_handle.hpp>
+#include <pika/async_cuda/custom_blas_api.hpp>
+#include <pika/async_cuda/then_with_stream.hpp>
+
+namespace pika::cuda::experimental::detail {
+    pika::cuda::experimental::cublas_handle const&
+    get_thread_local_cublas_handle(
+        cuda_stream const& stream, cublasPointerMode_t pointer_mode)
+    {
+        static thread_local pika::cuda::experimental::cublas_handle handle{
+            stream};
+
+        handle.set_stream(stream);
+        handle.set_pointer_mode(pointer_mode);
+
+        return handle;
+    }
+
+#if defined(PIKA_HAVE_CUDA)
+    pika::cuda::experimental::cusolver_handle const&
+    get_thread_local_cusolver_handle(cuda_stream const& stream)
+    {
+        static thread_local pika::cuda::experimental::cusolver_handle handle{
+            stream};
+
+        handle.set_stream(stream);
+
+        return handle;
+    }
+#endif
+}    // namespace pika::cuda::experimental::detail


### PR DESCRIPTION
After the initial attempt of having a global pool of streams in `cuda_pool` I'm reverting it back to what DLA-Future used originally, i.e. thread-local streams. To avoid having to create the `cuda_pool` after the pika runtime I simply create a vector with `hardware_concurrency * num_streams_per_thread`. pika worker threads will have their thread number set and index into the vector with the thread number. non-pika threads will have their thread number set to `-1` and will all use the same "thread-local" streams, but at least they will fall back to a valid stream. I create one vector of streams instead of using `thread_local` streams to avoid calling CUDA API functions at arbitrary points when the `thread_local`s are accessed the first time.

I've also moved the `thread_local` cuBLAS/cuSOLVER handles to a cpp file to make sure there is really only one handle per thread, instead of one per function instantiation (the `thread_local` handles were defined in a function template). These are true `thread_local`s unlike the streams because of thread-safety issues.

Because of the move from a global pool of streams to thread-local streams I moved the access of the "next stream" to just before CUDA functions are called in the receiver, instead of having it already in the sender constructor. This is because otherwise a full DLA-Future algorithm may end up using streams for only one worker thread because the senders are created on the same worker thread.

Finally, I've done two small cleanups:
- Add more `PIKA_NO_UNIQUE_ADDRESS`.
- Rename the internal `then_with_cuda` to `then_with_cuda_stream` because I think it describes it better.