### PR TITLE
Make sure `when_all_vector` works with noncopyable types

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -243,7 +243,7 @@ namespace pika::execution::experimental {
                                 values.reserve(num_predecessors);
                                 for (auto&& t : ts)
                                 {
-                                    values.push_back(t.value());
+                                    values.push_back(PIKA_MOVE(t.value()));
                                 }
                                 pika::execution::experimental::set_value(
                                     PIKA_MOVE(receiver), PIKA_MOVE(values));

--- a/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -162,6 +162,55 @@ int main()
         PIKA_TEST(set_value_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::any_sender<custom_type_non_default_constructible>>
+            senders;
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible{42}));
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible{43}));
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible{44}));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f = [](std::vector<custom_type_non_default_constructible> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(3));
+            PIKA_TEST_EQ(v[0].x, 42);
+            PIKA_TEST_EQ(v[1].x, 43);
+            PIKA_TEST_EQ(v[2].x, 44);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::vector<ex::unique_any_sender<
+            custom_type_non_default_constructible_non_copyable>>
+            senders;
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible_non_copyable{42}));
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible_non_copyable{43}));
+        senders.emplace_back(
+            ex::just(custom_type_non_default_constructible_non_copyable{44}));
+        auto s = ex::when_all_vector(std::move(senders));
+        auto f =
+            [](std::vector<custom_type_non_default_constructible_non_copyable>
+                    v) {
+                PIKA_TEST_EQ(v.size(), std::size_t(3));
+                PIKA_TEST_EQ(v[0].x, 42);
+                PIKA_TEST_EQ(v[1].x, 43);
+                PIKA_TEST_EQ(v[2].x, 44);
+            };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
     // Test a combination with when_all
     {
         std::atomic<bool> set_value_called{false};


### PR DESCRIPTION
## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
