### PR TITLE
Fix typo in include module CMakeLists.txt

### DIFF
--- a/libs/pika/include/CMakeLists.txt
+++ b/libs/pika/include/CMakeLists.txt
@@ -41,7 +41,7 @@ if(PIKA_WITH_GPU_SUPPORT)
 endif()
 
 if(PIKA_WITH_MPI)
-  list(APPEND include_additional_module_dependencies pika_async_cuda)
+  list(APPEND include_additional_module_dependencies pika_async_mpi)
 endif()
 
 include(pika_add_module)


### PR DESCRIPTION
`pika_async_cuda` was being linked when `pika_async_mpi` should've been linked.