### PR TITLE
Fix SFINAE in `then_with_stream`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -209,8 +209,8 @@ namespace pika::cuda::experimental::detail {
         }
 
         template <typename... Ts>
-        auto set_value(Ts&&... ts) noexcept
-            -> decltype(PIKA_INVOKE(PIKA_MOVE(f), stream.value(), ts...))
+        auto set_value(Ts&&... ts) noexcept -> decltype(
+            PIKA_INVOKE(PIKA_MOVE(f), stream.value(), ts...), void())
         {
             pika::detail::try_catch_exception_ptr(
                 [&]() mutable {
@@ -460,7 +460,7 @@ namespace pika::cuda::experimental::detail {
     template <typename R, typename F, typename... Ts>
     auto tag_invoke(pika::execution::experimental::set_value_t,
         then_with_cuda_stream_receiver<R, F>&& r, Ts&&... ts) noexcept
-        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
+        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...))
     {
         r.set_value(PIKA_FORWARD(Ts, ts)...);
     }

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -209,7 +209,8 @@ namespace pika::cuda::experimental::detail {
         }
 
         template <typename... Ts>
-        void set_value(Ts&&... ts) noexcept
+        auto set_value(Ts&&... ts) noexcept
+            -> decltype(PIKA_INVOKE(PIKA_MOVE(f), stream.value(), ts...))
         {
             pika::detail::try_catch_exception_ptr(
                 [&]() mutable {
@@ -236,9 +237,10 @@ namespace pika::cuda::experimental::detail {
                         }
                     }
 
-                    if constexpr (std::is_void_v<
-                                      typename pika::util::invoke_result<F,
-                                          cuda_stream const&, Ts...>::type>)
+                    if constexpr (std::is_void_v<pika::util::invoke_result_t<F,
+                                      cuda_stream const&,
+                                      std::add_lvalue_reference_t<
+                                          std::decay_t<Ts>>...>>)
                     {
                         // When the return type is void, there is no value to
                         // forward to the receiver
@@ -283,8 +285,8 @@ namespace pika::cuda::experimental::detail {
                     {
                         // When the return type is non-void, we have to forward
                         // the value to the receiver
-                        auto t = PIKA_INVOKE(PIKA_MOVE(f), stream.value(),
-                            PIKA_FORWARD(Ts, ts)...);
+                        auto t =
+                            PIKA_INVOKE(PIKA_MOVE(f), stream.value(), ts...);
 
                         if constexpr (is_then_with_cuda_stream_receiver<
                                           std::decay_t<R>>::value)
@@ -353,7 +355,8 @@ namespace pika::cuda::experimental::detail {
         template <template <typename...> class Tuple, typename... Ts>
         struct is_invocable_helper<Tuple<Ts...>>
         {
-            using type = pika::is_invocable<F, cuda_stream const&, Ts...>;
+            using type = pika::is_invocable<F, cuda_stream const&,
+                std::add_lvalue_reference_t<std::decay_t<Ts>>...>;
         };
 
         static constexpr bool value = pika::util::detail::change_pack_t<
@@ -400,7 +403,8 @@ namespace pika::cuda::experimental::detail {
         struct invoke_result_helper<Tuple<Ts...>>
         {
             using result_type =
-                pika::util::invoke_result_t<F, cuda_stream const&, Ts...>;
+                pika::util::invoke_result_t<F, cuda_stream const&,
+                    std::add_lvalue_reference_t<std::decay_t<Ts>>...>;
             using type = std::conditional_t<std::is_void_v<result_type>,
                 Tuple<>, Tuple<result_type>>;
         };
@@ -454,8 +458,9 @@ namespace pika::cuda::experimental::detail {
     // ("error: no instance of overloaded function std::forward matches the
     // argument list").
     template <typename R, typename F, typename... Ts>
-    void tag_invoke(pika::execution::experimental::set_value_t,
-        then_with_cuda_stream_receiver<R, F>&& r, Ts&&... ts)
+    auto tag_invoke(pika::execution::experimental::set_value_t,
+        then_with_cuda_stream_receiver<R, F>&& r, Ts&&... ts) noexcept
+        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
     {
         r.set_value(PIKA_FORWARD(Ts, ts)...);
     }

--- a/libs/pika/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_cuda/tests/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 set(cublas_matmul_PARAMETERS THREADS 4)
 set(cuda_future_PARAMETERS THREADS 4)
 set(then_with_stream_PARAMETERS THREADS 4)
+set(then_with_stream_DEPENDENCIES pika_execution_test_utilities)
 
 set(cublas_handle_CUDA ON)
 set(cuda_bulk_CUDA ON)
@@ -50,7 +51,7 @@ foreach(test ${tests})
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
-    DEPENDENCIES ${${test_program}_FLAGS}
+    DEPENDENCIES ${${test}_DEPENDENCIES}
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/AsyncCuda"
   )


### PR DESCRIPTION
The checks for invocability were not correctly testing with lvalue references. This meant that functions which take references to noncopyable types would incorrectly be diagnosed as not invocable. This also adds a regression test. Fixes #136.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [X] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
