### PR TITLE
Make argc and argv const in init to avoid having to cast

### DIFF
--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -132,13 +132,14 @@ namespace pika {
     }    // namespace detail
 
     inline int init(std::function<int(pika::program_options::variables_map&)> f,
-        int argc, char** argv, init_params const& params = init_params())
+        int const argc, char** const argv,
+        init_params const& params = init_params())
     {
         return detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, true);
     }
 
-    inline int init(std::function<int(int, char**)> f, int argc, char** argv,
-        init_params const& params = init_params())
+    inline int init(std::function<int(int, char**)> f, int const argc,
+        char** const argv, init_params const& params = init_params())
     {
         util::function_nonser<int(pika::program_options::variables_map&)>
             main_f = pika::util::bind_back(pika::detail::init_helper, f);
@@ -146,7 +147,7 @@ namespace pika {
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    inline int init(std::function<int()> f, int argc, char** argv,
+    inline int init(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
         util::function_nonser<int(pika::program_options::variables_map&)>
@@ -155,7 +156,7 @@ namespace pika {
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    inline int init(std::nullptr_t, int argc, char** argv,
+    inline int init(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
         util::function_nonser<int(pika::program_options::variables_map&)>
@@ -165,8 +166,9 @@ namespace pika {
     }
 
     inline bool start(
-        std::function<int(pika::program_options::variables_map&)> f, int argc,
-        char** argv, init_params const& params = init_params())
+        std::function<int(pika::program_options::variables_map&)> f,
+        int const argc, char** const argv,
+        init_params const& params = init_params())
     {
         return 0 ==
             detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, false);
@@ -182,7 +184,7 @@ namespace pika {
                 PIKA_MOVE(main_f), argc, argv, params, false);
     }
 
-    inline bool start(std::function<int()> f, int argc, char** argv,
+    inline bool start(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
         util::function_nonser<int(pika::program_options::variables_map&)>
@@ -192,7 +194,7 @@ namespace pika {
                 PIKA_MOVE(main_f), argc, argv, params, false);
     }
 
-    inline bool start(std::nullptr_t, int argc, char** argv,
+    inline bool start(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
         util::function_nonser<int(pika::program_options::variables_map&)>

--- a/libs/pika/init_runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/init_runtime/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    config_entry scoped_finalize
+    config_entry const_args_init scoped_finalize
     # shutdown_suspended_thread # Disabled due to unavailable timed suspension
 )
 

--- a/libs/pika/init_runtime/tests/unit/const_args_init.cpp
+++ b/libs/pika/init_runtime/tests/unit/const_args_init.cpp
@@ -1,0 +1,22 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This test checks that the runtime takes into account suspended threads before
+// initiating full shutdown.
+
+#include <pika/init.hpp>
+#include <pika/testing.hpp>
+
+int pika_main()
+{
+    return pika::finalize();
+}
+
+int main(const int argc, char** const argv)
+{
+    PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
Fixes #58