### PR TITLE
Remove explicit architecture flag for clang CUDA jenkins config because `CMAKE_CUDA_ARCHITECTURES` is enough

### DIFF
--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -41,4 +41,4 @@ configure_extra_options+=" -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF"
 # clang and nvcc compiler configurations, with the exception that
 # BOOST_HAS_FLOAT128 is unconditionally disabled.
 configure_extra_options+=" \"-DCMAKE_CXX_FLAGS=-I${src_dir}/.jenkins/cscs/ -DBOOST_USER_CONFIG='<boost_user_config_cray_clang.hpp>'\""
-configure_extra_options+=" \"-DCMAKE_CUDA_FLAGS=--cuda-gpu-arch=sm_60 -I${src_dir}/.jenkins/cscs/ -DBOOST_USER_CONFIG='<boost_user_config_cray_clang.hpp>'\""
+configure_extra_options+=" \"-DCMAKE_CUDA_FLAGS=-I${src_dir}/.jenkins/cscs/ -DBOOST_USER_CONFIG='<boost_user_config_cray_clang.hpp>'\""


### PR DESCRIPTION
At least this seems to work even with the oldest supported CMake 3.18.