### PR TITLE
Remove function_nonser from pika, replaced by function

### DIFF
--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -154,7 +154,7 @@ namespace executor_example {
         }
 
     private:
-        using thread_hook = pika::util::function_nonser<void()>;
+        using thread_hook = pika::util::function<void()>;
 
         BaseExecutor& exec_;
         thread_hook on_start_;

--- a/examples/quickstart/sort_by_key_demo.cpp
+++ b/examples/quickstart/sort_by_key_demo.cpp
@@ -51,6 +51,5 @@ int pika_main()
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    return pika::init(
-        pika_main, argc, argv);    // Initialize and run pika
+    return pika::init(pika_main, argc, argv);    // Initialize and run pika
 }

--- a/examples/quickstart/wait_composition.cpp
+++ b/examples/quickstart/wait_composition.cpp
@@ -43,6 +43,5 @@ int pika_main()
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    return pika::init(
-        pika_main, argc, argv);    // Initialize and run pika.
+    return pika::init(pika_main, argc, argv);    // Initialize and run pika.
 }

--- a/libs/pika/algorithms/include/pika/parallel/util/detail/handle_exception_termination_handler.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/detail/handle_exception_termination_handler.hpp
@@ -11,7 +11,7 @@
 
 namespace pika { namespace parallel { namespace util { namespace detail {
     using parallel_exception_termination_handler_type =
-        pika::util::function_nonser<void()>;
+        pika::util::function<void()>;
 
     PIKA_EXPORT void set_parallel_exception_termination_handler(
         parallel_exception_termination_handler_type f);

--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
@@ -23,7 +23,7 @@
 
 namespace pika { namespace cuda { namespace experimental { namespace detail {
     using event_callback_function_type =
-        pika::util::unique_function_nonser<void(cudaError_t)>;
+        pika::util::unique_function<void(cudaError_t)>;
 
     PIKA_EXPORT void add_event_callback(
         event_callback_function_type&& f, cudaStream_t stream);

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
@@ -31,7 +31,7 @@ namespace pika { namespace mpi { namespace experimental {
     namespace detail {
 
         using request_callback_function_type =
-            pika::util::unique_function_nonser<void(int)>;
+            pika::util::unique_function<void(int)>;
 
         PIKA_EXPORT void add_request_callback(
             request_callback_function_type&& f, MPI_Request req);

--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -23,7 +23,7 @@ namespace pika::detail {
     {
         command_line_handling(pika::util::runtime_configuration rtcfg,
             std::vector<std::string> ini_config,
-            util::function_nonser<int(pika::program_options::variables_map& vm)>
+            util::function<int(pika::program_options::variables_map& vm)>
                 pika_main_f)
           : rtcfg_(rtcfg)
           , ini_config_(ini_config)
@@ -47,7 +47,7 @@ namespace pika::detail {
         pika::util::runtime_configuration rtcfg_;
 
         std::vector<std::string> ini_config_;
-        util::function_nonser<int(pika::program_options::variables_map& vm)>
+        util::function<int(pika::program_options::variables_map& vm)>
             pika_main_f_;
 
         std::size_t num_threads_;

--- a/libs/pika/coroutines/include/pika/coroutines/coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/coroutine.hpp
@@ -59,8 +59,7 @@ namespace pika { namespace threads { namespace coroutines {
         using result_type = impl_type::result_type;
         using arg_type = impl_type::arg_type;
 
-        using functor_type =
-            util::unique_function<result_type(arg_type)>;
+        using functor_type = util::unique_function<result_type(arg_type)>;
 
         coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size = detail::default_stack_size)

--- a/libs/pika/coroutines/include/pika/coroutines/coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/coroutine.hpp
@@ -60,7 +60,7 @@ namespace pika { namespace threads { namespace coroutines {
         using arg_type = impl_type::arg_type;
 
         using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+            util::unique_function<result_type(arg_type)>;
 
         coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size = detail::default_stack_size)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_impl.hpp
@@ -64,8 +64,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using functor_type =
-            util::unique_function<result_type(arg_type)>;
+        using functor_type = util::unique_function<result_type(arg_type)>;
 
         coroutine_impl(
             functor_type&& f, thread_id_type id, std::ptrdiff_t stack_size)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_impl.hpp
@@ -65,7 +65,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
         using arg_type = thread_restart_state;
 
         using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+            util::unique_function<result_type(arg_type)>;
 
         coroutine_impl(
             functor_type&& f, thread_id_type id, std::ptrdiff_t stack_size)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
@@ -74,7 +74,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
         using arg_type = thread_restart_state;
 
         using yield_decorator_type =
-            util::function_nonser<arg_type(result_type)>;
+            util::function<arg_type(result_type)>;
 
         explicit coroutine_self(coroutine_self* next_self)
           : next_self_(next_self)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
@@ -73,8 +73,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using yield_decorator_type =
-            util::function<arg_type(result_type)>;
+        using yield_decorator_type = util::function<arg_type(result_type)>;
 
         explicit coroutine_self(coroutine_self* next_self)
           : next_self_(next_self)

--- a/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
@@ -54,8 +54,7 @@ namespace pika { namespace threads { namespace coroutines {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using functor_type =
-            util::unique_function<result_type(arg_type)>;
+        using functor_type = util::unique_function<result_type(arg_type)>;
 
         stackless_coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t /*stack_size*/ = default_stack_size)

--- a/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
@@ -55,7 +55,7 @@ namespace pika { namespace threads { namespace coroutines {
         using arg_type = thread_restart_state;
 
         using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+            util::unique_function<result_type(arg_type)>;
 
         stackless_coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t /*stack_size*/ = default_stack_size)

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -148,7 +148,7 @@ namespace pika { namespace execution { namespace experimental {
                     v;
 
                 using continuation_type =
-                    pika::util::unique_function_nonser<void()>;
+                    pika::util::unique_function<void()>;
                 pika::optional<continuation_type> continuation;
 
                 struct ensure_started_receiver

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -147,8 +147,7 @@ namespace pika { namespace execution { namespace experimental {
                     value_type>
                     v;
 
-                using continuation_type =
-                    pika::util::unique_function<void()>;
+                using continuation_type = pika::util::unique_function<void()>;
                 pika::optional<continuation_type> continuation;
 
                 struct ensure_started_receiver

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -150,7 +150,7 @@ namespace pika { namespace execution { namespace experimental {
                     v;
 
                 using continuation_type =
-                    pika::util::unique_function_nonser<void()>;
+                    pika::util::unique_function<void()>;
                 pika::detail::small_vector<continuation_type, 1> continuations;
 
                 struct split_receiver

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -149,8 +149,7 @@ namespace pika { namespace execution { namespace experimental {
                     value_type>
                     v;
 
-                using continuation_type =
-                    pika::util::unique_function<void()>;
+                using continuation_type = pika::util::unique_function<void()>;
                 pika::detail::small_vector<continuation_type, 1> continuations;
 
                 struct split_receiver

--- a/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
@@ -15,12 +15,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace pika { namespace parallel { namespace execution { namespace detail {
     /// \cond NOINTERNAL
-    using get_os_thread_count_type = pika::util::function_nonser<std::size_t()>;
+    using get_os_thread_count_type = pika::util::function<std::size_t()>;
     PIKA_EXPORT void set_get_os_thread_count(get_os_thread_count_type f);
     PIKA_EXPORT std::size_t get_os_thread_count();
 
     using get_pu_mask_type =
-        pika::util::function_nonser<threads::mask_cref_type(
+        pika::util::function<threads::mask_cref_type(
             threads::topology&, std::size_t)>;
     PIKA_EXPORT void set_get_pu_mask(get_pu_mask_type f);
     PIKA_EXPORT threads::mask_cref_type get_pu_mask(

--- a/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
@@ -19,9 +19,8 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     PIKA_EXPORT void set_get_os_thread_count(get_os_thread_count_type f);
     PIKA_EXPORT std::size_t get_os_thread_count();
 
-    using get_pu_mask_type =
-        pika::util::function<threads::mask_cref_type(
-            threads::topology&, std::size_t)>;
+    using get_pu_mask_type = pika::util::function<threads::mask_cref_type(
+        threads::topology&, std::size_t)>;
     PIKA_EXPORT void set_get_pu_mask(get_pu_mask_type f);
     PIKA_EXPORT threads::mask_cref_type get_pu_mask(
         threads::topology&, std::size_t);

--- a/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
@@ -289,8 +289,7 @@ namespace pika { namespace parallel { namespace execution {
         template <typename R, typename... Ts>
         struct never_blocking_oneway_vtable<R(Ts...)>
         {
-            using post_function_type =
-                pika::util::unique_function<R(Ts...)>;
+            using post_function_type = pika::util::unique_function<R(Ts...)>;
 
             // post
             template <typename T>
@@ -370,9 +369,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             using async_execute_function_type =
                 pika::util::unique_function<R(Ts...)>;
-            using then_execute_function_type =
-                pika::util::unique_function<R(
-                    pika::shared_future<void> const&, Ts...)>;
+            using then_execute_function_type = pika::util::unique_function<R(
+                pika::shared_future<void> const&, Ts...)>;
 
             // async_execute
             template <typename T>
@@ -482,9 +480,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             using bulk_async_execute_function_type =
                 pika::util::function<R(std::size_t, Ts...)>;
-            using bulk_then_execute_function_type =
-                pika::util::function<R(
-                    std::size_t, pika::shared_future<void> const&, Ts...)>;
+            using bulk_then_execute_function_type = pika::util::function<R(
+                std::size_t, pika::shared_future<void> const&, Ts...)>;
 
             // bulk_async_execute
             template <typename T>

--- a/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
@@ -290,7 +290,7 @@ namespace pika { namespace parallel { namespace execution {
         struct never_blocking_oneway_vtable<R(Ts...)>
         {
             using post_function_type =
-                pika::util::unique_function_nonser<R(Ts...)>;
+                pika::util::unique_function<R(Ts...)>;
 
             // post
             template <typename T>
@@ -328,7 +328,7 @@ namespace pika { namespace parallel { namespace execution {
         struct oneway_vtable<R(Ts...)>
         {
             using sync_execute_function_type =
-                pika::util::unique_function_nonser<R(Ts...)>;
+                pika::util::unique_function<R(Ts...)>;
 
             // sync_execute
             template <typename T>
@@ -369,9 +369,9 @@ namespace pika { namespace parallel { namespace execution {
         struct twoway_vtable<R(Ts...)>
         {
             using async_execute_function_type =
-                pika::util::unique_function_nonser<R(Ts...)>;
+                pika::util::unique_function<R(Ts...)>;
             using then_execute_function_type =
-                pika::util::unique_function_nonser<R(
+                pika::util::unique_function<R(
                     pika::shared_future<void> const&, Ts...)>;
 
             // async_execute
@@ -436,7 +436,7 @@ namespace pika { namespace parallel { namespace execution {
         struct bulk_oneway_vtable<R(Ts...)>
         {
             using bulk_sync_execute_function_type =
-                pika::util::function_nonser<R(std::size_t, Ts...)>;
+                pika::util::function<R(std::size_t, Ts...)>;
 
             // bulk_sync_execute
             template <typename T>
@@ -481,9 +481,9 @@ namespace pika { namespace parallel { namespace execution {
         struct bulk_twoway_vtable<R(Ts...)>
         {
             using bulk_async_execute_function_type =
-                pika::util::function_nonser<R(std::size_t, Ts...)>;
+                pika::util::function<R(std::size_t, Ts...)>;
             using bulk_then_execute_function_type =
-                pika::util::function_nonser<R(
+                pika::util::function<R(
                     std::size_t, pika::shared_future<void> const&, Ts...)>;
 
             // bulk_async_execute

--- a/libs/pika/executors/include/pika/executors/exception_list.hpp
+++ b/libs/pika/executors/include/pika/executors/exception_list.hpp
@@ -179,7 +179,7 @@ namespace pika { namespace parallel { inline namespace v1 {
 #endif
 
         using exception_list_termination_handler_type =
-            pika::util::function_nonser<void()>;
+            pika::util::function<void()>;
 
         PIKA_EXPORT void set_exception_list_termination_handler(
             exception_list_termination_handler_type f);

--- a/libs/pika/functional/include/pika/functional/function.hpp
+++ b/libs/pika/functional/include/pika/functional/function.hpp
@@ -67,9 +67,6 @@ namespace pika { namespace util {
         using base_type::reset;
         using base_type::target;
     };
-
-    template <typename Sig>
-    using function_nonser = function<Sig>;
 }}    // namespace pika::util
 
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)

--- a/libs/pika/functional/include/pika/functional/unique_function.hpp
+++ b/libs/pika/functional/include/pika/functional/unique_function.hpp
@@ -66,9 +66,6 @@ namespace pika { namespace util {
         using base_type::reset;
         using base_type::target;
     };
-
-    template <typename Sig>
-    using unique_function_nonser = unique_function<Sig>;
 }}    // namespace pika::util
 
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)

--- a/libs/pika/functional/tests/unit/allocator_test.cpp
+++ b/libs/pika/functional/tests/unit/allocator_test.cpp
@@ -81,7 +81,7 @@ static void do_nothing() {}
 
 int main(int, char*[])
 {
-    pika::util::function_nonser<int(int, int)> f;
+    pika::util::function<int(int, int)> f;
     f.assign(plus_int<disable_small_object_optimization>(),
         counting_allocator<int>());
     f.clear();
@@ -110,7 +110,7 @@ int main(int, char*[])
     f.assign(&do_minus, std::allocator<int>());
     f.clear();
 
-    pika::util::function_nonser<void()> fv;
+    pika::util::function<void()> fv;
     alloc_count = 0;
     dealloc_count = 0;
     fv.assign(DoNothing<disable_small_object_optimization>(),
@@ -141,7 +141,7 @@ int main(int, char*[])
     fv.assign(&do_nothing, std::allocator<int>());
     fv.clear();
 
-    pika::util::function_nonser<void()> fv2;
+    pika::util::function<void()> fv2;
     fv.assign(&do_nothing, std::allocator<int>());
     fv2.assign(fv, std::allocator<int>());
 

--- a/libs/pika/functional/tests/unit/contains_test.cpp
+++ b/libs/pika/functional/tests/unit/contains_test.cpp
@@ -56,7 +56,7 @@ struct Seventeen
 
 static void target_test()
 {
-    pika::util::function_nonser<int()> f;
+    pika::util::function<int()> f;
 
     f = &forty_two;
     PIKA_TEST_EQ(*f.target<int (*)()>(), &forty_two);
@@ -74,7 +74,7 @@ static void target_test()
 
 //static void equal_test()
 //{
-//    pika::util::function_nonser<int()> f;
+//    pika::util::function<int()> f;
 //
 //    f = &forty_two;
 //    PIKA_TEST(f == &forty_two);
@@ -104,7 +104,7 @@ static void target_test()
 //
 //    PIKA_TEST(f.contains(contain_test::ReturnIntFE(17)));
 //
-//    pika::util::function_nonser<int(void)> g;
+//    pika::util::function<int(void)> g;
 //
 //    g = &forty_two;
 //    PIKA_TEST(g == &forty_two);
@@ -125,7 +125,7 @@ static void target_test()
 //{
 //    {
 //        ReturnInt ri(17);
-//        pika::util::function_nonser0<int> f = std::ref(ri);
+//        pika::util::function<int> f = std::ref(ri);
 //
 //        // References and values are equal
 //        PIKA_TEST(f == std::ref(ri));
@@ -151,7 +151,7 @@ static void target_test()
 //
 //    {
 //        ReturnInt ri(17);
-//        pika::util::function_nonser<int(void)> f = std::ref(ri);
+//        pika::util::function<int(void)> f = std::ref(ri);
 //
 //        // References and values are equal
 //        PIKA_TEST(f == std::ref(ri));

--- a/libs/pika/functional/tests/unit/function_args.cpp
+++ b/libs/pika/functional/tests/unit/function_args.cpp
@@ -62,7 +62,7 @@ void f_value(counter) {}
 
 void test_by_value()
 {
-    pika::util::function_nonser<void(counter)> f = f_value;
+    pika::util::function<void(counter)> f = f_value;
 
     counter::reset();
 
@@ -81,7 +81,7 @@ void f_lvalue_ref(counter&) {}
 
 void test_by_lvalue_ref()
 {
-    pika::util::function_nonser<void(counter&)> f = f_lvalue_ref;
+    pika::util::function<void(counter&)> f = f_lvalue_ref;
 
     counter::reset();
 
@@ -100,7 +100,7 @@ void f_const_lvalue_ref(counter const&) {}
 
 void test_by_const_lvalue_ref()
 {
-    pika::util::function_nonser<void(counter const&)> f = f_const_lvalue_ref;
+    pika::util::function<void(counter const&)> f = f_const_lvalue_ref;
 
     counter::reset();
 
@@ -119,7 +119,7 @@ void f_rvalue_ref(counter&&) {}
 
 void test_by_rvalue_ref()
 {
-    pika::util::function_nonser<void(counter &&)> f = f_rvalue_ref;
+    pika::util::function<void(counter &&)> f = f_rvalue_ref;
 
     counter::reset();
 

--- a/libs/pika/functional/tests/unit/function_arith.cpp
+++ b/libs/pika/functional/tests/unit/function_arith.cpp
@@ -29,7 +29,7 @@ struct int_div
 
 int main()
 {
-    pika::util::function_nonser<double(int x, int y)> f;
+    pika::util::function<double(int x, int y)> f;
 
     f = int_div();
     PIKA_TEST(f);

--- a/libs/pika/functional/tests/unit/function_bind_test.cpp
+++ b/libs/pika/functional/tests/unit/function_bind_test.cpp
@@ -30,8 +30,7 @@ int main(int, char*[])
 
     pika::util::function<unsigned(bool, double)> f1 =
         pika::util::bind(func_impl, 15, _1, _2);
-    pika::util::function<unsigned(double)> f2 =
-        pika::util::bind(f1, false, _1);
+    pika::util::function<unsigned(double)> f2 = pika::util::bind(f1, false, _1);
     pika::util::function<unsigned()> f3 = pika::util::bind(f2, 4.0);
 
     PIKA_TEST_EQ(f3(), 120u);

--- a/libs/pika/functional/tests/unit/function_bind_test.cpp
+++ b/libs/pika/functional/tests/unit/function_bind_test.cpp
@@ -28,11 +28,11 @@ int main(int, char*[])
     using pika::util::placeholders::_1;
     using pika::util::placeholders::_2;
 
-    pika::util::function_nonser<unsigned(bool, double)> f1 =
+    pika::util::function<unsigned(bool, double)> f1 =
         pika::util::bind(func_impl, 15, _1, _2);
-    pika::util::function_nonser<unsigned(double)> f2 =
+    pika::util::function<unsigned(double)> f2 =
         pika::util::bind(f1, false, _1);
-    pika::util::function_nonser<unsigned()> f3 = pika::util::bind(f2, 4.0);
+    pika::util::function<unsigned()> f3 = pika::util::bind(f2, 4.0);
 
     PIKA_TEST_EQ(f3(), 120u);
 

--- a/libs/pika/functional/tests/unit/function_ref_wrapper.cpp
+++ b/libs/pika/functional/tests/unit/function_ref_wrapper.cpp
@@ -27,11 +27,11 @@ struct stateful_type
 int main()
 {
     stateful_type a_function_object;
-    pika::util::function_nonser<int(int)> f;
+    pika::util::function<int(int)> f;
 
     f = std::ref(a_function_object);
     PIKA_TEST_EQ(f(42), 42);
-    pika::util::function_nonser<int(int)> f2(f);
+    pika::util::function<int(int)> f2(f);
     PIKA_TEST_EQ(f2(42), 42);
 
     return pika::util::report_errors();

--- a/libs/pika/functional/tests/unit/function_target.cpp
+++ b/libs/pika/functional/tests/unit/function_target.cpp
@@ -21,13 +21,13 @@ struct foo
 int main()
 {
     {
-        pika::util::function_nonser<int()> fun = foo();
+        pika::util::function<int()> fun = foo();
 
         PIKA_TEST(fun.target<foo>() != nullptr);
     }
 
     {
-        pika::util::function_nonser<int()> fun = foo();
+        pika::util::function<int()> fun = foo();
 
         PIKA_TEST(fun.target<foo const>() != nullptr);
     }

--- a/libs/pika/functional/tests/unit/function_test.cpp
+++ b/libs/pika/functional/tests/unit/function_test.cpp
@@ -649,8 +649,7 @@ static void test_one_arg()
 
 static void test_two_args()
 {
-    pika::util::function<string(const string&, const string&)> cat(
-        &string_cat);
+    pika::util::function<string(const string&, const string&)> cat(&string_cat);
     PIKA_TEST_EQ(cat("str", "ing"), "string");
 
     pika::util::function<int(short, short)> sum(&sum_ints);

--- a/libs/pika/functional/tests/unit/function_test.cpp
+++ b/libs/pika/functional/tests/unit/function_test.cpp
@@ -11,8 +11,8 @@
 
 // For more information, see http://www.boost.org
 
-// NOTE: Warning caused by assignment of pika::util::function_nonser<float()> to
-// pika::util::function_nonser<double()> in test_emptiness. Triggered in
+// NOTE: Warning caused by assignment of pika::util::function<float()> to
+// pika::util::function<double()> in test_emptiness. Triggered in
 // pika/functional/function.hpp which is included latest by pika/include/util.hpp.
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -125,7 +125,7 @@ struct add_to_obj
 
 static void test_zero_args()
 {
-    typedef pika::util::function_nonser<void()> func_void_type;
+    typedef pika::util::function<void()> func_void_type;
 
     write_five_obj five;
     write_three_obj three;
@@ -572,8 +572,8 @@ static void test_zero_args()
 
     // Const vs. non-const
     write_const_1_nonconst_2 one_or_two;
-    const pika::util::function_nonser<void()> v7(one_or_two);
-    pika::util::function_nonser<void()> v8(one_or_two);
+    const pika::util::function<void()> v7(one_or_two);
+    pika::util::function<void()> v8(one_or_two);
 
     global_int = 0;
     v7();
@@ -593,7 +593,7 @@ static void test_zero_args()
     PIKA_TEST(v9np.empty());
 
     // Test return values
-    typedef pika::util::function_nonser<int()> func_int_type;
+    typedef pika::util::function<int()> func_int_type;
     generate_five_obj gen_five;
     generate_three_obj gen_three;
 
@@ -611,7 +611,7 @@ static void test_zero_args()
     PIKA_TEST(!i0);
 
     // Test return values with compatible types
-    typedef pika::util::function_nonser<long()> func_long_type;
+    typedef pika::util::function<long()> func_long_type;
     func_long_type i1(gen_five);
 
     PIKA_TEST_EQ(i1(), 5);
@@ -630,43 +630,43 @@ static void test_one_arg()
 {
     std::negate<int> neg;
 
-    pika::util::function_nonser<int(int)> f1(neg);
+    pika::util::function<int(int)> f1(neg);
     PIKA_TEST_EQ(f1(5), -5);
 
-    pika::util::function_nonser<string(string)> id(&identity_str);
+    pika::util::function<string(string)> id(&identity_str);
     PIKA_TEST_EQ(id("str"), "str");
 
-    pika::util::function_nonser<string(const char*)> id2(&identity_str);
+    pika::util::function<string(const char*)> id2(&identity_str);
     PIKA_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
-    pika::util::function_nonser<int(int)> f2(add_to);
+    pika::util::function<int(int)> f2(add_to);
     PIKA_TEST_EQ(f2(3), 8);
 
-    const pika::util::function_nonser<int(int)> cf2(add_to);
+    const pika::util::function<int(int)> cf2(add_to);
     PIKA_TEST_EQ(cf2(3), 8);
 }
 
 static void test_two_args()
 {
-    pika::util::function_nonser<string(const string&, const string&)> cat(
+    pika::util::function<string(const string&, const string&)> cat(
         &string_cat);
     PIKA_TEST_EQ(cat("str", "ing"), "string");
 
-    pika::util::function_nonser<int(short, short)> sum(&sum_ints);
+    pika::util::function<int(short, short)> sum(&sum_ints);
     PIKA_TEST_EQ(sum(2, 3), 5);
 }
 
 static void test_emptiness()
 {
-    pika::util::function_nonser<float()> f1;
+    pika::util::function<float()> f1;
     PIKA_TEST(f1.empty());
 
-    pika::util::function_nonser<float()> f2;
+    pika::util::function<float()> f2;
     f2 = f1;
     PIKA_TEST(f2.empty());
 
-    pika::util::function_nonser<double()> f3;
+    pika::util::function<double()> f3;
     f3 = f2;
     PIKA_TEST(f3.empty());
 }
@@ -692,7 +692,7 @@ struct X
 
 static void test_member_functions()
 {
-    pika::util::function_nonser<int(X*)> f1(&X::twice);
+    pika::util::function<int(X*)> f1(&X::twice);
 
     X one(1);
     X five(5);
@@ -700,13 +700,13 @@ static void test_member_functions()
     PIKA_TEST_EQ(f1(&one), 2);
     PIKA_TEST_EQ(f1(&five), 10);
 
-    pika::util::function_nonser<int(X*)> f1_2;
+    pika::util::function<int(X*)> f1_2;
     f1_2 = &X::twice;
 
     PIKA_TEST_EQ(f1_2(&one), 2);
     PIKA_TEST_EQ(f1_2(&five), 10);
 
-    pika::util::function_nonser<int(X&, int)> f2(&X::plus);
+    pika::util::function<int(X&, int)> f2(&X::plus);
     PIKA_TEST_EQ(f2(one, 3), 4);
     PIKA_TEST_EQ(f2(five, 4), 9);
 }
@@ -736,7 +736,7 @@ static void test_ref()
     add_with_throw_on_copy atc;
     try
     {
-        pika::util::function_nonser<int(int, int)> f(std::ref(atc));
+        pika::util::function<int(int, int)> f(std::ref(atc));
         PIKA_TEST_EQ(f(1, 3), 4);
     }
     catch (std::runtime_error const& /*e*/)
@@ -749,8 +749,8 @@ static void dummy() {}
 
 static void test_empty_ref()
 {
-    pika::util::function_nonser<void()> f1;
-    pika::util::function_nonser<void()> f2(std::ref(f1));
+    pika::util::function<void()> f1;
+    pika::util::function<void()> f2(std::ref(f1));
 
     try
     {
@@ -776,7 +776,7 @@ static void test_empty_ref()
 
 static void test_exception()
 {
-    pika::util::function_nonser<int(int, int)> f;
+    pika::util::function<int(int, int)> f;
     try
     {
         f(5, 4);
@@ -788,7 +788,7 @@ static void test_exception()
     }
 }
 
-typedef pika::util::function_nonser<void*(void* reader)> reader_type;
+typedef pika::util::function<void*(void* reader)> reader_type;
 typedef std::pair<int, reader_type> mapped_type;
 
 static void test_implicit()
@@ -797,12 +797,12 @@ static void test_implicit()
     m = mapped_type();
 }
 
-static void test_call_obj(pika::util::function_nonser<int(int, int)> f)
+static void test_call_obj(pika::util::function<int(int, int)> f)
 {
     PIKA_TEST(!f.empty());
 }
 
-static void test_call_cref(const pika::util::function_nonser<int(int, int)>& f)
+static void test_call_cref(const pika::util::function<int(int, int)>& f)
 {
     PIKA_TEST(!f.empty());
 }
@@ -912,7 +912,7 @@ int main(int, char*[])
     test_exception();
     test_implicit();
     test_call();
-    test_move_semantics<pika::util::function_nonser<void()>>();
+    test_move_semantics<pika::util::function<void()>>();
 
     return pika::util::report_errors();
 }

--- a/libs/pika/functional/tests/unit/nothrow_swap.cpp
+++ b/libs/pika/functional/tests/unit/nothrow_swap.cpp
@@ -60,8 +60,8 @@ bool MaybeThrowOnCopy::throwOnCopy = false;
 
 int main(int, char*[])
 {
-    pika::util::function_nonser<int()> f;
-    pika::util::function_nonser<int()> g;
+    pika::util::function<int()> f;
+    pika::util::function<int()> g;
 
     MaybeThrowOnCopy::throwOnCopy = false;
     f = MaybeThrowOnCopy(1);

--- a/libs/pika/functional/tests/unit/stateless_test.cpp
+++ b/libs/pika/functional/tests/unit/stateless_test.cpp
@@ -41,7 +41,7 @@ struct stateless_integer_add
 
 int main(int, char*[])
 {
-    pika::util::function_nonser<int(int, int)> f;
+    pika::util::function<int(int, int)> f;
     f = stateless_integer_add();
 
     return pika::util::report_errors();

--- a/libs/pika/functional/tests/unit/sum_avg.cpp
+++ b/libs/pika/functional/tests/unit/sum_avg.cpp
@@ -24,7 +24,7 @@ void do_sum_avg(int values[], int n, int& sum, double& avg)
 
 int main()
 {
-    pika::util::function_nonser<void(
+    pika::util::function<void(
         int values[], int n, int& sum, double& avg)>
         sum_avg;
     sum_avg = &do_sum_avg;

--- a/libs/pika/functional/tests/unit/sum_avg.cpp
+++ b/libs/pika/functional/tests/unit/sum_avg.cpp
@@ -24,8 +24,7 @@ void do_sum_avg(int values[], int n, int& sum, double& avg)
 
 int main()
 {
-    pika::util::function<void(
-        int values[], int n, int& sum, double& avg)>
+    pika::util::function<void(int values[], int n, int& sum, double& avg)>
         sum_avg;
     sum_avg = &do_sum_avg;
 

--- a/libs/pika/futures/include/pika/futures/detail/future_data.hpp
+++ b/libs/pika/futures/include/pika/futures/detail/future_data.hpp
@@ -53,7 +53,7 @@ namespace pika {
 namespace pika { namespace lcos { namespace detail {
 
     using run_on_completed_error_handler_type =
-        util::function_nonser<void(std::exception_ptr const& e)>;
+        util::function<void(std::exception_ptr const& e)>;
     PIKA_EXPORT void set_run_on_completed_error_handler(
         run_on_completed_error_handler_type f);
 
@@ -78,7 +78,7 @@ namespace pika { namespace lcos { namespace detail {
         future_data_refcnt_base& operator=(future_data_refcnt_base&&) = delete;
 
     public:
-        using completed_callback_type = util::unique_function_nonser<void()>;
+        using completed_callback_type = util::unique_function<void()>;
         using completed_callback_vector_type =
             pika::detail::small_vector<completed_callback_type, 1>;
 

--- a/libs/pika/futures/include/pika/futures/packaged_task.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_task.hpp
@@ -29,7 +29,7 @@ namespace pika { namespace lcos { namespace local {
     template <typename R, typename... Ts>
     class packaged_task<R(Ts...)>
     {
-        using function_type = util::unique_function_nonser<R(Ts...)>;
+        using function_type = util::unique_function<R(Ts...)>;
 
     public:
         // construction and destruction

--- a/libs/pika/include/include/pika/functional.hpp
+++ b/libs/pika/include/include/pika/functional.hpp
@@ -25,12 +25,10 @@ namespace pika {
     using pika::util::bind_back;
     using pika::util::bind_front;
     using pika::util::function;
-    using pika::util::function_nonser;
     using pika::util::invoke;
     using pika::util::invoke_fused;
     using pika::util::mem_fn;
     using pika::util::unique_function;
-    using pika::util::unique_function_nonser;
 
     namespace placeholders {
         using namespace pika::util::placeholders;

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -32,7 +32,7 @@ namespace pika { namespace util {
     class PIKA_EXPORT section
     {
     public:
-        typedef util::function_nonser<void(
+        typedef util::function<void(
             std::string const&, std::string const&)>
             entry_changed_func;
         typedef std::pair<std::string, entry_changed_func> entry_type;

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -32,8 +32,7 @@ namespace pika { namespace util {
     class PIKA_EXPORT section
     {
     public:
-        typedef util::function<void(
-            std::string const&, std::string const&)>
+        typedef util::function<void(std::string const&, std::string const&)>
             entry_changed_func;
         typedef std::pair<std::string, entry_changed_func> entry_type;
         typedef std::map<std::string, entry_type> entry_map;

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -549,7 +549,7 @@ namespace pika { namespace util {
 
     template <typename F1, typename F2>
     static PIKA_FORCEINLINE
-        util::function_nonser<void(std::string const&, std::string const&)>
+        util::function<void(std::string const&, std::string const&)>
         compose_callback(F1&& f1, F2&& f2)
     {
         if (!f1)

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -50,7 +50,7 @@ extern char** environ;
 namespace pika {
     namespace detail {
         PIKA_EXPORT int init_helper(pika::program_options::variables_map&,
-            util::function_nonser<int(int, char**)> const&);
+            util::function<int(int, char**)> const&);
     }
 
     namespace detail {
@@ -86,7 +86,7 @@ namespace pika {
 
         // Utilities to init the thread_pools of the resource partitioner
         using rp_callback_type =
-            pika::util::function_nonser<void(pika::resource::partitioner&,
+            pika::util::function<void(pika::resource::partitioner&,
                 pika::program_options::variables_map const&)>;
     }    // namespace detail
 
@@ -104,12 +104,12 @@ namespace pika {
 
     namespace detail {
         PIKA_EXPORT int run_or_start(
-            util::function_nonser<int(
+            util::function<int(
                 pika::program_options::variables_map& vm)> const& f,
             int argc, char** argv, init_params const& params, bool blocking);
 
         inline int init_start_impl(
-            util::function_nonser<int(pika::program_options::variables_map&)> f,
+            util::function<int(pika::program_options::variables_map&)> f,
             int argc, char** argv, init_params const& params, bool blocking)
         {
             if (argc == 0 || argv == nullptr)
@@ -141,7 +141,7 @@ namespace pika {
     inline int init(std::function<int(int, char**)> f, int const argc,
         char** const argv, init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f = pika::util::bind_back(pika::detail::init_helper, f);
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
@@ -150,7 +150,7 @@ namespace pika {
     inline int init(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f = pika::util::bind(f);
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
@@ -159,7 +159,7 @@ namespace pika {
     inline int init(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f;
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
@@ -177,7 +177,7 @@ namespace pika {
     inline bool start(std::function<int(int, char**)> f, int argc, char** argv,
         init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f = pika::util::bind_back(pika::detail::init_helper, f);
         return 0 ==
             detail::init_start_impl(
@@ -187,7 +187,7 @@ namespace pika {
     inline bool start(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f = pika::util::bind(f);
         return 0 ==
             detail::init_start_impl(
@@ -197,7 +197,7 @@ namespace pika {
     inline bool start(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function_nonser<int(pika::program_options::variables_map&)>
+        util::function<int(pika::program_options::variables_map&)>
             main_f;
         return 0 ==
             detail::init_start_impl(

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -104,8 +104,8 @@ namespace pika {
 
     namespace detail {
         PIKA_EXPORT int run_or_start(
-            util::function<int(
-                pika::program_options::variables_map& vm)> const& f,
+            util::function<int(pika::program_options::variables_map& vm)> const&
+                f,
             int argc, char** argv, init_params const& params, bool blocking);
 
         inline int init_start_impl(
@@ -141,8 +141,8 @@ namespace pika {
     inline int init(std::function<int(int, char**)> f, int const argc,
         char** const argv, init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f = pika::util::bind_back(pika::detail::init_helper, f);
+        util::function<int(pika::program_options::variables_map&)> main_f =
+            pika::util::bind_back(pika::detail::init_helper, f);
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
@@ -150,8 +150,8 @@ namespace pika {
     inline int init(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f = pika::util::bind(f);
+        util::function<int(pika::program_options::variables_map&)> main_f =
+            pika::util::bind(f);
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
@@ -159,8 +159,7 @@ namespace pika {
     inline int init(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f;
+        util::function<int(pika::program_options::variables_map&)> main_f;
         return detail::init_start_impl(
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
@@ -177,8 +176,8 @@ namespace pika {
     inline bool start(std::function<int(int, char**)> f, int argc, char** argv,
         init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f = pika::util::bind_back(pika::detail::init_helper, f);
+        util::function<int(pika::program_options::variables_map&)> main_f =
+            pika::util::bind_back(pika::detail::init_helper, f);
         return 0 ==
             detail::init_start_impl(
                 PIKA_MOVE(main_f), argc, argv, params, false);
@@ -187,8 +186,8 @@ namespace pika {
     inline bool start(std::function<int()> f, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f = pika::util::bind(f);
+        util::function<int(pika::program_options::variables_map&)> main_f =
+            pika::util::bind(f);
         return 0 ==
             detail::init_start_impl(
                 PIKA_MOVE(main_f), argc, argv, params, false);
@@ -197,8 +196,7 @@ namespace pika {
     inline bool start(std::nullptr_t, int const argc, char** const argv,
         init_params const& params = init_params())
     {
-        util::function<int(pika::program_options::variables_map&)>
-            main_f;
+        util::function<int(pika::program_options::variables_map&)> main_f;
         return 0 ==
             detail::init_start_impl(
                 PIKA_MOVE(main_f), argc, argv, params, false);

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -294,8 +294,8 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         int run(pika::runtime& rt,
-            util::function<int(
-                pika::program_options::variables_map& vm)> const& f,
+            util::function<int(pika::program_options::variables_map& vm)> const&
+                f,
             pika::program_options::variables_map& vm,
             startup_function_type startup, shutdown_function_type shutdown)
         {
@@ -313,8 +313,8 @@ namespace pika {
         }
 
         int start(pika::runtime& rt,
-            util::function<int(
-                pika::program_options::variables_map& vm)> const& f,
+            util::function<int(pika::program_options::variables_map& vm)> const&
+                f,
             pika::program_options::variables_map& vm,
             startup_function_type startup, shutdown_function_type shutdown)
         {
@@ -422,8 +422,8 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         int run_or_start(
-            util::function<int(
-                pika::program_options::variables_map& vm)> const& f,
+            util::function<int(pika::program_options::variables_map& vm)> const&
+                f,
             int argc, char** argv, init_params const& params, bool blocking)
         {
             init_environment();

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -71,7 +71,7 @@ namespace pika {
     namespace detail {
 
         int init_helper(pika::program_options::variables_map& /*vm*/,
-            util::function_nonser<int(int, char**)> const& f)
+            util::function<int(int, char**)> const& f)
         {
             std::string cmdline(
                 pika::get_config_entry("pika.reconstructed_cmd_line", ""));
@@ -294,7 +294,7 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         int run(pika::runtime& rt,
-            util::function_nonser<int(
+            util::function<int(
                 pika::program_options::variables_map& vm)> const& f,
             pika::program_options::variables_map& vm,
             startup_function_type startup, shutdown_function_type shutdown)
@@ -313,7 +313,7 @@ namespace pika {
         }
 
         int start(pika::runtime& rt,
-            util::function_nonser<int(
+            util::function<int(
                 pika::program_options::variables_map& vm)> const& f,
             pika::program_options::variables_map& vm,
             startup_function_type startup, shutdown_function_type shutdown)
@@ -422,7 +422,7 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         int run_or_start(
-            util::function_nonser<int(
+            util::function<int(
                 pika::program_options::variables_map& vm)> const& f,
             int argc, char** argv, init_params const& params, bool blocking)
         {

--- a/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
+++ b/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
@@ -128,7 +128,7 @@ namespace pika { namespace lcos { namespace local {
 
         PIKA_EXPORT void free(guard_task* task);
 
-        typedef util::unique_function_nonser<void()> guard_function;
+        typedef util::unique_function<void()> guard_function;
     }    // namespace detail
 
     class guard : public detail::debug_object

--- a/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
@@ -64,6 +64,6 @@ namespace pika { namespace lcos { namespace local {
 
     private:
         lcos::local::promise<void> promise_;
-        util::function_nonser<bool()> cond_;
+        util::function<bool()> cond_;
     };
 }}}    // namespace pika::lcos::local

--- a/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
+++ b/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
@@ -81,7 +81,7 @@ namespace pika { namespace util {
     PIKA_EXPORT void ignore_all_locks();
     PIKA_EXPORT void reset_ignored_all();
 
-    using registered_locks_error_handler_type = util::function_nonser<void()>;
+    using registered_locks_error_handler_type = util::function<void()>;
 
     /// Sets a handler which gets called when verifying that no locks are held
     /// fails. Can be used to print information at the point of failure such as
@@ -89,7 +89,7 @@ namespace pika { namespace util {
     PIKA_EXPORT void set_registered_locks_error_handler(
         registered_locks_error_handler_type);
 
-    using register_locks_predicate_type = util::function_nonser<bool()>;
+    using register_locks_predicate_type = util::function<bool()>;
 
     /// Sets a predicate which gets called each time a lock is registered,
     /// unregistered, or when locks are verified. If the predicate returns

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -171,9 +171,9 @@ namespace pika { namespace resource { namespace detail {
         void unassign_pu(std::string const& pool_name, std::size_t virt_core);
 
         std::size_t shrink_pool(std::string const& pool_name,
-            util::function_nonser<void(std::size_t)> const& remove_pu);
+            util::function<void(std::size_t)> const& remove_pu);
         std::size_t expand_pool(std::string const& pool_name,
-            util::function_nonser<void(std::size_t)> const& add_pu);
+            util::function<void(std::size_t)> const& add_pu);
 
         void set_default_pool_name(const std::string& name)
         {

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -50,7 +50,7 @@ namespace pika { namespace resource {
     };
 
     using scheduler_function =
-        util::function_nonser<std::unique_ptr<pika::threads::thread_pool_base>(
+        util::function<std::unique_ptr<pika::threads::thread_pool_base>(
             pika::threads::thread_pool_init_parameters,
             pika::threads::policies::thread_queue_init_parameters)>;
 

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -910,7 +910,7 @@ namespace pika { namespace resource { namespace detail {
     }
 
     std::size_t partitioner::shrink_pool(std::string const& pool_name,
-        util::function_nonser<void(std::size_t)> const& remove_pu)
+        util::function<void(std::size_t)> const& remove_pu)
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
@@ -955,7 +955,7 @@ namespace pika { namespace resource { namespace detail {
     }
 
     std::size_t partitioner::expand_pool(std::string const& pool_name,
-        util::function_nonser<void(std::size_t)> const& add_pu)
+        util::function<void(std::size_t)> const& add_pu)
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {

--- a/libs/pika/runtime/include/pika/runtime/config_entry.hpp
+++ b/libs/pika/runtime/include/pika/runtime/config_entry.hpp
@@ -31,6 +31,6 @@ namespace pika {
 
     /// Set the string value of a configuration entry given by \p key.
     PIKA_EXPORT void set_config_entry_callback(std::string const& key,
-        util::function_nonser<void(
+        util::function<void(
             std::string const&, std::string const&)> const& callback);
 }    // namespace pika

--- a/libs/pika/runtime/include/pika/runtime/config_entry.hpp
+++ b/libs/pika/runtime/include/pika/runtime/config_entry.hpp
@@ -31,6 +31,6 @@ namespace pika {
 
     /// Set the string value of a configuration entry given by \p key.
     PIKA_EXPORT void set_config_entry_callback(std::string const& key,
-        util::function<void(
-            std::string const&, std::string const&)> const& callback);
+        util::function<void(std::string const&, std::string const&)> const&
+            callback);
 }    // namespace pika

--- a/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
+++ b/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
@@ -114,8 +114,7 @@ namespace pika {
 
         PIKA_EXPORT void pre_exception_handler();
 
-        using get_full_build_string_type =
-            pika::util::function<std::string()>;
+        using get_full_build_string_type = pika::util::function<std::string()>;
         PIKA_EXPORT void set_get_full_build_string(
             get_full_build_string_type f);
         PIKA_EXPORT std::string get_full_build_string();

--- a/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
+++ b/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
@@ -115,7 +115,7 @@ namespace pika {
         PIKA_EXPORT void pre_exception_handler();
 
         using get_full_build_string_type =
-            pika::util::function_nonser<std::string()>;
+            pika::util::function<std::string()>;
         PIKA_EXPORT void set_get_full_build_string(
             get_full_build_string_type f);
         PIKA_EXPORT std::string get_full_build_string();

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -91,7 +91,7 @@ namespace pika {
         virtual ~runtime();
 
         /// \brief Manage list of functions to call on exit
-        void on_exit(util::function_nonser<void()> const& f);
+        void on_exit(util::function<void()> const& f);
 
         /// \brief Manage runtime 'stopped' state
         void starting();
@@ -140,7 +140,7 @@ namespace pika {
         ///                   as the result of the invocation of the function
         ///                   object given by the parameter \p func.
         virtual int run(
-            util::function_nonser<pika_main_function_type> const& func);
+            util::function<pika_main_function_type> const& func);
 
         /// \brief Run the pika runtime system, initially use the given number
         ///        of (OS) threads in the thread-manager and block waiting for
@@ -171,7 +171,7 @@ namespace pika {
         ///                   invocation of the function object given by the
         ///                   parameter \p func. Otherwise it will return zero.
         virtual int start(
-            util::function_nonser<pika_main_function_type> const& func,
+            util::function<pika_main_function_type> const& func,
             bool blocking = false);
 
         /// \brief Start the runtime system
@@ -342,7 +342,7 @@ namespace pika {
 
         /// Enumerate all OS threads that have registered with the runtime.
         virtual bool enumerate_os_threads(
-            util::function_nonser<bool(os_thread_data const&)> const& f) const;
+            util::function<bool(os_thread_data const&)> const& f) const;
 
         notification_policy_type::on_startstop_type on_start_func() const;
         notification_policy_type::on_startstop_type on_stop_func() const;
@@ -383,14 +383,14 @@ namespace pika {
         void deinit_global_data();
 
         threads::thread_result_type run_helper(
-            util::function_nonser<runtime::pika_main_function_type> const& func,
+            util::function<runtime::pika_main_function_type> const& func,
             int& result, bool call_startup_functions);
 
         void wait_helper(
             std::mutex& mtx, std::condition_variable& cond, bool& running);
 
         // list of functions to call on exit
-        using on_exit_type = std::vector<util::function_nonser<void()>>;
+        using on_exit_type = std::vector<util::function<void()>>;
         on_exit_type on_exit_functions_;
         mutable std::mutex mtx_;
 

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -139,8 +139,7 @@ namespace pika {
         /// \returns          This function will return the value as returned
         ///                   as the result of the invocation of the function
         ///                   object given by the parameter \p func.
-        virtual int run(
-            util::function<pika_main_function_type> const& func);
+        virtual int run(util::function<pika_main_function_type> const& func);
 
         /// \brief Run the pika runtime system, initially use the given number
         ///        of (OS) threads in the thread-manager and block waiting for
@@ -170,8 +169,7 @@ namespace pika {
         ///                   return the value as returned as the result of the
         ///                   invocation of the function object given by the
         ///                   parameter \p func. Otherwise it will return zero.
-        virtual int start(
-            util::function<pika_main_function_type> const& func,
+        virtual int start(util::function<pika_main_function_type> const& func,
             bool blocking = false);
 
         /// \brief Start the runtime system

--- a/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
@@ -51,14 +51,14 @@ namespace pika {
 
     /// Enumerate all OS threads that have registered with the runtime.
     PIKA_EXPORT bool enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f);
+        util::function<bool(os_thread_data const&)> const& f);
 
     /// Return the runtime instance number associated with the runtime instance
     /// the current thread is running in.
     PIKA_EXPORT std::size_t get_runtime_instance_number();
 
     /// Register a function to be called during system shutdown
-    PIKA_EXPORT bool register_on_exit(util::function_nonser<void()> const&);
+    PIKA_EXPORT bool register_on_exit(util::function<void()> const&);
 
     /// \cond NOINTERNAL
     namespace util {

--- a/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
@@ -15,7 +15,7 @@
 namespace pika {
     /// The type of a function which is registered to be executed as a
     /// shutdown or pre-shutdown function.
-    typedef util::unique_function_nonser<void()> shutdown_function_type;
+    typedef util::unique_function<void()> shutdown_function_type;
 
     /// \brief Add a function to be executed by a pika thread during
     /// \a pika::finalize() but guaranteed before any shutdown function is

--- a/libs/pika/runtime/include/pika/runtime/startup_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/startup_function.hpp
@@ -16,7 +16,7 @@ namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     /// The type of a function which is registered to be executed as a
     /// startup or pre-startup function.
-    typedef util::unique_function_nonser<void()> startup_function_type;
+    typedef util::unique_function<void()> startup_function_type;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add a function to be executed by a pika thread before pika_main

--- a/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
@@ -37,7 +37,7 @@ namespace pika { namespace util {
 
         // type for callback function invoked when thread is unregistered
         using thread_mapper_callback_type =
-            util::function_nonser<bool(std::uint32_t)>;
+            util::function<bool(std::uint32_t)>;
 
         // thread-specific data
         class PIKA_EXPORT os_thread_data
@@ -134,7 +134,7 @@ namespace pika { namespace util {
 
         // enumerate all registered OS threads
         bool enumerate_os_threads(
-            util::function_nonser<bool(os_thread_data const&)> const& f) const;
+            util::function<bool(os_thread_data const&)> const& f) const;
 
         // retrieve all data stored for a given thread
         os_thread_data get_os_thread_data(std::string const& label) const;

--- a/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
@@ -36,8 +36,7 @@ namespace pika { namespace util {
     namespace detail {
 
         // type for callback function invoked when thread is unregistered
-        using thread_mapper_callback_type =
-            util::function<bool(std::uint32_t)>;
+        using thread_mapper_callback_type = util::function<bool(std::uint32_t)>;
 
         // thread-specific data
         class PIKA_EXPORT os_thread_data

--- a/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
@@ -101,6 +101,6 @@ namespace pika { namespace threads {
     /// \param state    [in] This specifies the thread-state for which the
     ///                 threads should be enumerated.
     PIKA_EXPORT bool enumerate_threads(
-        util::function_nonser<bool(thread_id_type)> const& f,
+        util::function<bool(thread_id_type)> const& f,
         thread_schedule_state state = thread_schedule_state::unknown);
 }}    // namespace pika::threads

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -396,7 +396,7 @@ namespace pika {
         resource::detail::delete_partitioner();
     }
 
-    void runtime::on_exit(util::function_nonser<void()> const& f)
+    void runtime::on_exit(util::function<void()> const& f)
     {
         std::lock_guard<std::mutex> l(mtx_);
         on_exit_functions_.push_back(f);
@@ -411,7 +411,7 @@ namespace pika {
     {
         state_.store(state_stopped);
 
-        using value_type = util::function_nonser<void()>;
+        using value_type = util::function<void()>;
 
         std::lock_guard<std::mutex> l(mtx_);
         for (value_type const& f : on_exit_functions_)
@@ -708,7 +708,7 @@ namespace pika {
 
     /// Enumerate all OS threads that have registered with the runtime.
     bool enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f)
+        util::function<bool(os_thread_data const&)> const& f)
     {
         return get_runtime().enumerate_os_threads(f);
     }
@@ -747,7 +747,7 @@ namespace pika {
         get_runtime().get_thread_manager().report_error(num_thread, e);
     }
 
-    bool register_on_exit(util::function_nonser<void()> const& f)
+    bool register_on_exit(util::function<void()> const& f)
     {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
@@ -801,7 +801,7 @@ namespace pika {
     }
 
     void set_config_entry_callback(std::string const& key,
-        util::function_nonser<void(
+        util::function<void(
             std::string const&, std::string const&)> const& callback)
     {
         if (get_runtime_ptr() != nullptr)
@@ -1210,7 +1210,7 @@ namespace pika {
     }    // namespace detail
 
     threads::thread_result_type runtime::run_helper(
-        util::function_nonser<runtime::pika_main_function_type> const& func,
+        util::function<runtime::pika_main_function_type> const& func,
         int& result, bool call_startup)
     {
         bool caught_exception = false;
@@ -1285,7 +1285,7 @@ namespace pika {
     }
 
     int runtime::start(
-        util::function_nonser<pika_main_function_type> const& func,
+        util::function<pika_main_function_type> const& func,
         bool blocking)
     {
 #if defined(_WIN64) && defined(PIKA_DEBUG) &&                                  \
@@ -1349,7 +1349,7 @@ namespace pika {
 
     int runtime::start(bool blocking)
     {
-        util::function_nonser<pika_main_function_type> empty_main;
+        util::function<pika_main_function_type> empty_main;
         return start(empty_main, blocking);
     }
 
@@ -1616,7 +1616,7 @@ namespace pika {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    int runtime::run(util::function_nonser<pika_main_function_type> const& func)
+    int runtime::run(util::function<pika_main_function_type> const& func)
     {
         // start the main thread function
         start(func);
@@ -1838,7 +1838,7 @@ namespace pika {
 
     /// Enumerate all OS threads that have registered with the runtime.
     bool runtime::enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f) const
+        util::function<bool(os_thread_data const&)> const& f) const
     {
         return thread_support_->enumerate_os_threads(f);
     }

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -801,8 +801,8 @@ namespace pika {
     }
 
     void set_config_entry_callback(std::string const& key,
-        util::function<void(
-            std::string const&, std::string const&)> const& callback)
+        util::function<void(std::string const&, std::string const&)> const&
+            callback)
     {
         if (get_runtime_ptr() != nullptr)
         {
@@ -1285,8 +1285,7 @@ namespace pika {
     }
 
     int runtime::start(
-        util::function<pika_main_function_type> const& func,
-        bool blocking)
+        util::function<pika_main_function_type> const& func, bool blocking)
     {
 #if defined(_WIN64) && defined(PIKA_DEBUG) &&                                  \
     !defined(PIKA_HAVE_FIBER_BASED_COROUTINES)

--- a/libs/pika/runtime/src/thread_mapper.cpp
+++ b/libs/pika/runtime/src/thread_mapper.cpp
@@ -278,7 +278,7 @@ namespace pika { namespace util {
     }
 
     bool thread_mapper::enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f) const
+        util::function<bool(os_thread_data const&)> const& f) const
     {
         std::lock_guard<mutex_type> m(mtx_);
         for (auto const& tinfo : thread_map_)

--- a/libs/pika/runtime/src/thread_pool_helpers.cpp
+++ b/libs/pika/runtime/src/thread_pool_helpers.cpp
@@ -94,7 +94,7 @@ namespace pika { namespace threads {
         return get_thread_manager().get_idle_core_mask();
     }
 
-    bool enumerate_threads(util::function_nonser<bool(thread_id_type)> const& f,
+    bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
         thread_schedule_state state)
     {
         return get_thread_manager().enumerate_threads(f, state);

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -973,7 +973,7 @@ namespace pika { namespace threads { namespace policies {
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {
@@ -1281,7 +1281,7 @@ namespace pika { namespace threads { namespace policies {
                 first_mask = pu_mask;
 
             auto iterate =
-                [&](pika::util::function_nonser<bool(std::size_t)> f) {
+                [&](pika::util::function<bool(std::size_t)> f) {
                     // check our neighbors in a radial fashion (left and right
                     // alternating, increasing distance each iteration)
                     std::ptrdiff_t i = 1;

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -972,8 +972,7 @@ namespace pika { namespace threads { namespace policies {
 
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {
@@ -1280,40 +1279,39 @@ namespace pika { namespace threads { namespace policies {
             else
                 first_mask = pu_mask;
 
-            auto iterate =
-                [&](pika::util::function<bool(std::size_t)> f) {
-                    // check our neighbors in a radial fashion (left and right
-                    // alternating, increasing distance each iteration)
-                    std::ptrdiff_t i = 1;
-                    for (/**/; i < radius; ++i)
-                    {
-                        std::ptrdiff_t left =
-                            (static_cast<std::ptrdiff_t>(num_thread) - i) %
-                            static_cast<std::ptrdiff_t>(num_threads);
-                        if (left < 0)
-                            left = num_threads + left;
+            auto iterate = [&](pika::util::function<bool(std::size_t)> f) {
+                // check our neighbors in a radial fashion (left and right
+                // alternating, increasing distance each iteration)
+                std::ptrdiff_t i = 1;
+                for (/**/; i < radius; ++i)
+                {
+                    std::ptrdiff_t left =
+                        (static_cast<std::ptrdiff_t>(num_thread) - i) %
+                        static_cast<std::ptrdiff_t>(num_threads);
+                    if (left < 0)
+                        left = num_threads + left;
 
-                        if (f(std::size_t(left)))
-                        {
-                            victim_threads_[num_thread].data_.push_back(
-                                static_cast<std::size_t>(left));
-                        }
-
-                        std::size_t right = (num_thread + i) % num_threads;
-                        if (f(right))
-                        {
-                            victim_threads_[num_thread].data_.push_back(right);
-                        }
-                    }
-                    if ((num_threads % 2) == 0)
+                    if (f(std::size_t(left)))
                     {
-                        std::size_t right = (num_thread + i) % num_threads;
-                        if (f(right))
-                        {
-                            victim_threads_[num_thread].data_.push_back(right);
-                        }
+                        victim_threads_[num_thread].data_.push_back(
+                            static_cast<std::size_t>(left));
                     }
-                };
+
+                    std::size_t right = (num_thread + i) % num_threads;
+                    if (f(right))
+                    {
+                        victim_threads_[num_thread].data_.push_back(right);
+                    }
+                }
+                if ((num_threads % 2) == 0)
+                {
+                    std::size_t right = (num_thread + i) % num_threads;
+                    if (f(right))
+                    {
+                        victim_threads_[num_thread].data_.push_back(right);
+                    }
+                }
+            };
 
             // check for threads which share the same core...
             iterate([&](std::size_t other_num_thread) {

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -636,8 +636,7 @@ namespace pika { namespace threads { namespace policies {
 
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -637,7 +637,7 @@ namespace pika { namespace threads { namespace policies {
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
@@ -244,8 +244,7 @@ namespace pika { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const
         {
             bool result = true;

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
@@ -245,7 +245,7 @@ namespace pika { namespace threads { namespace policies {
 
         // ----------------------------------------------------------------
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const
         {
             bool result = true;

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -938,8 +938,7 @@ namespace pika { namespace threads { namespace policies {
         }
 
         // ------------------------------------------------------------
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_.data_;

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -939,7 +939,7 @@ namespace pika { namespace threads { namespace policies {
 
         // ------------------------------------------------------------
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_.data_;

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -456,10 +456,10 @@ namespace pika { namespace threads { namespace policies {
         bool steal_by_function(std::size_t domain, std::size_t q_index,
             bool steal_numa, bool steal_core, thread_holder_type* origin,
             T& var, const char* prefix,
-            util::function_nonser<bool(
+            util::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation_HP,
-            util::function_nonser<bool(
+            util::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation)
         {
@@ -933,7 +933,7 @@ namespace pika { namespace threads { namespace policies {
         //---------------------------------------------------------------------
         // Enumerate matching threads from all queues
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -932,8 +932,7 @@ namespace pika { namespace threads { namespace policies {
 
         //---------------------------------------------------------------------
         // Enumerate matching threads from all queues
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -937,7 +937,7 @@ namespace pika { namespace threads { namespace policies {
         }
 
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_;

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -936,8 +936,7 @@ namespace pika { namespace threads { namespace policies {
             }
         }
 
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -39,8 +39,7 @@ namespace pika { namespace experimental {
             shared_state_ptr_type next_state;
             pika::lcos::local::mutex mtx;
             pika::detail::small_vector<
-                pika::util::unique_function<void(shared_state_ptr_type)>,
-                1>
+                pika::util::unique_function<void(shared_state_ptr_type)>, 1>
                 continuations;
 
             async_rw_mutex_shared_state() = default;
@@ -108,8 +107,7 @@ namespace pika { namespace experimental {
             shared_state_ptr_type next_state;
             pika::lcos::local::mutex mtx;
             pika::detail::small_vector<
-                pika::util::unique_function<void(shared_state_ptr_type)>,
-                1>
+                pika::util::unique_function<void(shared_state_ptr_type)>, 1>
                 continuations;
 
             async_rw_mutex_shared_state() = default;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -39,7 +39,7 @@ namespace pika { namespace experimental {
             shared_state_ptr_type next_state;
             pika::lcos::local::mutex mtx;
             pika::detail::small_vector<
-                pika::util::unique_function_nonser<void(shared_state_ptr_type)>,
+                pika::util::unique_function<void(shared_state_ptr_type)>,
                 1>
                 continuations;
 
@@ -108,7 +108,7 @@ namespace pika { namespace experimental {
             shared_state_ptr_type next_state;
             pika::lcos::local::mutex mtx;
             pika::detail::small_vector<
-                pika::util::unique_function_nonser<void(shared_state_ptr_type)>,
+                pika::util::unique_function<void(shared_state_ptr_type)>,
                 1>
                 continuations;
 

--- a/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
+++ b/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
@@ -43,7 +43,7 @@ namespace pika { namespace threads {
     ///                  is pre-initialized to \a pika#throws the function will throw
     ///                  on error instead.
     PIKA_EXPORT void resume_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        util::function<void(void)> callback, std::size_t virt_core,
         error_code& ec = throws);
 
     /// Suspends the given processing unit. When the processing unit has been
@@ -78,7 +78,7 @@ namespace pika { namespace threads {
     ///                  is pre-initialized to \a pika#throws the function will throw
     ///                  on error instead.
     PIKA_EXPORT void suspend_processing_unit_cb(
-        util::function_nonser<void(void)> callback, thread_pool_base& pool,
+        util::function<void(void)> callback, thread_pool_base& pool,
         std::size_t virt_core, error_code& ec = throws);
 
     /// Resumes the thread pool. When the all OS threads on the thread pool have
@@ -101,7 +101,7 @@ namespace pika { namespace threads {
     ///                 is pre-initialized to \a pika#throws the function will throw
     ///                 on error instead.
     PIKA_EXPORT void resume_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec = throws);
+        util::function<void(void)> callback, error_code& ec = throws);
 
     /// Suspends the thread pool. When the all OS threads on the thread pool
     /// have been suspended the returned future will be ready.
@@ -130,5 +130,5 @@ namespace pika { namespace threads {
     /// \throws pika::exception if called from an pika thread which is running
     ///         on the pool itself.
     PIKA_EXPORT void suspend_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec = throws);
+        util::function<void(void)> callback, error_code& ec = throws);
 }}    // namespace pika::threads

--- a/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -41,7 +41,7 @@ namespace pika { namespace threads {
     }
 
     void resume_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        util::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
         if (!pool.get_scheduler()->has_scheduler_mode(
@@ -102,7 +102,7 @@ namespace pika { namespace threads {
     }
 
     void suspend_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        util::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
         if (!pool.get_scheduler()->has_scheduler_mode(
@@ -156,7 +156,7 @@ namespace pika { namespace threads {
     }
 
     void resume_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& /* ec */)
+        util::function<void(void)> callback, error_code& /* ec */)
     {
         auto resume_direct_wrapper =
             [&pool, callback = PIKA_MOVE(callback)]() -> void {
@@ -196,7 +196,7 @@ namespace pika { namespace threads {
     }
 
     void suspend_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec)
+        util::function<void(void)> callback, error_code& ec)
     {
         if (threads::get_self_ptr() && pika::this_thread::get_pool() == &pool)
         {

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -110,8 +110,7 @@ namespace pika { namespace threads { namespace detail {
             return sched_->Scheduler::get_background_thread_count();
         }
 
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const override
         {
             return sched_->Scheduler::enumerate_threads(f, state);

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -111,7 +111,7 @@ namespace pika { namespace threads { namespace detail {
         }
 
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const override
         {
             return sched_->Scheduler::enumerate_threads(f, state);

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -398,8 +398,8 @@ namespace pika { namespace threads { namespace detail {
 
     struct scheduling_callbacks
     {
-        using callback_type = util::unique_function_nonser<void()>;
-        using background_callback_type = util::unique_function_nonser<bool()>;
+        using callback_type = util::unique_function<void()>;
+        using background_callback_type = util::unique_function<bool()>;
 
         explicit scheduling_callbacks(callback_type&& outer,
             callback_type&& inner = callback_type(),

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -33,7 +33,7 @@
 namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     using thread_termination_handler_type =
-        util::function_nonser<void(std::exception_ptr const& e)>;
+        util::function<void(std::exception_ptr const& e)>;
     PIKA_EXPORT void set_thread_termination_handler(
         thread_termination_handler_type f);
 
@@ -143,9 +143,9 @@ namespace pika {
             id_ = threads::invalid_thread_id;
         }
         void start_thread(threads::thread_pool_base* pool,
-            util::unique_function_nonser<void()>&& func);
+            util::unique_function<void()>&& func);
         static threads::thread_result_type thread_function_nullary(
-            util::unique_function_nonser<void()> const& func);
+            util::unique_function<void()> const& func);
 
         mutable mutex_type mtx_;
         threads::thread_id_ref_type id_;

--- a/libs/pika/threading/src/thread.cpp
+++ b/libs/pika/threading/src/thread.cpp
@@ -161,8 +161,8 @@ namespace pika {
         return pika::threads::hardware_concurrency();
     }
 
-    void thread::start_thread(threads::thread_pool_base* pool,
-        util::unique_function<void()>&& func)
+    void thread::start_thread(
+        threads::thread_pool_base* pool, util::unique_function<void()>&& func)
     {
         PIKA_ASSERT(pool);
 

--- a/libs/pika/threading/src/thread.cpp
+++ b/libs/pika/threading/src/thread.cpp
@@ -114,7 +114,7 @@ namespace pika {
     }
 
     threads::thread_result_type thread::thread_function_nullary(
-        util::unique_function_nonser<void()> const& func)
+        util::unique_function<void()> const& func)
     {
         try
         {
@@ -162,7 +162,7 @@ namespace pika {
     }
 
     void thread::start_thread(threads::thread_pool_base* pool,
-        util::unique_function_nonser<void()>&& func)
+        util::unique_function<void()>&& func)
     {
         PIKA_ASSERT(pool);
 

--- a/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
@@ -20,10 +20,10 @@ namespace pika { namespace threads { namespace policies {
     class PIKA_EXPORT callback_notifier
     {
     public:
-        typedef util::function_nonser<void(
+        typedef util::function<void(
             std::size_t, std::size_t, char const*, char const*)>
             on_startstop_type;
-        typedef util::function_nonser<bool(
+        typedef util::function<bool(
             std::size_t, std::exception_ptr const&)>
             on_error_type;
 

--- a/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
@@ -23,8 +23,7 @@ namespace pika { namespace threads { namespace policies {
         typedef util::function<void(
             std::size_t, std::size_t, char const*, char const*)>
             on_startstop_type;
-        typedef util::function<bool(
-            std::size_t, std::exception_ptr const&)>
+        typedef util::function<bool(std::size_t, std::exception_ptr const&)>
             on_error_type;
 
         callback_notifier()

--- a/libs/pika/threading_base/include/pika/threading_base/detail/get_default_pool.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/get_default_pool.hpp
@@ -14,7 +14,7 @@
 #include <pika/threading_base/thread_pool_base.hpp>
 
 namespace pika { namespace threads { namespace detail {
-    using get_default_pool_type = util::function_nonser<thread_pool_base*()>;
+    using get_default_pool_type = util::function<thread_pool_base*()>;
     PIKA_EXPORT void set_get_default_pool(get_default_pool_type f);
     PIKA_EXPORT thread_pool_base* get_self_or_default_pool();
 }}}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
@@ -16,9 +16,9 @@ namespace pika { namespace threads { namespace detail {
 #if defined(PIKA_HAVE_BACKGROUND_THREAD_COUNTERS) &&                           \
     defined(PIKA_HAVE_THREAD_IDLE_RATES)
     using network_background_callback_type =
-        util::function_nonser<bool(std::size_t, std::int64_t&, std::int64_t&)>;
+        util::function<bool(std::size_t, std::int64_t&, std::int64_t&)>;
 #else
     using network_background_callback_type =
-        util::function_nonser<bool(std::size_t)>;
+        util::function<bool(std::size_t)>;
 #endif
 }}}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
@@ -18,7 +18,6 @@ namespace pika { namespace threads { namespace detail {
     using network_background_callback_type =
         util::function<bool(std::size_t, std::int64_t&, std::int64_t&)>;
 #else
-    using network_background_callback_type =
-        util::function<bool(std::size_t)>;
+    using network_background_callback_type = util::function<bool(std::size_t)>;
 #endif
 }}}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -167,7 +167,7 @@ namespace pika { namespace threads { namespace policies {
         // depending on the predicate
         std::vector<std::size_t> domain_threads(std::size_t local_id,
             const std::vector<std::size_t>& ts,
-            util::function_nonser<bool(std::size_t, std::size_t)> pred);
+            util::function<bool(std::size_t, std::size_t)> pred);
 
 #ifdef PIKA_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         virtual std::uint64_t get_creation_time(bool reset) = 0;
@@ -209,7 +209,7 @@ namespace pika { namespace threads { namespace policies {
 
         // Enumerate all matching threads
         virtual bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const = 0;
 

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -477,7 +477,7 @@ namespace pika { namespace threads {
 
         bool interruption_point(bool throw_on_interrupt = true);
 
-        bool add_thread_exit_callback(util::function_nonser<void()> const& f);
+        bool add_thread_exit_callback(util::function<void()> const& f);
         void run_thread_exit_callbacks();
         void free_thread_exit_callbacks();
 
@@ -621,7 +621,7 @@ namespace pika { namespace threads {
         bool const is_stackless_;
 
         // Singly linked list (heap-allocated)
-        std::forward_list<util::function_nonser<void()>> exit_funcs_;
+        std::forward_list<util::function<void()>> exit_funcs_;
 
         // reference to scheduler which created/manages this thread
         policies::scheduler_base* scheduler_base_;

--- a/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
@@ -381,7 +381,7 @@ namespace pika { namespace threads {
         thread_id_type const& id, error_code& ec = throws);
 
     PIKA_EXPORT bool add_thread_exit_callback(thread_id_type const& id,
-        util::function_nonser<void()> const& f, error_code& ec = throws);
+        util::function<void()> const& f, error_code& ec = throws);
 
     PIKA_EXPORT void free_thread_exit_callbacks(
         thread_id_type const& id, error_code& ec = throws);

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -493,7 +493,7 @@ namespace pika { namespace threads {
 
         ///////////////////////////////////////////////////////////////////////
         virtual bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& /*f*/,
+            util::function<bool(thread_id_type)> const& /*f*/,
             thread_schedule_state /*state*/ =
                 thread_schedule_state::unknown) const
         {

--- a/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
@@ -58,8 +58,7 @@ namespace pika::threads {
     using thread_arg_type = thread_restart_state;
 
     using thread_function_sig = thread_result_type(thread_arg_type);
-    using thread_function_type =
-        util::unique_function<thread_function_sig>;
+    using thread_function_type = util::unique_function<thread_function_sig>;
 
     using thread_self = coroutines::detail::coroutine_self;
     using thread_self_impl_type = coroutines::detail::coroutine_impl;

--- a/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
@@ -59,7 +59,7 @@ namespace pika::threads {
 
     using thread_function_sig = thread_result_type(thread_arg_type);
     using thread_function_type =
-        util::unique_function_nonser<thread_function_sig>;
+        util::unique_function<thread_function_sig>;
 
     using thread_self = coroutines::detail::coroutine_self;
     using thread_self_impl_type = coroutines::detail::coroutine_impl;

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -135,8 +135,7 @@ namespace pika { namespace threads {
         ran_exit_funcs_ = true;
     }
 
-    bool thread_data::add_thread_exit_callback(
-        util::function<void()> const& f)
+    bool thread_data::add_thread_exit_callback(util::function<void()> const& f)
     {
         std::lock_guard<pika::util::detail::spinlock> l(
             spinlock_pool::spinlock_for(this));

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -136,7 +136,7 @@ namespace pika { namespace threads {
     }
 
     bool thread_data::add_thread_exit_callback(
-        util::function_nonser<void()> const& f)
+        util::function<void()> const& f)
     {
         std::lock_guard<pika::util::detail::spinlock> l(
             spinlock_pool::spinlock_for(this));

--- a/libs/pika/threading_base/src/thread_helpers.cpp
+++ b/libs/pika/threading_base/src/thread_helpers.cpp
@@ -331,7 +331,7 @@ namespace pika { namespace threads {
     }
 
     bool add_thread_exit_callback(thread_id_type const& id,
-        util::function_nonser<void()> const& f, error_code& ec)
+        util::function<void()> const& f, error_code& ec)
     {
         if (PIKA_UNLIKELY(!id))
         {

--- a/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
+++ b/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
@@ -176,7 +176,7 @@ namespace pika { namespace threads {
 
         // Enumerate all matching threads
         bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const;
 
         // \brief Abort all threads which are in suspended state. This will set

--- a/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
+++ b/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
@@ -175,8 +175,7 @@ namespace pika { namespace threads {
         std::int64_t get_background_thread_count();
 
         // Enumerate all matching threads
-        bool enumerate_threads(
-            util::function<bool(thread_id_type)> const& f,
+        bool enumerate_threads(util::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const;
 
         // \brief Abort all threads which are in suspended state. This will set

--- a/libs/pika/threadmanager/src/threadmanager.cpp
+++ b/libs/pika/threadmanager/src/threadmanager.cpp
@@ -674,7 +674,7 @@ namespace pika { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     // Enumerate all matching threads
     bool threadmanager::enumerate_threads(
-        util::function_nonser<bool(thread_id_type)> const& f,
+        util::function<bool(thread_id_type)> const& f,
         thread_schedule_state state) const
     {
         std::lock_guard<mutex_type> lk(mtx_);

--- a/testing/include/pika/testing/performance.hpp
+++ b/testing/include/pika/testing/performance.hpp
@@ -80,7 +80,7 @@ namespace pika { namespace util {
 
     PIKA_EXPORT void perftests_report(std::string const& name,
         std::string const& exec, const std::size_t steps,
-        function_nonser<void(void)>&& test);
+        function<void(void)>&& test);
 
     PIKA_EXPORT void perftests_print_times();
 

--- a/testing/src/performance.cpp
+++ b/testing/src/performance.cpp
@@ -30,7 +30,7 @@ namespace pika { namespace util {
     }    // namespace detail
 
     void perftests_report(std::string const& name, std::string const& exec,
-        const std::size_t steps, function_nonser<void(void)>&& test)
+        const std::size_t steps, function<void(void)>&& test)
     {
         if (steps == 0)
             return;

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -381,8 +381,8 @@ void measure_function_futures_create_thread_hierarchical_placement(
             }
         };
         auto const thread_spawn_func =
-            pika::threads::detail::thread_function_nullary<
-                decltype(spawn_func)>{spawn_func};
+            pika::threads::detail::thread_function_nullary<decltype(
+                spawn_func)>{spawn_func};
 
         pika::threads::thread_init_data init(
             pika::threads::thread_function_type(thread_spawn_func), desc, prio,

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -124,8 +124,8 @@ void measure_function_futures_create_thread_hierarchical_placement(
                     }
                 };
                 auto const thread_spawn_func =
-                    pika::threads::detail::thread_function_nullary<
-                        decltype(spawn_func)>{spawn_func};
+                    pika::threads::detail::thread_function_nullary<decltype(
+                        spawn_func)>{spawn_func};
 
                 pika::threads::thread_init_data init(
                     pika::threads::thread_function_type(thread_spawn_func),

--- a/tests/performance/local/htts_v2/htts2_pika.cpp
+++ b/tests/performance/local/htts_v2/htts2_pika.cpp
@@ -38,9 +38,7 @@ struct pika_driver : htts2::driver
             "pika.os_threads=" + std::to_string(osthreads_),
             "pika.run_pika_main!=0", "pika.commandline.allow_unknown!=1"};
 
-        pika::util::function<int(
-            pika::program_options::variables_map & vm)>
-            f;
+        pika::util::function<int(pika::program_options::variables_map & vm)> f;
         pika::program_options::options_description desc;
 
         pika::init_params init_args;

--- a/tests/performance/local/htts_v2/htts2_pika.cpp
+++ b/tests/performance/local/htts_v2/htts2_pika.cpp
@@ -38,7 +38,7 @@ struct pika_driver : htts2::driver
             "pika.os_threads=" + std::to_string(osthreads_),
             "pika.run_pika_main!=0", "pika.commandline.allow_unknown!=1"};
 
-        pika::util::function_nonser<int(
+        pika::util::function<int(
             pika::program_options::variables_map & vm)>
             f;
         pika::program_options::options_description desc;

--- a/tests/performance/local/libcds_hazard_pointer_overhead.cpp
+++ b/tests/performance/local/libcds_hazard_pointer_overhead.cpp
@@ -201,8 +201,8 @@ void measure_function_futures_create_thread_hierarchical_placement(
             }
         };
         auto const thread_spawn_func =
-            pika::threads::detail::thread_function_nullary<
-                decltype(spawn_func)>{spawn_func};
+            pika::threads::detail::thread_function_nullary<decltype(
+                spawn_func)>{spawn_func};
 
         pika::threads::thread_init_data init(
             pika::threads::thread_function_type(thread_spawn_func), desc, prio,

--- a/tests/regressions/multiple_init_2918.cpp
+++ b/tests/regressions/multiple_init_2918.cpp
@@ -24,17 +24,17 @@ int main(int argc, char* argv[])
     using pika::util::placeholders::_2;
 
     expected = "first";
-    pika::util::function_nonser<int(int, char**)> callback1 =
+    pika::util::function<int(int, char**)> callback1 =
         pika::util::bind(&pika_init_test, expected, _1, _2);
     pika::init(callback1, argc, argv);
 
     expected = "second";
-    pika::util::function_nonser<int(int, char**)> callback2 =
+    pika::util::function<int(int, char**)> callback2 =
         pika::util::bind(&pika_init_test, expected, _1, _2);
     pika::init(callback2, argc, argv);
 
     expected = "third";
-    pika::util::function_nonser<int(int, char**)> callback3 =
+    pika::util::function<int(int, char**)> callback3 =
         pika::util::bind(&pika_init_test, expected, _1, _2);
     pika::init(callback3, argc, argv);
 

--- a/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
     pika::lcos::local::spinlock mtx;
     pika::lcos::local::condition_variable_any cond;
 
-    pika::util::function_nonser<int(int, char**)> start_function =
+    pika::util::function<int(int, char**)> start_function =
         pika::util::bind(&start_func, std::ref(mtx), std::ref(cond));
 
     pika::start(start_function, argc, argv);

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -56,7 +56,7 @@ namespace boost { namespace inspect {
             "std::unordered_multiset"},
         {"(\\bboost\\s*::\\s*detail\\s*::\\s*atomic_count\\b)",
             "pika::util::atomic_count"},
-        {"(\\bboost\\s*::\\s*function\\b)", "pika::util::function_nonser"},
+        {"(\\bboost\\s*::\\s*function\\b)", "pika::util::function"},
         {R"((\bboost\s*::\s*intrusive_ptr\b))", "pika::intrusive_ptr"},
         {"(\\bboost\\s*::\\s*shared_ptr\\b)", "std::shared_ptr"},
         {"(\\bboost\\s*::\\s*make_shared\\b)", "std::make_shared"},


### PR DESCRIPTION
Following #145, function_nonser can be removed since the default function is now non serializable.