### PR TITLE
Clean up affinity module

### DIFF
--- a/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
+++ b/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
@@ -18,7 +18,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace threads { namespace policies { namespace detail {
+namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     // Structure holding the information related to thread affinity selection
     // for the shepherd threads of this instance
@@ -54,10 +54,10 @@ namespace pika { namespace threads { namespace policies { namespace detail {
             return num_threads_;
         }
 
-        mask_cref_type get_pu_mask(
+        threads::mask_cref_type get_pu_mask(
             threads::topology const& topo, std::size_t num_thread) const;
 
-        mask_type get_used_pus_mask(
+        threads::mask_type get_used_pus_mask(
             threads::topology const& topo, std::size_t pu_num) const;
         std::size_t get_thread_occupancy(
             threads::topology const& topo, std::size_t pu_num) const;
@@ -95,9 +95,9 @@ namespace pika { namespace threads { namespace policies { namespace detail {
         std::size_t pu_step_;    ///< step between used processing units
         std::size_t used_cores_;
         std::string affinity_domain_;
-        std::vector<mask_type> affinity_masks_;
+        std::vector<threads::mask_type> affinity_masks_;
         std::vector<std::size_t> pu_nums_;
-        mask_type
+        threads::mask_type
             no_affinity_;    ///< mask of processing units which have no affinity
         bool
             use_process_mask_;    ///< use the process CPU mask to limit available PUs
@@ -105,6 +105,6 @@ namespace pika { namespace threads { namespace policies { namespace detail {
         static std::atomic<int>
             instance_number_counter_;    ///< counter for instance numbers
     };
-}}}}    // namespace pika::threads::policies::detail
+}    // namespace pika::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/affinity/include/pika/affinity/parse_affinity_options.hpp
+++ b/libs/pika/affinity/include/pika/affinity/parse_affinity_options.hpp
@@ -12,48 +12,31 @@
 
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
-#include <pika/modules/errors.hpp>
+#include <pika/errors/error_code.hpp>
 #include <pika/topology/cpu_mask.hpp>
-
-#include <boost/variant.hpp>
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <string>
-#include <utility>
 #include <vector>
 
-namespace pika { namespace threads {
-    namespace detail {
-        typedef std::vector<std::int64_t> bounds_type;
+namespace pika::detail {
+    enum distribution_type
+    {
+        compact = 0x01,
+        scatter = 0x02,
+        balanced = 0x04,
+        numa_balanced = 0x08
+    };
 
-        enum distribution_type
-        {
-            compact = 0x01,
-            scatter = 0x02,
-            balanced = 0x04,
-            numa_balanced = 0x08
-        };
+    using mappings_type = distribution_type;
 
-        using mappings_type = distribution_type;
-
-        PIKA_EXPORT void parse_mappings(std::string const& spec,
-            mappings_type& mappings, error_code& ec = throws);
-    }    // namespace detail
+    PIKA_EXPORT void parse_mappings(std::string const& spec,
+        mappings_type& mappings, error_code& ec = throws);
 
     PIKA_EXPORT void parse_affinity_options(std::string const& spec,
-        std::vector<mask_type>& affinities, std::size_t used_cores,
+        std::vector<threads::mask_type>& affinities, std::size_t used_cores,
         std::size_t max_cores, std::size_t num_threads,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec = throws);
-
-    // backwards compatibility helper
-    inline void parse_affinity_options(std::string const& spec,
-        std::vector<mask_type>& affinities, error_code& ec = throws)
-    {
-        std::vector<std::size_t> num_pus;
-        parse_affinity_options(
-            spec, affinities, 1, 1, affinities.size(), num_pus, false, ec);
-    }
-}}    // namespace pika::threads
+}    // namespace pika::detail

--- a/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
@@ -169,7 +169,7 @@ int main()
         std::size_t const num_threads = (std::min)(
             std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
         std::size_t const max_cores = num_threads;
-        pika::threads::policies::detail::affinity_data ad{};
+        pika::detail::affinity_data ad{};
         ad.init(num_threads, max_cores, 0, 1, 0, "core", "balanced", true);
         pika::threads::policies::callback_notifier notifier{};
         pika::threads::policies::thread_queue_init_parameters

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -448,8 +448,7 @@ namespace pika {
                 {
                     result = cmdline.call(params.desc_cmdline, argc, argv);
 
-                    pika::threads::policies::detail::affinity_data
-                        affinity_data{};
+                    pika::detail::affinity_data affinity_data{};
                     affinity_data.init(
                         pika::util::get_entry_as<std::size_t>(
                             cmdline.rtcfg_, "pika.os_threads", 0),

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/create_partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/create_partitioner.hpp
@@ -22,6 +22,6 @@
 namespace pika { namespace resource { namespace detail {
     PIKA_EXPORT partitioner& create_partitioner(
         resource::partitioner_mode rpmode, pika::util::section rtcfg,
-        pika::threads::policies::detail::affinity_data affinity_data);
+        pika::detail::affinity_data affinity_data);
 
 }}}    // namespace pika::resource::detail

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -115,8 +115,7 @@ namespace pika { namespace resource { namespace detail {
         void add_resource(const std::vector<pika::resource::numa_domain>& ndv,
             std::string const& pool_name, bool exclusive = true);
 
-        threads::policies::detail::affinity_data const& get_affinity_data()
-            const
+        pika::detail::affinity_data const& get_affinity_data() const
         {
             return affinity_data_;
         }
@@ -156,7 +155,7 @@ namespace pika { namespace resource { namespace detail {
             std::size_t global_thread_num) const;
 
         void init(resource::partitioner_mode rpmode, pika::util::section cfg,
-            pika::threads::policies::detail::affinity_data affinity_data);
+            pika::detail::affinity_data affinity_data);
 
         scheduler_function get_pool_creator(size_t index) const;
 
@@ -228,7 +227,7 @@ namespace pika { namespace resource { namespace detail {
         std::vector<detail::init_pool_data> initial_thread_pools_;
 
         // reference to the topology and affinity data
-        pika::threads::policies::detail::affinity_data affinity_data_;
+        pika::detail::affinity_data affinity_data_;
 
         // contains the internal topology back-end used to add resources to
         // initial_thread_pools

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
@@ -127,7 +127,7 @@ namespace pika { namespace resource {
     namespace detail {
         inline ::pika::resource::partitioner make_partitioner(
             resource::partitioner_mode rpmode, pika::util::section rtcfg,
-            pika::threads::policies::detail::affinity_data affinity_data);
+            pika::detail::affinity_data affinity_data);
     }
 
     class partitioner
@@ -135,11 +135,11 @@ namespace pika { namespace resource {
     private:
         friend ::pika::resource::partitioner detail::make_partitioner(
             resource::partitioner_mode rpmode, pika::util::section rtcfg,
-            pika::threads::policies::detail::affinity_data affinity_data);
+            pika::detail::affinity_data affinity_data);
 
         partitioner(resource::partitioner_mode rpmode,
             pika::util::section rtcfg,
-            pika::threads::policies::detail::affinity_data affinity_data)
+            pika::detail::affinity_data affinity_data)
           : partitioner_(
                 detail::create_partitioner(rpmode, rtcfg, affinity_data))
         {
@@ -206,7 +206,7 @@ namespace pika { namespace resource {
     namespace detail {
         ::pika::resource::partitioner make_partitioner(
             resource::partitioner_mode rpmode, pika::util::section rtcfg,
-            pika::threads::policies::detail::affinity_data affinity_data)
+            pika::detail::affinity_data affinity_data)
         {
             return ::pika::resource::partitioner(rpmode, rtcfg, affinity_data);
         }

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -871,8 +871,7 @@ namespace pika { namespace resource { namespace detail {
     }
 
     void partitioner::init(resource::partitioner_mode rpmode,
-        pika::util::section rtcfg,
-        pika::threads::policies::detail::affinity_data affinity_data)
+        pika::util::section rtcfg, pika::detail::affinity_data affinity_data)
     {
         mode_ = rpmode;
         rtcfg_ = rtcfg;

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -126,7 +126,7 @@ namespace pika { namespace resource {
     namespace detail {
         detail::partitioner& create_partitioner(
             resource::partitioner_mode rpmode, pika::util::section rtcfg,
-            pika::threads::policies::detail::affinity_data affinity_data)
+            pika::detail::affinity_data affinity_data)
         {
             std::unique_ptr<detail::partitioner>& rp =
                 detail::get_partitioner();

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -78,7 +78,7 @@ namespace pika { namespace threads { namespace policies {
         struct init_parameter
         {
             init_parameter(std::size_t num_queues,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 std::size_t num_high_priority_queues = std::size_t(-1),
                 thread_queue_init_parameters thread_queue_init = {},
                 char const* description = "local_priority_queue_scheduler")
@@ -94,7 +94,7 @@ namespace pika { namespace threads { namespace policies {
             }
 
             init_parameter(std::size_t num_queues,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 char const* description)
               : num_queues_(num_queues)
               , num_high_priority_queues_(num_queues)
@@ -107,7 +107,7 @@ namespace pika { namespace threads { namespace policies {
             std::size_t num_queues_;
             std::size_t num_high_priority_queues_;
             thread_queue_init_parameters thread_queue_init_;
-            detail::affinity_data const& affinity_data_;
+            pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };
         typedef init_parameter init_parameter_type;
@@ -1371,7 +1371,7 @@ namespace pika { namespace threads { namespace policies {
     protected:
         std::atomic<std::size_t> curr_queue_;
 
-        detail::affinity_data const& affinity_data_;
+        pika::detail::affinity_data const& affinity_data_;
 
         std::size_t const num_queues_;
         std::size_t const num_high_priority_queues_;

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -66,7 +66,7 @@ namespace pika { namespace threads { namespace policies {
         struct init_parameter
         {
             init_parameter(std::size_t num_queues,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 thread_queue_init_parameters thread_queue_init = {},
                 char const* description = "local_queue_scheduler")
               : num_queues_(num_queues)
@@ -77,7 +77,7 @@ namespace pika { namespace threads { namespace policies {
             }
 
             init_parameter(std::size_t num_queues,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 char const* description)
               : num_queues_(num_queues)
               , thread_queue_init_()
@@ -88,7 +88,7 @@ namespace pika { namespace threads { namespace policies {
 
             std::size_t num_queues_;
             thread_queue_init_parameters thread_queue_init_;
-            detail::affinity_data const& affinity_data_;
+            pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };
         typedef init_parameter init_parameter_type;
@@ -940,7 +940,7 @@ namespace pika { namespace threads { namespace policies {
         std::vector<thread_queue_type*> queues_;
         std::atomic<std::size_t> curr_queue_;
 
-        detail::affinity_data const& affinity_data_;
+        pika::detail::affinity_data const& affinity_data_;
 
 #if !defined(                                                                  \
     PIKA_NATIVE_MIC)    // we know that the MIC has one NUMA domain only

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -123,7 +123,7 @@ namespace pika { namespace threads { namespace policies {
         {
             init_parameter(std::size_t num_worker_threads,
                 const core_ratios& cores_per_queue,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 const thread_queue_init_parameters& thread_queue_init,
                 char const* description = "shared_priority_queue_scheduler")
               : num_worker_threads_(num_worker_threads)
@@ -136,7 +136,7 @@ namespace pika { namespace threads { namespace policies {
 
             init_parameter(std::size_t num_worker_threads,
                 const core_ratios& cores_per_queue,
-                detail::affinity_data const& affinity_data,
+                pika::detail::affinity_data const& affinity_data,
                 char const* description)
               : num_worker_threads_(num_worker_threads)
               , cores_per_queue_(cores_per_queue)
@@ -149,7 +149,7 @@ namespace pika { namespace threads { namespace policies {
             std::size_t num_worker_threads_;
             core_ratios cores_per_queue_;
             thread_queue_init_parameters thread_queue_init_;
-            detail::affinity_data const& affinity_data_;
+            pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };
         typedef init_parameter init_parameter_type;
@@ -1398,7 +1398,7 @@ namespace pika { namespace threads { namespace policies {
         // number of numa domains that the threads are occupying
         std::size_t num_domains_;
 
-        detail::affinity_data const& affinity_data_;
+        pika::detail::affinity_data const& affinity_data_;
 
         const thread_queue_init_parameters queue_parameters_;
 

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -121,7 +121,7 @@ namespace pika { namespace threads {
         std::size_t num_threads_;
         std::size_t thread_offset_;
         pika::threads::policies::callback_notifier& notifier_;
-        pika::threads::policies::detail::affinity_data const& affinity_data_;
+        pika::detail::affinity_data const& affinity_data_;
         pika::threads::detail::network_background_callback_type const&
             network_background_callback_;
         std::size_t max_background_threads_;
@@ -133,7 +133,7 @@ namespace pika { namespace threads {
             policies::scheduler_mode mode, std::size_t num_threads,
             std::size_t thread_offset,
             pika::threads::policies::callback_notifier& notifier,
-            pika::threads::policies::detail::affinity_data const& affinity_data,
+            pika::detail::affinity_data const& affinity_data,
             pika::threads::detail::network_background_callback_type const&
                 network_background_callback =
                     pika::threads::detail::network_background_callback_type(),
@@ -543,7 +543,7 @@ namespace pika { namespace threads {
         // global index = thread_offset_ + local index.
         std::size_t thread_offset_;
 
-        policies::detail::affinity_data const& affinity_data_;
+        pika::detail::affinity_data const& affinity_data_;
 
         // scale timestamps to nanoseconds
         double timestamp_scale_;


### PR DESCRIPTION
Move all functionality to detail namespace, replace typedef with using, use compact C++17 namespace declarations. Part of #16.