### PR TITLE
Move `sync_wait` to `pika::this_thread` namespace

### DIFF
--- a/libs/pika/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -343,12 +343,13 @@ void test_for_each_sender(ExPolicy&& p, IteratorTag)
     std::iota(std::begin(c), std::end(c), std::rand());
 
     namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
 
     auto rng = pika::util::make_iterator_range(
         iterator(std::begin(c)), iterator(std::end(c)));
     auto f = [](std::size_t& v) { v = 42; };
     auto result = ex::just(rng, f) |
-        pika::ranges::for_each(std::forward<ExPolicy>(p)) | ex::sync_wait();
+        pika::ranges::for_each(std::forward<ExPolicy>(p)) | tt::sync_wait();
     PIKA_TEST(result == iterator(std::end(c)));
 
     // verify values
@@ -364,6 +365,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception_sender(ExPolicy p, IteratorTag)
 {
     namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -379,7 +381,7 @@ void test_for_each_exception_sender(ExPolicy p, IteratorTag)
     try
     {
         ex::just(rng, f) | pika::ranges::for_each(std::forward<ExPolicy>(p)) |
-            ex::sync_wait();
+            tt::sync_wait();
 
         PIKA_TEST(false);
     }
@@ -400,6 +402,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc_sender(ExPolicy p, IteratorTag)
 {
     namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -415,7 +418,7 @@ void test_for_each_bad_alloc_sender(ExPolicy p, IteratorTag)
     try
     {
         ex::just(rng, f) | pika::ranges::for_each(std::forward<ExPolicy>(p)) |
-            ex::sync_wait();
+            tt::sync_wait();
 
         PIKA_TEST(false);
     }

--- a/libs/pika/async_cuda/tests/performance/synchronize.cu
+++ b/libs/pika/async_cuda/tests/performance/synchronize.cu
@@ -16,8 +16,9 @@ __global__ void dummy() {}
 
 int pika_main(pika::program_options::variables_map& vm)
 {
-    namespace ex = pika::execution::experimental;
     namespace cu = pika::cuda::experimental;
+    namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
 
     std::size_t const iterations = vm["iterations"].as<std::size_t>();
     std::size_t const batch_size = 10;
@@ -89,7 +90,7 @@ int pika_main(pika::program_options::variables_map& vm)
         pika::chrono::high_resolution_timer timer;
         for (std::size_t i = 0; i != iterations; ++i)
         {
-            ex::schedule(sched) | cu::then_with_stream(f) | ex::sync_wait();
+            ex::schedule(sched) | cu::then_with_stream(f) | tt::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout
@@ -115,12 +116,12 @@ int pika_main(pika::program_options::variables_map& vm)
                 cu::then_with_stream(f) | cu::then_with_stream(f) |
                 cu::then_with_stream(f) | cu::then_with_stream(f) |
                 cu::then_with_stream(f) | cu::then_with_stream(f) |
-                cu::then_with_stream(f) | ex::sync_wait();
+                cu::then_with_stream(f) | tt::sync_wait();
         }
         // Do the remainder one-by-one
         for (std::size_t i = 0; i < non_batch_iterations; ++i)
         {
-            ex::schedule(sched) | cu::then_with_stream(f) | ex::sync_wait();
+            ex::schedule(sched) | cu::then_with_stream(f) | tt::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout
@@ -162,12 +163,12 @@ int pika_main(pika::program_options::variables_map& vm)
                 ex::transfer(ex::thread_pool_scheduler{}) | ex::then([] {}) |
                 ex::transfer(sched) | cu::then_with_stream(f) |
                 ex::transfer(ex::thread_pool_scheduler{}) | ex::then([] {}) |
-                ex::transfer(sched) | cu::then_with_stream(f) | ex::sync_wait();
+                ex::transfer(sched) | cu::then_with_stream(f) | tt::sync_wait();
         }
         // Do the remainder one-by-one
         for (std::size_t i = 0; i < non_batch_iterations; ++i)
         {
-            ex::schedule(sched) | cu::then_with_stream(f) | ex::sync_wait();
+            ex::schedule(sched) | cu::then_with_stream(f) | tt::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout
@@ -186,7 +187,7 @@ int pika_main(pika::program_options::variables_map& vm)
         for (std::size_t i = 0; i != iterations; ++i)
         {
             ex::schedule(sched) | cu::then_with_stream(f) |
-                ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+                ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout
@@ -213,13 +214,13 @@ int pika_main(pika::program_options::variables_map& vm)
                 cu::then_with_stream(f) | cu::then_with_stream(f) |
                 cu::then_with_stream(f) | cu::then_with_stream(f) |
                 cu::then_with_stream(f) |
-                ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+                ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         }
         // Do the remainder one-by-one
         for (std::size_t i = 0; i < non_batch_iterations; ++i)
         {
             ex::schedule(sched) | cu::then_with_stream(f) |
-                ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+                ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout

--- a/libs/pika/async_cuda/tests/unit/cuda_bulk.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_bulk.cu
@@ -16,8 +16,9 @@
 
 int hpx_main()
 {
-    namespace ex = pika::execution::experimental;
     namespace cu = pika::cuda::experimental;
+    namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
 
     cu::enable_user_polling poll("default");
     cu::cuda_pool pool{};
@@ -69,7 +70,7 @@ int hpx_main()
         auto s = ex::transfer_just(sched, device_ptr, n) |
             cu::then_with_stream(malloc) | ex::bulk(n, f) |
             cu::then_with_stream(memcpy) | cu::then_with_stream(free);
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
 
         for (element_type i = 0; i < n; ++i)
         {
@@ -98,7 +99,7 @@ int hpx_main()
             cu::then_with_stream(malloc) |
             ex::bulk(pika::util::detail::make_counting_shape(n), f) |
             cu::then_with_stream(memcpy) | cu::then_with_stream(free);
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
 
         for (element_type i = 0; i < n; ++i)
         {

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -206,6 +206,7 @@ int pika_main()
 {
     namespace cu = ::pika::cuda::experimental;
     namespace ex = ::pika::execution::experimental;
+    namespace tt = ::pika::this_thread::experimental;
 
     cu::cuda_pool pool{};
 
@@ -218,7 +219,7 @@ int pika_main()
             cu::then_with_stream(dummy{});
         // NOTE: then_with_stream calls triggers the receiver on a plain
         // std::thread. We explicitly change the context back to an pika::thread.
-        ex::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
+        tt::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(1));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(0));
@@ -232,7 +233,7 @@ int pika_main()
         auto s = ex::just() | ex::transfer(cu::cuda_scheduler(pool)) |
             cu::then_with_stream(dummy{}) | cu::then_with_stream(dummy{}) |
             cu::then_with_stream(dummy{});
-        ex::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
+        tt::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(3));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(0));
@@ -249,7 +250,7 @@ int pika_main()
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{}) |
             ex::transfer(cu::cuda_scheduler(pool)) |
             cu::then_with_stream(dummy{});
-        ex::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
+        tt::sync_wait(ex::transfer(std::move(s), ex::thread_pool_scheduler{}));
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(1));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(2));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(0));
@@ -264,7 +265,7 @@ int pika_main()
             ex::transfer(cu::cuda_scheduler(pool)) |
             cu::then_with_stream(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(2));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(1));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(0));
@@ -278,7 +279,7 @@ int pika_main()
         dummy::reset_counts();
         auto s = ex::just(1) | ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(ex::transfer(
+        PIKA_TEST_EQ(tt::sync_wait(ex::transfer(
                          std::move(s), ex::thread_pool_scheduler{})),
             2.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
@@ -294,7 +295,7 @@ int pika_main()
         auto s = ex::just(1) | ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(dummy{}) | cu::then_with_stream(dummy{}) |
             cu::then_with_stream(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(ex::transfer(
+        PIKA_TEST_EQ(tt::sync_wait(ex::transfer(
                          std::move(s), ex::thread_pool_scheduler{})),
             4.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
@@ -310,7 +311,7 @@ int pika_main()
         auto s = ex::just(custom_type_non_default_constructible{42}) |
             ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(&non_default_constructible_params);
-        PIKA_TEST_EQ(ex::sync_wait(ex::transfer(std::move(s),
+        PIKA_TEST_EQ(tt::sync_wait(ex::transfer(std::move(s),
                                        ex::thread_pool_scheduler{}))
                          .x,
             42);
@@ -321,7 +322,7 @@ int pika_main()
             ex::just(custom_type_non_default_constructible_non_copyable{42}) |
             ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(&non_default_constructible_non_copyable_params);
-        PIKA_TEST_EQ(ex::sync_wait(ex::transfer(std::move(s),
+        PIKA_TEST_EQ(tt::sync_wait(ex::transfer(std::move(s),
                                        ex::thread_pool_scheduler{}))
                          .x,
             42);
@@ -335,7 +336,7 @@ int pika_main()
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{}) |
             ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(ex::transfer(
+        PIKA_TEST_EQ(tt::sync_wait(ex::transfer(
                          std::move(s), ex::thread_pool_scheduler{})),
             4.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
@@ -352,7 +353,7 @@ int pika_main()
             ex::then(dummy{}) | ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 4.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 4.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(2));
@@ -368,7 +369,7 @@ int pika_main()
             ex::then(dummy{}) | ex::transfer(cu::cuda_scheduler{pool}) |
             cu::then_with_stream(dummy{}) | cu::then_with_stream(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 5.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 5.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::host_int_calls.load(), std::size_t(1));
@@ -401,7 +402,7 @@ int pika_main()
             ex::transfer(ex::thread_pool_scheduler{}) |
             ex::then(&cu::check_cuda_error) |
             ex::then([&p_h] { PIKA_TEST_EQ(p_h, 3); }) |
-            ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+            ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
 
         cu::check_cuda_error(cudaFree(p));
     }
@@ -416,7 +417,7 @@ int pika_main()
             cu::then_with_cublas(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             cu::then_with_cusolver(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 6);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 6);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -439,7 +440,7 @@ int pika_main()
             cu::then_with_cublas(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             cu::then_with_cusolver(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 7.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 7.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -465,7 +466,7 @@ int pika_main()
             cu::then_with_any_cuda(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             cu::then_with_any_cuda(dummy{}) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 7.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 7.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -489,7 +490,7 @@ int pika_main()
             cu::then_with_any_cuda(
                 dummy_cublas{cublas_called}, CUBLAS_POINTER_MODE_HOST) |
             cu::then_with_any_cuda(dummy_cusolver{cusolver_called});
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
         PIKA_TEST(stream_called);
         PIKA_TEST(cublas_called);
         PIKA_TEST(cusolver_called);
@@ -502,7 +503,7 @@ int pika_main()
             cu::then_with_stream(dummy{}) |
             cu::then_with_cublas(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 6);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 6);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -524,7 +525,7 @@ int pika_main()
             cu::then_with_stream(dummy{}) | cu::then_on_host(dummy{}) |
             cu::then_with_cublas(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 7.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 7.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -549,7 +550,7 @@ int pika_main()
             cu::then_with_any_cuda(dummy{}) | cu::then_on_host(dummy{}) |
             cu::then_with_any_cuda(dummy{}, CUBLAS_POINTER_MODE_HOST) |
             ex::transfer(ex::thread_pool_scheduler{}) | ex::then(dummy{});
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 7.0);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 7.0);
         PIKA_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         PIKA_TEST_EQ(dummy::cublas_void_calls.load(), std::size_t(0));
@@ -571,7 +572,7 @@ int pika_main()
             cu::then_with_any_cuda(dummy_stream{stream_called}) |
             cu::then_with_any_cuda(
                 dummy_cublas{cublas_called}, CUBLAS_POINTER_MODE_HOST);
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
         PIKA_TEST(stream_called);
         PIKA_TEST(cublas_called);
     }

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -19,6 +19,7 @@
 
 namespace ex = pika::execution::experimental;
 namespace mpi = pika::mpi::experimental;
+namespace tt = pika::this_thread::experimental;
 
 // This overload is only used to check dispatching. It is not a useful
 // implementation.
@@ -56,7 +57,7 @@ int pika_main()
                 }
                 auto s = mpi::transform_mpi(
                     ex::just(&data, count, datatype, 0, comm), MPI_Ibcast);
-                auto result = ex::sync_wait(PIKA_MOVE(s));
+                auto result = tt::sync_wait(PIKA_MOVE(s));
                 if (rank != 0)
                 {
                     PIKA_TEST_EQ(data, 42);
@@ -81,7 +82,7 @@ int pika_main()
                         return MPI_Ibcast(
                             data, count, datatype, i, comm, request);
                     });
-                auto result = ex::sync_wait(PIKA_MOVE(s));
+                auto result = tt::sync_wait(PIKA_MOVE(s));
                 if (rank != 0)
                 {
                     PIKA_TEST_EQ(data, 42);
@@ -105,7 +106,7 @@ int pika_main()
                         MPI_Comm comm, MPI_Request* request) {
                         MPI_Ibcast(data, count, datatype, i, comm, request);
                     });
-                ex::sync_wait(PIKA_MOVE(s));
+                tt::sync_wait(PIKA_MOVE(s));
                 if (rank != 0)
                 {
                     PIKA_TEST_EQ(data, 42);
@@ -121,7 +122,7 @@ int pika_main()
                     c.x = 3;
                 }
                 auto s = mpi::transform_mpi(c);
-                ex::sync_wait(s);
+                tt::sync_wait(s);
                 if (rank == 0)
                 {
                     PIKA_TEST_EQ(c.x, 3);
@@ -138,7 +139,7 @@ int pika_main()
                     data = 42;
                 }
                 auto result = ex::just(&data, count, datatype, 0, comm) |
-                    mpi::transform_mpi(MPI_Ibcast) | ex::sync_wait();
+                    mpi::transform_mpi(MPI_Ibcast) | tt::sync_wait();
                 if (rank != 0)
                 {
                     PIKA_TEST_EQ(data, 42);
@@ -158,7 +159,7 @@ int pika_main()
                     mpi::transform_mpi(
                         error_sender<int*, int, MPI_Datatype, int, MPI_Comm>{},
                         MPI_Ibcast) |
-                        ex::sync_wait();
+                        tt::sync_wait();
                     PIKA_TEST(false);
                 }
                 catch (std::runtime_error const& e)
@@ -182,7 +183,7 @@ int pika_main()
                     });
                 try
                 {
-                    ex::sync_wait(PIKA_MOVE(s));
+                    tt::sync_wait(PIKA_MOVE(s));
                 }
                 catch (std::runtime_error const& e)
                 {
@@ -204,7 +205,7 @@ int pika_main()
                 {
                     mpi::transform_mpi(
                         ex::just(data, count, datatype, -1, comm), MPI_Ibcast) |
-                        ex::sync_wait();
+                        tt::sync_wait();
                     PIKA_TEST(false);
                 }
                 catch (std::runtime_error const& e)
@@ -229,7 +230,7 @@ int pika_main()
                 {
                     mpi::transform_mpi(
                         ex::just(data, count, datatype, -1, comm), MPI_Ibcast) |
-                        ex::sync_wait();
+                        tt::sync_wait();
                     PIKA_TEST(false);
                 }
                 catch (std::runtime_error const&)

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
+namespace pika::this_thread::experimental {
     namespace detail {
         struct sync_wait_error_visitor
         {
@@ -58,8 +58,9 @@ namespace pika { namespace execution { namespace experimental {
             // The type of the single void or non-void result that we store. If
             // there are multiple variants or multiple values sync_wait will
             // fail to compile.
-            using result_type = std::decay_t<single_result_t<
-                predecessor_value_types<pika::util::pack, pika::util::pack>>>;
+            using result_type = std::decay_t<pika::execution::experimental::
+                    detail::single_result_t<predecessor_value_types<
+                        pika::util::pack, pika::util::pack>>>;
 
             // Constant to indicate if the type of the result from the
             // predecessor sender is void or not
@@ -142,15 +143,16 @@ namespace pika { namespace execution { namespace experimental {
             }
 
             template <typename Error>
-            friend void tag_invoke(
-                set_error_t, sync_wait_receiver&& r, Error&& error) noexcept
+            friend void tag_invoke(pika::execution::experimental::set_error_t,
+                sync_wait_receiver&& r, Error&& error) noexcept
             {
                 r.state.value.template emplace<error_type>(
                     PIKA_FORWARD(Error, error));
                 r.signal_set_called();
             }
 
-            friend void tag_invoke(set_done_t, sync_wait_receiver&& r) noexcept
+            friend void tag_invoke(pika::execution::experimental::set_done_t,
+                sync_wait_receiver&& r) noexcept
             {
                 r.signal_set_called();
             }
@@ -159,8 +161,8 @@ namespace pika { namespace execution { namespace experimental {
                 typename =
                     std::enable_if_t<(is_void_result && sizeof...(Us) == 0) ||
                         (!is_void_result && sizeof...(Us) == 1)>>
-            friend void tag_invoke(
-                set_value_t, sync_wait_receiver&& r, Us&&... us) noexcept
+            friend void tag_invoke(pika::execution::experimental::set_value_t,
+                sync_wait_receiver&& r, Us&&... us) noexcept
             {
                 r.state.value.template emplace<value_type>(
                     PIKA_FORWARD(Us, us)...);
@@ -176,7 +178,7 @@ namespace pika { namespace execution { namespace experimental {
         // clang-format off
         template <typename Sender,
             PIKA_CONCEPT_REQUIRES_(
-                is_sender_v<Sender>
+                pika::execution::experimental::is_sender_v<Sender>
             )>
         // clang-format on
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
@@ -196,7 +198,8 @@ namespace pika { namespace execution { namespace experimental {
 
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(sync_wait_t)
         {
-            return detail::partial_algorithm<sync_wait_t>{};
+            return pika::execution::experimental::detail::partial_algorithm<
+                sync_wait_t>{};
         }
     } sync_wait{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::this_thread::experimental

--- a/libs/pika/execution/tests/unit/algorithm_split.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_split.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
 
 // This overload is only used to check dispatching. It is not a useful
 // implementation.
@@ -158,7 +159,7 @@ int main()
         // This is not required by the ADL test, but required by split. The
         // shared state destructor of the sender returned by split asserts that
         // the sender has been connected and started before being released.
-        ex::sync_wait(std::move(s));
+        tt::sync_wait(std::move(s));
     }
 
     return pika::util::report_errors();

--- a/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
@@ -18,10 +18,11 @@
 #include <utility>
 
 namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
 
 // NOTE: This is not a conforming sync_wait implementation. It only exists to
 // check that the tag_invoke overload is called.
-void tag_invoke(ex::sync_wait_t, custom_sender2 s)
+void tag_invoke(tt::sync_wait_t, custom_sender2 s)
 {
     s.tag_invoke_overload_called = true;
 }
@@ -33,7 +34,7 @@ int pika_main()
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        ex::sync_wait(custom_sender{
+        tt::sync_wait(custom_sender{
             start_called, connect_called, tag_invoke_overload_called});
         PIKA_TEST(start_called);
         PIKA_TEST(connect_called);
@@ -41,19 +42,19 @@ int pika_main()
     }
 
     {
-        PIKA_TEST_EQ(ex::sync_wait(ex::just(3)), 3);
+        PIKA_TEST_EQ(tt::sync_wait(ex::just(3)), 3);
     }
 
     {
         PIKA_TEST_EQ(
-            ex::sync_wait(ex::just(custom_type_non_default_constructible{42}))
+            tt::sync_wait(ex::just(custom_type_non_default_constructible{42}))
                 .x,
             42);
     }
 
     {
         PIKA_TEST_EQ(
-            ex::sync_wait(
+            tt::sync_wait(
                 ex::just(
                     custom_type_non_default_constructible_non_copyable{42}))
                 .x,
@@ -67,14 +68,14 @@ int pika_main()
         std::atomic<bool> tag_invoke_overload_called{false};
         custom_sender{
             start_called, connect_called, tag_invoke_overload_called} |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST(start_called);
         PIKA_TEST(connect_called);
         PIKA_TEST(!tag_invoke_overload_called);
     }
 
     {
-        PIKA_TEST_EQ(ex::just(3) | ex::sync_wait(), 3);
+        PIKA_TEST_EQ(ex::just(3) | tt::sync_wait(), 3);
     }
 
     // tag_invoke overload
@@ -82,7 +83,7 @@ int pika_main()
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        ex::sync_wait(custom_sender2{custom_sender{
+        tt::sync_wait(custom_sender2{custom_sender{
             start_called, connect_called, tag_invoke_overload_called}});
         PIKA_TEST(!start_called);
         PIKA_TEST(!connect_called);
@@ -94,7 +95,7 @@ int pika_main()
         bool exception_thrown = false;
         try
         {
-            ex::sync_wait(error_sender{});
+            tt::sync_wait(error_sender{});
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
 
 struct custom_type_non_copyable
 {
@@ -575,7 +576,7 @@ struct wait_globals
 {
     ~wait_globals()
     {
-        ex::sync_wait(std::move(global_any_sender));
+        tt::sync_wait(std::move(global_any_sender));
     }
 } waiter{};
 

--- a/libs/pika/executors/include/pika/executors/scheduler_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/scheduler_executor.hpp
@@ -216,9 +216,10 @@ namespace pika { namespace execution { namespace experimental {
         template <typename F, typename... Ts>
         decltype(auto) sync_execute(F&& f, Ts&&... ts)
         {
-            return sync_wait(then(schedule(sched_),
-                pika::util::deferred_call(
-                    PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...)));
+            return pika::this_thread::experimental::sync_wait(
+                then(schedule(sched_),
+                    pika::util::deferred_call(
+                        PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...)));
         }
 
         // TwoWayExecutor interface
@@ -304,9 +305,10 @@ namespace pika { namespace execution { namespace experimental {
         template <typename F, typename S, typename... Ts>
         void bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            sync_wait(bulk(schedule(sched_), shape,
-                pika::util::bind_back(
-                    PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...)));
+            pika::this_thread::experimental::sync_wait(
+                bulk(schedule(sched_), shape,
+                    pika::util::bind_back(
+                        PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...)));
         }
 
         template <typename F, typename S, typename Future, typename... Ts>

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -42,6 +42,7 @@ struct custom_type_non_default_constructible_non_copyable
 };
 
 namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_execute()
@@ -157,7 +158,7 @@ void test_sender_receiver_then_wait()
         ++then_count;
         executed = true;
     });
-    ex::sync_wait(std::move(work2));
+    tt::sync_wait(std::move(work2));
 
     PIKA_TEST_EQ(then_count, std::size_t(2));
     PIKA_TEST(executed);
@@ -176,7 +177,7 @@ void test_sender_receiver_then_sync_wait()
         ++then_count;
         return 42;
     });
-    auto result = ex::sync_wait(std::move(work));
+    auto result = tt::sync_wait(std::move(work));
     PIKA_TEST_EQ(then_count, std::size_t(1));
     static_assert(
         std::is_same<int, typename std::decay<decltype(result)>::type>::value,
@@ -210,7 +211,7 @@ void test_sender_receiver_then_arguments()
         ++then_count;
         return 2 * s.size();
     });
-    auto result = ex::sync_wait(std::move(work3));
+    auto result = tt::sync_wait(std::move(work3));
     PIKA_TEST_EQ(then_count, std::size_t(3));
     static_assert(std::is_same<std::size_t,
                       typename std::decay<decltype(result)>::type>::value,
@@ -387,7 +388,7 @@ void test_transfer_basic()
         PIKA_TEST_NEQ(current_id, parent_id);
     });
 
-    ex::sync_wait(work5);
+    tt::sync_wait(work5);
 }
 
 void test_transfer_arguments()
@@ -427,7 +428,7 @@ void test_transfer_arguments()
         return s + "!";
     });
 
-    auto result = ex::sync_wait(work5);
+    auto result = tt::sync_wait(work5);
     static_assert(std::is_same<std::string,
                       typename std::decay<decltype(result)>::type>::value,
         "result should be a std::string");
@@ -443,7 +444,7 @@ void test_just_void()
         auto work1 = ex::then(begin, [parent_id]() {
             PIKA_TEST_EQ(parent_id, pika::this_thread::get_id());
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 
     {
@@ -454,7 +455,7 @@ void test_just_void()
         auto work1 = ex::then(transfer1, [parent_id]() {
             PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 }
 
@@ -468,7 +469,7 @@ void test_just_one_arg()
             PIKA_TEST_EQ(parent_id, pika::this_thread::get_id());
             PIKA_TEST_EQ(x, 3);
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 
     {
@@ -480,7 +481,7 @@ void test_just_one_arg()
             PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
             PIKA_TEST_EQ(x, 3);
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 }
 
@@ -495,7 +496,7 @@ void test_just_two_args()
             PIKA_TEST_EQ(x, 3);
             PIKA_TEST_EQ(y, std::string("hello"));
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 
     {
@@ -508,7 +509,7 @@ void test_just_two_args()
             PIKA_TEST_EQ(x, 3);
             PIKA_TEST_EQ(y, std::string("hello"));
         });
-        ex::sync_wait(work1);
+        tt::sync_wait(work1);
     }
 }
 
@@ -520,7 +521,7 @@ void test_transfer_just_void()
     auto work1 = ex::then(begin, [parent_id]() {
         PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
     });
-    ex::sync_wait(work1);
+    tt::sync_wait(work1);
 }
 
 void test_transfer_just_one_arg()
@@ -532,7 +533,7 @@ void test_transfer_just_one_arg()
         PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
         PIKA_TEST_EQ(x, 3);
     });
-    ex::sync_wait(work1);
+    tt::sync_wait(work1);
 }
 
 void test_transfer_just_two_args()
@@ -546,7 +547,7 @@ void test_transfer_just_two_args()
         PIKA_TEST_EQ(x, 3);
         PIKA_TEST_EQ(y, std::string("hello"));
     });
-    ex::sync_wait(work1);
+    tt::sync_wait(work1);
 }
 
 void test_when_all()
@@ -583,7 +584,7 @@ void test_when_all()
                 PIKA_TEST_EQ(z, 3.14);
                 executed = true;
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST(executed);
     }
 
@@ -610,7 +611,7 @@ void test_when_all()
         {
             ex::when_all(std::move(work1), std::move(work2)) |
                 ex::then([](int, std::string) { PIKA_TEST(false); }) |
-                ex::sync_wait();
+                tt::sync_wait();
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)
@@ -645,7 +646,7 @@ void test_when_all()
         {
             ex::when_all(std::move(work1), std::move(work2)) |
                 ex::then([](int, std::string) { PIKA_TEST(false); }) |
-                ex::sync_wait();
+                tt::sync_wait();
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)
@@ -694,7 +695,7 @@ void test_when_all_vector()
                 PIKA_TEST_EQ(v[2], 3.14);
                 executed = true;
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST(executed);
     }
 
@@ -723,7 +724,7 @@ void test_when_all_vector()
         {
             ex::when_all_vector(std::move(senders)) |
                 ex::then([](std::vector<int>) { PIKA_TEST(false); }) |
-                ex::sync_wait();
+                tt::sync_wait();
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)
@@ -760,7 +761,7 @@ void test_when_all_vector()
         {
             ex::when_all_vector(std::move(senders)) |
                 ex::then([](std::vector<int>) { PIKA_TEST(false); }) |
-                ex::sync_wait();
+                tt::sync_wait();
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)
@@ -783,10 +784,10 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(f)>>,
             "a future should be a sender");
         static_assert(
-            std::is_void<decltype(ex::sync_wait(std::move(f)))>::value,
+            std::is_void<decltype(tt::sync_wait(std::move(f)))>::value,
             "sync_wait should return void");
 
-        ex::sync_wait(std::move(f));
+        tt::sync_wait(std::move(f));
         PIKA_TEST(called);
 
         bool exception_thrown = false;
@@ -794,7 +795,7 @@ void test_future_sender()
         {
             // The move is intentional. sync_wait should throw.
             // NOLINTNEXTLINE(bugprone-use-after-move)
-            ex::sync_wait(std::move(f));
+            tt::sync_wait(std::move(f));
             PIKA_TEST(false);
         }
         catch (...)
@@ -814,7 +815,7 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(f)>>,
             "a future should be a sender");
 
-        PIKA_TEST_EQ(ex::sync_wait(std::move(f)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(f)), 42);
         PIKA_TEST(called);
 
         bool exception_thrown = false;
@@ -822,7 +823,7 @@ void test_future_sender()
         {
             // The move is intentional. sync_wait should throw.
             // NOLINTNEXTLINE(bugprone-use-after-move)
-            ex::sync_wait(std::move(f));
+            tt::sync_wait(std::move(f));
             PIKA_TEST(false);
         }
         catch (...)
@@ -840,7 +841,7 @@ void test_future_sender()
         });
 
         PIKA_TEST_EQ(
-            ex::sync_wait(ex::then(std::move(f), [](int x) { return x / 2; })),
+            tt::sync_wait(ex::then(std::move(f), [](int x) { return x / 2; })),
             21);
         PIKA_TEST(called);
     }
@@ -852,18 +853,18 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(sf)>>,
             "a shared_future should be a sender");
         static_assert(
-            std::is_void<decltype(ex::sync_wait(std::move(sf)))>::value,
+            std::is_void<decltype(tt::sync_wait(std::move(sf)))>::value,
             "sync_wait should return void");
 
-        ex::sync_wait(sf);
-        ex::sync_wait(sf);
-        ex::sync_wait(std::move(sf));
+        tt::sync_wait(sf);
+        tt::sync_wait(sf);
+        tt::sync_wait(std::move(sf));
         PIKA_TEST_EQ(calls, std::size_t(1));
 
         bool exception_thrown = false;
         try
         {
-            ex::sync_wait(sf);
+            tt::sync_wait(sf);
             PIKA_TEST(false);
         }
         catch (...)
@@ -883,15 +884,15 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(sf)>>,
             "a shared_future should be a sender");
 
-        PIKA_TEST_EQ(ex::sync_wait(sf), 42);
-        PIKA_TEST_EQ(ex::sync_wait(sf), 42);
-        PIKA_TEST_EQ(ex::sync_wait(std::move(sf)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(sf), 42);
+        PIKA_TEST_EQ(tt::sync_wait(sf), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(sf)), 42);
         PIKA_TEST_EQ(calls, std::size_t(1));
 
         bool exception_thrown = false;
         try
         {
-            ex::sync_wait(sf);
+            tt::sync_wait(sf);
             PIKA_TEST(false);
         }
         catch (...)
@@ -948,7 +949,7 @@ void test_future_sender()
 
     // mixing senders and futures
     {
-        PIKA_TEST_EQ(ex::sync_wait(ex::make_future(
+        PIKA_TEST_EQ(tt::sync_wait(ex::make_future(
                          ex::transfer_just(ex::thread_pool_scheduler{}, 42))),
             42);
     }
@@ -989,27 +990,27 @@ void test_ensure_started()
     ex::thread_pool_scheduler sched{};
 
     {
-        ex::schedule(sched) | ex::ensure_started() | ex::sync_wait();
+        ex::schedule(sched) | ex::ensure_started() | tt::sync_wait();
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::ensure_started();
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::ensure_started() |
             ex::transfer(sched);
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
     {
         auto s =
             ex::transfer_just(sched, 42) | ex::ensure_started() | ex::split();
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 }
 
@@ -1044,7 +1045,7 @@ void test_ensure_started_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             3);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1079,7 +1080,7 @@ void test_ensure_started_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             9);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1113,7 +1114,7 @@ void test_ensure_started_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             9);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1125,26 +1126,26 @@ void test_split()
     ex::thread_pool_scheduler sched{};
 
     {
-        ex::schedule(sched) | ex::split() | ex::sync_wait();
+        ex::schedule(sched) | ex::split() | tt::sync_wait();
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::split();
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
     {
         auto s =
             ex::transfer_just(sched, 42) | ex::split() | ex::transfer(sched);
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::split();
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(s), 42);
-        PIKA_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(s), 42);
+        PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 }
 
@@ -1167,7 +1168,7 @@ void test_split_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             3);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1190,7 +1191,7 @@ void test_split_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             9);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1213,7 +1214,7 @@ void test_split_when_all()
         });
         PIKA_TEST_EQ(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             9);
         PIKA_TEST_EQ(first_task_calls, std::size_t(1));
         PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1227,42 +1228,42 @@ void test_let_value()
     // void predecessor
     {
         auto result = ex::schedule(sched) |
-            ex::let_value([]() { return ex::just(42); }) | ex::sync_wait();
+            ex::let_value([]() { return ex::just(42); }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
     {
         auto result = ex::schedule(sched) |
             ex::let_value([=]() { return ex::transfer_just(sched, 42); }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
     {
         auto result = ex::just() |
             ex::let_value([=]() { return ex::transfer_just(sched, 42); }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
     // int predecessor, value ignored
     {
         auto result = ex::transfer_just(sched, 43) |
-            ex::let_value([](int&) { return ex::just(42); }) | ex::sync_wait();
+            ex::let_value([](int&) { return ex::just(42); }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
     {
         auto result = ex::transfer_just(sched, 43) |
             ex::let_value([=](int&) { return ex::transfer_just(sched, 42); }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
     {
         auto result = ex::just(43) |
             ex::let_value([=](int&) { return ex::transfer_just(sched, 42); }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1270,7 +1271,7 @@ void test_let_value()
     {
         auto result = ex::transfer_just(sched, 43) | ex::let_value([](int& x) {
             return ex::just(42) | ex::then([&](int y) { return x + y; });
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 85);
     }
 
@@ -1278,7 +1279,7 @@ void test_let_value()
         auto result = ex::transfer_just(sched, 43) | ex::let_value([=](int& x) {
             return ex::transfer_just(sched, 42) |
                 ex::then([&](int y) { return x + y; });
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 85);
     }
 
@@ -1286,7 +1287,7 @@ void test_let_value()
         auto result = ex::just(43) | ex::let_value([=](int& x) {
             return ex::transfer_just(sched, 42) |
                 ex::then([&](int y) { return x + y; });
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 85);
     }
 
@@ -1302,7 +1303,7 @@ void test_let_value()
             }) | ex::let_value([](int&) {
                 PIKA_TEST(false);
                 return ex::just(0);
-            }) | ex::sync_wait();
+            }) | tt::sync_wait();
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)
@@ -1344,7 +1345,7 @@ void test_let_error()
             called = true;
             check_exception_ptr_message(ep, "error");
             return ex::just();
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST(called);
     }
 
@@ -1356,7 +1357,7 @@ void test_let_error()
             called = true;
             check_exception_ptr_message(ep, "error");
             return ex::transfer_just(sched);
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST(called);
     }
 
@@ -1368,7 +1369,7 @@ void test_let_error()
                 check_exception_ptr_message(ep, "error");
                 return ex::transfer_just(sched);
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST(called);
     }
 
@@ -1380,7 +1381,7 @@ void test_let_error()
         }) | ex::let_error([](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::just(42);
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1391,7 +1392,7 @@ void test_let_error()
         }) | ex::let_error([=](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::transfer_just(sched, 42);
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1402,7 +1403,7 @@ void test_let_error()
         }) | ex::let_error([=](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::transfer_just(sched, 42);
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1413,7 +1414,7 @@ void test_let_error()
                 PIKA_TEST(false);
                 return ex::just(43);
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1423,7 +1424,7 @@ void test_let_error()
                 PIKA_TEST(false);
                 return ex::transfer_just(sched, 43);
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 
@@ -1431,7 +1432,7 @@ void test_let_error()
         auto result = ex::just(42) | ex::let_error([=](std::exception_ptr) {
             PIKA_TEST(false);
             return ex::transfer_just(sched, 43);
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
         PIKA_TEST_EQ(result, 42);
     }
 }
@@ -1485,7 +1486,7 @@ void test_keep_future_sender()
     {
         pika::make_ready_future<void>() | ex::keep_future() |
             ex::then([](pika::future<void>&& f) { PIKA_TEST(f.is_ready()); }) |
-            ex::sync_wait();
+            tt::sync_wait();
     }
 
     {
@@ -1493,7 +1494,7 @@ void test_keep_future_sender()
             ex::then([](pika::shared_future<void>&& f) {
                 PIKA_TEST(f.is_ready());
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
     }
 
     {
@@ -1502,7 +1503,7 @@ void test_keep_future_sender()
                 PIKA_TEST(f.is_ready());
                 PIKA_TEST_EQ(f.get(), 42);
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
     }
 
     {
@@ -1511,14 +1512,14 @@ void test_keep_future_sender()
                 PIKA_TEST(f.is_ready());
                 PIKA_TEST_EQ(f.get(), 42);
             }) |
-            ex::sync_wait();
+            tt::sync_wait();
     }
 
     {
         std::atomic<bool> called{false};
         auto f = pika::async([&]() { called = true; });
 
-        auto r = ex::sync_wait(std::move(f) | ex::keep_future());
+        auto r = tt::sync_wait(std::move(f) | ex::keep_future());
         static_assert(
             std::is_same<std::decay_t<decltype(r)>, pika::future<void>>::value,
             "sync_wait should return future<void>");
@@ -1531,7 +1532,7 @@ void test_keep_future_sender()
         {
             // The move is intentional. sync_wait should throw.
             // NOLINTNEXTLINE(bugprone-use-after-move)
-            ex::sync_wait(std::move(f) | ex::keep_future());
+            tt::sync_wait(std::move(f) | ex::keep_future());
             PIKA_TEST(false);
         }
         catch (...)
@@ -1548,7 +1549,7 @@ void test_keep_future_sender()
             return 42;
         });
 
-        auto r = ex::sync_wait(std::move(f) | ex::keep_future());
+        auto r = tt::sync_wait(std::move(f) | ex::keep_future());
         static_assert(
             std::is_same<std::decay_t<decltype(r)>, pika::future<int>>::value,
             "sync_wait should return future<int>");
@@ -1562,7 +1563,7 @@ void test_keep_future_sender()
         {
             // The move is intentional. sync_wait should throw.
             // NOLINTNEXTLINE(bugprone-use-after-move)
-            ex::sync_wait(std::move(f) | ex::keep_future());
+            tt::sync_wait(std::move(f) | ex::keep_future());
             PIKA_TEST(false);
         }
         catch (...)
@@ -1579,7 +1580,7 @@ void test_keep_future_sender()
             return 42;
         });
 
-        PIKA_TEST_EQ(ex::sync_wait(ex::then(std::move(f) | ex::keep_future(),
+        PIKA_TEST_EQ(tt::sync_wait(ex::then(std::move(f) | ex::keep_future(),
                          [](pika::future<int>&& f) { return f.get() / 2; })),
             21);
         PIKA_TEST(called);
@@ -1589,15 +1590,15 @@ void test_keep_future_sender()
         std::atomic<std::size_t> calls{0};
         auto sf = pika::async([&]() { ++calls; }).share();
 
-        ex::sync_wait(sf | ex::keep_future());
-        ex::sync_wait(sf | ex::keep_future());
-        ex::sync_wait(std::move(sf) | ex::keep_future());
+        tt::sync_wait(sf | ex::keep_future());
+        tt::sync_wait(sf | ex::keep_future());
+        tt::sync_wait(std::move(sf) | ex::keep_future());
         PIKA_TEST_EQ(calls, std::size_t(1));
 
         bool exception_thrown = false;
         try
         {
-            ex::sync_wait(sf | ex::keep_future());
+            tt::sync_wait(sf | ex::keep_future());
             PIKA_TEST(false);
         }
         catch (...)
@@ -1614,16 +1615,16 @@ void test_keep_future_sender()
             return 42;
         }).share();
 
-        PIKA_TEST_EQ(ex::sync_wait(sf | ex::keep_future()).get(), 42);
-        PIKA_TEST_EQ(ex::sync_wait(sf | ex::keep_future()).get(), 42);
+        PIKA_TEST_EQ(tt::sync_wait(sf | ex::keep_future()).get(), 42);
+        PIKA_TEST_EQ(tt::sync_wait(sf | ex::keep_future()).get(), 42);
         PIKA_TEST_EQ(
-            ex::sync_wait(std::move(sf) | ex::keep_future()).get(), 42);
+            tt::sync_wait(std::move(sf) | ex::keep_future()).get(), 42);
         PIKA_TEST_EQ(calls, std::size_t(1));
 
         bool exception_thrown = false;
         try
         {
-            ex::sync_wait(sf | ex::keep_future());
+            tt::sync_wait(sf | ex::keep_future());
             PIKA_TEST(false);
         }
         catch (...)
@@ -1638,7 +1639,7 @@ void test_keep_future_sender()
         auto f = pika::async([&]() { return 42; });
 
         auto r = std::move(f) | ex::keep_future() |
-            ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+            ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         PIKA_TEST(r.is_ready());
         PIKA_TEST_EQ(r.get(), 42);
     }
@@ -1647,7 +1648,7 @@ void test_keep_future_sender()
         auto sf = pika::async([&]() { return 42; }).share();
 
         auto r = std::move(sf) | ex::keep_future() |
-            ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+            ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         PIKA_TEST(r.is_ready());
         PIKA_TEST_EQ(r.get(), 42);
     }
@@ -1663,7 +1664,7 @@ void test_keep_future_sender()
         // noncopyable, and storing a reference is not acceptable since the
         // reference may outlive the value.
         auto r = std::move(sf) | ex::keep_future() |
-            ex::transfer(ex::thread_pool_scheduler{}) | ex::sync_wait();
+            ex::transfer(ex::thread_pool_scheduler{}) | tt::sync_wait();
         PIKA_TEST(r.is_ready());
         PIKA_TEST_EQ(r.get().x, 42);
     }
@@ -1677,7 +1678,7 @@ void test_keep_future_sender()
             [](int&& x, double const& y) { return x * 2 + (int(y) / 2); });
         PIKA_TEST_EQ(ex::when_all(std::move(f) | ex::keep_future(),
                          sf | ex::keep_future()) |
-                ex::then(fun) | ex::sync_wait(),
+                ex::then(fun) | tt::sync_wait(),
             85);
     }
 
@@ -1690,7 +1691,7 @@ void test_keep_future_sender()
         PIKA_TEST_EQ(ex::when_all(std::move(f) | ex::keep_future(),
                          sf | ex::keep_future()) |
                 ex::transfer(ex::thread_pool_scheduler{}) | ex::then(fun) |
-                ex::sync_wait(),
+                tt::sync_wait(),
             85);
     }
 }
@@ -1707,7 +1708,7 @@ void test_bulk()
         ex::schedule(ex::thread_pool_scheduler{}) | ex::bulk(n, [&](int i) {
             ++v[i];
             PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
-        }) | ex::sync_wait();
+        }) | tt::sync_wait();
 
         for (int i = 0; i < n; ++i)
         {
@@ -1727,7 +1728,7 @@ void test_bulk()
                     v[i] = i;
                     PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
                 }) |
-            ex::sync_wait();
+            tt::sync_wait();
 
         for (int i = 0; i < n; ++i)
         {
@@ -1748,7 +1749,7 @@ void test_bulk()
                     std::lock_guard lk(mtx);
                     string_map.insert(s);
                 }) |
-            ex::sync_wait();
+            tt::sync_wait();
 
         for (auto const& s : v_ref)
         {
@@ -1774,7 +1775,7 @@ void test_bulk()
                         }
                         v[i] = i;
                     }) |
-                ex::sync_wait();
+                tt::sync_wait();
 
             if (expect_exception)
             {

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -19,11 +19,11 @@
 #include <vector>
 
 using pika::execution::experimental::execute;
-using pika::execution::experimental::sync_wait;
 using pika::execution::experimental::then;
 using pika::execution::experimental::thread_pool_scheduler;
 using pika::execution::experimental::transfer;
 using pika::experimental::async_rw_mutex;
+using pika::this_thread::experimental::sync_wait;
 
 unsigned int seed = std::random_device{}();
 

--- a/libs/pika/threading_base/tests/unit/annotation_check.cpp
+++ b/libs/pika/threading_base/tests/unit/annotation_check.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
 
 //
 // This test generates a set of tasks with certain names, then checks
@@ -214,7 +215,7 @@ pika::future<void> test_execution(Execution& exec)
 
 int pika_main()
 {
-    ex::sync_wait(test_senders());
+    tt::sync_wait(test_senders());
 
     // setup executors
     pika::execution::parallel_executor par_exec{};


### PR DESCRIPTION
P2300 defines `sync_wait` in `std::this_thread`. This moves our `sync_wait` to `pika::this_thread` to be analogous to the proposed one.