### PR TITLE
Store values sent from predecessor to `then_with_stream` in operation state

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
@@ -129,10 +129,10 @@ namespace pika::cuda::experimental {
             }
 
             template <typename T>
-            T operator()(T&& t, cudaStream_t stream) const
+            std::decay_t<T> operator()(T&& t, cudaStream_t stream) const
             {
                 launch_bulk_function(f, shape, t, stream);
-                return t;
+                return PIKA_MOVE(t);
             }
         };
     }    // namespace detail


### PR DESCRIPTION
Fixes #138 together with #156. The changes here are very similar to in #156, i.e. instead of storing the callable, the successor receiver, the scheduler, and the values sent from the predecessor in the `then_with_cuda_stream_receiver` they are now stored in the operation state. This simplifies the handling of the callback as we can just capture a reference to the operation state in the event callback.