### PR TITLE
Format all C++ files and enforce it in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,11 +126,16 @@ jobs:
       - attach_workspace:
           at: /pika
       - run:
-          name: Check that the modules are well clang-formatted
+          name: Check that C++ files are well clang-formatted
           command: |
-              cd /pika/source/libs && shopt -s globstar # to activate the ** globbing
+              cd /pika/source
+              # activate the ** globbing
+              shopt -s globstar
+              # ignore globs that have no matches (e.g. no cu.in files exist
+              # currently)
+              shopt -s nullglob
               clang-format-11 --version
-              clang-format-11 -i **/*.{cpp,hpp}
+              clang-format-11 -i **/*.{cpp,hpp,cu}{,.in}
               git diff --exit-code > /tmp/modified_clang_format_files.txt
       - store_artifacts:
           path: /tmp/modified_clang_format_files.txt

--- a/cmake/templates/config_defines_strings.hpp.in
+++ b/cmake/templates/config_defines_strings.hpp.in
@@ -9,11 +9,10 @@
 #pragma once
 
 namespace pika {
-
+    // clang-format off
     char const* const config_strings[] =
     {@pika_config_information@
         nullptr
     };
-}
-
-
+    // clang-format on
+}    // namespace pika

--- a/cmake/templates/global_module_header.hpp.in
+++ b/cmake/templates/global_module_header.hpp.in
@@ -10,4 +10,6 @@
 
 #include <pika/config.hpp>
 
+// clang-format off
 @module_headers@
+    // clang-format on

--- a/cmake/templates/modules_enabled.hpp.in
+++ b/cmake/templates/modules_enabled.hpp.in
@@ -8,4 +8,6 @@
 
 #pragma once
 
+// clang-format off
 @MODULE_ENABLED_MODULE_DEFINES@
+    // clang-format on

--- a/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
@@ -18,12 +18,13 @@ inline constexpr bool is_cuda_scheduler_v =
     std::is_same_v<std::decay_t<Scheduler>, cu::cuda_scheduler>;
 
 #define CHECK_CUDA_COMPLETION_SCHEDULER(...)                                   \
-    static_assert(is_cuda_scheduler_v<                                         \
-        decltype(ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
+    static_assert(is_cuda_scheduler_v<decltype(                                \
+            ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
 
 #define CHECK_NOT_CUDA_COMPLETION_SCHEDULER(...)                               \
-    static_assert(!is_cuda_scheduler_v<decltype(ex::get_completion_scheduler<  \
-                      ex::set_value_t>(__VA_ARGS__))>)
+    static_assert(                                                             \
+        !is_cuda_scheduler_v<decltype(                                         \
+            ex::get_completion_scheduler<ex::set_value_t>(__VA_ARGS__))>)
 
 int main()
 {

--- a/libs/pika/async_cuda/tests/unit/cuda_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_stream.cu
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/testing.hpp>
 #include <pika/cuda.hpp>
+#include <pika/testing.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/pika/async_cuda/tests/unit/saxpy.cu
+++ b/libs/pika/async_cuda/tests/unit/saxpy.cu
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <pika/future.hpp>
 #include <pika/cuda.hpp>
+#include <pika/future.hpp>
 
 #include <cstddef>
 

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -321,7 +321,8 @@ int pika_main()
         auto s =
             ex::just(custom_type_non_default_constructible_non_copyable{42}) |
             ex::transfer(cu::cuda_scheduler{pool}) |
-            cu::then_with_stream(&non_default_constructible_non_copyable_params);
+            cu::then_with_stream(
+                &non_default_constructible_non_copyable_params);
         PIKA_TEST_EQ(tt::sync_wait(ex::transfer(std::move(s),
                                        ex::thread_pool_scheduler{}))
                          .x,

--- a/libs/pika/config/cmake/templates/config_defines.hpp.in
+++ b/libs/pika/config/cmake/templates/config_defines.hpp.in
@@ -8,10 +8,10 @@
 
 #pragma once
 
+// clang-format off
 @pika_config_defines@
-#if defined(PIKA_HAVE_MAX_CPU_COUNT) && (PIKA_HAVE_MAX_CPU_COUNT > 64) &&       \
+// clang-format on
+#if defined(PIKA_HAVE_MAX_CPU_COUNT) && (PIKA_HAVE_MAX_CPU_COUNT > 64) &&      \
     !defined(PIKA_HAVE_MORE_THAN_64_THREADS)
 #define PIKA_HAVE_MORE_THAN_64_THREADS
 #endif
-
-

--- a/libs/pika/config/cmake/templates/config_version.hpp.in
+++ b/libs/pika/config/cmake/templates/config_version.hpp.in
@@ -18,27 +18,31 @@
 
 #include <boost/version.hpp>
 
+// clang-format off
 /// Evaluates to the major version of pika
 #define PIKA_VERSION_MAJOR @PIKA_VERSION_MAJOR@
 /// Evaluates to the minor version of pika
 #define PIKA_VERSION_MINOR @PIKA_VERSION_MINOR@
 /// Evaluates to the patch version of pika
 #define PIKA_VERSION_PATCH @PIKA_VERSION_PATCH@
+// clang-format on
 
 /// Evaluates to the pika version:
 /// ``PIKA_VERSION_FULL & 0xFF0000 == PIKA_VERSION_MAJOR``
 /// ``PIKA_VERSION_FULL & 0x00FF00 == PIKA_VERSION_MINOR``
 /// ``PIKA_VERSION_FULL & 0x0000FF == PIKA_VERSION_PATCH``
-#define PIKA_VERSION_FULL                                                 \
-    ((PIKA_VERSION_MAJOR << 16) | (PIKA_VERSION_MINOR << 8) |        \
+#define PIKA_VERSION_FULL                                                      \
+    ((PIKA_VERSION_MAJOR << 16) | (PIKA_VERSION_MINOR << 8) |                  \
         PIKA_VERSION_PATCH)
 
+// clang-format off
 /// Evaluates to the release date of this pika version in the format YYYYMMDD.
 #define PIKA_VERSION_DATE @PIKA_VERSION_DATE@
 
 /// Evaluates to the version tag (empty for releases, ``-trunk`` on the
 /// development branch, ``-rcX`` on a release candidate.
 #define PIKA_VERSION_TAG "@PIKA_VERSION_TAG@"
+// clang-format on
 
 #if !defined(PIKA_HAVE_GIT_COMMIT)
 #define PIKA_HAVE_GIT_COMMIT "unknown"
@@ -47,16 +51,15 @@
 ///////////////////////////////////////////////////////////////////////////////
 // The version check enforces the major and minor version numbers to match for
 // every compilation unit to be compiled.
-#define PIKA_CHECK_VERSION                                                \
-    PIKA_PP_CAT(pika_check_version_,                                       \
-        PIKA_PP_CAT(                                                            \
-            PIKA_VERSION_MAJOR, PIKA_PP_CAT(_, PIKA_VERSION_MINOR)))  \
+#define PIKA_CHECK_VERSION                                                     \
+    PIKA_PP_CAT(pika_check_version_,                                           \
+        PIKA_PP_CAT(PIKA_VERSION_MAJOR, PIKA_PP_CAT(_, PIKA_VERSION_MINOR)))   \
     /**/
 
 // The version check enforces the major and minor version numbers to match for
 // every compilation unit to be compiled.
-#define PIKA_CHECK_BOOST_VERSION                                          \
-    PIKA_PP_CAT(pika_check_boost_version_, BOOST_VERSION)                  \
+#define PIKA_CHECK_BOOST_VERSION                                               \
+    PIKA_PP_CAT(pika_check_boost_version_, BOOST_VERSION)                      \
     /**/
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/performance/local/htts_v2/htts2.hpp
+++ b/tests/performance/local/htts_v2/htts2.hpp
@@ -30,7 +30,7 @@ namespace htts2 {
     {
         using base_clock = BaseClock;
         using rep = typename base_clock::rep;
-        using period = typename std::nano;
+        using period = std::nano;
         using duration = std::chrono::duration<rep, period>;
 
         static_assert(


### PR DESCRIPTION
This expands the existing check to include all C++/CUDA files, not just C++ files in modules. The templates needed some `clang-format off` to avoid reformatting the actual template parts of them (`clang-format` wants to turn `@var@` into `@var @`).

Fixes #168.