### PR TITLE
Clean up `version` module

### DIFF
--- a/libs/pika/version/CMakeLists.txt
+++ b/libs/pika/version/CMakeLists.txt
@@ -17,6 +17,7 @@ pika_add_module(
   SOURCES ${version_sources}
   HEADERS ${version_headers}
   MODULE_DEPENDENCIES pika_config pika_format pika_prefix
+  CMAKE_SUBDIRS tests
 )
 
 target_include_directories(

--- a/libs/pika/version/CMakeLists.txt
+++ b/libs/pika/version/CMakeLists.txt
@@ -10,11 +10,6 @@ set(version_headers pika/version.hpp)
 
 set(version_sources version.cpp)
 
-if(PIKA_WITH_MPI)
-  include(pika_setup_mpi)
-  set(mpi_dependencies Mpi::mpi)
-endif()
-
 include(pika_add_module)
 pika_add_module(
   pika version
@@ -22,7 +17,6 @@ pika_add_module(
   SOURCES ${version_sources}
   HEADERS ${version_headers}
   MODULE_DEPENDENCIES pika_config pika_format pika_prefix
-  DEPENDENCIES Hwloc::hwloc ${mpi_dependencies}
 )
 
 target_include_directories(

--- a/libs/pika/version/include/pika/version.hpp
+++ b/libs/pika/version/include/pika/version.hpp
@@ -9,48 +9,84 @@
 #pragma once
 
 #include <pika/config.hpp>
+#include <pika/config/config_strings.hpp>
+#include <pika/config/version.hpp>
+#include <pika/modules/format.hpp>
+#include <pika/prefix/find_prefix.hpp>
+#include <pika/preprocessor/stringize.hpp>
 
 #include <cstdint>
+#include <sstream>
 #include <string>
+#include <string_view>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace pika {
     // Returns the major pika version.
-    PIKA_EXPORT std::uint8_t major_version();
+    constexpr std::uint8_t major_version()
+    {
+        return PIKA_VERSION_MAJOR;
+    }
 
     // Returns the minor pika version.
-    PIKA_EXPORT std::uint8_t minor_version();
+    constexpr std::uint8_t minor_version()
+    {
+        return PIKA_VERSION_MINOR;
+    }
 
     // Returns the sub-minor/patch-level pika version.
-    PIKA_EXPORT std::uint8_t patch_version();
+    constexpr std::uint8_t patch_version()
+    {
+        return PIKA_VERSION_PATCH;
+    }
 
     // Returns the full pika version.
-    PIKA_EXPORT std::uint32_t full_version();
+    constexpr std::uint32_t full_version()
+    {
+        return PIKA_VERSION_FULL;
+    }
 
     // Returns the full pika version.
     PIKA_EXPORT std::string full_version_as_string();
 
     // Returns the tag.
-    PIKA_EXPORT std::string tag();
+    constexpr std::string_view tag()
+    {
+        return PIKA_VERSION_TAG;
+    }
 
-    // Returns the pika full build information string.
-    PIKA_EXPORT std::string full_build_string();
+    // Return the pika configuration information.
+    PIKA_EXPORT std::string configuration_string();
 
     // Returns the pika version string.
     PIKA_EXPORT std::string build_string();
 
-    // Returns the copyright string.
-    PIKA_EXPORT std::string copyright();
-
-    // Returns the full version string.
-    PIKA_EXPORT std::string complete_version();
-
     // Returns the pika build type ('Debug', 'Release', etc.)
-    PIKA_EXPORT std::string build_type();
+    constexpr std::string_view build_type()
+    {
+        return PIKA_PP_STRINGIZE(PIKA_BUILD_TYPE);
+    }
 
     // Returns the pika build date and time
     PIKA_EXPORT std::string build_date_time();
 
-    // Return the pika configuration information
-    PIKA_EXPORT std::string configuration_string();
+    // Returns the pika full build information string.
+    PIKA_EXPORT std::string full_build_string();
+
+    // Returns the copyright string.
+    constexpr std::string_view copyright()
+    {
+        char const* const copyright =
+            "pika\n\n"
+            "Copyright (c) 2021-2022, ETH Zurich,\n"
+            "https://github.com/pika-org/pika\n\n"
+            "Distributed under the Boost Software License, "
+            "Version 1.0. (See accompanying\n"
+            "file LICENSE_1_0.txt or copy at "
+            "http://www.boost.org/LICENSE_1_0.txt)\n";
+        return copyright;
+    }
+
+    // Returns the full version string.
+    PIKA_EXPORT std::string complete_version();
 }    // namespace pika

--- a/libs/pika/version/include/pika/version.hpp
+++ b/libs/pika/version/include/pika/version.hpp
@@ -39,18 +39,6 @@ namespace pika {
     // Returns the pika version string.
     PIKA_EXPORT std::string build_string();
 
-    // Returns the Boost version string.
-    PIKA_EXPORT std::string boost_version();
-
-    // Returns the Boost platform string.
-    PIKA_EXPORT std::string boost_platform();
-
-    // Returns the Boost compiler string.
-    PIKA_EXPORT std::string boost_compiler();
-
-    // Returns the Boost standard library string.
-    PIKA_EXPORT std::string boost_stdlib();
-
     // Returns the copyright string.
     PIKA_EXPORT std::string copyright();
 

--- a/libs/pika/version/src/version.cpp
+++ b/libs/pika/version/src/version.cpp
@@ -22,25 +22,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace pika {
-    std::uint8_t major_version()
-    {
-        return PIKA_VERSION_MAJOR;
-    }
-
-    std::uint8_t minor_version()
-    {
-        return PIKA_VERSION_MINOR;
-    }
-
-    std::uint8_t patch_version()
-    {
-        return PIKA_VERSION_PATCH;
-    }
-
-    std::uint32_t full_version()
-    {
-        return PIKA_VERSION_FULL;
-    }
 
     std::string full_version_as_string()
     {
@@ -48,25 +29,6 @@ namespace pika {
             PIKA_VERSION_MAJOR, PIKA_VERSION_MINOR, PIKA_VERSION_PATCH);
     }
 
-    std::string tag()
-    {
-        return PIKA_VERSION_TAG;
-    }
-
-    std::string copyright()
-    {
-        char const* const copyright =
-            "pika\n\n"
-            "Copyright (c) 2021-2022, ETH Zurich,\n"
-            "https://github.com/pika-org/pika\n\n"
-            "Distributed under the Boost Software License, "
-            "Version 1.0. (See accompanying\n"
-            "file LICENSE_1_0.txt or copy at "
-            "http://www.boost.org/LICENSE_1_0.txt)\n";
-        return copyright;
-    }
-
-    // Returns the pika full build information string.
     std::string full_build_string()
     {
         std::ostringstream strm;
@@ -111,11 +73,6 @@ namespace pika {
             build_string(), build_type(), build_date_time());
 
         return version;
-    }
-
-    std::string build_type()
-    {
-        return PIKA_PP_STRINGIZE(PIKA_BUILD_TYPE);
     }
 
     std::string build_date_time()

--- a/libs/pika/version/src/version.cpp
+++ b/libs/pika/version/src/version.cpp
@@ -15,32 +15,6 @@
 #include <pika/preprocessor/stringize.hpp>
 #include <pika/version.hpp>
 
-#include <boost/config.hpp>
-#include <boost/version.hpp>
-
-#if defined(PIKA_HAVE_MODULE_MPI_BASE)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-
-// Intel MPI does not like to be included after stdio.h. As such, we include mpi.h
-// as soon as possible.
-#include <mpi.h>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-#endif
-
-#include <hwloc.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <sstream>
@@ -79,33 +53,6 @@ namespace pika {
         return PIKA_VERSION_TAG;
     }
 
-#if defined(PIKA_HAVE_MODULE_MPI_BASE)
-    std::string mpi_version()
-    {
-        std::ostringstream strm;
-
-        // add type and library version
-#if defined(OPEN_MPI)
-        pika::util::format_to(strm, "OpenMPI V{}.{}.{}", OMPI_MAJOR_VERSION,
-            OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION);
-#elif defined(MPICH)
-        pika::util::format_to(strm, "MPICH V{}", MPICH_VERSION);
-#elif defined(MVAPICH2_VERSION)
-        pika::util::format_to(strm, "MVAPICH2 V{}", MVAPICH2_VERSION);
-#else
-        strm << "Unknown MPI";
-#endif
-        // add general MPI version
-#if defined(MPI_VERSION) && defined(MPI_SUBVERSION)
-        pika::util::format_to(
-            strm, ", MPI V{}.{}", MPI_VERSION, MPI_SUBVERSION);
-#else
-        strm << ", unknown MPI version";
-#endif
-        return strm.str();
-    }
-#endif
-
     std::string copyright()
     {
         char const* const copyright =
@@ -126,12 +73,8 @@ namespace pika {
         strm << "{config}:\n"
              << configuration_string() << "{version}: " << build_string()
              << "\n"
-             << "{boost}: " << boost_version() << "\n"
              << "{build-type}: " << build_type() << "\n"
-             << "{date}: " << build_date_time() << "\n"
-             << "{platform}: " << boost_platform() << "\n"
-             << "{compiler}: " << boost_compiler() << "\n"
-             << "{stdlib}: " << boost_stdlib() << "\n";
+             << "{date}: " << build_date_time() << "\n";
 
         return strm.str();
     }
@@ -142,11 +85,6 @@ namespace pika {
         std::ostringstream strm;
 
         strm << "pika:\n";
-
-#if defined(PIKA_HAVE_MALLOC)
-        pika::util::format_to(
-            strm, "  PIKA_HAVE_MALLOC={}\n", PIKA_HAVE_MALLOC);
-#endif
 
         char const* const* p = pika::config_strings;
         while (*p)
@@ -162,68 +100,15 @@ namespace pika {
             full_version_as_string(), PIKA_VERSION_TAG, PIKA_HAVE_GIT_COMMIT);
     }
 
-    std::string boost_version()
-    {
-        // BOOST_VERSION: 107100
-        return pika::util::format("V{}.{}.{}", BOOST_VERSION / 100000,
-            BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
-    }
-
-    std::string hwloc_version()
-    {
-        // HWLOC_API_VERSION: 0x00010700
-        return pika::util::format("V{}.{}.{}", HWLOC_API_VERSION / 0x10000,
-            HWLOC_API_VERSION / 0x100 % 0x100, HWLOC_API_VERSION % 0x100);
-    }
-
-#if defined(PIKA_HAVE_MALLOC)
-    std::string malloc_version()
-    {
-        return PIKA_HAVE_MALLOC;
-    }
-#endif
-
-    std::string boost_platform()
-    {
-        return BOOST_PLATFORM;
-    }
-
-    std::string boost_compiler()
-    {
-        return BOOST_COMPILER;
-    }
-
-    std::string boost_stdlib()
-    {
-        return BOOST_STDLIB;
-    }
-
     std::string complete_version()
     {
-        std::string version = pika::util::format("Versions:\n"
+        std::string version = pika::util::format("Version:\n"
                                                  "  pika: {}\n"
-                                                 "  Boost: {}\n"
-                                                 "  Hwloc: {}\n"
-#if defined(PIKA_HAVE_MODULE_MPI_BASE)
-                                                 "  MPI: {}\n"
-#endif
                                                  "\n"
                                                  "Build:\n"
                                                  "  Type: {}\n"
-                                                 "  Date: {}\n"
-                                                 "  Platform: {}\n"
-                                                 "  Compiler: {}\n"
-                                                 "  Standard Library: {}\n",
-            build_string(), boost_version(), hwloc_version(),
-#if defined(PIKA_HAVE_MODULE_MPI_BASE)
-            mpi_version(),
-#endif
-            build_type(), build_date_time(), boost_platform(), boost_compiler(),
-            boost_stdlib());
-
-#if defined(PIKA_HAVE_MALLOC)
-        version += "  Allocator: " + malloc_version() + "\n";
-#endif
+                                                 "  Date: {}\n",
+            build_string(), build_type(), build_date_time());
 
         return version;
     }

--- a/libs/pika/version/tests/CMakeLists.txt
+++ b/libs/pika/version/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(pika_message)
+include(pika_option)
+
+if(PIKA_WITH_TESTS)
+  if(PIKA_WITH_TESTS_UNIT)
+    pika_add_pseudo_target(tests.unit.modules.version)
+    pika_add_pseudo_dependencies(tests.unit.modules tests.unit.modules.version)
+    add_subdirectory(unit)
+  endif()
+
+  if(PIKA_WITH_TESTS_HEADERS)
+    pika_add_header_tests(
+      modules.version
+      HEADERS ${version_headers}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      NOLIBS
+      DEPENDENCIES pika_version
+    )
+  endif()
+endif()

--- a/libs/pika/version/tests/unit/CMakeLists.txt
+++ b/libs/pika/version/tests/unit/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) 2022 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# compile only tests
+if(PIKA_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests constexpr_version)
+
+  foreach(compile_test ${compile_tests})
+    set(sources ${compile_test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    pika_add_unit_compile_test(
+      "modules.version" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Unit/Modules/Version/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/pika/version/tests/unit/constexpr_version.cpp
+++ b/libs/pika/version/tests/unit/constexpr_version.cpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/version.hpp>
+
+#include <cstdint>
+
+template <std::uint8_t, std::uint8_t, std::uint8_t>
+void test_constexpr_versions()
+{
+}
+
+int main()
+{
+    test_constexpr_versions<pika::major_version(), pika::minor_version(),
+        pika::patch_version()>();
+}


### PR DESCRIPTION
Part of #16. Removes hwloc, boost and mpi dependency in the `version` module.