### PR TITLE
Clean up topology module

### DIFF
--- a/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
+++ b/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
@@ -39,12 +39,12 @@ namespace pika::detail {
         }
 
         void set_affinity_masks(
-            std::vector<threads::mask_type> const& affinity_masks)
+            std::vector<threads::detail::mask_type> const& affinity_masks)
         {
             affinity_masks_ = affinity_masks;
         }
         void set_affinity_masks(
-            std::vector<threads::mask_type>&& affinity_masks)
+            std::vector<threads::detail::mask_type>&& affinity_masks)
         {
             affinity_masks_ = PIKA_MOVE(affinity_masks);
         }
@@ -54,13 +54,14 @@ namespace pika::detail {
             return num_threads_;
         }
 
-        threads::mask_cref_type get_pu_mask(
-            threads::topology const& topo, std::size_t num_thread) const;
+        threads::detail::mask_cref_type get_pu_mask(
+            threads::detail::topology const& topo,
+            std::size_t num_thread) const;
 
-        threads::mask_type get_used_pus_mask(
-            threads::topology const& topo, std::size_t pu_num) const;
+        threads::detail::mask_type get_used_pus_mask(
+            threads::detail::topology const& topo, std::size_t pu_num) const;
         std::size_t get_thread_occupancy(
-            threads::topology const& topo, std::size_t pu_num) const;
+            threads::detail::topology const& topo, std::size_t pu_num) const;
 
         std::size_t get_pu_num(std::size_t num_thread) const
         {
@@ -95,9 +96,9 @@ namespace pika::detail {
         std::size_t pu_step_;    ///< step between used processing units
         std::size_t used_cores_;
         std::string affinity_domain_;
-        std::vector<threads::mask_type> affinity_masks_;
+        std::vector<threads::detail::mask_type> affinity_masks_;
         std::vector<std::size_t> pu_nums_;
-        threads::mask_type
+        threads::detail::mask_type
             no_affinity_;    ///< mask of processing units which have no affinity
         bool
             use_process_mask_;    ///< use the process CPU mask to limit available PUs

--- a/libs/pika/affinity/include/pika/affinity/parse_affinity_options.hpp
+++ b/libs/pika/affinity/include/pika/affinity/parse_affinity_options.hpp
@@ -35,8 +35,8 @@ namespace pika::detail {
         mappings_type& mappings, error_code& ec = throws);
 
     PIKA_EXPORT void parse_affinity_options(std::string const& spec,
-        std::vector<threads::mask_type>& affinities, std::size_t used_cores,
-        std::size_t max_cores, std::size_t num_threads,
+        std::vector<threads::detail::mask_type>& affinities,
+        std::size_t used_cores, std::size_t max_cores, std::size_t num_threads,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec = throws);
 }    // namespace pika::detail

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/parallel_stable_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/parallel_stable_sort.hpp
@@ -164,8 +164,8 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
             std::less<typename std::iterator_traits<Iter>::value_type>;
 
         return parallel_stable_sort(PIKA_FORWARD(Exec, exec), first, last,
-            pika::threads::hardware_concurrency(), stable_sort_limit_per_task,
-            compare{});
+            pika::threads::detail::hardware_concurrency(),
+            stable_sort_limit_per_task, compare{});
     }
 
 }}}}    // namespace pika::parallel::v1::detail

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
@@ -439,7 +439,7 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
         using compare = std::less<value_type>;
 
         return sample_sort(PIKA_FORWARD(Exec, exec), first, last, compare{},
-            (std::uint32_t) pika::threads::hardware_concurrency(),
+            (std::uint32_t) pika::threads::detail::hardware_concurrency(),
             (value_type*) nullptr, std::size_t(0),
             std::size_t(sample_sort_limit_per_task));
     }

--- a/libs/pika/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
@@ -139,7 +139,7 @@ void test5()
     {
         range<std::uint64_t*> Rbuf(Ptr, Ptr + KMax);
         sample_sort(parallel_executor{}, K.begin(), K.end(), comp,
-            pika::threads::hardware_concurrency(), Rbuf);
+            pika::threads::detail::hardware_concurrency(), Rbuf);
     }
     catch (...)
     {
@@ -219,8 +219,8 @@ void test7()
 
     range<std::uint64_t*> Rbuf(&B[1000], (&B[1000]) + NELEM);
     sample_sort(parallel_executor{}, A.begin(), A.end(),
-        std::less<std::uint64_t>(), pika::threads::hardware_concurrency(),
-        Rbuf);
+        std::less<std::uint64_t>(),
+        pika::threads::detail::hardware_concurrency(), Rbuf);
 
     for (iter_t it = A.begin() + 1; it != A.end(); ++it)
     {
@@ -237,8 +237,8 @@ void test7()
         A.push_back(NELEM - i);
 
     sample_sort(parallel_executor{}, A.begin(), A.end(),
-        std::less<std::uint64_t>(), pika::threads::hardware_concurrency(),
-        Rbuf);
+        std::less<std::uint64_t>(),
+        pika::threads::detail::hardware_concurrency(), Rbuf);
 
     for (iter_t it = A.begin() + 1; it != A.end(); ++it)
     {

--- a/libs/pika/async_cuda/src/cuda_pool.cpp
+++ b/libs/pika/async_cuda/src/cuda_pool.cpp
@@ -21,7 +21,7 @@ namespace pika::cuda::experimental {
         std::size_t num_streams_per_thread,
         pika::threads::thread_priority priority)
       : num_streams_per_thread(num_streams_per_thread)
-      , concurrency(pika::threads::hardware_concurrency())
+      , concurrency(pika::threads::detail::hardware_concurrency())
       , streams(
             num_streams_per_thread * concurrency, cuda_stream{device, priority})
       , active_stream_indices(concurrency, {0})

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -204,31 +204,31 @@ namespace pika::detail {
     {
         if (use_process_mask)
         {
-            threads::topology& top = threads::create_topology();
-            return threads::count(top.get_cpubind_mask());
+            threads::detail::topology& top = threads::detail::create_topology();
+            return threads::detail::count(top.get_cpubind_mask());
         }
         else
         {
-            return threads::hardware_concurrency();
+            return threads::detail::hardware_concurrency();
         }
     }
 
     std::size_t get_number_of_default_cores(bool use_process_mask)
     {
-        threads::topology& top = threads::create_topology();
+        threads::detail::topology& top = threads::detail::create_topology();
 
         std::size_t num_cores = top.get_number_of_cores();
 
         if (use_process_mask)
         {
-            threads::mask_type proc_mask = top.get_cpubind_mask();
+            threads::detail::mask_type proc_mask = top.get_cpubind_mask();
             std::size_t num_cores_proc_mask = 0;
 
             for (std::size_t num_core = 0; num_core < num_cores; ++num_core)
             {
-                threads::mask_type core_mask =
+                threads::detail::mask_type core_mask =
                     top.init_core_affinity_mask_from_core(num_core);
-                if (threads::bit_and(core_mask, proc_mask))
+                if (threads::detail::bit_and(core_mask, proc_mask))
                 {
                     ++num_cores_proc_mask;
                 }
@@ -411,7 +411,7 @@ namespace pika::detail {
     void command_line_handling::check_pu_offset() const
     {
         if (pu_offset_ != std::size_t(-1) &&
-            pu_offset_ >= pika::threads::hardware_concurrency())
+            pu_offset_ >= pika::threads::detail::hardware_concurrency())
         {
             throw pika::detail::command_line_error(
                 "Invalid command line option "
@@ -422,9 +422,9 @@ namespace pika::detail {
 
     void command_line_handling::check_pu_step() const
     {
-        if (pika::threads::hardware_concurrency() > 1 &&
+        if (pika::threads::detail::hardware_concurrency() > 1 &&
             (pu_step_ == 0 ||
-                pu_step_ >= pika::threads::hardware_concurrency()))
+                pu_step_ >= pika::threads::detail::hardware_concurrency()))
         {
             throw pika::detail::command_line_error(
                 "Invalid command line option "

--- a/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/execution_parameter_callbacks.hpp
@@ -19,10 +19,11 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     PIKA_EXPORT void set_get_os_thread_count(get_os_thread_count_type f);
     PIKA_EXPORT std::size_t get_os_thread_count();
 
-    using get_pu_mask_type = pika::util::function<threads::mask_cref_type(
-        threads::topology&, std::size_t)>;
+    using get_pu_mask_type =
+        pika::util::function<threads::detail::mask_cref_type(
+            threads::detail::topology&, std::size_t)>;
     PIKA_EXPORT void set_get_pu_mask(get_pu_mask_type f);
-    PIKA_EXPORT threads::mask_cref_type get_pu_mask(
-        threads::topology&, std::size_t);
+    PIKA_EXPORT threads::detail::mask_cref_type get_pu_mask(
+        threads::detail::topology&, std::size_t);
     /// \endcond
 }}}}    // namespace pika::parallel::execution::detail

--- a/libs/pika/execution/include/pika/execution/executors/execution_information.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_information.hpp
@@ -96,7 +96,7 @@ namespace pika { namespace parallel { namespace execution {
             )>
         // clang-format on
         friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_pu_mask_t, Executor&& /*exec*/, threads::topology& topo,
+            get_pu_mask_t, Executor&& /*exec*/, threads::detail::topology& topo,
             std::size_t thread_num)
         {
             return detail::get_pu_mask(topo, thread_num);
@@ -110,7 +110,8 @@ namespace pika { namespace parallel { namespace execution {
             )>
         // clang-format on
         friend PIKA_FORCEINLINE decltype(auto) tag_invoke(get_pu_mask_t,
-            Executor&& exec, threads::topology& topo, std::size_t thread_num)
+            Executor&& exec, threads::detail::topology& topo,
+            std::size_t thread_num)
         {
             return exec.get_pu_mask(topo, thread_num);
         }

--- a/libs/pika/execution/src/execution_parameter_callbacks.cpp
+++ b/libs/pika/execution/src/execution_parameter_callbacks.cpp
@@ -57,8 +57,8 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         get_get_pu_mask() = f;
     }
 
-    threads::mask_cref_type get_pu_mask(
-        threads::topology& topo, std::size_t thread_num)
+    threads::detail::mask_cref_type get_pu_mask(
+        threads::detail::topology& topo, std::size_t thread_num)
     {
         if (get_get_pu_mask())
         {
@@ -75,7 +75,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
                 "handler with "
                 "pika::parallel::execution::detail::set_get_pu_mask.");
 
-            static threads::mask_type mask{};
+            static threads::detail::mask_type mask{};
             return mask;
         }
     }

--- a/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
@@ -166,8 +166,8 @@ int main()
             pika::threads::policies::local_priority_queue_scheduler<>;
 
         // Choose all the parameters for the thread pool and scheduler.
-        std::size_t const num_threads = (std::min)(
-            std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+        std::size_t const num_threads = (std::min)(std::size_t(4),
+            std::size_t(pika::threads::detail::hardware_concurrency()));
         std::size_t const max_cores = num_threads;
         pika::detail::affinity_data ad{};
         ad.init(num_threads, max_cores, 0, 1, 0, "core", "balanced", true);

--- a/libs/pika/resource_partitioner/examples/system_characteristics.hpp
+++ b/libs/pika/resource_partitioner/examples/system_characteristics.hpp
@@ -22,7 +22,7 @@ void print_system_characteristics()
 
     pika::runtime* rt = pika::get_runtime_ptr();
     pika::util::runtime_configuration cfg = rt->get_config();
-    const pika::threads::topology& topo = rt->get_topology();
+    const pika::threads::detail::topology& topo = rt->get_topology();
 
     // -------------------------------------- //
     //      print runtime characteristics     //

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -61,7 +61,7 @@ namespace pika { namespace resource { namespace detail {
         scheduling_policy scheduling_policy_;
 
         // PUs this pool is allowed to run on
-        std::vector<threads::mask_type> assigned_pus_;    // mask
+        std::vector<threads::detail::mask_type> assigned_pus_;    // mask
 
         // pu index/exclusive/assigned
         std::vector<pika::tuple<std::size_t, bool, bool>> assigned_pu_nums_;
@@ -136,7 +136,7 @@ namespace pika { namespace resource { namespace detail {
 
         ////////////////////////////////////////////////////////////////////////
         scheduling_policy which_scheduler(std::string const& pool_name);
-        threads::topology& get_topology() const;
+        threads::detail::topology& get_topology() const;
 
         std::size_t get_num_pools() const;
 
@@ -151,7 +151,7 @@ namespace pika { namespace resource { namespace detail {
         std::size_t get_pool_index(std::string const& pool_name) const;
 
         std::size_t get_pu_num(std::size_t global_thread_num);
-        threads::mask_cref_type get_pu_mask(
+        threads::detail::mask_cref_type get_pu_mask(
             std::size_t global_thread_num) const;
 
         void init(resource::partitioner_mode rpmode, pika::util::section cfg,
@@ -238,7 +238,7 @@ namespace pika { namespace resource { namespace detail {
         resource::partitioner_mode mode_;
 
         // topology information
-        threads::topology& topo_;
+        threads::detail::topology& topo_;
 
         threads::policies::scheduler_mode default_scheduler_mode_;
     };

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
@@ -193,7 +193,7 @@ namespace pika { namespace resource {
         PIKA_EXPORT std::size_t get_number_requested_threads();
 
         // return the topology object managed by the internal partitioner
-        PIKA_EXPORT pika::threads::topology const& get_topology() const;
+        PIKA_EXPORT pika::threads::detail::topology const& get_topology() const;
 
         // Does initialization of all resources and internal data of the
         // resource partitioner called in pika_init

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -202,7 +202,7 @@ namespace pika { namespace resource {
         return partitioner_.numa_domains();
     }
 
-    pika::threads::topology const& partitioner::get_topology() const
+    pika::threads::detail::topology const& partitioner::get_topology() const
     {
         return partitioner_.get_topology();
     }

--- a/libs/pika/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 // dummy function we will call using async
 void dummy_task(std::size_t n, std::string const& text)

--- a/libs/pika/resource_partitioner/tests/unit/resource_partitioner_info.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/resource_partitioner_info.cpp
@@ -18,7 +18,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main()
 {
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
     pika::init_params init_args;
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
-            std::size_t(pika::threads::hardware_concurrency()))))};
+            std::size_t(pika::threads::detail::hardware_concurrency()))))};
 
     // now run the test
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main()
 {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
 
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
-            std::size_t(pika::threads::hardware_concurrency()))))};
+            std::size_t(pika::threads::detail::hardware_concurrency()))))};
     init_args.rp_callback = [](auto& rp,
                                 pika::program_options::variables_map const&) {
         // Explicitly disable elasticity if it is in defaults

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -29,7 +29,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main()
 {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -33,7 +33,7 @@ void test_scheduler(
 
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
-            std::size_t(pika::threads::hardware_concurrency()))))};
+            std::size_t(pika::threads::detail::hardware_concurrency()))))};
     init_args.rp_callback = [scheduler](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);

--- a/libs/pika/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -26,7 +26,7 @@ void test_scheduler(
 
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
-            std::size_t(pika::threads::hardware_concurrency()))))};
+            std::size_t(pika::threads::detail::hardware_concurrency()))))};
     init_args.rp_callback = [scheduler](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main()
 {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main()
 {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(pika::threads::hardware_concurrency()));
+    std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
 int pika_main(int argc, char* argv[])
 {

--- a/libs/pika/resource_partitioner/tests/unit/used_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/used_pus.cpp
@@ -23,12 +23,12 @@ int pika_main()
         pika::resource::get_thread_pool("default");
 
     auto used_pu_mask = tp.get_used_processing_units();
-    PIKA_TEST_EQ(pika::threads::count(used_pu_mask), num_threads);
+    PIKA_TEST_EQ(pika::threads::detail::count(used_pu_mask), num_threads);
 
     for (std::size_t t = 0; t < num_threads; ++t)
     {
         auto thread_mask = pika::resource::get_partitioner().get_pu_mask(t);
-        PIKA_TEST(pika::threads::bit_or(used_pu_mask, thread_mask));
+        PIKA_TEST(pika::threads::detail::bit_or(used_pu_mask, thread_mask));
     }
 
     return pika::finalize();
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
     pika::init_params init_args;
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
-            std::size_t(pika::threads::hardware_concurrency()))))};
+            std::size_t(pika::threads::detail::hardware_concurrency()))))};
 
     // now run the test
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -115,7 +115,7 @@ namespace pika {
         /// \brief Return a reference to the internal PAPI thread manager
         util::thread_mapper& get_thread_mapper();
 
-        threads::topology const& get_topology() const;
+        threads::detail::topology const& get_topology() const;
 
         /// \brief Run the pika runtime system, use the given function for the
         ///        main \a thread and block waiting for all threads to
@@ -402,7 +402,7 @@ namespace pika {
         std::unique_ptr<util::thread_mapper> thread_support_;
 
         // topology and affinity data
-        threads::topology& topology_;
+        threads::detail::topology& topology_;
 
         std::atomic<state> state_;
 

--- a/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
@@ -175,7 +175,7 @@ namespace pika {
             threads::policies::scheduler_mode to_remove);
 
         /// Get the global topology instance
-        PIKA_EXPORT topology const& get_topology();
+        PIKA_EXPORT detail::topology const& get_topology();
         /// \endcond
     }    // namespace threads
 

--- a/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
@@ -28,6 +28,6 @@ namespace pika { namespace detail {
     PIKA_EXPORT bool register_locks_predicate();
 #endif
     PIKA_EXPORT threads::thread_pool_base* get_default_pool();
-    PIKA_EXPORT threads::mask_cref_type get_pu_mask(
-        threads::topology& topo, std::size_t thread_num);
+    PIKA_EXPORT threads::detail::mask_cref_type get_pu_mask(
+        threads::detail::topology& topo, std::size_t thread_num);
 }}    // namespace pika::detail

--- a/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
@@ -90,7 +90,7 @@ namespace pika { namespace threads {
 
     /// The function \a get_idle_core_mask returns a bit-mask representing the
     /// currently idling threads (cores).
-    PIKA_EXPORT mask_type get_idle_core_mask();
+    PIKA_EXPORT detail::mask_type get_idle_core_mask();
 
     /// The function \a enumerate_threads will invoke the given function \a f
     /// for each thread with a matching thread state.

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -140,8 +140,8 @@ namespace pika { namespace detail {
         return &rt->get_thread_manager().default_pool();
     }
 
-    threads::mask_cref_type get_pu_mask(
-        threads::topology& /* topo */, std::size_t thread_num)
+    threads::detail::mask_cref_type get_pu_mask(
+        threads::detail::topology& /* topo */, std::size_t thread_num)
     {
         auto& rp = pika::resource::get_partitioner();
         return rp.get_pu_mask(thread_num);

--- a/libs/pika/runtime/src/thread_pool_helpers.cpp
+++ b/libs/pika/runtime/src/thread_pool_helpers.cpp
@@ -89,7 +89,7 @@ namespace pika { namespace threads {
         return get_thread_manager().get_idle_core_count();
     }
 
-    mask_type get_idle_core_mask()
+    detail::mask_type get_idle_core_mask()
     {
         return get_thread_manager().get_idle_core_mask();
     }

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -158,10 +158,10 @@ namespace pika { namespace threads { namespace policies {
           : scheduler_base(init.num_worker_threads_, init.description_,
                 init.thread_queue_init_)
 #if !defined(PIKA_HAVE_MAX_CPU_COUNT)
-          , d_lookup_(pika::threads::hardware_concurrency())
-          , q_lookup_(pika::threads::hardware_concurrency())
+          , d_lookup_(pika::threads::detail::hardware_concurrency())
+          , q_lookup_(pika::threads::detail::hardware_concurrency())
 #ifdef SHARED_PRIORITY_SCHEDULER_LINUX
-          , schedcpu_(pika::threads::hardware_concurrency())
+          , schedcpu_(pika::threads::detail::hardware_concurrency())
 #endif
 #endif
           , cores_per_queue_(init.cores_per_queue_)
@@ -953,7 +953,7 @@ namespace pika { namespace threads { namespace policies {
             spq_deb.debug(
                 debug::str<>("start_thread"), "local_thread", local_thread);
 
-            auto const& topo = create_topology();
+            auto const& topo = ::pika::threads::detail::create_topology();
             // the main initialization can be done by any one thread
             std::unique_lock<Mutex> lock(init_mutex);
             if (!initialized_)

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -132,7 +132,7 @@ namespace pika { namespace threads { namespace detail {
            << "] with scheduler " << sched_->Scheduler::get_scheduler_name()
            << "\n"
            << "is running on PUs : \n";
-        os << pika::threads::to_string(get_used_processing_units())
+        os << pika::threads::detail::to_string(get_used_processing_units())
 #ifdef PIKA_HAVE_MAX_CPU_COUNT
            << " "
            << std::bitset<PIKA_HAVE_MAX_CPU_COUNT>(get_used_processing_units())
@@ -275,7 +275,7 @@ namespace pika { namespace threads { namespace detail {
         PIKA_ASSERT(l.owns_lock());
 
         LTM_(info).format("run: {} number of processing units available: {}",
-            id_.name(), threads::hardware_concurrency());
+            id_.name(), threads::detail::hardware_concurrency());
         LTM_(info).format(
             "run: {} creating {} OS thread(s)", id_.name(), pool_threads);
 
@@ -303,13 +303,13 @@ namespace pika { namespace threads { namespace detail {
             std::make_shared<util::barrier>(pool_threads + 1);
         try
         {
-            topology const& topo = create_topology();
+            topology const& topo = detail::create_topology();
 
             for (/**/; thread_num != pool_threads; ++thread_num)
             {
                 std::size_t global_thread_num =
                     this->thread_offset_ + thread_num;
-                threads::mask_cref_type mask =
+                threads::detail::mask_cref_type mask =
                     affinity_data_.get_pu_mask(topo, global_thread_num);
 
                 // thread_num ordering: 1. threads of default pool
@@ -322,7 +322,7 @@ namespace pika { namespace threads { namespace detail {
                     "run: {} create OS thread {}: will run on processing units "
                     "within this mask: {}",
                     id_.name(), global_thread_num,
-                    pika::threads::to_string(mask));
+                    pika::threads::detail::to_string(mask));
 
                 // create a new thread
                 add_processing_unit_internal(
@@ -425,10 +425,10 @@ namespace pika { namespace threads { namespace detail {
         std::size_t thread_num, std::size_t global_thread_num,
         std::shared_ptr<util::barrier> startup)
     {
-        topology const& topo = create_topology();
+        topology const& topo = detail::create_topology();
 
         // Set the affinity for the current thread.
-        threads::mask_cref_type mask =
+        threads::detail::mask_cref_type mask =
             affinity_data_.get_pu_mask(topo, global_thread_num);
 
         if (LPIKA_ENABLED(debug))
@@ -1810,7 +1810,7 @@ namespace pika { namespace threads { namespace detail {
 
     template <typename Scheduler>
     void scheduled_thread_pool<Scheduler>::get_idle_core_mask(
-        mask_type& mask) const
+        detail::mask_type& mask) const
     {
         std::size_t i = 0;
         for (auto const& data : counter_data_)

--- a/libs/pika/threading/include/pika/threading/jthread.hpp
+++ b/libs/pika/threading/include/pika/threading/jthread.hpp
@@ -254,7 +254,7 @@ namespace pika {
         // Returns: thread::hardware_concurrency().
         PIKA_NODISCARD static unsigned int hardware_concurrency()
         {
-            return pika::threads::hardware_concurrency();
+            return pika::threads::detail::hardware_concurrency();
         }
 
     private:

--- a/libs/pika/threading/src/thread.cpp
+++ b/libs/pika/threading/src/thread.cpp
@@ -158,7 +158,7 @@ namespace pika {
 
     unsigned int thread::hardware_concurrency() noexcept
     {
-        return pika::threads::hardware_concurrency();
+        return pika::threads::detail::hardware_concurrency();
     }
 
     void thread::start_thread(

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -263,8 +263,8 @@ namespace pika { namespace threads {
             return nullptr;
         }
 
-        mask_type get_used_processing_units() const;
-        hwloc_bitmap_ptr get_numa_domain_bitmap() const;
+        detail::mask_type get_used_processing_units() const;
+        detail::hwloc_bitmap_ptr get_numa_domain_bitmap() const;
 
         // performance counters
 #if defined(PIKA_HAVE_THREAD_CUMULATIVE_COUNTS)
@@ -442,7 +442,7 @@ namespace pika { namespace threads {
             return 0;
         }
 
-        virtual void get_idle_core_mask(mask_type&) const {}
+        virtual void get_idle_core_mask(detail::mask_type&) const {}
 
         virtual std::int64_t get_background_thread_count()
         {

--- a/libs/pika/threading_base/src/thread_pool_base.cpp
+++ b/libs/pika/threading_base/src/thread_pool_base.cpp
@@ -36,13 +36,14 @@ namespace pika { namespace threads {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    mask_type thread_pool_base::get_used_processing_units() const
+    detail::mask_type thread_pool_base::get_used_processing_units() const
     {
-        auto const& topo = create_topology();
+        auto const& topo = detail::create_topology();
         auto const sched = get_scheduler();
 
-        mask_type used_processing_units = mask_type();
-        threads::resize(used_processing_units, hardware_concurrency());
+        detail::mask_type used_processing_units = detail::mask_type();
+        threads::detail::resize(
+            used_processing_units, detail::hardware_concurrency());
 
         for (std::size_t thread_num = 0; thread_num < get_os_thread_count();
              ++thread_num)
@@ -57,10 +58,10 @@ namespace pika { namespace threads {
         return used_processing_units;
     }
 
-    hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
+    detail::hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
     {
-        auto const& topo = create_topology();
-        mask_type used_processing_units = get_used_processing_units();
+        auto const& topo = detail::create_topology();
+        detail::mask_type used_processing_units = get_used_processing_units();
         return topo.cpuset_to_nodeset(used_processing_units);
     }
 

--- a/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
+++ b/libs/pika/threadmanager/include/pika/modules/threadmanager.hpp
@@ -170,7 +170,7 @@ namespace pika { namespace threads {
 
         std::int64_t get_idle_core_count();
 
-        mask_type get_idle_core_mask();
+        detail::mask_type get_idle_core_mask();
 
         std::int64_t get_background_thread_count();
 
@@ -232,11 +232,12 @@ namespace pika { namespace threads {
     public:
         /// Returns the mask identifying all processing units used by this
         /// thread manager.
-        mask_type get_used_processing_units() const
+        detail::mask_type get_used_processing_units() const
         {
-            mask_type total_used_processing_punits = mask_type();
-            threads::resize(
-                total_used_processing_punits, hardware_concurrency());
+            detail::mask_type total_used_processing_punits =
+                detail::mask_type();
+            threads::detail::resize(
+                total_used_processing_punits, detail::hardware_concurrency());
 
             for (auto& pool_iter : pools_)
             {
@@ -247,7 +248,7 @@ namespace pika { namespace threads {
             return total_used_processing_punits;
         }
 
-        hwloc_bitmap_ptr get_pool_numa_bitmap(
+        detail::hwloc_bitmap_ptr get_pool_numa_bitmap(
             const std::string& pool_name) const
         {
             return get_pool(pool_name).get_numa_domain_bitmap();

--- a/libs/pika/threadmanager/src/threadmanager.cpp
+++ b/libs/pika/threadmanager/src/threadmanager.cpp
@@ -643,10 +643,10 @@ namespace pika { namespace threads {
         return total_count;
     }
 
-    mask_type threadmanager::get_idle_core_mask()
+    detail::mask_type threadmanager::get_idle_core_mask()
     {
-        mask_type mask = mask_type();
-        resize(mask, hardware_concurrency());
+        detail::mask_type mask = detail::mask_type();
+        detail::resize(mask, detail::hardware_concurrency());
 
         std::lock_guard<mutex_type> lk(mtx_);
 

--- a/libs/pika/topology/docs/index.rst
+++ b/libs/pika/topology/docs/index.rst
@@ -11,7 +11,7 @@
 topology
 ========
 
-This module provides the class :cpp:class:`pika::threads::topology` which
+This module provides the class :cpp:class:`pika::threads::detail::topology` which
 represents the hardware resources available on a node. The class is a light
 wrapper around the |hwloc|_ library. The :cpp:class:`pika::threads::cpu_mask` is
 a small companion class that represents a set of resources on a node.

--- a/libs/pika/topology/include/pika/topology/cpu_mask.hpp
+++ b/libs/pika/topology/include/pika/topology/cpu_mask.hpp
@@ -30,7 +30,7 @@
 #endif
 // clang-format on
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
     /// \cond NOINTERNAL
 #if !defined(PIKA_HAVE_MORE_THAN_64_THREADS) ||                                \
     (defined(PIKA_HAVE_MAX_CPU_COUNT) && PIKA_HAVE_MAX_CPU_COUNT <= 64)
@@ -233,6 +233,6 @@ namespace pika { namespace threads {
 
 #endif
 
-        PIKA_EXPORT std::string to_string(mask_cref_type);
-        /// \endcond
-}}    // namespace pika::threads
+    PIKA_EXPORT std::string to_string(mask_cref_type);
+    /// \endcond
+}    // namespace pika::threads::detail

--- a/libs/pika/topology/include/pika/topology/topology.hpp
+++ b/libs/pika/topology/include/pika/topology/topology.hpp
@@ -58,12 +58,12 @@ namespace pika::threads::detail {
             bmp_ = bmp;
         }
 
-        explicit operator bool() const
+        explicit operator bool() const noexcept
         {
             return bmp_ != nullptr;
         }
 
-        hwloc_bitmap_t get_bmp() const
+        hwloc_bitmap_t get_bmp() const noexcept
         {
             return bmp_;
         }
@@ -412,7 +412,7 @@ namespace pika::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
     PIKA_EXPORT topology& create_topology();
 
-    PIKA_NODISCARD PIKA_EXPORT unsigned int hardware_concurrency();
+    PIKA_NODISCARD PIKA_EXPORT unsigned int hardware_concurrency() noexcept;
 
     ///////////////////////////////////////////////////////////////////////////
     // abstract away memory page size, calls to system functions are

--- a/libs/pika/topology/include/pika/topology/topology.hpp
+++ b/libs/pika/topology/include/pika/topology/topology.hpp
@@ -29,7 +29,7 @@
 #error On Intel Xeon/Phi coprocessors pika cannot be use with a HWLOC version earlier than V1.6.
 #endif
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
 
     struct pika_hwloc_bitmap_wrapper
     {
@@ -284,7 +284,7 @@ namespace pika { namespace threads {
         void* allocate_membind(std::size_t len, hwloc_bitmap_ptr bitmap,
             pika_hwloc_membind_policy policy, int flags) const;
 
-        threads::mask_type get_area_membind_nodeset(
+        threads::detail::mask_type get_area_membind_nodeset(
             const void* addr, std::size_t len) const;
 
         bool set_area_membind_nodeset(
@@ -419,6 +419,6 @@ namespace pika { namespace threads {
     // expensive, so return a value initialized at startup
     inline std::size_t get_memory_page_size()
     {
-        return pika::threads::topology::memory_page_size_;
+        return pika::threads::detail::topology::memory_page_size_;
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/topology/src/cpu_mask.cpp
+++ b/libs/pika/topology/src/cpu_mask.cpp
@@ -27,11 +27,11 @@
 #endif
 // clang-format on
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
     std::string to_string(mask_cref_type val)
     {
         std::ostringstream ostr;
         ostr << std::hex << PIKA_CPU_MASK_PREFIX << val;
         return ostr.str();
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -1585,7 +1585,7 @@ namespace pika::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
     struct hw_concurrency
     {
-        hw_concurrency()
+        hw_concurrency() noexcept
 #if defined(__ANDROID__) && defined(ANDROID)
           : num_of_cores_(::android_getCpuCount())
 #else
@@ -1599,7 +1599,7 @@ namespace pika::threads::detail {
         std::size_t num_of_cores_;
     };
 
-    unsigned int hardware_concurrency()
+    unsigned int hardware_concurrency() noexcept
     {
         static detail::hw_concurrency hwc;
         return static_cast<unsigned int>(hwc.num_of_cores_);

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -52,10 +52,10 @@
 #include <unistd.h>
 #endif
 
-namespace pika { namespace threads { namespace detail {
+namespace pika::threads::detail {
     std::size_t hwloc_hardware_concurrency()
     {
-        threads::topology& top = threads::create_topology();
+        threads::detail::topology& top = threads::detail::create_topology();
         return top.get_number_of_pus();
     }
 
@@ -66,8 +66,8 @@ namespace pika { namespace threads { namespace detail {
 
     void write_to_log_mask(char const* valuename, mask_cref_type value)
     {
-        LTM_(debug).format(
-            "topology: {}: {}", valuename, pika::threads::to_string(value));
+        LTM_(debug).format("topology: {}: {}", valuename,
+            pika::threads::detail::to_string(value));
     }
 
     void write_to_log(
@@ -91,7 +91,7 @@ namespace pika { namespace threads { namespace detail {
         for (mask_cref_type value : values)
         {
             LTM_(debug).format("topology: {}({}): {}", valuename, i++,
-                pika::threads::to_string(value));
+                pika::threads::detail::to_string(value));
         }
     }
 
@@ -133,12 +133,8 @@ namespace pika { namespace threads { namespace detail {
 #endif
     }
 
-}}}    // namespace pika::threads::detail
+    std::size_t topology::memory_page_size_ = get_memory_page_size_impl();
 
-std::size_t pika::threads::topology::memory_page_size_ =
-    pika::threads::detail::get_memory_page_size_impl();
-
-namespace pika { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     std::ostream& operator<<(
         std::ostream& os, pika_hwloc_bitmap_wrapper const* bmp)
@@ -414,7 +410,7 @@ namespace pika { namespace threads {
         }
 
         PIKA_THROWS_IF(ec, bad_parameter,
-            "pika::threads::topology::get_socket_affinity_mask",
+            "pika::threads::detail::topology::get_socket_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
     }    // }}}
@@ -433,7 +429,7 @@ namespace pika { namespace threads {
         }
 
         PIKA_THROWS_IF(ec, bad_parameter,
-            "pika::threads::topology::get_numa_node_affinity_mask",
+            "pika::threads::detail::topology::get_numa_node_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
     }    // }}}
@@ -452,7 +448,7 @@ namespace pika { namespace threads {
         }
 
         PIKA_THROWS_IF(ec, bad_parameter,
-            "pika::threads::topology::get_core_affinity_mask",
+            "pika::threads::detail::topology::get_core_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
     }
@@ -471,7 +467,7 @@ namespace pika { namespace threads {
         }
 
         PIKA_THROWS_IF(ec, bad_parameter,
-            "pika::threads::topology::get_thread_affinity_mask",
+            "pika::threads::detail::topology::get_thread_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
     }    // }}}
@@ -513,9 +509,10 @@ namespace pika { namespace threads {
                     hwloc_bitmap_free(cpuset);
 
                     PIKA_THROWS_IF(ec, kernel_error,
-                        "pika::threads::topology::set_thread_affinity_mask",
+                        "pika::threads::detail::topology::set_thread_affinity_"
+                        "mask",
                         "failed to set thread affinity mask ({}) for cpuset {}",
-                        pika::threads::to_string(mask), buffer.get());
+                        pika::threads::detail::to_string(mask), buffer.get());
                     return;
                 }
             }
@@ -743,7 +740,7 @@ namespace pika { namespace threads {
         if (0 > nobjs)
         {
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_number_of_sockets",
+                "pika::threads::detail::topology::get_number_of_sockets",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
         }
@@ -756,7 +753,7 @@ namespace pika { namespace threads {
         if (0 > nobjs)
         {
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_number_of_numa_nodes",
+                "pika::threads::detail::topology::get_number_of_numa_nodes",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
         }
@@ -771,7 +768,7 @@ namespace pika { namespace threads {
         if (0 > nobjs)
         {
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_number_of_cores",
+                "pika::threads::detail::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type(HWLOC_OBJ_CORE) failed");
             return std::size_t(nobjs);
         }
@@ -783,7 +780,7 @@ namespace pika { namespace threads {
             if (0 > nobjs)
             {
                 PIKA_THROW_EXCEPTION(kernel_error,
-                    "pika::threads::topology::get_number_of_cores",
+                    "pika::threads::detail::topology::get_number_of_cores",
                     "hwloc_get_nbobjs_by_type(HWLOC_OBJ_PU) failed");
                 return std::size_t(nobjs);
             }
@@ -794,7 +791,7 @@ namespace pika { namespace threads {
         if (0 == nobjs)
         {
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_number_of_cores",
+                "pika::threads::detail::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type reports zero cores/pus");
             return std::size_t(nobjs);
         }
@@ -918,49 +915,47 @@ namespace pika { namespace threads {
         hwloc_cpuset_to_nodeset_strict(topo, cpuset, nodeset);
 #endif
         hwloc_bitmap_free(cpuset);
-        return std::make_shared<pika::threads::pika_hwloc_bitmap_wrapper>(
-            nodeset);
+        return std::make_shared<
+            pika::threads::detail::pika_hwloc_bitmap_wrapper>(nodeset);
     }
 
-    namespace detail {
-        void print_info(
-            std::ostream& os, hwloc_obj_t obj, char const* name, bool comma)
+    void print_info(
+        std::ostream& os, hwloc_obj_t obj, char const* name, bool comma)
+    {
+        if (comma)
+            os << ", ";
+        os << name;
+
+        if (obj->logical_index != ~0x0u)
+            os << "L#" << obj->logical_index;
+        if (obj->os_index != ~0x0u)
+            os << "(P#" << obj->os_index << ")";
+    }
+
+    void print_info(std::ostream& os, hwloc_obj_t obj, bool comma = false)
+    {
+        switch (obj->type)
         {
-            if (comma)
-                os << ", ";
-            os << name;
+        case HWLOC_OBJ_PU:
+            print_info(os, obj, "PU ", comma);
+            break;
 
-            if (obj->logical_index != ~0x0u)
-                os << "L#" << obj->logical_index;
-            if (obj->os_index != ~0x0u)
-                os << "(P#" << obj->os_index << ")";
+        case HWLOC_OBJ_CORE:
+            print_info(os, obj, "Core ", comma);
+            break;
+
+        case HWLOC_OBJ_SOCKET:
+            print_info(os, obj, "Socket ", comma);
+            break;
+
+        case HWLOC_OBJ_NODE:
+            print_info(os, obj, "NUMANode ", comma);
+            break;
+
+        default:
+            break;
         }
-
-        void print_info(std::ostream& os, hwloc_obj_t obj, bool comma = false)
-        {
-            switch (obj->type)
-            {
-            case HWLOC_OBJ_PU:
-                print_info(os, obj, "PU ", comma);
-                break;
-
-            case HWLOC_OBJ_CORE:
-                print_info(os, obj, "Core ", comma);
-                break;
-
-            case HWLOC_OBJ_SOCKET:
-                print_info(os, obj, "Socket ", comma);
-                break;
-
-            case HWLOC_OBJ_NODE:
-                print_info(os, obj, "NUMANode ", comma);
-                break;
-
-            default:
-                break;
-            }
-        }
-    }    // namespace detail
+    }
 
     void topology::print_affinity_mask(std::ostream& os, std::size_t num_thread,
         mask_cref_type m, const std::string& pool_name) const
@@ -975,7 +970,7 @@ namespace pika { namespace threads {
             if (!obj)
             {
                 PIKA_THROW_EXCEPTION(kernel_error,
-                    "pika::threads::topology::print_affinity_mask",
+                    "pika::threads::detail::topology::print_affinity_mask",
                     "object not found");
                 return;
             }
@@ -1024,7 +1019,7 @@ namespace pika { namespace threads {
         }
 
         PIKA_THROW_EXCEPTION(kernel_error,
-            "pika::threads::topology::init_machine_affinity_mask",
+            "pika::threads::detail::topology::init_machine_affinity_mask",
             "failed to initialize machine affinity mask");
         return empty_mask;
     }    // }}}
@@ -1169,7 +1164,8 @@ namespace pika { namespace threads {
             if (num_cores <= 0)
             {
                 PIKA_THROW_EXCEPTION(kernel_error,
-                    "pika::threads::topology::init_thread_affinity_mask",
+                    "pika::threads::detail::topology::init_thread_affinity_"
+                    "mask",
                     "hwloc_get_nbobjs_by_type failed");
                 return empty_mask;
             }
@@ -1245,7 +1241,7 @@ namespace pika { namespace threads {
             {
                 hwloc_bitmap_free(cpuset);
                 PIKA_THROWS_IF(ec, kernel_error,
-                    "pika::threads::topology::get_cpubind_mask",
+                    "pika::threads::detail::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
             }
@@ -1292,7 +1288,7 @@ namespace pika { namespace threads {
             {
                 hwloc_bitmap_free(cpuset);
                 PIKA_THROWS_IF(ec, kernel_error,
-                    "pika::threads::topology::get_cpubind_mask",
+                    "pika::threads::detail::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
             }
@@ -1365,7 +1361,7 @@ namespace pika { namespace threads {
             if (errno == EXDEV)
                 msg = "the binding cannot be enforced";
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::set_area_membind_nodeset",
+                "pika::threads::detail::topology::set_area_membind_nodeset",
                 "hwloc_set_area_membind_nodeset failed : {}", msg);
             return false;
         }
@@ -1387,7 +1383,7 @@ namespace pika { namespace threads {
         }
     }    // namespace
 
-    threads::mask_type topology::get_area_membind_nodeset(
+    threads::detail::mask_type topology::get_area_membind_nodeset(
         const void* addr, std::size_t len) const
     {
         pika_hwloc_bitmap_wrapper& nodeset = bitmap_storage();
@@ -1411,7 +1407,7 @@ namespace pika { namespace threads {
             == -1)
         {
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_area_membind_nodeset",
+                "pika::threads::detail::topology::get_area_membind_nodeset",
                 "hwloc_get_area_membind_nodeset failed");
             return bitmap_to_mask(ns, HWLOC_OBJ_MACHINE);
         }
@@ -1442,14 +1438,15 @@ namespace pika { namespace threads {
 #else
             std::string msg(strerror(errno));
             PIKA_THROW_EXCEPTION(kernel_error,
-                "pika::threads::topology::get_numa_domain",
+                "pika::threads::detail::topology::get_numa_domain",
                 "hwloc_get_area_memlocation failed {}", msg);
             return -1;
 #endif
         }
 
-        threads::mask_type mask = bitmap_to_mask(ns, HWLOC_OBJ_NUMANODE);
-        return static_cast<int>(threads::find_first(mask));
+        threads::detail::mask_type mask =
+            bitmap_to_mask(ns, HWLOC_OBJ_NUMANODE);
+        return static_cast<int>(threads::detail::find_first(mask));
 #else
         PIKA_UNUSED(addr);
         return 0;
@@ -1518,7 +1515,7 @@ namespace pika { namespace threads {
 
         for (std::size_t i = 0; i != s; i++)
         {
-            os << pika::threads::to_string(v[i]) << "\n";
+            os << pika::threads::detail::to_string(v[i]) << "\n";
         }
         os << "\n";
     }
@@ -1550,12 +1547,12 @@ namespace pika { namespace threads {
            << "number of cores       : " << get_number_of_cores() << "\n"
            << "number of PUs         : " << get_number_of_pus() << "\n"
            << "hardware concurrency  : "
-           << pika::threads::hardware_concurrency() << "\n"
+           << pika::threads::detail::hardware_concurrency() << "\n"
            << std::endl;
         //! -------------------------------------- topology (affinity masks)
         os << "[HWLOC topology info] affinity masks :\n"
            << "machine               : \n"
-           << pika::threads::to_string(machine_affinity_mask_) << "\n";
+           << pika::threads::detail::to_string(machine_affinity_mask_) << "\n";
 
         os << "socket                : \n";
         print_mask_vector(os, socket_affinity_masks_);
@@ -1586,27 +1583,25 @@ namespace pika { namespace threads {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        struct hw_concurrency
-        {
-            hw_concurrency()
+    struct hw_concurrency
+    {
+        hw_concurrency()
 #if defined(__ANDROID__) && defined(ANDROID)
-              : num_of_cores_(::android_getCpuCount())
+          : num_of_cores_(::android_getCpuCount())
 #else
-              : num_of_cores_(hwloc_hardware_concurrency())
+          : num_of_cores_(hwloc_hardware_concurrency())
 #endif
-            {
-                if (num_of_cores_ == 0)
-                    num_of_cores_ = 1;
-            }
+        {
+            if (num_of_cores_ == 0)
+                num_of_cores_ = 1;
+        }
 
-            std::size_t num_of_cores_;
-        };
-    }    // namespace detail
+        std::size_t num_of_cores_;
+    };
 
     unsigned int hardware_concurrency()
     {
         static detail::hw_concurrency hwc;
         return static_cast<unsigned int>(hwc.num_of_cores_);
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -35,9 +35,10 @@ bool csv = false;
 bool header = false;
 
 ///////////////////////////////////////////////////////////////////////////////
-pika::threads::topology& retrieve_topology()
+pika::threads::detail::topology& retrieve_topology()
 {
-    static pika::threads::topology& topo = pika::threads::create_topology();
+    static pika::threads::detail::topology& topo =
+        pika::threads::detail::create_topology();
     return topo;
 }
 

--- a/tests/performance/local/stream_report.cpp
+++ b/tests/performance/local/stream_report.cpp
@@ -57,9 +57,10 @@ std::string get_executor_name(std::size_t executor)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-pika::threads::topology& retrieve_topology()
+pika::threads::detail::topology& retrieve_topology()
 {
-    static pika::threads::topology& topo = pika::threads::create_topology();
+    static pika::threads::detail::topology& topo =
+        pika::threads::detail::create_topology();
     return topo;
 }
 

--- a/tests/regressions/threads/threads_all_1422.cpp
+++ b/tests/regressions/threads/threads_all_1422.cpp
@@ -34,7 +34,7 @@ int pika_main()
 int main(int argc, char** argv)
 {
     // Get number of cores from OS
-    num_cores = pika::threads::hardware_concurrency();
+    num_cores = pika::threads::detail::hardware_concurrency();
 
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"pika.os_threads=all"};

--- a/tools/asan.supp
+++ b/tools/asan.supp
@@ -11,4 +11,4 @@ leak:hwloc_topology_init
 
 # Tmp: Topology leak which appeared when changing the base image used for the
 # github action. Ignored temporarily as it is not related to bumping cmake
-leak:*pika::threads::topology::topology*
+leak:*pika::threads::detail::topology::topology*


### PR DESCRIPTION
Fixes partially #16
- Moves all topology symbols into the detail namespace

TODO:
- [x] Mark `constexpr`, `noexcept` the functionalities when relevant
