### PR TITLE
Change reference counting again in ensure_started

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -152,21 +152,21 @@ namespace pika { namespace execution { namespace experimental {
 
                 struct ensure_started_receiver
                 {
-                    shared_state& state;
+                    pika::intrusive_ptr<shared_state> state;
 
                     template <typename Error>
                     friend void tag_invoke(set_error_t,
                         ensure_started_receiver&& r, Error&& error) noexcept
                     {
-                        r.state.v.template emplace<error_type>(
+                        r.state->v.template emplace<error_type>(
                             error_type(PIKA_FORWARD(Error, error)));
-                        r.state.set_predecessor_done();
+                        r.state->set_predecessor_done();
                     }
 
                     friend void tag_invoke(
                         set_done_t, ensure_started_receiver&& r) noexcept
                     {
-                        r.state.set_predecessor_done();
+                        r.state->set_predecessor_done();
                     };
 
                     // This typedef is duplicated from the parent struct. The
@@ -188,10 +188,9 @@ namespace pika { namespace execution { namespace experimental {
                                         PIKA_FORWARD(Ts, ts)...)),
                             void())
                     {
-                        r.state.v.template emplace<value_type>(
+                        r.state->v.template emplace<value_type>(
                             pika::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
-
-                        r.state.set_predecessor_done();
+                        r.state->set_predecessor_done();
                     }
                 };
 
@@ -204,7 +203,7 @@ namespace pika { namespace execution { namespace experimental {
                     os.emplace(pika::util::detail::with_result_of([&]() {
                         return pika::execution::experimental::connect(
                             PIKA_FORWARD(Sender_, sender),
-                            ensure_started_receiver{*this});
+                            ensure_started_receiver{this});
                     }));
                 }
 

--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -171,5 +171,10 @@ int main()
         PIKA_TEST(receiver_set_value_called);
     }
 
+    // It's allowed to discard the sender from ensure_started
+    {
+        ex::just() | ex::ensure_started();
+    }
+
     return pika::util::report_errors();
 }

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1012,6 +1012,11 @@ void test_ensure_started()
         PIKA_TEST_EQ(tt::sync_wait(s), 42);
         PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
+
+    // It's allowed to discard the sender from ensure_started
+    {
+        ex::schedule(ex::thread_pool_scheduler{}) | ex::ensure_started();
+    }
 }
 
 void test_ensure_started_when_all()


### PR DESCRIPTION
Keep one reference alive in the `ensure_started_receiver` in case the `ensure_started_sender` is discarded without being connected.

Fixes #174. I improved the situation for `split` in #111, but made it worse for `ensure_started`. If the sender from `ensure_started` is discarded (which is allowed) the shared state would be released immediately because the receiver from `ensure_started` only kept a reference to the shared state (not a counted reference). This makes the reference an `intrusive_ptr` again. After #143 `ensure_started` sends rvalues to connected receivers which means that the `ensure_started_receiver` holding onto stored values is less of a concern. ~Just in case, I'm still resetting the shared state after continuations have been signaled.~ (Edit: the extra reset is not necessary, and actively harmful) I'm not 100% confident that I'm not introducing yet another bug with this, but I'm again slightly more certain that this goes in the right direction. Until the next one...

I could eventually reproduce at least one segfault coming from the `ensure_started` tests in `thread_pool_scheduler_test`. This seems to fix those as well. I.e. possibly fixes #60.