### PR TITLE
Remove enabler in `then`'s `set_value`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -91,8 +91,7 @@ namespace pika { namespace execution { namespace experimental {
                     });
             }
 
-            template <typename... Ts,
-                typename = std::enable_if_t<pika::is_invocable_v<F, Ts...>>>
+            template <typename... Ts>
             friend void tag_invoke(
                 set_value_t, then_receiver_type&& r, Ts&&... ts) noexcept
             {

--- a/libs/pika/execution/tests/unit/algorithm_then.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_then.cpp
@@ -66,6 +66,17 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
+        auto s = ex::then(
+            ex::just(42), [](auto i) { return i + 1; });    // generic lambda
+        auto f = [](int x) { PIKA_TEST_EQ(x, 43); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
         auto s = ex::then(ex::just(custom_type_non_default_constructible{0}),
             [](custom_type_non_default_constructible x) {
                 ++(x.x);


### PR DESCRIPTION
Fixes #181

The problem is that `tag_invoke` of any tag instantiates the enable_if, before the function is excluded from the overload set. For generic lambdas the body has to be instantiated to get the return type which is a hard error.
To my understanding there is nothing to disambiguate in the `then::tag_invoke(set_value, ...)` and it can be removed (alternatively the enabler can be put in a trailing return type).

## Any background context you want to provide?

Maybe this is a general problem of the tag_invoke mechanism? C++20 constraints have the same problem. I am wondering about compile time of codes with many tag_invoke overloads if all non-trailing constraints might have to be evaluated. Or am I missing something?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
