### PR TITLE
Remove unnecessary boost dependencies when `PIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON`

### DIFF
--- a/cmake/pika_setup_boost.cmake
+++ b/cmake/pika_setup_boost.cmake
@@ -42,7 +42,7 @@ if(NOT TARGET pika_dependencies_boost)
   set(__boost_libraries "")
   if(PIKA_WITH_GENERIC_CONTEXT_COROUTINES)
     # if context is needed, we should still link with boost thread and chrono
-    set(__boost_libraries ${__boost_libraries} context thread chrono)
+    set(__boost_libraries ${__boost_libraries} context)
   endif()
 
   list(REMOVE_DUPLICATES __boost_libraries)


### PR DESCRIPTION
Fixes #183. `thread` and `chrono` are not needed anymore. They may be an artifact of missing dependencies with previous Boost CMake configurations. These dependencies were added when requiring Boost 1.51.0 in HPX.