### PR TITLE
Inherit annotations from scheduling task instead of spawning task in `transfer` for `thread_pool_scheduler`

### DIFF
--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -11,6 +11,7 @@
 #include <pika/coroutines/thread_enums.hpp>
 #include <pika/errors/try_catch_exception_ptr.hpp>
 #include <pika/execution/algorithms/execute.hpp>
+#include <pika/execution/algorithms/schedule_from.hpp>
 #include <pika/execution/executors/execution_parameters.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
@@ -135,9 +136,9 @@ namespace pika { namespace execution { namespace experimental {
         }
 
         template <typename F>
-        void execute(F&& f) const
+        void execute(F&& f, char const* fallback_annotation) const
         {
-            pika::util::thread_description desc(f, annotation_);
+            pika::util::thread_description desc(f, fallback_annotation);
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(PIKA_FORWARD(F, f)), desc,
                 priority_, schedulehint_, stacksize_);
@@ -148,7 +149,7 @@ namespace pika { namespace execution { namespace experimental {
         friend void tag_invoke(
             execute_t, thread_pool_scheduler const& sched, F&& f)
         {
-            sched.execute(PIKA_FORWARD(F, f));
+            sched.execute(PIKA_FORWARD(F, f), sched.get_fallback_annotation());
         }
 
         template <typename Scheduler, typename Receiver>
@@ -156,12 +157,16 @@ namespace pika { namespace execution { namespace experimental {
         {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            char const* fallback_annotation;
 
             template <typename Scheduler_, typename Receiver_>
-            operation_state(Scheduler_&& scheduler, Receiver_&& receiver)
+            operation_state(Scheduler_&& scheduler, Receiver_&& receiver,
+                char const* fallback_annotation)
               : scheduler(PIKA_FORWARD(Scheduler_, scheduler))
               , receiver(PIKA_FORWARD(Receiver_, receiver))
+              , fallback_annotation(fallback_annotation)
             {
+                PIKA_ASSERT(fallback_annotation != nullptr);
             }
 
             operation_state(operation_state&&) = delete;
@@ -177,7 +182,8 @@ namespace pika { namespace execution { namespace experimental {
                             [receiver = PIKA_MOVE(os.receiver)]() mutable {
                                 pika::execution::experimental::set_value(
                                     PIKA_MOVE(receiver));
-                            });
+                            },
+                            os.fallback_annotation);
                     },
                     [&](std::exception_ptr ep) {
                         pika::execution::experimental::set_error(
@@ -190,6 +196,13 @@ namespace pika { namespace execution { namespace experimental {
         struct sender
         {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+
+            // We explicitly get the fallback annotation when constructing the
+            // sender so that if the scheduler has no annotation, the annotation
+            // is instead taken from the context creating the sender, not from
+            // the context when the task is actually spawned (if different).
+            char const* fallback_annotation =
+                scheduler.get_fallback_annotation();
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
@@ -204,15 +217,16 @@ namespace pika { namespace execution { namespace experimental {
             friend operation_state<Scheduler, Receiver> tag_invoke(
                 connect_t, sender&& s, Receiver&& receiver)
             {
-                return {
-                    PIKA_MOVE(s.scheduler), PIKA_FORWARD(Receiver, receiver)};
+                return {PIKA_MOVE(s.scheduler),
+                    PIKA_FORWARD(Receiver, receiver), s.fallback_annotation};
             }
 
             template <typename Receiver>
             friend operation_state<Scheduler, Receiver> tag_invoke(
                 connect_t, sender& s, Receiver&& receiver)
             {
-                return {s.scheduler, PIKA_FORWARD(Receiver, receiver)};
+                return {s.scheduler, PIKA_FORWARD(Receiver, receiver),
+                    s.fallback_annotation};
             }
 
             template <typename CPO,
@@ -226,21 +240,85 @@ namespace pika { namespace execution { namespace experimental {
             }
         };
 
-        friend constexpr sender<thread_pool_scheduler> tag_invoke(
+        friend sender<thread_pool_scheduler> tag_invoke(
             schedule_t, thread_pool_scheduler&& sched)
         {
             return {PIKA_MOVE(sched)};
         }
 
-        friend constexpr sender<thread_pool_scheduler> tag_invoke(
+        friend sender<thread_pool_scheduler> tag_invoke(
             schedule_t, thread_pool_scheduler const& sched)
         {
             return {sched};
+        }
+
+        // We customize schedule_from to customize transfer. We want transfer to
+        // take the annotation from the calling context of transfer if needed
+        // and available. If we don't customize schedule_from the schedule
+        // customization will be called much later by the schedule_from default
+        // implementation, and the annotation may no longer come from the
+        // calling context  of transfer.
+        //
+        // This updates the annotation of the scheduler with
+        // get_fallback_annotation. If scheduler already has an annotation it
+        // will simply set the same annotation. However, if scheduler doesn't
+        // have an annotation set it will get it from the context calling
+        // transfer if available, and otherwise fall back to the default
+        // annotation. Once the scheduler annotation has been updated we
+        // construct a sender from the default schedule_from implementation.
+        //
+        // TODO: Can we simply dispatch to the default implementation?
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend auto tag_invoke(schedule_from_t,
+            thread_pool_scheduler&& scheduler, Sender&& predecessor_sender)
+        {
+            return schedule_from_detail::schedule_from_sender<Sender,
+                thread_pool_scheduler>{PIKA_FORWARD(Sender, predecessor_sender),
+                with_annotation(
+                    PIKA_MOVE(scheduler), scheduler.get_fallback_annotation())};
+        }
+
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend auto tag_invoke(schedule_from_t,
+            thread_pool_scheduler const& scheduler, Sender&& predecessor_sender)
+        {
+            return schedule_from_detail::schedule_from_sender<Sender,
+                thread_pool_scheduler>{PIKA_FORWARD(Sender, predecessor_sender),
+                with_annotation(
+                    scheduler, scheduler.get_fallback_annotation())};
         }
         /// \endcond
 
     private:
         /// \cond NOINTERNAL
+        char const* get_fallback_annotation() const
+        {
+            // Scheduler annotations have priority
+            if (annotation_)
+            {
+                return annotation_;
+            }
+
+            // Next is the annotation from the current context scheduling work
+            pika::threads::thread_id_type id = pika::threads::get_self_id();
+            if (id)
+            {
+                pika::util::thread_description desc =
+                    pika::threads::get_thread_description(id);
+                if (desc.kind() ==
+                    pika::util::thread_description::data_type_description)
+                {
+                    return desc.get_description();
+                }
+            }
+
+            // If there are no annotations in the scheduler or scheduling
+            // context, use "<unknown>". Explicitly do not use nullptr here to
+            // avoid thread_description taking the current annotation from the
+            // spawning context.
+            return "<unknown>";
+        }
+
         pika::threads::thread_pool_base* pool_ =
             pika::threads::detail::get_self_or_default_pool();
         pika::threads::thread_priority priority_ =

--- a/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
@@ -137,6 +137,12 @@ namespace pika {
                 threads::get_thread_id_data(self->get_thread_id())
                     ->set_description(desc_);
             }
+
+#if defined(PIKA_HAVE_APEX)
+            threads::set_self_timer_data(
+                pika::detail::external_timer::update_task(
+                    threads::get_self_timer_data(), desc_));
+#endif
         }
 
         pika::util::thread_description desc_;

--- a/libs/pika/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/unit/CMakeLists.txt
@@ -9,7 +9,7 @@ set(tests resume_suspended_same_thread)
 set(resume_suspended_same_thread_PARAMETERS THREADS 2)
 
 if(PIKA_WITH_APEX)
-  list(APPEND tests annotation_check)
+  list(APPEND tests annotation_check_futures annotation_check_senders)
 endif()
 
 foreach(test ${tests})
@@ -69,9 +69,34 @@ if(PIKA_WITH_APEX)
   endforeach()
 
   set_tests_properties(
-    tests.unit.modules.threading_base.annotation_check
-    PROPERTIES
-      PASS_REGULAR_EXPRESSION
-      "${REGEX_MATCH_S_}${REGEX_MATCH_D_}${REGEX_MATCH_C_}${REGEX_MATCH_ANN_}"
+    tests.unit.modules.threading_base.annotation_check_futures
+    PROPERTIES PASS_REGULAR_EXPRESSION
+               "${REGEX_MATCH_D_}${REGEX_MATCH_C_}${REGEX_MATCH_ANN_}"
+  )
+
+  string(
+    CONCAT REGEX_MATCH_S_
+           "0-execute-no-parent-A :[ ]+1[ ]+.*"
+           "0-execute-no-parent-C :[ ]+1[ ]+.*"
+           "1-execute-parent :[ ]+2[ ]+.*"
+           "1-execute-parent-A :[ ]+1[ ]+.*"
+           "1-execute-parent-C :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-A :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-B :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-C :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-D :[ ]+1[ ]+.*"
+           "3-schedule-parent :[ ]+7[ ]+.*"
+           "3-schedule-parent-A :[ ]+1[ ]+.*"
+           "3-schedule-parent-B :[ ]+1[ ]+.*"
+           "3-schedule-parent-C :[ ]+1[ ]+.*"
+           "3-schedule-parent-D :[ ]+1[ ]+.*"
+           "3-schedule-parent-E :[ ]+1[ ]+.*"
+           "3-schedule-parent-F :[ ]+1[ ]+.*"
+           "<unknown> :[ ]+8[ ]+.*"
+  )
+
+  set_tests_properties(
+    tests.unit.modules.threading_base.annotation_check_senders
+    PROPERTIES PASS_REGULAR_EXPRESSION "${REGEX_MATCH_S_}"
   )
 endif()

--- a/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
+++ b/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
@@ -1,0 +1,154 @@
+//  Copyright (c) 2022 ETH Zurich
+//  Copyright (c) 2019 John Biddiscombe
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/execution.hpp>
+#include <pika/functional.hpp>
+#include <pika/init.hpp>
+#include <pika/testing.hpp>
+
+#include <apex_options.hpp>
+
+#include <utility>
+
+namespace ex = pika::execution::experimental;
+namespace tt = pika::this_thread::experimental;
+
+auto test_senders_execute_no_parent_annotation()
+{
+    // <unknown>
+    ex::execute(ex::thread_pool_scheduler{}, [] {});
+
+    // 0-execute-no-parent-A
+    ex::execute(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "0-execute-no-parent-A"),
+        [] {});
+
+    // 0-execute-no-parent-C
+    ex::execute(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "0-execute-no-parent-B"),
+        pika::annotated_function([] {}, "0-execute-no-parent-C"));
+}
+
+auto test_senders_execute_parent_annotation()
+{
+    // 1-execute-parent
+    ex::execute(
+        ex::with_annotation(ex::thread_pool_scheduler{}, "1-execute-parent"),
+        [] {
+            // 1-execute-parent
+            ex::execute(ex::thread_pool_scheduler{}, [] {});
+
+            // 1-execute-parent-A
+            ex::execute(ex::with_annotation(
+                            ex::thread_pool_scheduler{}, "1-execute-parent-A"),
+                [] {});
+
+            // 1-execute-no-parent-C
+            ex::execute(ex::with_annotation(
+                            ex::thread_pool_scheduler{}, "1-execute-parent-B"),
+                pika::annotated_function([] {}, "1-execute-parent-C"));
+        });
+}
+
+auto test_senders_schedule_no_parent_annotation()
+{
+    return ex::when_all(
+        // <unknown>
+        ex::schedule(ex::thread_pool_scheduler{}),
+
+        // 2-schedule-no-parent-A
+        ex::schedule(ex::with_annotation(
+            ex::thread_pool_scheduler{}, "2-schedule-no-parent-A")),
+
+        // <unknown> and 2-schedule-parent-B, plus one yielded <unknown> which
+        // does not show up in the call count (but does show up in OTF2 files)
+        ex::schedule(ex::thread_pool_scheduler{}) |
+            ex::then(pika::annotated_function([] {}, "2-schedule-no-parent-B")),
+
+        // 2-schedule-parent-C and 2-schedule-parent-D
+        ex::schedule(ex::with_annotation(
+            ex::thread_pool_scheduler{}, "2-schedule-no-parent-C")) |
+            ex::then(pika::annotated_function([] {}, "2-schedule-no-parent-D")),
+
+        // 2 x <unknown>
+        ex::schedule(ex::thread_pool_scheduler{}) |
+            ex::transfer(ex::thread_pool_scheduler{}),
+
+        // 2-schedule-no-parent-E and <unknown>
+        ex::schedule(ex::with_annotation(
+            ex::thread_pool_scheduler{}, "2-schedule-no-parent-E")) |
+            ex::transfer(ex::thread_pool_scheduler{}),
+
+        // 2-schedule-no-parent-F and <unknown>
+        ex::schedule(ex::thread_pool_scheduler{}) |
+            ex::transfer(ex::with_annotation(
+                ex::thread_pool_scheduler{}, "2-schedule-no-parent-F"))
+        //
+    );
+}
+
+auto test_senders_schedule_parent_annotation()
+{
+    // 3-schedule-parent
+    return ex::schedule(ex::with_annotation(
+               ex::thread_pool_scheduler{}, "3-schedule-parent")) |
+        ex::let_value([]() {
+            return ex::when_all(
+                // 3-schedule-parent
+                ex::schedule(ex::thread_pool_scheduler{}),
+
+                // 3-schedule-parent-A
+                ex::schedule(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "3-schedule-parent-A")),
+
+                // 3-schedule-parent and 3-schedule-parent-B, plus one yielded
+                // 3-schedule-parent which does not show up in the call count
+                // (but does show up in OTF2 files)
+                ex::schedule(ex::thread_pool_scheduler{}) |
+                    ex::then(
+                        pika::annotated_function([] {}, "3-schedule-parent-B")),
+
+                // 3-schedule-parent-C and 3-schedule-parent-D
+                ex::schedule(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "3-schedule-parent-C")) |
+                    ex::then(
+                        pika::annotated_function([] {}, "3-schedule-parent-D")),
+
+                // 2 x 3-schedule-parent
+                ex::schedule(ex::thread_pool_scheduler{}) |
+                    ex::transfer(ex::thread_pool_scheduler{}),
+
+                // 3-schedule-parent-E and 3-schedule-parent
+                ex::schedule(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "3-schedule-parent-E")) |
+                    ex::transfer(ex::thread_pool_scheduler{}),
+
+                // 3-schedule-parent-F and 3-schedule-parent
+                ex::schedule(ex::thread_pool_scheduler{}) |
+                    ex::transfer(ex::with_annotation(
+                        ex::thread_pool_scheduler{}, "3-schedule-parent-F"))
+                //
+            );
+        });
+}
+
+int main(int argc, char* argv[])
+{
+    apex::apex_options::use_screen_output(true);
+    pika::start(nullptr, argc, argv);
+
+    test_senders_execute_no_parent_annotation();
+    test_senders_execute_parent_annotation();
+    tt::sync_wait(test_senders_schedule_no_parent_annotation());
+    tt::sync_wait(test_senders_schedule_parent_annotation());
+
+    // <unknown>
+    ex::execute(ex::thread_pool_scheduler{}, [] { pika::finalize(); });
+
+    PIKA_TEST_EQ(pika::stop(), 0);
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
Fixes #172.

Changes the behaviour of `execute` and `schedule` for `thread_pool_sheduler` to take a fallback annotation from the calling context. Also customizes `schedule_from` for `thread_pool_scheduler` in order to get the fallback annotation from the context where `transfer` is called. The default `transfer` implementation otherwise calls `schedule` only when it's time to schedule the new task, which would inherit the wrong annotation without the `schedule_from` customization.

Open issues that will likely be left out from this PR:
- APEX develop seems to have changed the output format when screen output is enabled. I think we will have to change how the annotation tests check for correct output, but I'm still targeting this against the latest release of APEX.
- The `schedule_from` customization for `thread_pool_scheduler` currently relies on knowing the sender type of the default `schedule_from` implementation. We should think about how we can customize an operation but then also be able to dispatch to the default implementation (in this case we only want to add an annotation to the scheduler and then use the default implementation).
- The behaviour of annotations for other adaptors such as `bulk`, `when_all` etc. haven't really been considered. I think they are covered by the changes here but I'll add some more notes to #172 about those cases tomorrow.