### PR TITLE
Update annotations for thread_pool_scheduler bulk customization

### DIFF
--- a/libs/pika/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ set(resume_suspended_same_thread_PARAMETERS THREADS 2)
 
 if(PIKA_WITH_APEX)
   list(APPEND tests annotation_check_futures annotation_check_senders)
+  set(annotation_check_senders_PARAMETERS THREADS 2)
 endif()
 
 foreach(test ${tests})
@@ -85,14 +86,20 @@ if(PIKA_WITH_APEX)
            "2-schedule-no-parent-B :[ ]+1[ ]+.*"
            "2-schedule-no-parent-C :[ ]+1[ ]+.*"
            "2-schedule-no-parent-D :[ ]+1[ ]+.*"
-           "3-schedule-parent :[ ]+7[ ]+.*"
+           "2-schedule-no-parent-E :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-F :[ ]+1[ ]+.*"
+           "2-schedule-no-parent-G :[ ]+2[ ]+.*"
+           "2-schedule-no-parent-H :[ ]+1[ ]+.*"
+           "3-schedule-parent :[ ]+11[ ]+.*"
            "3-schedule-parent-A :[ ]+1[ ]+.*"
            "3-schedule-parent-B :[ ]+1[ ]+.*"
            "3-schedule-parent-C :[ ]+1[ ]+.*"
            "3-schedule-parent-D :[ ]+1[ ]+.*"
            "3-schedule-parent-E :[ ]+1[ ]+.*"
            "3-schedule-parent-F :[ ]+1[ ]+.*"
-           "<unknown> :[ ]+8[ ]+.*"
+           "3-schedule-parent-G :[ ]+2[ ]+.*"
+           "3-schedule-parent-H :[ ]+1[ ]+.*"
+           "<unknown> :[ ]+12[ ]+.*"
   )
 
   set_tests_properties(

--- a/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
+++ b/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
@@ -86,8 +86,23 @@ auto test_senders_schedule_no_parent_annotation()
         // 2-schedule-no-parent-F and <unknown>
         ex::schedule(ex::thread_pool_scheduler{}) |
             ex::transfer(ex::with_annotation(
-                ex::thread_pool_scheduler{}, "2-schedule-no-parent-F"))
-        //
+                ex::thread_pool_scheduler{}, "2-schedule-no-parent-F")),
+
+        // 2 x <unknown>
+        ex::schedule(ex::thread_pool_scheduler{}) | ex::bulk(2, [](int) {}),
+
+        // 2 x 2-schedule-no-parent-G
+        ex::schedule(ex::with_annotation(
+            ex::thread_pool_scheduler{}, "2-schedule-no-parent-G")) |
+            ex::bulk(2, [](int) {}),
+
+        // 2 x <unknown>, 1 x 3-schedule-no-parent-H, plus one yielded
+        // 3-schedule-no-parent-H which does not show up in the call count (but
+        // does show up in OTF2 files)
+        ex::schedule(ex::thread_pool_scheduler{}) |
+            ex::bulk(2,
+                pika::annotated_function([](int) {}, "2-schedule-no-parent-H"))
+
     );
 }
 
@@ -130,7 +145,24 @@ auto test_senders_schedule_parent_annotation()
                 // 3-schedule-parent-F and 3-schedule-parent
                 ex::schedule(ex::thread_pool_scheduler{}) |
                     ex::transfer(ex::with_annotation(
-                        ex::thread_pool_scheduler{}, "3-schedule-parent-F"))
+                        ex::thread_pool_scheduler{}, "3-schedule-parent-F")),
+
+                // 2 x 3-schedule-parent
+                ex::schedule(ex::thread_pool_scheduler{}) |
+                    ex::bulk(2, [](int) {}),
+
+                // 2 x 3-schedule-parent-G
+                ex::schedule(ex::with_annotation(
+                    ex::thread_pool_scheduler{}, "3-schedule-parent-G")) |
+                    ex::bulk(2, [](int) {}),
+
+                // 2 x 3-schedule-parent, 1 x 3-schedule-parent-H, plus one
+                // yielded 3-schedule-parent-H which does not show up in the
+                // call count (but does show up in OTF2 files)
+                ex::schedule(ex::thread_pool_scheduler{}) |
+                    ex::bulk(2,
+                        pika::annotated_function(
+                            [](int) {}, "3-schedule-parent-H"))
                 //
             );
         });


### PR DESCRIPTION
Also fixes #172.

This sets the annotations for "bulk regions" spawned by the `bulk` customization for `thread_pool_scheduler` as described in https://github.com/pika-org/pika/issues/172#issuecomment-1096447599. Annotations set on the element-wise function are lifted up to a scoped annotation around the work loop on each worker thread, and annotations already set on the pika thread are propagated to the worker threads as well.

A quirk of how APEX counts functions means that the counts that are checked for the test may not immediately make sense. APEX counts "calls" only for newly created annotations which happens when spawning a pika thread. "Nested" annotations (created e.g. with `scoped_annotation`) count as "yields". They don't show up in the APEX screen output in the latest version of APEX, but will show up in the next one. Once that is out we can update the regexes to count the "yields" as well.