### PR TITLE
Fix lifetime bug in `split`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -297,12 +297,16 @@ namespace pika { namespace execution { namespace experimental {
 
                     if (!continuations.empty())
                     {
-                        for (auto const& continuation : continuations)
+                        // We move the continuations to a local variable to
+                        // release them once all continuations have been called.
+                        // We cannot call clear on continuations after the loop
+                        // because the shared state may already be released by
+                        // the last continuation to run.
+                        auto continuations_local = PIKA_MOVE(continuations);
+                        for (auto const& continuation : continuations_local)
                         {
                             continuation();
                         }
-
-                        continuations.clear();
                     }
                 }
 

--- a/libs/pika/execution/tests/regressions/CMakeLists.txt
+++ b/libs/pika/execution/tests/regressions/CMakeLists.txt
@@ -4,8 +4,14 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests annotated_minmax_2593 bulk_then_execute_3182 chunk_size_4118
-          future_then_async_executor is_executor_1691 parallel_executor_1781
+set(tests
+    annotated_minmax_2593
+    bulk_then_execute_3182
+    chunk_size_4118
+    future_then_async_executor
+    is_executor_1691
+    parallel_executor_1781
+    split_continuation_clear
 )
 
 if(PIKA_WITH_DATAPAR)

--- a/libs/pika/execution/tests/regressions/split_continuation_clear.cpp
+++ b/libs/pika/execution/tests/regressions/split_continuation_clear.cpp
@@ -1,0 +1,44 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test reproduces a segfault in the split sender adaptor which happens if
+// the continuations are cleared after all continuations are called. This may
+// happen because the last continuation to run may reset the shared state of the
+// split adaptor. If the shared state has been reset the continuations have
+// already been released. There is a corresponding comment in the set_value
+// implementation of split_receiver.
+
+#include <pika/execution.hpp>
+#include <pika/init.hpp>
+#include <pika/testing.hpp>
+
+#include <cstddef>
+
+namespace ex = pika::execution::experimental;
+
+int pika_main()
+{
+    ex::thread_pool_scheduler sched;
+
+    for (std::size_t i = 0; i < 100; ++i)
+    {
+        auto s = ex::schedule(sched) | ex::split();
+        for (std::size_t j = 0; j < 10; ++j)
+        {
+            ex::start_detached(s);
+        }
+    }
+
+    return pika::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    PIKA_TEST_EQ_MSG(pika::init(pika_main, argc, argv), 0,
+        "pika main exited with non-zero status");
+
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
Fixes another lifetime bug in the `split` sender adaptor. The comments in the code and regression test explain the failure mode. The regression test fails almost every run without the fix and does not fail with the fix.

## Checklist

- [x] I have fixed a bug and have added a regression test.
