### PR TITLE
Fix `--pika:help` command line argument

### DIFF
--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -731,32 +731,8 @@ namespace pika::detail {
     {
         if (vm_.count("pika:help"))
         {
-            std::string help_option(vm_["pika:help"].as<std::string>());
-            if (0 == std::string("minimal").find(help_option))
-            {
-                // print static help only
-                std::cout << help << std::endl;
-                return true;
-            }
-            else if (0 == std::string("full").find(help_option))
-            {
-                // defer printing help until after dynamic part has been
-                // acquired
-                std::ostringstream strm;
-                strm << help << std::endl;
-                ini_config_.emplace_back(
-                    "pika.cmd_line_help!=" + detail::encode_string(strm.str()));
-                ini_config_.emplace_back(
-                    "pika.cmd_line_help_option!=" + help_option);
-            }
-            else
-            {
-                throw pika::detail::command_line_error(pika::util::format(
-                    "Invalid argument for option --pika:help: "
-                    "'{1}', allowed values: "
-                    "'minimal' (default) and 'full'",
-                    help_option));
-            }
+            std::cout << help << std::endl;
+            return true;
         }
         return false;
     }

--- a/libs/pika/command_line_handling/src/parse_command_line.cpp
+++ b/libs/pika/command_line_handling/src/parse_command_line.cpp
@@ -297,9 +297,7 @@ namespace pika::detail {
             options_description cmdline_options(
                 "pika options (allowed on command line only)");
             cmdline_options.add_options()
-                ("pika:help", value<std::string>()->implicit_value("minimal"),
-                    "print out program usage (default: this message), possible "
-                    "values: 'full' (additionally prints options from components)")
+                ("pika:help", "print out program usage (this message)")
                 ("pika:version", "print out pika version and copyright information")
                 ("pika:info", "print out pika configuration information")
                 ("pika:options-file", value<std::vector<std::string> >()->composing(),


### PR DESCRIPTION
Fixes #199. Don't accept arguments to `--pika:help` anymore since dynamically loaded command line options aren't supported.