### PR TITLE
Add `then_with_cusolver` support for HIP

### DIFF
--- a/cmake/pika_setup_hip.cmake
+++ b/cmake/pika_setup_hip.cmake
@@ -4,8 +4,11 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(PIKA_WITH_HIP AND (NOT TARGET roc::hipblas OR NOT TARGET roc::rocblas OR NOT
-  TARGET roc::rocsolver))
+if(PIKA_WITH_HIP
+   AND (NOT TARGET roc::hipblas
+        OR NOT TARGET roc::rocblas
+        OR NOT TARGET roc::rocsolver)
+)
 
   if(PIKA_WITH_CUDA)
     pika_error(

--- a/cmake/pika_setup_hip.cmake
+++ b/cmake/pika_setup_hip.cmake
@@ -4,12 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(PIKA_WITH_HIP
-   AND (NOT TARGET roc::hipblas
-        OR NOT TARGET roc::rocblas
-        OR NOT TARGET roc::rocsolver)
-)
-
+if(PIKA_WITH_HIP AND NOT TARGET roc::rocblas)
   if(PIKA_WITH_CUDA)
     pika_error(
       "Both PIKA_WITH_CUDA and PIKA_WITH_HIP are ON. Please choose one of \
@@ -17,21 +12,11 @@ if(PIKA_WITH_HIP
     )
   endif(PIKA_WITH_CUDA)
 
-  # Needed on rostam
-  list(APPEND CMAKE_PREFIX_PATH $ENV{HIP_PATH}/lib/cmake/hip)
-  list(APPEND CMAKE_PREFIX_PATH $ENV{DEVICE_LIB_PATH}/cmake/AMDDeviceLibs)
-  list(APPEND CMAKE_PREFIX_PATH $ENV{DEVICE_LIB_PATH}/cmake/amd_comgr)
-  list(APPEND CMAKE_PREFIX_PATH $ENV{DEVICE_LIB_PATH}/cmake/hsa-runtime64)
-  # Setup hipblas (creates roc::hipblas)
-  find_package(hipblas REQUIRED HINTS $ENV{HIPBLAS_ROOT} CONFIG)
-
-  # Tmp! Until hipSOLVER is complete for DLA-Future
   find_package(rocblas REQUIRED HINTS $ENV{ROCBLAS_ROOT})
   find_package(rocsolver REQUIRED HINTS $ENV{ROCSOLVER_ROOT})
+  find_package(hipblas REQUIRED HINTS $ENV{HIPBLAS_ROOT} CONFIG)
 
   if(NOT PIKA_FIND_PACKAGE)
-    # The cmake variables are supposed to be cached no need to redefine them
     pika_add_config_define(PIKA_HAVE_HIP)
   endif()
-
 endif()

--- a/cmake/pika_setup_hip.cmake
+++ b/cmake/pika_setup_hip.cmake
@@ -4,7 +4,8 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(PIKA_WITH_HIP AND NOT TARGET roc::hipblas)
+if(PIKA_WITH_HIP AND (NOT TARGET roc::hipblas OR NOT TARGET roc::rocblas OR NOT
+  TARGET roc::rocsolver))
 
   if(PIKA_WITH_CUDA)
     pika_error(
@@ -20,6 +21,10 @@ if(PIKA_WITH_HIP AND NOT TARGET roc::hipblas)
   list(APPEND CMAKE_PREFIX_PATH $ENV{DEVICE_LIB_PATH}/cmake/hsa-runtime64)
   # Setup hipblas (creates roc::hipblas)
   find_package(hipblas REQUIRED HINTS $ENV{HIPBLAS_ROOT} CONFIG)
+
+  # Tmp! Until hipSOLVER is complete for DLA-Future
+  find_package(rocblas REQUIRED HINTS $ENV{ROCBLAS_ROOT})
+  find_package(rocsolver REQUIRED HINTS $ENV{ROCSOLVER_ROOT})
 
   if(NOT PIKA_FIND_PACKAGE)
     # The cmake variables are supposed to be cached no need to redefine them

--- a/libs/pika/async_cuda/CMakeLists.txt
+++ b/libs/pika/async_cuda/CMakeLists.txt
@@ -47,15 +47,11 @@ set(async_cuda_sources
     then_with_stream.cpp
 )
 
-if(PIKA_WITH_HIP
-   AND TARGET roc::hipblas
-   AND TARGET roc::rocblas
-   AND TARGET roc::rocsolver
-)
+if(PIKA_WITH_HIP)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas roc::rocblas
                             roc::rocsolver
   )
-elseif(PIKA_WITH_CUDA AND TARGET Cuda::cuda)
+elseif(PIKA_WITH_CUDA)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} Cuda::cuda
                             ${CUDA_CUBLAS_LIBRARIES} ${CUDA_CUSOLVER_LIBRARIES}
   )

--- a/libs/pika/async_cuda/CMakeLists.txt
+++ b/libs/pika/async_cuda/CMakeLists.txt
@@ -47,8 +47,8 @@ set(async_cuda_sources
     then_with_stream.cpp
 )
 
-if(PIKA_WITH_HIP AND TARGET roc::hipblas)
-  set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas)
+if(PIKA_WITH_HIP AND TARGET roc::hipblas AND TARGET roc::rocblas AND TARGET roc::rocsolver)
+  set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas roc::rocblas roc::rocsolver)
 elseif(PIKA_WITH_CUDA AND TARGET Cuda::cuda)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} Cuda::cuda
                             ${CUDA_CUBLAS_LIBRARIES} ${CUDA_CUSOLVER_LIBRARIES}

--- a/libs/pika/async_cuda/CMakeLists.txt
+++ b/libs/pika/async_cuda/CMakeLists.txt
@@ -47,8 +47,14 @@ set(async_cuda_sources
     then_with_stream.cpp
 )
 
-if(PIKA_WITH_HIP AND TARGET roc::hipblas AND TARGET roc::rocblas AND TARGET roc::rocsolver)
-  set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas roc::rocblas roc::rocsolver)
+if(PIKA_WITH_HIP
+   AND TARGET roc::hipblas
+   AND TARGET roc::rocblas
+   AND TARGET roc::rocsolver
+)
+  set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas roc::rocblas
+                            roc::rocsolver
+  )
 elseif(PIKA_WITH_CUDA AND TARGET Cuda::cuda)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} Cuda::cuda
                             ${CUDA_CUBLAS_LIBRARIES} ${CUDA_CUSOLVER_LIBRARIES}

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
@@ -48,8 +48,7 @@ namespace pika::cuda::experimental {
 #if defined(PIKA_COMPUTE_CODE)
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename Shape>
-        PIKA_DEVICE auto shape_dereference_impl(
-            std::true_type, Shape&& shape, int i)
+        PIKA_DEVICE auto shape_dereference_impl(std::true_type, Shape&&, int i)
         {
             return static_cast<std::decay_t<Shape>>(i);
         }

--- a/libs/pika/async_cuda/include/pika/async_cuda/cusolver_exception.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cusolver_exception.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <pika/config.hpp>
-#if defined(PIKA_HAVE_CUDA)
+#if defined(PIKA_HAVE_GPU_SUPPORT)
 #include <pika/async_cuda/custom_lapack_api.hpp>
 #include <pika/errors/exception.hpp>
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/cusolver_handle.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cusolver_handle.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <pika/config.hpp>
-#if defined(PIKA_HAVE_CUDA)
+#if defined(PIKA_HAVE_GPU_SUPPORT)
 #include <pika/async_cuda/cuda_exception.hpp>
 #include <pika/async_cuda/cuda_stream.hpp>
 #include <pika/async_cuda/custom_gpu_api.hpp>

--- a/libs/pika/async_cuda/include/pika/async_cuda/custom_blas_api.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/custom_blas_api.hpp
@@ -18,14 +18,8 @@
 #define cublasPointerMode_t hipblasPointerMode_t
 #define cublasSetPointerMode hipblasSetPointerMode
 #define cublasSetStream hipblasSetStream
-#define cublasSgemm hipblasSgemm
 #define cublasStatus_t hipblasStatus_t
 
-// Note that this is currently not even attempting to be a complete
-// translation layer from cuBLAS to hipblas.
-#define cublasSasum hipblasSasum
-
-#define CUBLAS_OP_N HIPBLAS_OP_N
 #define CUBLAS_POINTER_MODE_HOST HIPBLAS_POINTER_MODE_HOST
 #define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
 #define CUBLAS_STATUS_NOT_INITIALIZED HIPBLAS_STATUS_NOT_INITIALIZED

--- a/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
@@ -15,31 +15,31 @@
 #include <rocsolver.h>
 
 // Use of rocblas when the corresponding rocsolver functions are deprecated
-#define cusolverDnChegst    rocsolver_chegst
-#define cusolverDnCreate    rocblas_create_handle
-#define cusolverDnDestroy   rocblas_destroy_handle
-#define cusolverDnDsygst    rocsolver_dsygst
+#define cusolverDnChegst rocsolver_chegst
+#define cusolverDnCreate rocblas_create_handle
+#define cusolverDnDestroy rocblas_destroy_handle
+#define cusolverDnDsygst rocsolver_dsygst
 #define cusolverDnGetStream rocblas_get_stream
-#define cusolverDnHandle_t  rocblas_handle
+#define cusolverDnHandle_t rocblas_handle
 #define cusolverDnSetStream rocblas_set_stream
-#define cusolverDnSsygst    rocsolver_ssygst
-#define cusolverDnZhegst    rocsolver_zhegst
-#define cusolverStatus_t    rocblas_status
+#define cusolverDnSsygst rocsolver_ssygst
+#define cusolverDnZhegst rocsolver_zhegst
+#define cusolverStatus_t rocblas_status
 
 // In ascendent order of error codes value
-#define CUSOLVER_STATUS_SUCCESS             rocblas_status_success
-#define CUSOLVER_STATUS_INVALID_HANDLE      rocblas_status_invalid_handle
-#define CUSOLVER_STATUS_NOT_IMPLEMENTED     rocblas_status_not_implemented
-#define CUSOLVER_STATUS_INVALID_POINTER     rocblas_status_invalid_pointer
-#define CUSOLVER_STATUS_INVALID_SIZE        rocblas_status_invalid_size
-#define CUSOLVER_STATUS_MEMORY_ERROR        rocblas_status_memory_error
-#define CUSOLVER_STATUS_INTERNAL_ERROR      rocblas_status_internal_error
-#define CUSOLVER_STATUS_PERF_DEGRADED       rocblas_status_perf_degraded
+#define CUSOLVER_STATUS_SUCCESS rocblas_status_success
+#define CUSOLVER_STATUS_INVALID_HANDLE rocblas_status_invalid_handle
+#define CUSOLVER_STATUS_NOT_IMPLEMENTED rocblas_status_not_implemented
+#define CUSOLVER_STATUS_INVALID_POINTER rocblas_status_invalid_pointer
+#define CUSOLVER_STATUS_INVALID_SIZE rocblas_status_invalid_size
+#define CUSOLVER_STATUS_MEMORY_ERROR rocblas_status_memory_error
+#define CUSOLVER_STATUS_INTERNAL_ERROR rocblas_status_internal_error
+#define CUSOLVER_STATUS_PERF_DEGRADED rocblas_status_perf_degraded
 #define CUSOLVER_STATUS_SIZE_QUERY_MISMATCH rocblas_status_size_query_mismatch
-#define CUSOLVER_STATUS_SIZE_INCREASED      rocblas_status_size_increased
-#define CUSOLVER_STATUS_SIZE_UNCHANGED      rocblas_status_size_unchanged
-#define CUSOLVER_STATUS_INVALID_VALUE       rocblas_status_invalid_value
-#define CUSOLVER_STATUS_CONTINUE            rocblas_status_continue
+#define CUSOLVER_STATUS_SIZE_INCREASED rocblas_status_size_increased
+#define CUSOLVER_STATUS_SIZE_UNCHANGED rocblas_status_size_unchanged
+#define CUSOLVER_STATUS_INVALID_VALUE rocblas_status_invalid_value
+#define CUSOLVER_STATUS_CONTINUE rocblas_status_continue
 #define CUSOLVER_STATUS_CHECK_NUMERICS_FAIL rocblas_status_check_numerics_fail
 
 #elif defined(PIKA_HAVE_CUDA)

--- a/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
@@ -8,7 +8,41 @@
 
 #include <pika/config.hpp>
 
-#if defined(PIKA_HAVE_CUDA)
+#if defined(PIKA_HAVE_GPU_SUPPORT)
+
+#include <hipblas.h>
+#include <rocblas.h>
+#include <rocsolver.h>
+
+// Use of rocblas when the corresponding rocsolver functions are deprecated
+#define cusolverDnChegst    rocsolver_chegst
+#define cusolverDnCreate    rocblas_create_handle
+#define cusolverDnDestroy   rocblas_destroy_handle
+#define cusolverDnDsygst    rocsolver_dsygst
+#define cusolverDnGetStream rocblas_get_stream
+#define cusolverDnHandle_t  rocblas_handle
+#define cusolverDnSetStream rocblas_set_stream
+#define cusolverDnSsygst    rocsolver_ssygst
+#define cusolverDnZhegst    rocsolver_zhegst
+#define cusolverStatus_t    rocblas_status
+
+// In ascendent order of error codes value
+#define CUSOLVER_STATUS_SUCCESS             rocblas_status_success
+#define CUSOLVER_STATUS_INVALID_HANDLE      rocblas_status_invalid_handle
+#define CUSOLVER_STATUS_NOT_IMPLEMENTED     rocblas_status_not_implemented
+#define CUSOLVER_STATUS_INVALID_POINTER     rocblas_status_invalid_pointer
+#define CUSOLVER_STATUS_INVALID_SIZE        rocblas_status_invalid_size
+#define CUSOLVER_STATUS_MEMORY_ERROR        rocblas_status_memory_error
+#define CUSOLVER_STATUS_INTERNAL_ERROR      rocblas_status_internal_error
+#define CUSOLVER_STATUS_PERF_DEGRADED       rocblas_status_perf_degraded
+#define CUSOLVER_STATUS_SIZE_QUERY_MISMATCH rocblas_status_size_query_mismatch
+#define CUSOLVER_STATUS_SIZE_INCREASED      rocblas_status_size_increased
+#define CUSOLVER_STATUS_SIZE_UNCHANGED      rocblas_status_size_unchanged
+#define CUSOLVER_STATUS_INVALID_VALUE       rocblas_status_invalid_value
+#define CUSOLVER_STATUS_CONTINUE            rocblas_status_continue
+#define CUSOLVER_STATUS_CHECK_NUMERICS_FAIL rocblas_status_check_numerics_fail
+
+#elif defined(PIKA_HAVE_CUDA)
 
 #if defined(PIKA_GCC_VERSION)
 #pragma GCC diagnostic push

--- a/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/custom_lapack_api.hpp
@@ -8,22 +8,17 @@
 
 #include <pika/config.hpp>
 
-#if defined(PIKA_HAVE_GPU_SUPPORT)
+#if defined(PIKA_HAVE_HIP)
 
-#include <hipblas.h>
 #include <rocblas.h>
 #include <rocsolver.h>
 
 // Use of rocblas when the corresponding rocsolver functions are deprecated
-#define cusolverDnChegst rocsolver_chegst
 #define cusolverDnCreate rocblas_create_handle
 #define cusolverDnDestroy rocblas_destroy_handle
-#define cusolverDnDsygst rocsolver_dsygst
 #define cusolverDnGetStream rocblas_get_stream
 #define cusolverDnHandle_t rocblas_handle
 #define cusolverDnSetStream rocblas_set_stream
-#define cusolverDnSsygst rocsolver_ssygst
-#define cusolverDnZhegst rocsolver_zhegst
 #define cusolverStatus_t rocblas_status
 
 // In ascendent order of error codes value

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -48,7 +48,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             PIKA_FORWARD(Ts, ts)...);
     }
 
-#if defined(PIKA_HAVE_CUDA)
     PIKA_EXPORT pika::cuda::experimental::cusolver_handle const&
     get_thread_local_cusolver_handle(cuda_stream const& stream);
 
@@ -61,7 +60,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             get_thread_local_cusolver_handle(stream).get(),
             PIKA_FORWARD(Ts, ts)...);
     }
-#endif
 
     template <typename R, typename... Ts>
     void set_value_event_callback_helper(cudaError_t status, R&& r, Ts&&... ts)
@@ -588,7 +586,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
         }
     };
 
-#if defined(PIKA_HAVE_CUDA)
     // This is a wrapper for functions that expect a cusolverHandle_t in the
     // first position (as is convention for cuBLAS functions taking handles).
     template <typename F>
@@ -610,7 +607,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 stream, f, PIKA_FORWARD(Ts, ts)...);
         }
     };
-#endif
 }    // namespace pika::cuda::experimental::then_with_stream_detail
 
 namespace pika::cuda::experimental {
@@ -694,7 +690,6 @@ namespace pika::cuda::experimental {
         }
     } then_with_cublas{};
 
-#if defined(PIKA_HAVE_CUDA)
     /// Attach a continuation to run f with an additional cuSOLVER handle.
     ///
     /// Attaches a continuation to the given sender which will call f with the
@@ -727,7 +722,6 @@ namespace pika::cuda::experimental {
                 then_with_cusolver_t, F>{PIKA_FORWARD(F, f)};
         }
     } then_with_cusolver{};
-#endif
 
     /// Attach a continuation to run f with a CUDA stream, cuBLAS handle, or
     /// cuSOLVER handle.
@@ -755,14 +749,12 @@ namespace pika::cuda::experimental {
                 return then_with_cublas(PIKA_FORWARD(Sender, sender),
                     PIKA_FORWARD(F, f), pointer_mode);
             }
-#if defined(PIKA_HAVE_CUDA)
             else if constexpr (std::is_invocable_v<then_with_cusolver_t, Sender,
                                    F>)
             {
                 return then_with_cusolver(
                     PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f));
             }
-#endif
             else
             {
                 static_assert(sizeof(Sender) == 0,

--- a/libs/pika/async_cuda/src/cusolver_exception.cpp
+++ b/libs/pika/async_cuda/src/cusolver_exception.cpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <pika/config.hpp>
-#if defined(PIKA_HAVE_CUDA)
+#if defined(PIKA_HAVE_GPU_SUPPORT)
 #include <pika/async_cuda/cusolver_exception.hpp>
 #include <pika/async_cuda/custom_lapack_api.hpp>
 #include <pika/errors/exception.hpp>
@@ -22,18 +22,19 @@ namespace pika::cuda::experimental {
             {
             case CUSOLVER_STATUS_SUCCESS:
                 return "CUSOLVER_STATUS_SUCCESS";
+            case CUSOLVER_STATUS_INVALID_VALUE:
+                return "CUSOLVER_STATUS_INVALID_VALUE";
+            case CUSOLVER_STATUS_INTERNAL_ERROR:
+                return "CUSOLVER_STATUS_INTERNAL_ERROR";
+#if defined(PIKA_HAVE_CUDA)
             case CUSOLVER_STATUS_NOT_INITIALIZED:
                 return "CUSOLVER_STATUS_NOT_INITIALIZED";
             case CUSOLVER_STATUS_ALLOC_FAILED:
                 return "CUSOLVER_STATUS_ALLOC_FAILED";
-            case CUSOLVER_STATUS_INVALID_VALUE:
-                return "CUSOLVER_STATUS_INVALID_VALUE";
             case CUSOLVER_STATUS_ARCH_MISMATCH:
                 return "CUSOLVER_STATUS_ARCH_MISMATCH";
             case CUSOLVER_STATUS_EXECUTION_FAILED:
                 return "CUSOLVER_STATUS_EXECUTION_FAILED";
-            case CUSOLVER_STATUS_INTERNAL_ERROR:
-                return "CUSOLVER_STATUS_INTERNAL_ERROR";
             case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
                 return "CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED";
             case CUSOLVER_STATUS_MAPPING_ERROR:
@@ -71,6 +72,30 @@ namespace pika::cuda::experimental {
                 return "CUSOLVER_STATUS_IRS_MATRIX_SINGULAR";
             case CUSOLVER_STATUS_INVALID_WORKSPACE:
                 return "CUSOLVER_STATUS_INVALID_WORKSPACE";
+#elif defined(PIKA_HAVE_HIP)
+            case CUSOLVER_STATUS_INVALID_HANDLE:
+                return "CUSOLVER_STATUS_INVALID_HANDLE";
+            case CUSOLVER_STATUS_NOT_IMPLEMENTED:
+                return "CUSOLVER_STATUS_NOT_IMPLEMENTED";
+            case CUSOLVER_STATUS_INVALID_POINTER:
+                return "CUSOLVER_STATUS_INVALID_POINTER";
+            case CUSOLVER_STATUS_INVALID_SIZE:
+                return "CUSOLVER_STATUS_INVALID_SIZE";
+            case CUSOLVER_STATUS_MEMORY_ERROR:
+                return "CUSOLVER_STATUS_MEMORY_ERROR";
+            case CUSOLVER_STATUS_PERF_DEGRADED:
+                return "CUSOLVER_STATUS_PERF_DEGRADED";
+            case CUSOLVER_STATUS_SIZE_QUERY_MISMATCH:
+                return "CUSOLVER_STATUS_SIZE_QUERY_MISMATCH";
+            case CUSOLVER_STATUS_SIZE_INCREASED:
+                return "CUSOLVER_STATUS_SIZE_INCREASED";
+            case CUSOLVER_STATUS_SIZE_UNCHANGED:
+                return "CUSOLVER_STATUS_SIZE_UNCHANGED";
+            case CUSOLVER_STATUS_CONTINUE:
+                return "CUSOLVER_STATUS_CONTINUE";
+            case CUSOLVER_STATUS_CHECK_NUMERICS_FAIL:
+                return "CUSOLVER_STATUS_CHECK_NUMERICS_FAIL";
+#endif
             }
             return "<unknown>";
         }

--- a/libs/pika/async_cuda/src/cusolver_handle.cpp
+++ b/libs/pika/async_cuda/src/cusolver_handle.cpp
@@ -5,7 +5,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/config.hpp>
-#if defined(PIKA_HAVE_CUDA)
 #include <pika/async_cuda/cuda_device_scope.hpp>
 #include <pika/async_cuda/cuda_stream.hpp>
 #include <pika/async_cuda/cusolver_exception.hpp>
@@ -115,4 +114,3 @@ namespace pika::cuda::experimental {
         return os;
     }
 }    // namespace pika::cuda::experimental
-#endif

--- a/libs/pika/async_cuda/src/then_with_stream.cpp
+++ b/libs/pika/async_cuda/src/then_with_stream.cpp
@@ -27,7 +27,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
         return handle;
     }
 
-#if defined(PIKA_HAVE_CUDA)
     pika::cuda::experimental::cusolver_handle const&
     get_thread_local_cusolver_handle(cuda_stream const& stream)
     {
@@ -38,5 +37,4 @@ namespace pika::cuda::experimental::then_with_stream_detail {
 
         return handle;
     }
-#endif
 }    // namespace pika::cuda::experimental::then_with_stream_detail

--- a/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
+++ b/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
@@ -37,7 +37,12 @@
 #include <string>
 #include <utility>
 #include <vector>
-//
+
+#if defined(PIKA_HAVE_HIP)
+#define CUBLAS_OP_N HIPBLAS_OP_N
+#define cublasSgemm hipblasSgemm
+#endif
+
 std::mt19937 gen;
 
 namespace cu = pika::cuda::experimental;

--- a/libs/pika/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_cuda/tests/unit/CMakeLists.txt
@@ -12,11 +12,9 @@ set(tests
     cuda_scheduler
     cuda_sender
     cuda_stream
+    cusolver_handle
     then_with_stream
 )
-if(PIKA_WITH_CUDA)
-  list(APPEND tests cusolver_handle)
-endif()
 
 set(cublas_matmul_PARAMETERS THREADS 4)
 set(cuda_sender_PARAMETERS THREADS 4)

--- a/libs/pika/async_cuda/tests/unit/cublas_handle.cu
+++ b/libs/pika/async_cuda/tests/unit/cublas_handle.cu
@@ -9,6 +9,10 @@
 
 #include <utility>
 
+#if defined(PIKA_HAVE_HIP)
+#define cublasSasum hipblasSasum
+#endif
+
 namespace cu = pika::cuda::experimental;
 
 __global__ void kernel(float* p)

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -43,6 +43,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(PIKA_HAVE_HIP)
+#define CUBLAS_OP_N HIPBLAS_OP_N
+#define cublasSgemm hipblasSgemm
+#endif
+
 std::mt19937 gen;
 
 namespace cu = pika::cuda::experimental;

--- a/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_scheduler.cu
@@ -54,13 +54,11 @@ int main()
         CHECK_CUDA_COMPLETION_SCHEDULER(s);
     }
 
-#if defined(PIKA_WITH_CUDA)
     {
         auto s = ex::schedule(sched) |
             cu::then_with_cusolver([](cusolverDnHandle_t) {});
         CHECK_CUDA_COMPLETION_SCHEDULER(s);
     }
-#endif
 
     {
         auto s = ex::schedule(sched) |

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -156,7 +156,7 @@ int pika_main(pika::program_options::variables_map& vm)
 
     // --------------------
     // test kernel launch<double> using apply and async
-    float testd = 1.2345;
+    double testd = 1.2345;
     std::cout << "schedule : cuda kernel <double>  : " << testf << std::endl;
     tt::sync_wait(ex::transfer_just(cuda_sched, testd) |
         cu::then_with_stream(&cuda_trivial_kernel<double>));

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -184,12 +184,12 @@ struct cuda_memcpy_async
 };
 
 auto non_default_constructible_params(
-    custom_type_non_default_constructible& x, cudaStream_t stream)
+    custom_type_non_default_constructible& x, cudaStream_t)
 {
     return std::move(x);
 }
 auto non_default_constructible_non_copyable_params(
-    custom_type_non_default_constructible_non_copyable& x, cudaStream_t stream)
+    custom_type_non_default_constructible_non_copyable& x, cudaStream_t)
 {
     return std::move(x);
 }


### PR DESCRIPTION
Maybe fixes #48

TODO:
- [x] Test pika on ault
- [x] Test with DLA-Future
- [ ] Add `rocblas` and `rocsolver` dependency to spack package (this will be done for 0.5.0)