### PR TITLE
Update CI image to version 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ working_dir_default: &working_dir_default
 
 docker_default: &docker_default
     docker:
-      - image: pikaorg/pika-ci-base:2
+      - image: pikaorg/pika-ci-base:3
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,10 +8,11 @@ Checks: >
     -*,
     bugprone-*,
     -bugprone-assert-side-effect,
+    -bugprone-easily-swappable-parameters,
     -bugprone-exception-escape,
     -bugprone-forward-declaration-namespace,
     -bugprone-macro-parentheses,
-    modernize-use-nullptr,
+    -bugprone-narrowing-conversions,
     misc-assert-side-effect
     misc-dangling-handle
     misc-forwarding-reference-overload
@@ -21,6 +22,7 @@ Checks: >
     misc-non-copyable-objects
     misc-use-after-move
     misc-virtual-near-miss
+    modernize-use-nullptr,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*pika.*'
 CheckOptions:

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:2
+    container: pikaorg/pika-ci-base:3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/fetchcontent/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:2
+    container: pikaorg/pika-ci-base:3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/sanitizers/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:2
+    container: pikaorg/pika-ci-base:3
 
     steps:
     - uses: actions/checkout@v2

--- a/cmake/pika_add_module.cmake
+++ b/cmake/pika_add_module.cmake
@@ -314,6 +314,15 @@ function(pika_add_module libname modulename)
 
   if(PIKA_WITH_UNITY_BUILD AND NOT module_is_interface_library)
     set_target_properties(pika_${modulename} PROPERTIES UNITY_BUILD ON)
+    set_target_properties(
+      pika_${modulename}
+      PROPERTIES UNITY_BUILD_CODE_BEFORE_INCLUDE
+                 "// NOLINTBEGIN(bugprone-suspicious-include)"
+    )
+    set_target_properties(
+      pika_${modulename} PROPERTIES UNITY_BUILD_CODE_AFTER_INCLUDE
+                                    "// NOLINTEND(bugprone-suspicious-include)"
+    )
   endif()
 
   if(MSVC)

--- a/cmake/pika_setup_target.cmake
+++ b/cmake/pika_setup_target.cmake
@@ -138,6 +138,14 @@ function(pika_setup_target target)
 
   if(target_UNITY_BUILD)
     set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
+    set_target_properties(
+      ${target} PROPERTIES UNITY_BUILD_CODE_BEFORE_INCLUDE
+                           "// NOLINTBEGIN(bugprone-suspicious-include)"
+    )
+    set_target_properties(
+      ${target} PROPERTIES UNITY_BUILD_CODE_AFTER_INCLUDE
+                           "// NOLINTEND(bugprone-suspicious-include)"
+    )
   endif()
 
   get_target_property(target_EXCLUDE_FROM_ALL ${target} EXCLUDE_FROM_ALL)

--- a/examples/1d_stencil/1d_stencil_3.cpp
+++ b/examples/1d_stencil/1d_stencil_3.cpp
@@ -56,7 +56,7 @@ struct partition_data
     partition_data(std::size_t size, double initial_value)
       : data_(size)
     {
-        double base_value = double(initial_value * size);
+        double base_value = initial_value * static_cast<double>(size);
         for (std::size_t i = 0; i != size; ++i)
             data_[i] = base_value + double(i);
     }

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -67,7 +67,8 @@ public:
       : data_(new double[size])
       , size_(size)
     {
-        double base_value = double(initial_value * size);
+        double base_value =
+            static_cast<double>(initial_value) * static_cast<double>(size);
         for (std::size_t i = 0; i != size; ++i)
             data_[i] = base_value + double(i);
     }
@@ -165,7 +166,7 @@ struct stepper
         });
 
         // limit depth of dependency tree
-        pika::lcos::local::sliding_semaphore sem(nd);
+        pika::lcos::local::sliding_semaphore sem(static_cast<std::int64_t>(nd));
 
         auto Op = unwrapping(&stepper::heat_part);
 
@@ -188,13 +189,13 @@ struct stepper
             {
                 next[0].then([&sem, t](partition&&) {
                     // inform semaphore about new lower limit
-                    sem.signal(t);
+                    sem.signal(static_cast<std::int64_t>(t));
                 });
             }
 
             // suspend if the tree has become too deep, the continuation above
             // will resume this thread once the computation has caught up
-            sem.wait(t);
+            sem.wait(static_cast<std::int64_t>(t));
         }
 
         // Return the solution at time-step 'nt'.

--- a/examples/1d_stencil/1d_stencil_4_parallel.cpp
+++ b/examples/1d_stencil/1d_stencil_4_parallel.cpp
@@ -58,18 +58,18 @@ struct partition_data
       : data_(new double[size])
       , size_(size)
     {
-        double base_value = double(initial_value * size);
+        double base_value = initial_value * static_cast<double>(size);
         for (std::size_t i = 0; i != size; ++i)
-            data_[i] = base_value + double(i);
+            data_[static_cast<std::ptrdiff_t>(i)] = base_value + double(i);
     }
 
     double& operator[](std::size_t idx)
     {
-        return data_[idx];
+        return data_[static_cast<std::ptrdiff_t>(idx)];
     }
     double operator[](std::size_t idx) const
     {
-        return data_[idx];
+        return data_[static_cast<std::ptrdiff_t>(idx)];
     }
 
     std::size_t size() const

--- a/examples/1d_stencil/print_time_results.hpp
+++ b/examples/1d_stencil/print_time_results.hpp
@@ -32,7 +32,7 @@ void print_time_results(std::uint32_t num_localities,
 
     pika::util::format_to(std::cout,
         "{:-6} {:-6} {:.14g}, {:-21} {:-21} {:-21}\n", locs_str, threads_str,
-        elapsed / 1e9, nx_str, np_str, nt_str)
+        static_cast<double>(elapsed) / 1e9, nx_str, np_str, nt_str)
         << std::flush;
 }
 
@@ -51,7 +51,7 @@ void print_time_results(std::uint64_t num_os_threads, std::uint64_t elapsed,
     std::string const nt_str = pika::util::format("{} ", nt);
 
     pika::util::format_to(std::cout, "{:-21} {:.14g}, {:-21} {:-21} {:-21}\n",
-        threads_str, elapsed / 1e9, nx_str, np_str, nt_str)
+        threads_str, static_cast<double>(elapsed) / 1e9, nx_str, np_str, nt_str)
         << std::flush;
 }
 
@@ -68,6 +68,6 @@ void print_time_results(std::uint64_t num_os_threads, std::uint64_t elapsed,
     std::string const nt_str = pika::util::format("{} ", nt);
 
     pika::util::format_to(std::cout, "{:-21} {:10.12}, {:-21} {:-21}\n",
-        threads_str, elapsed / 1e9, nx_str, nt_str)
+        threads_str, static_cast<double>(elapsed) / 1e9, nx_str, nt_str)
         << std::flush;
 }

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -42,7 +42,7 @@ double delay()
 {
     double d = 0.;
     for (std::uint64_t i = 0; i < num_iterations; ++i)
-        d += 1 / (2. * i + 1);
+        d += 1 / (2. * static_cast<double>(i) + 1);
     return d;
 }
 

--- a/examples/jacobi_smp/jacobi_pika.cpp
+++ b/examples/jacobi_smp/jacobi_pika.cpp
@@ -40,8 +40,8 @@ namespace jacobi_smp {
 
         using deps_vector = std::vector<pika::shared_future<void>>;
 
-        std::size_t n_block =
-            static_cast<std::size_t>(std::ceil(double(n) / block_size));
+        std::size_t n_block = static_cast<std::size_t>(std::ceil(
+            static_cast<double>(n) / static_cast<double>(block_size)));
 
         std::shared_ptr<deps_vector> deps_new(
             new deps_vector(n_block, pika::make_ready_future()));

--- a/examples/quickstart/channel_example.cpp
+++ b/examples/quickstart/channel_example.cpp
@@ -27,8 +27,15 @@ void calculate_sum()
     std::vector<int> s = {7, 2, 8, -9, 4, 0};
     pika::lcos::local::channel<int> c;
 
-    pika::apply(&sum, std::vector<int>(s.begin(), s.begin() + s.size() / 2), c);
-    pika::apply(&sum, std::vector<int>(s.begin() + s.size() / 2, s.end()), c);
+    using difference_type = std::vector<int>::iterator::difference_type;
+    pika::apply(&sum,
+        std::vector<int>(
+            s.begin(), s.begin() + static_cast<difference_type>(s.size()) / 2),
+        c);
+    pika::apply(&sum,
+        std::vector<int>(
+            s.begin() + static_cast<difference_type>(s.size()) / 2, s.end()),
+        c);
 
     int x = c.get(pika::launch::sync);    // receive from c
     int y = c.get(pika::launch::sync);

--- a/examples/quickstart/matrix_multiplication.cpp
+++ b/examples/quickstart/matrix_multiplication.cpp
@@ -66,7 +66,8 @@ int pika_main(pika::program_options::variables_map& vm)
     std::size_t upper = vm["u"].as<std::size_t>();
 
     // Matrices have random values in the range [lower, upper]
-    std::uniform_int_distribution<element_type> dis(lower, upper);
+    std::uniform_int_distribution<element_type> dis(
+        static_cast<element_type>(lower), static_cast<element_type>(upper));
     auto generator = std::bind(dis, gen);
     pika::ranges::generate(A, generator);
     pika::ranges::generate(B, generator);

--- a/examples/transpose/transpose_serial.cpp
+++ b/examples/transpose/transpose_serial.cpp
@@ -34,7 +34,7 @@ int pika_main(pika::program_options::variables_map& vm)
     verbose = vm.count("verbose") ? true : false;
 
     std::uint64_t bytes =
-        static_cast<std::uint64_t>(2.0 * sizeof(double) * order * order);
+        static_cast<std::uint64_t>(2 * sizeof(double) * order * order);
 
     std::vector<double> A(order * order);
     std::vector<double> B(order * order);
@@ -52,7 +52,8 @@ int pika_main(pika::program_options::variables_map& vm)
     {
         for (std::uint64_t j = 0; j < order; ++j)
         {
-            A[i * order + j] = COL_SHIFT * j + ROW_SHIFT * i;
+            A[i * order + j] = COL_SHIFT * static_cast<double>(j) +
+                ROW_SHIFT * static_cast<double>(i);
             B[i * order + j] = -1.0;
         }
     }
@@ -117,7 +118,8 @@ int pika_main(pika::program_options::variables_map& vm)
         avgtime = avgtime /
             static_cast<double>(
                 (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
-        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+        std::cout << "Rate (MB/s): "
+                  << 1.e-6 * static_cast<double>(bytes) / mintime << ", "
                   << "Avg time (s): " << avgtime << ", "
                   << "Min time (s): " << mintime << ", "
                   << "Max time (s): " << maxtime << "\n";
@@ -172,8 +174,9 @@ double test_results(std::uint64_t order, std::vector<double> const& trans)
     {
         for (std::uint64_t j = 0; j < order; ++j)
         {
-            double diff =
-                trans[i * order + j] - (COL_SHIFT * i + ROW_SHIFT * j);
+            double diff = trans[i * order + j] -
+                (COL_SHIFT * static_cast<double>(i) +
+                    ROW_SHIFT * static_cast<double>(j));
             errsq += diff * diff;
         }
     }

--- a/examples/transpose/transpose_serial_block.cpp
+++ b/examples/transpose/transpose_serial_block.cpp
@@ -41,7 +41,7 @@ int pika_main(pika::program_options::variables_map& vm)
     verbose = vm.count("verbose") ? true : false;
 
     std::uint64_t bytes =
-        static_cast<std::uint64_t>(2.0 * sizeof(double) * order * order);
+        static_cast<std::uint64_t>(2 * sizeof(double) * order * order);
 
     std::uint64_t block_order = order / num_blocks;
     std::uint64_t col_block_size = order * block_order;
@@ -67,7 +67,8 @@ int pika_main(pika::program_options::variables_map& vm)
                 double col_val =
                     COL_SHIFT * static_cast<double>(b * block_order + j);
 
-                A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
+                A[b][i * block_order + j] =
+                    col_val + ROW_SHIFT * static_cast<double>(i);
                 B[b][i * block_order + j] = -1.0;
             }
         }
@@ -118,7 +119,8 @@ int pika_main(pika::program_options::variables_map& vm)
         avgtime = avgtime /
             static_cast<double>(
                 (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
-        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+        std::cout << "Rate (MB/s): "
+                  << 1.e-6 * static_cast<double>(bytes) / mintime << ", "
                   << "Avg time (s): " << avgtime << ", "
                   << "Min time (s): " << mintime << ", "
                   << "Max time (s): " << maxtime << "\n";
@@ -210,7 +212,7 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
     {
         for (std::uint64_t i = 0; i < order; ++i)
         {
-            double col_val = COL_SHIFT * i;
+            double col_val = COL_SHIFT * static_cast<double>(i);
             for (std::uint64_t j = 0; j < block_order; ++j)
             {
                 double diff = trans[b][i * block_order + j] -

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -36,7 +36,7 @@ int pika_main(pika::program_options::variables_map& vm)
     verbose = vm.count("verbose") ? true : false;
 
     std::uint64_t bytes =
-        static_cast<std::uint64_t>(2.0 * sizeof(double) * order * order);
+        static_cast<std::uint64_t>(2 * sizeof(double) * order * order);
 
     std::vector<double> A(order * order);
     std::vector<double> B(order * order);
@@ -60,7 +60,8 @@ int pika_main(pika::program_options::variables_map& vm)
     for_each(par, range, [&](std::uint64_t i) {
         for (std::uint64_t j = 0; j < order; ++j)
         {
-            A[i * order + j] = COL_SHIFT * j + ROW_SHIFT * i;
+            A[i * order + j] = COL_SHIFT * static_cast<double>(j) +
+                ROW_SHIFT * static_cast<double>(i);
             B[i * order + j] = -1.0;
         }
     });
@@ -127,7 +128,8 @@ int pika_main(pika::program_options::variables_map& vm)
         avgtime = avgtime /
             static_cast<double>(
                 (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
-        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+        std::cout << "Rate (MB/s): "
+                  << 1.e-6 * static_cast<double>(bytes) / mintime << ", "
                   << "Avg time (s): " << avgtime << ", "
                   << "Min time (s): " << mintime << ", "
                   << "Max time (s): " << maxtime << "\n";
@@ -185,8 +187,9 @@ double test_results(std::uint64_t order, std::vector<double> const& trans)
             double errsq = 0.0;
             for (std::uint64_t j = 0; j < order; ++j)
             {
-                double diff =
-                    trans[i * order + j] - (COL_SHIFT * i + ROW_SHIFT * j);
+                double diff = trans[i * order + j] -
+                    (COL_SHIFT * static_cast<double>(i) +
+                        ROW_SHIFT * static_cast<double>(j));
                 errsq += diff * diff;
             }
             return errsq;

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -43,7 +43,7 @@ int pika_main(pika::program_options::variables_map& vm)
     verbose = vm.count("verbose") ? true : false;
 
     std::uint64_t bytes =
-        static_cast<std::uint64_t>(2.0 * sizeof(double) * order * order);
+        static_cast<std::uint64_t>(2 * sizeof(double) * order * order);
 
     std::uint64_t block_order = order / num_blocks;
     std::uint64_t col_block_size = order * block_order;
@@ -75,7 +75,8 @@ int pika_main(pika::program_options::variables_map& vm)
                 double col_val =
                     COL_SHIFT * static_cast<double>(b * block_order + j);
 
-                A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
+                A[b][i * block_order + j] =
+                    col_val + ROW_SHIFT * static_cast<double>(i);
                 B[b][i * block_order + j] = -1.0;
             }
         }
@@ -133,7 +134,8 @@ int pika_main(pika::program_options::variables_map& vm)
         avgtime = avgtime /
             static_cast<double>(
                 (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
-        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+        std::cout << "Rate (MB/s): "
+                  << 1.e-6 * static_cast<double>(bytes) / mintime << ", "
                   << "Avg time (s): " << avgtime << ", "
                   << "Min time (s): " << mintime << ", "
                   << "Max time (s): " << maxtime << "\n";
@@ -230,7 +232,7 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
             double errsq = 0.0;
             for (std::uint64_t i = 0; i < order; ++i)
             {
-                double col_val = COL_SHIFT * i;
+                double col_val = COL_SHIFT * static_cast<double>(i);
                 for (std::uint64_t j = 0; j < block_order; ++j)
                 {
                     double diff = trans[b][i * block_order + j] -

--- a/libs/pika/affinity/src/affinity_data.cpp
+++ b/libs/pika/affinity/src/affinity_data.cpp
@@ -52,10 +52,12 @@ namespace pika::detail {
         --instance_number_counter_;
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void affinity_data::init(std::size_t num_threads, std::size_t max_cores,
         std::size_t pu_offset, std::size_t pu_step, std::size_t used_cores,
         std::string affinity_domain,    // -V813
         std::string const& affinity_description, bool use_process_mask)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
 #if defined(__APPLE__)
         use_process_mask = false;
@@ -285,8 +287,10 @@ namespace pika::detail {
         }
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     std::size_t affinity_data::get_pu_num(
         std::size_t num_thread, std::size_t hardware_concurrency) const
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // The offset shouldn't be larger than the number of available
         // processing units.

--- a/libs/pika/affinity/src/parse_affinity_options.cpp
+++ b/libs/pika/affinity/src/parse_affinity_options.cpp
@@ -147,11 +147,13 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void decode_compact_distribution(threads::detail::topology& t,
         std::vector<threads::detail::mask_type>& affinities,
         std::size_t used_cores, std::size_t max_cores,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         std::size_t num_threads = affinities.size();
 
@@ -201,11 +203,13 @@ namespace pika::detail {
         }
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void decode_scatter_distribution(threads::detail::topology& t,
         std::vector<threads::detail::mask_type>& affinities,
         std::size_t used_cores, std::size_t max_cores,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         std::size_t num_threads = affinities.size();
 
@@ -271,11 +275,13 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void decode_balanced_distribution(threads::detail::topology& t,
         std::vector<threads::detail::mask_type>& affinities,
         std::size_t used_cores, std::size_t max_cores,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         std::size_t num_threads = affinities.size();
 
@@ -360,11 +366,13 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void decode_numabalanced_distribution(threads::detail::topology& t,
         std::vector<threads::detail::mask_type>& affinities,
         std::size_t used_cores, std::size_t max_cores,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         PIKA_UNUSED(max_cores);
         std::size_t num_threads = affinities.size();
@@ -510,11 +518,13 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void decode_distribution(distribution_type d, threads::detail::topology& t,
         std::vector<threads::detail::mask_type>& affinities,
         std::size_t used_cores, std::size_t max_cores, std::size_t num_threads,
         std::vector<std::size_t>& num_pus, bool use_process_mask,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         affinities.resize(num_threads);
         switch (d)

--- a/libs/pika/algorithms/tests/performance/benchmark_inplace_merge.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_inplace_merge.cpp
@@ -28,13 +28,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 unsigned int seed = (unsigned int) std::random_device{}();
-std::mt19937 _rand(seed);
+std::mt19937 rng(seed);
 ///////////////////////////////////////////////////////////////////////////////
 
 struct random_fill
 {
     random_fill(std::size_t random_range)
-      : gen(_rand())
+      : gen(rng())
       , dist(0, random_range - 1)
     {
     }
@@ -162,7 +162,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
     {
         seed = vm["seed"].as<unsigned int>();
-        _rand.seed(seed);
+        rng.seed(seed);
     }
 
     // pull values from cmd

--- a/libs/pika/algorithms/tests/performance/benchmark_is_heap.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_is_heap.cpp
@@ -25,13 +25,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 unsigned int seed = (unsigned int) std::random_device{}();
-std::mt19937 _rand(seed);
+std::mt19937 rng(seed);
 ///////////////////////////////////////////////////////////////////////////////
 
 struct random_fill
 {
     random_fill()
-      : gen(_rand())
+      : gen(rng())
       , dist(0, RAND_MAX)
     {
     }
@@ -131,7 +131,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
     {
         seed = vm["seed"].as<unsigned int>();
-        _rand.seed(seed);
+        rng.seed(seed);
     }
 
     // pull values from cmd

--- a/libs/pika/algorithms/tests/performance/benchmark_is_heap_until.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_is_heap_until.cpp
@@ -25,13 +25,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 unsigned int seed = (unsigned int) std::random_device{}();
-std::mt19937 _rand(seed);
+std::mt19937 rng(seed);
 ///////////////////////////////////////////////////////////////////////////////
 
 struct random_fill
 {
     random_fill()
-      : gen(_rand())
+      : gen(rng())
       , dist(0, RAND_MAX)
     {
     }
@@ -138,7 +138,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
     {
         seed = vm["seed"].as<unsigned int>();
-        _rand.seed(seed);
+        rng.seed(seed);
     }
 
     // pull values from cmd

--- a/libs/pika/algorithms/tests/performance/benchmark_partition_copy.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_partition_copy.cpp
@@ -27,14 +27,14 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 unsigned int seed = (unsigned int) std::random_device{}();
-std::mt19937 _rand(seed);
+std::mt19937 rng(seed);
 
 ///////////////////////////////////////////////////////////////////////////////
 
 struct random_fill
 {
     random_fill()
-      : gen(_rand())
+      : gen(rng())
       , dist(0, RAND_MAX)
     {
     }
@@ -110,7 +110,7 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
 
     std::cout << "* Running Benchmark..." << std::endl;
 
-    int rand_base = _rand();
+    int rand_base = rng();
 
     auto pred = [rand_base](int t) { return t < rand_base; };
 
@@ -157,7 +157,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 
-    _rand.seed(seed);
+    rng.seed(seed);
 
     // pull values from cmd
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();

--- a/libs/pika/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/pika/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -22,13 +22,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 auto seed = std::random_device{}();
-std::mt19937 _rand(seed);
+std::mt19937 rng(seed);
 
 struct random_fill
 {
     random_fill() = default;
     random_fill(int rand_base, int range)
-      : gen(_rand())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -143,7 +143,7 @@ int pika_main()
 
     // Do modulus operation for avoiding overflow in ramdom_fill. (#2954)
     std::uniform_int_distribution<> dis(0, 9999);
-    int rand_base = dis(_rand);
+    int rand_base = dis(rng);
 
     using namespace pika::execution;
 

--- a/libs/pika/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -24,11 +24,11 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-std::mt19937 _gen(0);
+std::mt19937 rng(0);
 
 inline void inplace_merge_seed(unsigned int seed)
 {
-    _gen.seed(seed);
+    rng.seed(seed);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ struct user_defined_type
       : val(rand_no)
     {
         std::uniform_int_distribution<> dist(0, name_list.size() - 1);
-        name = name_list[dist(_gen)];
+        name = name_list[dist(rng)];
     }
 
     bool operator<(user_defined_type const& t) const
@@ -105,7 +105,7 @@ struct random_fill
 {
     random_fill() = default;
     random_fill(int rand_base, int range)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -558,7 +558,7 @@ void test_inplace_merge()
 {
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Test cases for 'int' type.
     test_inplace_merge(

--- a/libs/pika/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -23,11 +23,11 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-std::mt19937 _gen(0);
+std::mt19937 rng(0);
 
 inline void merge_seed(unsigned int seed)
 {
-    _gen.seed(seed);
+    rng.seed(seed);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,7 +56,7 @@ struct user_defined_type
       : val(rand_no)
     {
         std::uniform_int_distribution<> dis(0, name_list.size() - 1);
-        name = name_list[dis(_gen)];
+        name = name_list[dis(rng)];
     }
 
     bool operator<(user_defined_type const& t) const
@@ -104,7 +104,7 @@ struct random_fill
 {
     random_fill() = default;
     random_fill(int rand_base, int range)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -569,7 +569,7 @@ void test_merge()
 {
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Test cases for 'int' type.
     test_merge(

--- a/libs/pika/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
@@ -22,7 +22,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 rng(seed);
 
 struct throw_always
 {
@@ -49,7 +49,7 @@ struct user_defined_type
       : val(rand_no)
     {
         std::uniform_int_distribution<> dis(0, name_list.size() - 1);
-        name = name_list[dis(_gen)];
+        name = name_list[dis(rng)];
     }
 
     bool operator<(int rand_base) const
@@ -81,7 +81,7 @@ const std::vector<std::string> user_defined_type::name_list{
 struct random_fill
 {
     random_fill(int rand_base, int range)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -206,7 +206,7 @@ void test_partition_copy_exception(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 10007;
     std::vector<int> c(size), d_true(size), d_false(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_exception = false;
     try
@@ -239,7 +239,7 @@ void test_partition_copy_exception_async(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 10007;
     std::vector<int> c(size), d_true(size), d_false(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
@@ -279,7 +279,7 @@ void test_partition_copy_bad_alloc(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 10007;
     std::vector<int> c(size), d_true(size), d_false(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_bad_alloc = false;
     try
@@ -311,7 +311,7 @@ void test_partition_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 10007;
     std::vector<int> c(size), d_true(size), d_false(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;
@@ -344,7 +344,7 @@ void test_partition_copy()
 {
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Test cases for 'int' type.
     test_partition_copy(

--- a/libs/pika/algorithms/tests/unit/algorithms/partition_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/partition_tests.hpp
@@ -22,7 +22,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 rng(seed);
 
 struct throw_always
 {
@@ -49,7 +49,7 @@ struct user_defined_type
       : val(rand_no)
     {
         std::uniform_int_distribution<> dis(0, name_list.size() - 1);
-        name = name_list[dis(_gen)];
+        name = name_list[dis(rng)];
     }
 
     bool operator<(int rand_base) const
@@ -87,7 +87,7 @@ const std::vector<std::string> user_defined_type::name_list{
 struct random_fill
 {
     random_fill(int rand_base, int half_range /* >= 0 */)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - half_range, rand_base + half_range)
     {
     }
@@ -216,7 +216,7 @@ void test_partition_exception(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 30007;
     std::vector<int> c(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_exception = false;
     try
@@ -248,7 +248,7 @@ void test_partition_exception_async(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 30007;
     std::vector<int> c(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
@@ -287,7 +287,7 @@ void test_partition_bad_alloc(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 30007;
     std::vector<int> c(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_bad_alloc = false;
     try
@@ -318,7 +318,7 @@ void test_partition_bad_alloc_async(ExPolicy policy, IteratorTag)
 
     std::size_t const size = 30007;
     std::vector<int> c(size);
-    std::iota(std::begin(c), std::end(c), _gen());
+    std::iota(std::begin(c), std::end(c), rng());
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;
@@ -388,8 +388,8 @@ void test_partition_heavy(
         16, 24, 32, 48, 64,                   /* intent the number of core */
         123, 4567, 65432, 123456,             /* various size */
         961230, 170228, 3456789,              /* big size */
-        dis(_gen),                            /* random size */
-        dis(_gen)};
+        dis(rng),                             /* random size */
+        dis(rng)};
 
     for (auto size : size_list)
     {
@@ -410,7 +410,7 @@ void test_partition()
 {
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Test cases for 'int' type.
     test_partition(

--- a/libs/pika/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -22,7 +22,7 @@
 
 ////////////////////////////////////////////////////////////////////////////
 int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 rng(seed);
 
 ////////////////////////////////////////////////////////////////////////////
 struct user_defined_type
@@ -30,7 +30,7 @@ struct user_defined_type
     user_defined_type() = default;
     user_defined_type(int rand_no)
       : val(rand_no)
-      , name(name_list[_gen() % name_list.size()])
+      , name(name_list[rng() % name_list.size()])
     {
     }
 
@@ -78,7 +78,7 @@ const std::vector<std::string> user_defined_type::name_list{
 struct random_fill
 {
     random_fill(int rand_base, int range)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -244,7 +244,7 @@ void test_inplace_merge_stable()
     ////////// Test cases for checking whether the algorithm is stable.
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Test cases for checking whether the algorithm is stable.
     test_inplace_merge_stable(seq, IteratorTag(), int(), rand_base);
@@ -364,7 +364,7 @@ void test_inplace_merge_etc()
 {
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Another test cases for justifying the implementation.
     test_inplace_merge_etc(IteratorTag(), DataType(), rand_base);
@@ -385,7 +385,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
     {
         seed = vm["seed"].as<unsigned int>();
-        _gen.seed(seed);
+        rng.seed(seed);
     }
     std::cout << "using seed: " << seed << std::endl;
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -22,7 +22,7 @@
 
 ////////////////////////////////////////////////////////////////////////////
 int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 rng(seed);
 
 ////////////////////////////////////////////////////////////////////////////
 struct user_defined_type
@@ -30,7 +30,7 @@ struct user_defined_type
     user_defined_type() = default;
     user_defined_type(int rand_no)
       : val(rand_no)
-      , name(name_list[_gen() % name_list.size()])
+      , name(name_list[rng() % name_list.size()])
     {
     }
 
@@ -78,7 +78,7 @@ const std::vector<std::string> user_defined_type::name_list{
 struct random_fill
 {
     random_fill(int rand_base, int range)
-      : gen(_gen())
+      : gen(rng())
       , dist(rand_base - range / 2, rand_base + range / 2)
     {
     }
@@ -409,7 +409,7 @@ void test_merge_stable()
     ////////// Test cases for checking whether the algorithm is stable.
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     test_merge_stable(IteratorTag(), int(), rand_base);
     test_merge_stable(seq, IteratorTag(), int(), rand_base);
@@ -426,7 +426,7 @@ void test_merge_etc()
     ////////// Test cases for checking whether the algorithm is stable.
     using namespace pika::execution;
 
-    int rand_base = _gen();
+    int rand_base = rng();
 
     ////////// Another test cases for justifying the implementation.
     test_merge_etc(IteratorTag(), user_defined_type(), rand_base);
@@ -440,7 +440,7 @@ int pika_main(pika::program_options::variables_map& vm)
     if (vm.count("seed"))
     {
         seed = vm["seed"].as<unsigned int>();
-        _gen.seed(seed);
+        rng.seed(seed);
     }
     std::cout << "using seed: " << seed << std::endl;
 

--- a/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
+++ b/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
@@ -22,12 +22,14 @@
 // used for its APIs
 #include <jemalloc/jemalloc.h>
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void* __aligned_alloc(std::size_t alignment, std::size_t size) noexcept
 {
     return PIKA_PP_CAT(PIKA_HAVE_JEMALLOC_PREFIX, aligned_alloc)(
         alignment, size);
 }
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void __aligned_free(void* p) noexcept
 {
     return PIKA_PP_CAT(PIKA_HAVE_JEMALLOC_PREFIX, free)(p);
@@ -37,11 +39,13 @@ inline void __aligned_free(void* p) noexcept
 
 #include <cstdlib>
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void* __aligned_alloc(std::size_t alignment, std::size_t size) noexcept
 {
     return std::aligned_alloc(alignment, size);
 }
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void __aligned_free(void* p) noexcept
 {
     std::free(p);
@@ -51,11 +55,13 @@ inline void __aligned_free(void* p) noexcept
 
 #include <stdlib.h>
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void* __aligned_alloc(std::size_t alignment, std::size_t size) noexcept
 {
     return aligned_alloc(alignment, size);
 }
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void __aligned_free(void* p) noexcept
 {
     free(p);
@@ -66,6 +72,7 @@ inline void __aligned_free(void* p) noexcept
 #include <cstdlib>
 
 // provide our own (simple) implementation of aligned_alloc
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void* __aligned_alloc(std::size_t alignment, std::size_t size) noexcept
 {
     if (alignment < alignof(void*))
@@ -89,6 +96,7 @@ inline void* __aligned_alloc(std::size_t alignment, std::size_t size) noexcept
     return aligned_mem;
 }
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 inline void __aligned_free(void* p) noexcept
 {
     if (nullptr != p)

--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -27,6 +27,7 @@ namespace pika::detail {
                 pika_main_f)
           : rtcfg_(rtcfg)
           , ini_config_(ini_config)
+          // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
           , pika_main_f_(pika_main_f)
           , num_threads_(1)
           , num_cores_(1)

--- a/libs/pika/command_line_handling/src/late_command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/late_command_line_handling.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 namespace pika::detail {
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void decode(std::string& str, char const* s, char const* r)
     {
         std::string::size_type pos = 0;

--- a/libs/pika/coroutines/include/pika/coroutines/detail/combined_tagged_state.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/combined_tagged_state.hpp
@@ -41,12 +41,14 @@ namespace pika { namespace threads { namespace detail {
 
         static thread_state_type extract_state(tagged_state_type const& i)
         {
-            return (i >> state_shift) & state_mask;
+            return static_cast<thread_state_type>(
+                (i >> state_shift) & state_mask);
         }
 
         static thread_state_ex_type extract_state_ex(tagged_state_type const& i)
         {
-            return (i >> state_ex_shift) & state_ex_mask;
+            return static_cast<thread_state_ex_type>(
+                (i >> state_ex_shift) & state_ex_mask);
         }
 
         static tagged_state_type pack_state(

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_self.hpp
@@ -177,8 +177,10 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
     ////////////////////////////////////////////////////////////////////////////
     struct reset_self_on_exit
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         reset_self_on_exit(
             coroutine_self* val, coroutine_self* old_val = nullptr)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : old_self(old_val)
         {
             coroutine_self::set_self(val);

--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
@@ -221,6 +221,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
             int int_[2];
             T* ptr;
 
+            // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
             splitter(int first_, int second_)
             {
                 int_[0] = first_;

--- a/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
@@ -206,8 +206,8 @@ namespace pika { namespace threads { namespace coroutines {
     private:
         struct reset_on_exit
         {
-            reset_on_exit(stackless_coroutine& this__)
-              : this_(this__)
+            reset_on_exit(stackless_coroutine& self)
+              : this_(self)
             {
                 this_.state_ = stackless_coroutine::ctx_running;
             }

--- a/libs/pika/debugging/src/backtrace.cpp
+++ b/libs/pika/debugging/src/backtrace.cpp
@@ -133,7 +133,7 @@ namespace pika { namespace util { namespace stack_trace {
 
     std::size_t trace(void** array, std::size_t n)
     {
-        return ::backtrace(array, n);
+        return ::backtrace(array, static_cast<int>(n));
     }
 
 #elif defined(PIKA_MSVC)

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -255,8 +255,9 @@ namespace pika { namespace debug {
            << " CRC32:" << pika::debug::hex<8>(detail::crc32(p.addr_, p.len_))
            << "\n";
 
-        for (std::size_t i = 0;
-             i < (std::min)(size_t(std::ceil(p.len_ / 8.0)), std::size_t(128));
+        for (std::size_t i = 0; i <
+             (std::min)(size_t(std::ceil(static_cast<double>(p.len_) / 8.0)),
+                 std::size_t(128));
              i++)
         {
             os << pika::debug::hex<16>(*uintBuf++) << " ";

--- a/libs/pika/errors/src/throw_exception.cpp
+++ b/libs/pika/errors/src/throw_exception.cpp
@@ -15,8 +15,10 @@
 #include <system_error>
 
 namespace pika { namespace detail {
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     PIKA_NORETURN void throw_exception(error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         std::filesystem::path p(file);
         pika::detail::throw_exception(

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -115,6 +115,7 @@ namespace pika { namespace execution { namespace experimental {
 
         template <typename Sender>
         constexpr bool specialized(
+            // NOLINTNEXTLINE(bugprone-reserved-identifier)
             typename sender_traits<Sender>::__unspecialized*)
         {
             return false;
@@ -348,6 +349,7 @@ namespace pika { namespace execution { namespace experimental {
         template <typename Sender>
         struct sender_traits_base<false /* HasSenderTraits */, Sender>
         {
+            // NOLINTNEXTLINE(bugprone-reserved-identifier)
             using __unspecialized = void;
         };
 
@@ -373,6 +375,7 @@ namespace pika { namespace execution { namespace experimental {
     template <>
     struct sender_traits<void>
     {
+        // NOLINTNEXTLINE(bugprone-reserved-identifier)
         using __unspecialized = void;
     };
 

--- a/libs/pika/execution_base/tests/unit/execution_context.cpp
+++ b/libs/pika/execution_base/tests/unit/execution_context.cpp
@@ -111,7 +111,9 @@ void test_yield()
     simple_spinlock mutex;
     std::size_t counter = 0;
     std::size_t repetitions = 1000;
-    for (std::size_t i = 0; i != std::thread::hardware_concurrency() * 10; ++i)
+    for (std::size_t i = 0; i !=
+         static_cast<std::size_t>(std::thread::hardware_concurrency()) * 10;
+         ++i)
     {
         ts.emplace_back([&mutex, &counter, repetitions]() {
             for (std::size_t repeat = 0; repeat != repetitions; ++repeat)

--- a/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
+++ b/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
@@ -39,11 +39,13 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     template <typename Launch, typename F, typename S, typename... Ts>
     std::vector<
         pika::future<typename detail::bulk_function_result<F, S, Ts...>::type>>
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     hierarchical_bulk_async_execute_helper(
         pika::util::thread_description const& desc,
         threads::thread_pool_base* pool, std::size_t first_thread,
         std::size_t num_threads, std::size_t hierarchical_threshold,
         Launch policy, F&& f, S const& shape, Ts&&... ts)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         PIKA_ASSERT(pool);
 

--- a/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
@@ -317,8 +317,9 @@ namespace pika { namespace execution { namespace experimental {
               , priority_(priority)
               , stacksize_(stacksize)
               , schedule_(schedule)
-              , yield_delay_(std::uint64_t(
-                    yield_delay.count() / pool_->timestamp_scale()))
+              , yield_delay_(
+                    std::uint64_t(static_cast<double>(yield_delay.count()) /
+                        pool_->timestamp_scale()))
               , num_threads_(pool_->get_os_thread_count())
               , exception_mutex_()
               , exception_()

--- a/libs/pika/format/include/pika/modules/format.hpp
+++ b/libs/pika/format/include/pika/modules/format.hpp
@@ -84,7 +84,7 @@ namespace pika { namespace util {
                     conv_spec);
 
                 T const& value = *static_cast<T const*>(ptr);
-                std::size_t length = std::snprintf(nullptr, 0, format, value);
+                auto length = std::snprintf(nullptr, 0, format, value);
                 std::vector<char> buffer(length + 1);
                 length =
                     std::snprintf(buffer.data(), length + 1, format, value);
@@ -140,8 +140,7 @@ namespace pika { namespace util {
                     std::sprintf(
                         format, "%%%.*ss", (int) spec.size(), spec.data());
 
-                    std::size_t length =
-                        std::snprintf(nullptr, 0, format, value);
+                    auto length = std::snprintf(nullptr, 0, format, value);
                     std::vector<char> buffer(length + 1);
                     length =
                         std::snprintf(buffer.data(), length + 1, format, value);
@@ -162,7 +161,8 @@ namespace pika { namespace util {
                     *static_cast<std::string const*>(ptr);
 
                 if (spec.empty() || spec == "s")
-                    os.write(value.data(), value.size());
+                    os.write(value.data(),
+                        static_cast<std::streamsize>(value.size()));
                 else
                     formatter<char const*>::call(os, spec, value.c_str());
             }
@@ -194,7 +194,7 @@ namespace pika { namespace util {
                         buffer.resize(buffer.capacity() * 2);
                 } while (length == 0);
 
-                os.write(buffer.data(), length);
+                os.write(buffer.data(), static_cast<std::streamsize>(length));
             }
         };
 

--- a/libs/pika/format/include/pika/util/bad_lexical_cast.hpp
+++ b/libs/pika/format/include/pika/util/bad_lexical_cast.hpp
@@ -27,8 +27,10 @@ namespace pika { namespace util {
 
         virtual ~bad_lexical_cast() noexcept;
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         bad_lexical_cast(std::type_info const& source_type_arg,
             std::type_info const& target_type_arg) noexcept
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : source(&source_type_arg)
           , target(&target_type_arg)
         {

--- a/libs/pika/format/src/format.cpp
+++ b/libs/pika/format/src/format.cpp
@@ -104,11 +104,12 @@ namespace pika { namespace util { namespace detail {
             }
             else
             {
-                std::size_t const next = format_str.find_first_of("{}");
-                std::size_t const count =
+                auto const next = format_str.find_first_of("{}");
+                auto const count =
                     next != format_str.npos ? next : format_str.size();
 
-                os.write(format_str.data(), count);
+                os.write(
+                    format_str.data(), static_cast<std::streamsize>(count));
                 format_str.remove_prefix(count);
             }
         }

--- a/libs/pika/functional/tests/unit/is_invocable.cpp
+++ b/libs/pika/functional/tests/unit/is_invocable.cpp
@@ -4,9 +4,21 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// This test triggers a warning about promotion from float to double. This
+// implicit conversion is intentional so we silence the warning. The warning is
+// triggered in the invoke.hpp header, not at the site of the is_invocable use.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#endif
+
 #include <pika/config.hpp>
 #include <pika/functional/traits/is_invocable.hpp>
 #include <pika/testing.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 struct X
 {

--- a/libs/pika/hardware/include/pika/hardware/cpuid/linux_x86.hpp
+++ b/libs/pika/hardware/include/pika/hardware/cpuid/linux_x86.hpp
@@ -36,8 +36,10 @@ namespace pika { namespace util { namespace hardware {
                              :);
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     inline void cpuidex(
         std::uint32_t (&cpuinfo)[4], std::uint32_t eax, std::uint32_t ecx)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         __asm__ __volatile__("cpuid ;\n"
                              : "=a"(cpuinfo[cpuid_register::eax]),

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -104,9 +104,11 @@ namespace pika { namespace util {
             std::vector<std::string> const& lines, bool verify_existing = true,
             bool weed_out_comments = true, bool replace_existing = true);
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void parse(std::string const& sourcename, std::string const& line,
             bool verify_existing = true, bool weed_out_comments = true,
             bool replace_existing = true)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             std::vector<std::string> lines;
             lines.push_back(line);

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -658,8 +658,10 @@ namespace pika { namespace util {
         return "";
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     std::string section::get_entry(std::unique_lock<mutex_type>& l,
         std::string const& key, std::string const& default_val) const
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         using string_vector = std::vector<std::string>;
 

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -795,8 +795,10 @@ namespace pika { namespace util {
         }
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void enable_logging(logging_destination dest, std::string const& level,
         std::string logdest, std::string logformat)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         auto lvl = pika::util::logging::level::enable_all;
         if (!level.empty())

--- a/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
+++ b/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
@@ -12,12 +12,14 @@
 #include <cstdint>
 #include <cstring>
 
+// NOLINTBEGIN(bugprone-reserved-identifier)
 struct ___itt_caller;
 struct ___itt_string_handle;
 struct ___itt_domain;
 struct ___itt_id;
 using __itt_heap_function = void*;
 struct ___itt_counter;
+// NOLINTEND(bugprone-reserved-identifier)
 
 ///////////////////////////////////////////////////////////////////////////////
 #define PIKA_ITT_SYNC_CREATE(obj, type, name) itt_sync_create(obj, type, name)

--- a/libs/pika/logging/include/pika/logging/format/named_write.hpp
+++ b/libs/pika/logging/include/pika/logging/format/named_write.hpp
@@ -116,8 +116,10 @@ You could have an output like this:
             compute_write_steps();
         }
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void configure(
             std::string const& name, std::string const& configure_str)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             auto iter = find_named(formatters, name);
             if (iter != formatters.end())
@@ -241,8 +243,10 @@ In the above example, I know that the available destinations are @c out_file,
             compute_write_steps();
         }
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void configure(
             std::string const& name, std::string const& configure_str)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             auto iter = find_named(destinations, name);
             if (iter != destinations.end())
@@ -386,8 +390,10 @@ This will just configure "file" twice, ending up with writing only to "two.txt" 
 
         /** @brief Specifies the formats and destinations in one step
     */
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void write(
             std::string const& format_str, std::string const& destination_str)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             format(format_str);
             destination(destination_str);

--- a/libs/pika/program_options/include/pika/program_options/errors.hpp
+++ b/libs/pika/program_options/include/pika/program_options/errors.hpp
@@ -148,8 +148,10 @@ namespace pika { namespace program_options {
         }
 
         /** Add context to an exception */
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void add_context(const std::string& option_name,
             const std::string& original_token, int option_style)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             set_option_name(option_name);
             set_original_token(original_token);

--- a/libs/pika/program_options/src/options_description.cpp
+++ b/libs/pika/program_options/src/options_description.cpp
@@ -284,17 +284,21 @@ namespace pika { namespace program_options {
 
     const unsigned options_description::m_default_line_length = 80;
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     options_description::options_description(
         unsigned line_length, unsigned min_description_length)
       : m_line_length(line_length)
       , m_min_description_length(min_description_length)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // we require a space between the option and description parts, so add 1.
         PIKA_ASSERT(m_min_description_length < m_line_length - 1);
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     options_description::options_description(const std::string& caption,
         unsigned line_length, unsigned min_description_length)
+      // NOLINTEND(bugprone-easily-swappable-parameters)
       : m_caption(caption)
       , m_line_length(line_length)
       , m_min_description_length(min_description_length)
@@ -487,7 +491,9 @@ namespace pika { namespace program_options {
                     unsigned remaining = static_cast<unsigned>(
                         std::distance(line_begin, par_end));
                     string::const_iterator line_end = line_begin +
-                        ((remaining < line_length) ? remaining : line_length);
+                        static_cast<string::const_iterator::difference_type>(
+                            (remaining < line_length) ? remaining :
+                                                        line_length);
 
                     // prevent chopped words
                     // Is line_end between two non-space characters?

--- a/libs/pika/program_options/src/utf8_codecvt_facet.cpp
+++ b/libs/pika/program_options/src/utf8_codecvt_facet.cpp
@@ -175,8 +175,10 @@ namespace pika { namespace program_options { namespace detail {
 
     // How many char objects can I process to get <= max_limit
     // wchar_t objects?
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     int utf8_codecvt_facet::do_length(std::mbstate_t&, const char* from,
         const char* from_end, std::size_t max_limit) const noexcept
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // RG - this code is confusing!  I need a better way to express it.
         // and test cases.

--- a/libs/pika/program_options/src/value_semantic.cpp
+++ b/libs/pika/program_options/src/value_semantic.cpp
@@ -218,9 +218,11 @@ namespace pika { namespace program_options {
         set_substitute("value", bad_value);
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     error_with_option_name::error_with_option_name(const std::string& template_,
         const std::string& option_name, const std::string& original_token,
         int option_style)
+      // NOLINTEND(bugprone-easily-swappable-parameters)
       : error(template_)
       , m_option_style(option_style)
       , m_error_template(template_)

--- a/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
@@ -47,7 +47,8 @@ void async_guided(std::size_t n, bool printout, std::string const& message)
     }
     for (std::size_t i(0); i < n; ++i)
     {
-        double f = std::sin(2 * M_PI * i / n);
+        double f = std::sin(
+            2 * M_PI * static_cast<double>(i) / static_cast<double>(n));
         if (printout)
         {
             std::cout << "sin(" << i << ") = " << f << ", ";

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -55,7 +55,8 @@ void do_stuff(std::size_t n, bool printout)
         std::cout << "[do stuff] " << n << "\n";
     for (std::size_t i(0); i < n; ++i)
     {
-        double f = std::sin(2 * M_PI * i / n);
+        double f = std::sin(
+            2 * M_PI * static_cast<double>(i) / static_cast<double>(n));
         if (printout)
             std::cout << "sin(" << i << ") = " << f << ", ";
     }

--- a/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -46,7 +46,8 @@ void do_stuff(std::size_t n, bool printout)
         std::cout << "[do stuff] " << n << "\n";
     for (std::size_t i(0); i < n; ++i)
     {
-        double f = std::sin(2 * M_PI * i / n);
+        double f = std::sin(
+            2 * M_PI * static_cast<double>(i) / static_cast<double>(n));
         if (printout)
             std::cout << "sin(" << i << ") = " << f << ", ";
     }

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -486,8 +486,9 @@ namespace pika {
 
     std::uint64_t runtime::get_system_uptime()
     {
-        std::int64_t diff =
-            pika::chrono::high_resolution_clock::now() - runtime_uptime();
+        std::int64_t diff = static_cast<std::int64_t>(
+                                pika::chrono::high_resolution_clock::now()) -
+            static_cast<std::int64_t>(runtime_uptime());
         return diff < 0LL ? 0ULL : static_cast<std::uint64_t>(diff);
     }
 
@@ -1684,10 +1685,12 @@ namespace pika {
             pool_name, postfix, service_thread, ec);
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void runtime::init_tss_ex(char const* context, os_thread_type type,
         std::size_t local_thread_num, std::size_t global_thread_num,
         char const* pool_name, char const* postfix, bool service_thread,
         error_code& ec)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // set the thread's name, if it's not already set
         PIKA_ASSERT(detail::thread_name().empty());

--- a/libs/pika/runtime/src/thread_mapper.cpp
+++ b/libs/pika/runtime/src/thread_mapper.cpp
@@ -47,7 +47,7 @@ namespace pika { namespace util {
           , id_(std::this_thread::get_id())
           , tid_(get_system_thread_id())
 #if defined(__linux__) && !defined(__ANDROID) && !defined(ANDROID)
-          , linux_tid_(syscall(SYS_gettid))
+          , linux_tid_(static_cast<pid_t>(syscall(SYS_gettid)))
 #endif
           , cleanup_()
           , type_(type)

--- a/libs/pika/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/pika/runtime_configuration/src/init_ini_data.cpp
@@ -47,8 +47,10 @@ namespace pika { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     bool handle_ini_file_env(
         section& ini, char const* env_var, char const* file_suffix)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         char const* env = getenv(env_var);
         if (nullptr != env)

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -82,6 +82,7 @@ namespace pika { namespace util {
             // create default installation location and logging settings
             "[pika]",
             "master_ini_path = $[system.executable_prefix]/",
+            // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
             "master_ini_path_suffixes = /share/pika" PIKA_INI_PATH_DELIMITER
                 "/../share/pika",
 #ifdef PIKA_HAVE_ITTNOTIFY

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -1296,7 +1296,7 @@ namespace pika { namespace threads { namespace policies {
                         (static_cast<std::ptrdiff_t>(num_thread) - i) %
                         static_cast<std::ptrdiff_t>(num_threads);
                     if (left < 0)
-                        left = num_threads + left;
+                        left = static_cast<std::ptrdiff_t>(num_threads) + left;
 
                     if (f(std::size_t(left)))
                     {

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
@@ -73,6 +73,7 @@ namespace pika { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
         void init(std::size_t domain, std::size_t queues)
         {
             num_queues_ = queues;
@@ -232,7 +233,7 @@ namespace pika { namespace threads { namespace policies {
             std::size_t len = 0;
             for (auto& q : queues_)
                 len += q->get_thread_count(state, priority);
-            return len;
+            return static_cast<std::int64_t>(len);
         }
 
         // ----------------------------------------------------------------

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -194,10 +194,12 @@ namespace pika { namespace threads { namespace policies {
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         queue_holder_thread(QueueType* bp_queue, QueueType* hp_queue,
             QueueType* np_queue, QueueType* lp_queue, std::size_t domain,
             std::size_t queue, std::size_t thread_num, std::size_t owner,
             const thread_queue_init_parameters& init, std::thread::id owner_id)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : bp_queue_(bp_queue)
           , hp_queue_(hp_queue)
           , np_queue_(np_queue)

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -77,8 +77,10 @@ namespace pika { namespace threads { namespace policies {
     /// Holds core/queue ratios used by schedulers.
     struct core_ratios
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         core_ratios(std::size_t high_priority, std::size_t normal_priority,
             std::size_t low_priority)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : high_priority(high_priority)
           , normal_priority(normal_priority)
           , low_priority(low_priority)
@@ -432,6 +434,7 @@ namespace pika { namespace threads { namespace policies {
         /// since high priority tasks on other queues take precedence to
         /// local tasks of lower priority
         template <typename T>
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         bool steal_by_function(std::size_t domain, std::size_t q_index,
             bool steal_numa, bool steal_core, thread_holder_type* origin,
             T& var, const char* prefix,
@@ -441,6 +444,7 @@ namespace pika { namespace threads { namespace policies {
             util::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation)
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             bool result;
 

--- a/libs/pika/synchronization/src/detail/sliding_semaphore.cpp
+++ b/libs/pika/synchronization/src/detail/sliding_semaphore.cpp
@@ -18,8 +18,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 namespace pika { namespace lcos { namespace local { namespace detail {
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     sliding_semaphore::sliding_semaphore(
         std::int64_t max_difference, std::int64_t lower_limit)
+      // NOLINTEND(bugprone-easily-swappable-parameters)
       : max_difference_(max_difference)
       , lower_limit_(lower_limit)
       , cond_()
@@ -28,8 +30,10 @@ namespace pika { namespace lcos { namespace local { namespace detail {
 
     sliding_semaphore::~sliding_semaphore() = default;
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     void sliding_semaphore::set_max_difference(std::unique_lock<mutex_type>& l,
         std::int64_t max_difference, std::int64_t lower_limit)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         PIKA_ASSERT_OWNS_LOCK(l);
 

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -69,8 +69,10 @@ namespace pika { namespace threads { namespace detail {
     template <typename Scheduler>
     struct init_tss_helper
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         init_tss_helper(scheduled_thread_pool<Scheduler>& pool,
             std::size_t local_thread_num, std::size_t global_thread_num)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : pool_(pool)
           , local_thread_num_(local_thread_num)
           , global_thread_num_(global_thread_num)

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -337,6 +337,7 @@ namespace pika { namespace threads { namespace detail {
     defined(PIKA_HAVE_THREAD_IDLE_RATES)
     struct scheduling_counters
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         scheduling_counters(std::int64_t& executed_threads,
             std::int64_t& executed_thread_phases, std::int64_t& tfunc_time,
             std::int64_t& exec_time, std::int64_t& idle_loop_count,
@@ -344,6 +345,7 @@ namespace pika { namespace threads { namespace detail {
             std::int64_t& background_work_duration,
             std::int64_t& background_send_duration,
             std::int64_t& background_receive_duration)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : executed_threads_(executed_threads)
           , executed_thread_phases_(executed_thread_phases)
           , tfunc_time_(tfunc_time)
@@ -371,10 +373,12 @@ namespace pika { namespace threads { namespace detail {
 #else
     struct scheduling_counters
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         scheduling_counters(std::int64_t& executed_threads,
             std::int64_t& executed_thread_phases, std::int64_t& tfunc_time,
             std::int64_t& exec_time, std::int64_t& idle_loop_count,
             std::int64_t& busy_loop_count, bool& is_active)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : executed_threads_(executed_threads)
           , executed_thread_phases_(executed_thread_phases)
           , tfunc_time_(tfunc_time)
@@ -401,13 +405,15 @@ namespace pika { namespace threads { namespace detail {
         using callback_type = util::unique_function<void()>;
         using background_callback_type = util::unique_function<bool()>;
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         explicit scheduling_callbacks(callback_type&& outer,
             callback_type&& inner = callback_type(),
             background_callback_type&& background = background_callback_type(),
             std::size_t max_background_threads =
                 (std::numeric_limits<std::size_t>::max)(),
-            std::size_t max_idle_loop_count = PIKA_IDLE_LOOP_COUNT_MAX,
-            std::size_t max_busy_loop_count = PIKA_BUSY_LOOP_COUNT_MAX)
+            std::int64_t max_idle_loop_count = PIKA_IDLE_LOOP_COUNT_MAX,
+            std::int64_t max_busy_loop_count = PIKA_BUSY_LOOP_COUNT_MAX)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : outer_(PIKA_MOVE(outer))
           , inner_(PIKA_MOVE(inner))
           , background_(PIKA_MOVE(background))
@@ -478,6 +484,7 @@ namespace pika { namespace threads { namespace detail {
     template <typename SchedulingPolicy>
 #if defined(PIKA_HAVE_BACKGROUND_THREAD_COUNTERS) &&                           \
     defined(PIKA_HAVE_THREAD_IDLE_RATES)
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     bool call_background_thread(thread_id_ref_type& background_thread,
         thread_id_ref_type& next_thrd, SchedulingPolicy& scheduler,
         std::size_t num_thread, bool /* running */,
@@ -490,6 +497,7 @@ namespace pika { namespace threads { namespace detail {
         std::size_t num_thread, bool /* running */,
         pika::execution_base::this_thread::detail::agent_storage*
             context_storage)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
 #endif
     {
         if (PIKA_UNLIKELY(background_thread))

--- a/libs/pika/threading/tests/unit/stop_token_cb1.cpp
+++ b/libs/pika/threading/tests/unit/stop_token_cb1.cpp
@@ -410,9 +410,9 @@ void test_cancellation_single_thread_performance()
                   << std::endl;
     };
 
-    report("Individual", time1, iteration_count);
-    report("Batch10", time2, 10 * iteration_count);
-    report("Batch50", time3, 50 * iteration_count);
+    report("Individual", time1, static_cast<std::uint64_t>(iteration_count));
+    report("Batch10", time2, 10 * static_cast<std::uint64_t>(iteration_count));
+    report("Batch50", time3, 50 * static_cast<std::uint64_t>(iteration_count));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -112,11 +112,13 @@ namespace pika { namespace threads {
         ///                 thread's status word. To change the thread's
         ///                 scheduling status \a threadmanager#set_state should
         ///                 be used.
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         thread_state set_state(thread_schedule_state state,
             thread_restart_state state_ex = thread_restart_state::unknown,
             std::memory_order load_order = std::memory_order_acquire,
             std::memory_order exchange_order =
                 std::memory_order_seq_cst) noexcept
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             thread_state prev_state = current_state_.load(load_order);
 
@@ -176,10 +178,12 @@ namespace pika { namespace threads {
         ///
         /// \returns This function returns \a true if the state has been
         ///          changed successfully
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         bool restore_state(thread_state new_state, thread_state old_state,
             std::memory_order load_order = std::memory_order_relaxed,
             std::memory_order load_exchange =
                 std::memory_order_seq_cst) noexcept
+        // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             // ignore the state_ex while compare-exchanging
             thread_state current_state = current_state_.load(load_order);

--- a/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
@@ -632,6 +632,7 @@ namespace pika { namespace this_thread {
     // returns whether the remaining stack-space is at least as large as
     // requested
     PIKA_EXPORT bool has_sufficient_stack_space(
-        std::size_t space_needed = 8 * PIKA_THREADS_STACK_OVERHEAD);
+        std::size_t space_needed = static_cast<std::size_t>(8) *
+            PIKA_THREADS_STACK_OVERHEAD);
     /// \endcond
 }}    // namespace pika::this_thread

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -129,6 +129,7 @@ namespace pika { namespace threads {
         std::size_t max_busy_loop_count_;
         std::size_t shutdown_check_count_;
 
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         thread_pool_init_parameters(std::string const& name, std::size_t index,
             policies::scheduler_mode mode, std::size_t num_threads,
             std::size_t thread_offset,
@@ -141,6 +142,7 @@ namespace pika { namespace threads {
             std::size_t max_idle_loop_count = PIKA_IDLE_LOOP_COUNT_MAX,
             std::size_t max_busy_loop_count = PIKA_BUSY_LOOP_COUNT_MAX,
             std::size_t shutdown_check_count = 10)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : name_(name)
           , index_(index)
           , mode_(mode)

--- a/libs/pika/threading_base/include/pika/threading_base/thread_queue_init_parameters.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_queue_init_parameters.hpp
@@ -16,6 +16,7 @@
 namespace pika { namespace threads { namespace policies {
     struct thread_queue_init_parameters
     {
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         thread_queue_init_parameters(
             std::int64_t max_thread_count = std::int64_t(
                 PIKA_THREAD_QUEUE_MAX_THREAD_COUNT),
@@ -40,6 +41,7 @@ namespace pika { namespace threads { namespace policies {
             std::ptrdiff_t medium_stacksize = PIKA_MEDIUM_STACK_SIZE,
             std::ptrdiff_t large_stacksize = PIKA_LARGE_STACK_SIZE,
             std::ptrdiff_t huge_stacksize = PIKA_HUGE_STACK_SIZE)
+          // NOLINTEND(bugprone-easily-swappable-parameters)
           : max_thread_count_(max_thread_count)
           , min_tasks_to_steal_pending_(min_tasks_to_steal_pending)
           , min_tasks_to_steal_staged_(min_tasks_to_steal_staged)

--- a/libs/pika/timing/include/pika/timing/high_resolution_timer.hpp
+++ b/libs/pika/timing/include/pika/timing/high_resolution_timer.hpp
@@ -33,7 +33,7 @@ namespace pika { namespace chrono {
 
         static double now() noexcept
         {
-            return take_time_stamp() * 1e-9;
+            return static_cast<double>(take_time_stamp()) * 1e-9;
         }
 
         void restart() noexcept

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -344,8 +344,10 @@ namespace pika::threads::detail {
             hwloc_topology_destroy(topo);
     }
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     std::size_t topology::get_pu_number(
         std::size_t num_core, std::size_t num_pu, error_code& ec) const
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {    // {{{
         std::unique_lock<mutex_type> lk(topo_mtx);
 
@@ -1148,8 +1150,10 @@ namespace pika::threads::detail {
         return mask;
     }    // }}}
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     mask_type topology::init_thread_affinity_mask(
         std::size_t num_core, std::size_t num_pu) const
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {    // {{{
         hwloc_obj_t obj = nullptr;
 

--- a/testing/src/testing.cpp
+++ b/testing/src/testing.cpp
@@ -96,7 +96,7 @@ namespace pika { namespace util {
 
     void print_cdash_timing(const char* name, std::uint64_t time)
     {
-        print_cdash_timing(name, time / 1e9);
+        print_cdash_timing(name, static_cast<double>(time) / 1e9);
     }
 
 }}    // namespace pika::util


### PR DESCRIPTION
Uses clang 14 and introduces a lot of warnings mainly about narrowing conversions. I've attempted to fix them in the core library and examples. I have not yet fixed any warnings in tests and will let CI tell me just how bad it is. We may have to disable the `bugprone-narrowing-conversions` check.

I've fixed some `bugprone-reserved-identifier` warnings, and suppressed others (in the ITT support header). I've suppressed the `bugprone-easily-swappable-parameters` check in libpika, but I've also left the check disabled in the config file since there are again a lot of them in examples and tests. I'm not sure if we can have a different config file for library files and tests/examples.