### PR TITLE
Add list of public API headers to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,15 +59,37 @@ pika is configured using CMake variables. The most important variables are:
   Can be set to ``tcmalloc``, ``jemalloc``, ``mimalloc``, or ``system``. Setting
   it to ``system`` can be useful in debug builds.
 * ``PIKA_WITH_CUDA``: Enable CUDA support.
-* ``PIKA_WITH_HIP``: Enable HIP support. To enabled this set the compiler to
+* ``PIKA_WITH_HIP``: Enable HIP support. To enable this set the compiler to
   ``hipcc`` instead of setting the variable explicitly.
 * ``PIKA_WITH_MPI``: Enable MPI support.
-* ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enables the use of Boost.Context for
+* ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enable the use of Boost.Context for
   fiber context switching. This has to be enabled on non-Linux and non-x86
   platforms.
 
 Tests and examples are disabled by default and can be enabled with
 ``PIKA_WITH_TESTS``, ``PIKA_WITH_TESTS_*``, and ``PIKA_WITH_EXAMPLES``.
+
+Documentation
+=============
+
+Documentation is a work in progress. The following headers are part of the
+public API. Any other headers are internal implementation details.
+
+- ``pika/algorithm.hpp``
+- ``pika/barrier.hpp``
+- ``pika/channel.hpp``
+- ``pika/condition_variable.hpp``
+- ``pika/cuda.hpp``
+- ``pika/execution.hpp``
+- ``pika/latch.hpp``
+- ``pika/memory.hpp``
+- ``pika/mpi.hpp``
+- ``pika/mutex.hpp``
+- ``pika/numeric.hpp``
+- ``pika/runtime.hpp``
+- ``pika/semaphore.hpp``
+- ``pika/shared_mutex.hpp``
+- ``pika/thread.hpp``
 
 Acknowledgements
 ================


### PR DESCRIPTION
Part of #49.

I've listed a subset of the headers in the `include` module. I've left out `pika/future.hpp` and `pika/unwrap.hpp` as they're due for removal (though DLA-Future is free to keep using it until then). I've also left out all the utilities that don't really require special versions for user-level threads, meaning `functional`, `any`, `optional`, `chrono`, `exception`, `stop_token`, `system_error`, `tuple`, and `type_traits`. I've left out `task_block` as it's similar in spirit to the proposed `async_scope` and could probably be removed if that works as a replacement.

Fixes a few typos as a flyby in the README.