### PR TITLE
Reduce the number of iterations in `cross_pool_injection` test

### DIFF
--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -96,7 +96,7 @@ int pika_main()
     // randomly create tasks that run on a random pool
     // attach continuations to them that run on different
     // random pools
-    int const loops = 1000;
+    int const loops = 500;
     //
     std::cout << "1: Starting HP " << loops << std::endl;
     std::atomic<int> counter(loops);


### PR DESCRIPTION
Reduces the number of iterations, but hopefully still keeps the test useful for triggering bugs. With 1000 iterations the test takes around 2 minutes on CircleCI and is clearly the longest-running test we have. I'm hoping this will bring it down to around a minute.