### PR TITLE
Fix unicode symbols in `plot.py`

### DIFF
--- a/tools/perftests_ci/perftest/plot.py
+++ b/tools/perftests_ci/perftest/plot.py
@@ -181,21 +181,21 @@ def _add_explanation_of_symbols(report):
                 row.fill(string, meaning)
 
         add_help("Symbol", "MEANING")
-        add_help("=", "No performance change (confidence interval within Â±1%)")
+        add_help("=", "No performance change (confidence interval within ±1%)")
         add_help(
-            "(=)", "Probably no performance change (confidence interval within Â±2%)"
+            "(=)", "Probably no performance change (confidence interval within ±2%)"
         )
-        add_help("(+)/(-)", "Very small performance improvement/degradation (â¤1%)")
-        add_help("+/-", "Small performance improvement/degradation (â¤5%)")
-        add_help("++/--", "Large performance improvement/degradation (â¤10%)")
+        add_help("(+)/(-)", "Very small performance improvement/degradation (≤1%)")
+        add_help("+/-", "Small performance improvement/degradation (>10%)")
+        add_help("++/--", "Large performance improvement/degradation (>10%)")
         add_help("+++/---", "Very large performance improvement/degradation (>10%)")
         add_help(
             "?",
             "Probably no change, but quite large uncertainty "
-            "(confidence interval with Â±5%)",
+            "(confidence interval with ±5%)",
         )
-        add_help("??", "Unclear result, very large uncertainty (Â±10%)")
-        add_help("???", "Something unexpectedâ¦")
+        add_help("??", "Unclear result, very large uncertainty (±10%)")
+        add_help("???", "Something unexpected…")
 
 
 def _histogram_plot(title, before, after, output):
@@ -231,13 +231,13 @@ def _add_info(report, labels, data):
             with table.row() as row:
                 row.cell(var._project_name + " " + k.title())
                 for d in data:
-                    row.cell(d[var._project_name].get(k, "â"))
+                    row.cell(d[var._project_name].get(k, "—"))
 
         for k in {k for d in data for k in d["environment"].keys()}:
             with table.row() as row:
                 row.cell(k.title())
                 for d in data:
-                    row.cell(d["environment"].get(k, "â"))
+                    row.cell(d["environment"].get(k, "—"))
 
 
 def compare_one(report, before, after, output):


### PR DESCRIPTION
They got garbled in https://github.com/pika-org/pika/pull/224, though it's not clearly black that is the cause of it. Running black again on the file did not change the symbols, so I'm not quite sure what happened.