### PR TITLE
Replace typedefs with using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,17 +13,18 @@ Checks: >
     -bugprone-forward-declaration-namespace,
     -bugprone-macro-parentheses,
     -bugprone-narrowing-conversions,
-    misc-assert-side-effect
-    misc-dangling-handle
-    misc-forwarding-reference-overload
-    misc-move-constructor-init
-    misc-move-forwarding-reference
-    misc-multiple-statement-macro
-    misc-non-copyable-objects
-    misc-use-after-move
-    misc-virtual-near-miss
+    misc-assert-side-effect,
+    misc-dangling-handle,
+    misc-forwarding-reference-overload,
+    misc-move-constructor-init,
+    misc-move-forwarding-reference,
+    misc-multiple-statement-macro,
+    misc-non-copyable-objects,
+    misc-use-after-move,
+    misc-virtual-near-miss,
     modernize-use-nullptr,
-WarningsAsErrors: '*'
+    modernize-use-using,
+# WarningsAsErrors: '*'
 HeaderFilterRegex: '.*pika.*'
 CheckOptions:
   - key: bugprone-assert-side-effect.CheckFunctionCalls

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -57,8 +57,8 @@ void get_os_thread_num(barrier& barr, queue<std::size_t>& os_threads)
 ///////////////////////////////////////////////////////////////////////////////
 using result_map = std::map<std::size_t, std::size_t>;
 
-typedef std::multimap<std::size_t, std::size_t, std::greater<std::size_t>>
-    sorter;
+using sorter =
+    std::multimap<std::size_t, std::size_t, std::greater<std::size_t>>;
 
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main(variables_map& vm)

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -39,9 +39,8 @@ std::uint64_t add(
 ///////////////////////////////////////////////////////////////////////////////
 struct when_all_wrapper
 {
-    typedef pika::tuple<pika::future<std::uint64_t>,
-        pika::future<std::uint64_t>>
-        data_type;
+    using data_type =
+        pika::tuple<pika::future<std::uint64_t>, pika::future<std::uint64_t>>;
 
     std::uint64_t operator()(pika::future<data_type> data) const
     {

--- a/examples/quickstart/wait_composition.cpp
+++ b/examples/quickstart/wait_composition.cpp
@@ -15,8 +15,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 struct cout_continuation
 {
-    typedef pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>>
-        data_type;
+    using data_type =
+        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>>;
 
     void operator()(pika::future<data_type> data) const
     {

--- a/examples/transpose/transpose_serial_block.cpp
+++ b/examples/transpose/transpose_serial_block.cpp
@@ -20,7 +20,7 @@
 bool verbose = false;
 
 using block = std::vector<double>;
-typedef double* sub_block;
+using sub_block = double*;
 
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,
     std::uint64_t tile_size);

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -22,7 +22,7 @@
 bool verbose = false;
 
 using block = std::vector<double>;
-typedef double* sub_block;
+using sub_block = double*;
 
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,
     std::uint64_t tile_size);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/copy.hpp
@@ -312,8 +312,8 @@ namespace pika { namespace parallel { inline namespace v1 {
                     nullptr;
                 return PIKA_MOVE(*dummy);
 #else
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
 
                 return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(
@@ -375,8 +375,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, FwdIter1 first, std::size_t count,
                 FwdIter2 dest)
             {
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
 
                 return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(
@@ -449,11 +449,10 @@ namespace pika { namespace parallel { inline namespace v1 {
                 FwdIter3 dest, Pred&& pred, Proj&& proj /* = Proj()*/)
             {
                 using zip_iterator = pika::util::zip_iterator<FwdIter1, bool*>;
-                typedef util::detail::algorithm_result<ExPolicy,
-                    util::in_out_result<FwdIter1, FwdIter3>>
-                    result;
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
+                using result = util::detail::algorithm_result<ExPolicy,
+                    util::in_out_result<FwdIter1, FwdIter3>>;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter1>::difference_type;
 
                 if (first == last)
                 {
@@ -472,9 +471,8 @@ namespace pika { namespace parallel { inline namespace v1 {
 
                 using pika::get;
                 using pika::util::make_zip_iterator;
-                typedef util::scan_partitioner<ExPolicy,
-                    util::in_out_result<FwdIter1, FwdIter3>, std::size_t>
-                    scan_partitioner_type;
+                using scan_partitioner_type = util::scan_partitioner<ExPolicy,
+                    util::in_out_result<FwdIter1, FwdIter3>, std::size_t>;
 
                 auto f1 = [pred = PIKA_FORWARD(Pred, pred),
                               proj = PIKA_FORWARD(decltype(proj), proj)](

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
@@ -174,7 +174,9 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t nelem = static_cast<std::size_t>(last - first);
 
         // Adjust when there are many threads and only a few elements
-        while (nelem > chunk_size && (nthreads * nthreads) > (nelem >> 3))
+        while (nelem > chunk_size &&
+            (static_cast<std::uint64_t>(nthreads) *
+                static_cast<std::uint64_t>(nthreads)) > (nelem >> 3))
         {
             nthreads /= 2;
         }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/search.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/search.hpp
@@ -187,10 +187,10 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
             Proj2&& proj2)
         {
             using reference = typename std::iterator_traits<FwdIter>::reference;
-            typedef typename std::iterator_traits<FwdIter>::difference_type
-                difference_type;
-            typedef typename std::iterator_traits<FwdIter2>::difference_type
-                s_difference_type;
+            using difference_type =
+                typename std::iterator_traits<FwdIter>::difference_type;
+            using s_difference_type =
+                typename std::iterator_traits<FwdIter2>::difference_type;
             using result = util::detail::algorithm_result<ExPolicy, FwdIter>;
 
             s_difference_type diff = std::distance(s_first, s_last);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/set_operation.hpp
@@ -71,8 +71,9 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
         };
 
         using value_type = typename std::iterator_traits<FwdIter>::value_type;
-        typedef typename std::conditional<std::is_scalar<value_type>::value,
-            value_type, rewritable_ref<value_type>>::type type;
+        using type =
+            typename std::conditional<std::is_scalar<value_type>::value,
+                value_type, rewritable_ref<value_type>>::type;
     };
 
     struct set_chunk_data

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/equal.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/equal.hpp
@@ -244,10 +244,10 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
                 Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
-                typedef typename std::iterator_traits<Iter1>::difference_type
-                    difference_type1;
-                typedef typename std::iterator_traits<Iter2>::difference_type
-                    difference_type2;
+                using difference_type1 =
+                    typename std::iterator_traits<Iter1>::difference_type;
+                using difference_type2 =
+                    typename std::iterator_traits<Iter2>::difference_type;
 
                 if (first1 == last1)
                 {
@@ -347,12 +347,12 @@ namespace pika { namespace parallel { inline namespace v1 {
                         true);
                 }
 
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter1>::difference_type;
                 difference_type count = std::distance(first1, last1);
 
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
                 using reference = typename zip_iterator::reference;
 
                 util::cancellation_token<> tok;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/find.hpp
@@ -431,8 +431,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, Iter>;
                 using type = typename std::iterator_traits<Iter>::value_type;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
                 if (count <= 0)
@@ -513,8 +513,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, Iter>;
                 using type = typename std::iterator_traits<Iter>::value_type;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
                 if (count <= 0)
@@ -598,8 +598,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, Iter>;
                 using type = typename std::iterator_traits<Iter>::value_type;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
                 if (count <= 0)
@@ -875,14 +875,14 @@ namespace pika { namespace parallel { inline namespace v1 {
                     FwdIter2 s_first, FwdIter2 s_last, Pred&& op, Proj1&& proj1,
                     Proj2&& proj2)
             {
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter>
-                    result;
-                typedef
-                    typename std::iterator_traits<FwdIter>::reference reference;
-                typedef typename std::iterator_traits<FwdIter>::difference_type
-                    difference_type;
-                typedef typename std::iterator_traits<FwdIter2>::difference_type
-                    s_difference_type;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, FwdIter>;
+                using reference =
+                    typename std::iterator_traits<FwdIter>::reference;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter>::difference_type;
+                using s_difference_type =
+                    typename std::iterator_traits<FwdIter2>::difference_type;
 
                 s_difference_type diff = std::distance(s_first, s_last);
                 if (diff <= 0)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/is_heap.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/is_heap.hpp
@@ -169,8 +169,8 @@ namespace pika { namespace parallel { inline namespace v1 {
         template <typename Iter, typename Sent, typename Comp, typename Proj>
         bool sequential_is_heap(Iter first, Sent last, Comp&& comp, Proj&& proj)
         {
-            typedef typename std::iterator_traits<Iter>::difference_type
-                difference_type;
+            using difference_type =
+                typename std::iterator_traits<Iter>::difference_type;
 
             difference_type count = detail::distance(first, last);
 
@@ -193,8 +193,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, bool>;
                 using type = typename std::iterator_traits<Iter>::value_type;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
                 if (count <= 1)
@@ -281,8 +281,8 @@ namespace pika { namespace parallel { inline namespace v1 {
         Iter sequential_is_heap_until(
             Iter first, Sent last, Comp&& comp, Proj&& proj)
         {
-            typedef typename std::iterator_traits<Iter>::difference_type
-                difference_type;
+            using difference_type =
+                typename std::iterator_traits<Iter>::difference_type;
 
             difference_type count = detail::distance(first, last);
 
@@ -305,8 +305,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, Iter>;
                 using type = typename std::iterator_traits<Iter>::value_type;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
                 if (count <= 1)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/is_partitioned.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/is_partitioned.hpp
@@ -177,10 +177,10 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, Iter first, Sent last, Pred&& pred,
                 Proj&& proj)
             {
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
-                typedef typename util::detail::algorithm_result<ExPolicy, bool>
-                    result;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
+                using result =
+                    typename util::detail::algorithm_result<ExPolicy, bool>;
 
                 difference_type count = std::distance(first, last);
                 if (count <= 1)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/is_sorted.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/is_sorted.hpp
@@ -275,10 +275,10 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
                 Proj&& proj)
             {
-                typedef typename std::iterator_traits<FwdIter>::difference_type
-                    difference_type;
-                typedef typename util::detail::algorithm_result<ExPolicy, bool>
-                    result;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter>::difference_type;
+                using result =
+                    typename util::detail::algorithm_result<ExPolicy, bool>;
 
                 difference_type count = std::distance(first, last);
                 if (count <= 1)
@@ -361,13 +361,12 @@ namespace pika { namespace parallel { inline namespace v1 {
                 parallel(ExPolicy&& policy, FwdIter first, Sent last,
                     Pred&& pred, Proj&& proj)
             {
-                typedef
-                    typename std::iterator_traits<FwdIter>::reference reference;
-                typedef typename std::iterator_traits<FwdIter>::difference_type
-                    difference_type;
-                typedef
-                    typename util::detail::algorithm_result<ExPolicy, FwdIter>
-                        result;
+                using reference =
+                    typename std::iterator_traits<FwdIter>::reference;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter>::difference_type;
+                using result =
+                    typename util::detail::algorithm_result<ExPolicy, FwdIter>;
 
                 difference_type count = std::distance(first, last);
                 if (count <= 1)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/lexicographical_compare.hpp
@@ -220,8 +220,8 @@ namespace pika { namespace parallel { inline namespace v1 {
                 FwdIter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
                 Proj2&& proj2)
             {
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
                 using reference = typename zip_iterator::reference;
 
                 std::size_t count1 = detail::distance(first1, last1);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/merge.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/merge.hpp
@@ -443,8 +443,8 @@ namespace pika { namespace parallel { inline namespace v1 {
                 Proj2&& proj2)
             {
                 using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
-                typedef util::detail::algorithm_result<ExPolicy, result_type>
-                    algorithm_result;
+                using algorithm_result =
+                    util::detail::algorithm_result<ExPolicy, result_type>;
 
                 try
                 {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/move.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/move.hpp
@@ -130,8 +130,7 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(
                 ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
             {
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator = pika::util::zip_iterator<FwdIter1, FwdIter2>;
 
                 return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort.hpp
@@ -537,8 +537,8 @@ namespace pika { namespace parallel { inline namespace v1 {
         parallel(ExPolicy&& policy, Iter first, Iter middle, Sent last,
             Comp&& comp, Proj&& proj)
         {
-            typedef util::detail::algorithm_result<ExPolicy, Iter>
-                algorithm_result;
+            using algorithm_result =
+                util::detail::algorithm_result<ExPolicy, Iter>;
 
             try
             {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/reduce_by_key.hpp
@@ -55,10 +55,10 @@ namespace pika { namespace parallel { inline namespace v1 {
             template <typename This, typename Iterator>
             struct result<This(Iterator)>
             {
-                typedef typename std::iterator_traits<Iterator>::reference
-                    element_type;
-                typedef pika::tuple<element_type, element_type, element_type>
-                    type;
+                using element_type =
+                    typename std::iterator_traits<Iterator>::reference;
+                using type =
+                    pika::tuple<element_type, element_type, element_type>;
             };
 
             // call operator for stencil transform
@@ -67,9 +67,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             typename result<reduce_stencil_transformer(Iterator)>::type
             operator()(Iterator const& it) const
             {
-                typedef
-                    typename result<reduce_stencil_transformer(Iterator)>::type
-                        type;
+                using type =
+                    typename result<reduce_stencil_transformer(Iterator)>::type;
                 return type(*std::prev(it), *it, *std::next(it));
             }
         };
@@ -83,8 +82,8 @@ namespace pika { namespace parallel { inline namespace v1 {
           : public pika::util::transform_iterator<Iterator, Transformer>
         {
         private:
-            typedef pika::util::transform_iterator<Iterator, Transformer>
-                base_type;
+            using base_type =
+                pika::util::transform_iterator<Iterator, Transformer>;
 
         public:
             reduce_stencil_iterator() {}
@@ -128,12 +127,14 @@ namespace pika { namespace parallel { inline namespace v1 {
             typename KeyStateIterType, typename Compare>
         struct reduce_stencil_generate
         {
-            typedef typename Transformer::template result<Transformer(
-                StencilIterType)>::element_type element_type;
-            typedef typename Transformer::template result<Transformer(
-                StencilIterType)>::type tuple_type;
-            typedef typename std::iterator_traits<KeyStateIterType>::reference
-                KeyStateType;
+            using element_type =
+                typename Transformer::template result<Transformer(
+                    StencilIterType)>::element_type;
+            using tuple_type =
+                typename Transformer::template result<Transformer(
+                    StencilIterType)>::type;
+            using KeyStateType =
+                typename std::iterator_traits<KeyStateIterType>::reference;
 
             reduce_stencil_generate() {}
 
@@ -525,9 +526,8 @@ namespace pika { namespace parallel { inline namespace v1 {
         RanIter2 values_first, FwdIter1 keys_output, FwdIter2 values_output,
         Compare&& comp = Compare(), Func&& func = Func())
     {
-        typedef util::detail::algorithm_result<ExPolicy,
-            util::in_out_result<FwdIter1, FwdIter2>>
-            result;
+        using result = util::detail::algorithm_result<ExPolicy,
+            util::in_out_result<FwdIter1, FwdIter2>>;
 
         static_assert(
             (pika::traits::is_random_access_iterator<RanIter>::value) &&

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/remove.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/remove.hpp
@@ -289,10 +289,10 @@ namespace pika { namespace parallel { inline namespace v1 {
                 Proj&& proj)
             {
                 using zip_iterator = pika::util::zip_iterator<Iter, bool*>;
-                typedef util::detail::algorithm_result<ExPolicy, Iter>
-                    algorithm_result;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using algorithm_result =
+                    util::detail::algorithm_result<ExPolicy, Iter>;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 difference_type count = detail::distance(first, last);
 
@@ -308,9 +308,9 @@ namespace pika { namespace parallel { inline namespace v1 {
 
                 using pika::get;
                 using pika::util::make_zip_iterator;
-                typedef util::scan_partitioner<ExPolicy, Iter, std::size_t,
-                    void, util::scan_partitioner_sequential_f3_tag>
-                    scan_partitioner_type;
+                using scan_partitioner_type =
+                    util::scan_partitioner<ExPolicy, Iter, std::size_t, void,
+                        util::scan_partitioner_sequential_f3_tag>;
 
                 // Note: replacing the invoke() with PIKA_INVOKE()
                 // below makes gcc generate errors

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/remove_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/remove_copy.hpp
@@ -374,8 +374,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
-                typedef typename std::iterator_traits<FwdIter1>::value_type
-                    value_type;
+                using value_type =
+                    typename std::iterator_traits<FwdIter1>::value_type;
 
                 return copy_if<IterPair>().call(
                     PIKA_FORWARD(ExPolicy, policy), first, last, dest,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/replace.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/replace.hpp
@@ -665,8 +665,8 @@ namespace pika { namespace parallel { inline namespace v1 {
                 FwdIter2 dest, T const& old_value, T const& new_value,
                 Proj&& proj)
             {
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
                 using reference = typename zip_iterator::reference;
 
                 return util::detail::get_in_out_result(
@@ -740,8 +740,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, FwdIter1 first, Sent sent,
                 FwdIter2 dest, F&& f, T const& new_value, Proj&& proj)
             {
-                typedef pika::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<FwdIter1, FwdIter2>;
                 using reference = typename zip_iterator::reference;
 
                 return util::detail::get_in_out_result(

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/reverse.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/reverse.hpp
@@ -236,9 +236,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 auto last2{pika::ranges::next(first, last)};
                 using destination_iterator = std::reverse_iterator<BidirIter>;
-                typedef pika::util::zip_iterator<BidirIter,
-                    destination_iterator>
-                    zip_iterator;
+                using zip_iterator =
+                    pika::util::zip_iterator<BidirIter, destination_iterator>;
                 using reference = typename zip_iterator::reference;
 
                 return util::detail::convert_to_result(

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
@@ -441,8 +441,8 @@ namespace pika { namespace parallel { inline namespace v1 {
                 Comp&& comp, Proj&& proj)
             {
                 auto last = detail::advance_to_sentinel(first, last_s);
-                typedef util::detail::algorithm_result<ExPolicy, RandomIt>
-                    algorithm_result;
+                using algorithm_result =
+                    util::detail::algorithm_result<ExPolicy, RandomIt>;
 
                 try
                 {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/transform_reduce.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/transform_reduce.hpp
@@ -507,8 +507,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             {
                 using result = util::detail::algorithm_result<ExPolicy, T>;
                 using zip_iterator = pika::util::zip_iterator<Iter, Iter2>;
-                typedef typename std::iterator_traits<Iter>::difference_type
-                    difference_type;
+                using difference_type =
+                    typename std::iterator_traits<Iter>::difference_type;
 
                 if (first1 == last1)
                 {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_copy.hpp
@@ -253,8 +253,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             InIter1 first, std::size_t count, InIter2 dest,
             util::cancellation_token<util::detail::no_data>& tok)
         {
-            typedef
-                typename std::iterator_traits<InIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter2>::value_type;
 
             return {std::next(first, count),
                 util::loop_with_cleanup_n_with_token(
@@ -281,8 +281,8 @@ namespace pika { namespace parallel { inline namespace v1 {
 
             using zip_iterator = pika::util::zip_iterator<Iter, FwdIter2>;
             using partition_result_type = std::pair<FwdIter2, FwdIter2>;
-            typedef
-                typename std::iterator_traits<FwdIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<FwdIter2>::value_type;
 
             util::cancellation_token<util::detail::no_data> tok;
 

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
@@ -250,8 +250,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             }
 
             using partition_result_type = std::pair<FwdIter, FwdIter>;
-            typedef
-                typename std::iterator_traits<FwdIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<FwdIter>::value_type;
 
             util::cancellation_token<util::detail::no_data> tok;
             return util::partitioner_with_cleanup<ExPolicy, FwdIter,
@@ -327,8 +327,8 @@ namespace pika { namespace parallel { inline namespace v1 {
         InIter std_uninitialized_default_construct_n(
             InIter first, std::size_t count)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             InIter s_first = first;
             try

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_move.hpp
@@ -289,8 +289,8 @@ namespace pika { namespace parallel { inline namespace v1 {
 
             using zip_iterator = pika::util::zip_iterator<Iter, FwdIter2>;
             using partition_result_type = std::pair<FwdIter2, FwdIter2>;
-            typedef
-                typename std::iterator_traits<FwdIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<FwdIter2>::value_type;
 
             util::cancellation_token<util::detail::no_data> tok;
             return util::partitioner_with_cleanup<ExPolicy,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
@@ -252,8 +252,8 @@ namespace pika { namespace parallel { inline namespace v1 {
             }
 
             using partition_result_type = std::pair<FwdIter, FwdIter>;
-            typedef
-                typename std::iterator_traits<FwdIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<FwdIter>::value_type;
 
             util::cancellation_token<util::detail::no_data> tok;
             return util::partitioner_with_cleanup<ExPolicy, FwdIter,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove.hpp
@@ -661,9 +661,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at least input iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::remove_if(
                 PIKA_FORWARD(Rng, rng),
@@ -720,9 +719,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::remove_if(
                 PIKA_FORWARD(ExPolicy, policy), PIKA_FORWARD(Rng, rng),

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove_copy.hpp
@@ -780,9 +780,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at input forward iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::remove_copy_if(
                 PIKA_FORWARD(Rng, rng), dest,
@@ -841,9 +840,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::remove_copy_if(
                 PIKA_FORWARD(ExPolicy, policy), PIKA_FORWARD(Rng, rng), dest,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/replace.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/replace.hpp
@@ -1266,9 +1266,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at least input iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::replace_if(
                 PIKA_FORWARD(Rng, rng),
@@ -1329,9 +1328,8 @@ namespace pika { namespace ranges {
                     typename pika::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::replace_if(
                 PIKA_FORWARD(ExPolicy, policy), PIKA_FORWARD(Rng, rng),
@@ -1549,9 +1547,8 @@ namespace pika { namespace ranges {
             static_assert((pika::traits::is_output_iterator<OutIter>::value),
                 "Required at least output iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::replace_copy_if(
                 pika::execution::seq, pika::util::begin(rng),
@@ -1622,9 +1619,8 @@ namespace pika { namespace ranges {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            typedef typename std::iterator_traits<
-                typename pika::traits::range_iterator<Rng>::type>::value_type
-                Type;
+            using Type = typename std::iterator_traits<
+                typename pika::traits::range_iterator<Rng>::type>::value_type;
 
             return pika::ranges::replace_copy_if(
                 PIKA_FORWARD(ExPolicy, policy), pika::util::begin(rng),

--- a/libs/pika/algorithms/include/pika/parallel/datapar/zip_iterator.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/zip_iterator.hpp
@@ -91,7 +91,7 @@ namespace pika { namespace parallel { namespace traits {
     template <typename... Vector, typename ValueType>
     struct vector_pack_load<pika::tuple<Vector...>, ValueType>
     {
-        typedef pika::tuple<Vector...> value_type;
+        using value_type = pika::tuple<Vector...>;
 
         template <typename... Iter>
         static value_type aligned(pika::util::zip_iterator<Iter...> const& iter)

--- a/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
@@ -122,9 +122,9 @@ namespace pika { namespace parallel { namespace util {
             typename std::vector<std::size_t>::const_iterator chunk_size_it =
                 pika::util::begin(chunk_sizes);
 
-            typedef typename pika::tuple<typename data_type::value_type,
-                FwdIter, std::size_t>
-                tuple_type;
+            using tuple_type =
+                typename pika::tuple<typename data_type::value_type, FwdIter,
+                    std::size_t>;
 
             // schedule every chunk on a separate thread
             std::vector<tuple_type> shape;

--- a/libs/pika/algorithms/include/pika/parallel/util/prefetching.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/prefetching.hpp
@@ -209,7 +209,7 @@ namespace pika { namespace parallel { namespace util {
         struct prefetcher_context
         {
         private:
-            typedef pika::tuple<std::reference_wrapper<Ts>...> ranges_type;
+            using ranges_type = pika::tuple<std::reference_wrapper<Ts>...>;
 
             Itr it_begin_;
             Itr it_end_;
@@ -464,10 +464,10 @@ namespace pika { namespace parallel { namespace util {
         template <typename Itr, typename... Ts>
         struct loop<prefetching::prefetching_iterator<Itr, Ts...>>
         {
-            typedef prefetching::prefetching_iterator<Itr, Ts...> iterator_type;
+            using iterator_type = prefetching::prefetching_iterator<Itr, Ts...>;
             using type = typename iterator_type::base_iterator;
-            typedef typename pika::util::make_index_pack<sizeof...(Ts)>::type
-                index_pack_type;
+            using index_pack_type =
+                typename pika::util::make_index_pack<sizeof...(Ts)>::type;
 
             template <typename End, typename F>
             static iterator_type call(iterator_type it, End end, F&& f)
@@ -524,10 +524,10 @@ namespace pika { namespace parallel { namespace util {
         template <typename Itr, typename... Ts>
         struct loop_ind<prefetching::prefetching_iterator<Itr, Ts...>>
         {
-            typedef prefetching::prefetching_iterator<Itr, Ts...> iterator_type;
+            using iterator_type = prefetching::prefetching_iterator<Itr, Ts...>;
             using type = typename iterator_type::base_iterator;
-            typedef typename pika::util::make_index_pack<sizeof...(Ts)>::type
-                index_pack_type;
+            using index_pack_type =
+                typename pika::util::make_index_pack<sizeof...(Ts)>::type;
 
             template <typename End, typename F>
             static iterator_type call(iterator_type it, End end, F&& f)

--- a/libs/pika/algorithms/include/pika/parallel/util/scan_partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/scan_partitioner.hpp
@@ -100,8 +100,9 @@ namespace pika { namespace parallel { namespace util {
                     std::size_t count_ = count;
 
                     // estimate a chunk size based on number of cores used
-                    typedef typename execution::extract_has_variable_chunk_size<
-                        parameters_type>::type has_variable_chunk_size;
+                    using has_variable_chunk_size =
+                        typename execution::extract_has_variable_chunk_size<
+                            parameters_type>::type;
 
                     auto shape = detail::get_bulk_iteration_shape(
                         has_variable_chunk_size(), policy, workitems, f1, first,
@@ -219,8 +220,9 @@ namespace pika { namespace parallel { namespace util {
                     bool tested = false;
 
                     // estimate a chunk size based on number of cores used
-                    typedef typename execution::extract_has_variable_chunk_size<
-                        parameters_type>::type has_variable_chunk_size;
+                    using has_variable_chunk_size =
+                        typename execution::extract_has_variable_chunk_size<
+                            parameters_type>::type;
 
                     auto shape = detail::get_bulk_iteration_shape(
                         has_variable_chunk_size(), policy, workitems, f1, first,

--- a/libs/pika/algorithms/include/pika/parallel/util/zip_iterator.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/zip_iterator.hpp
@@ -27,8 +27,8 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
     template <int N, typename R, typename ZipIter>
     R get_iter(pika::future<ZipIter>&& zipiter)
     {
-        typedef typename pika::tuple_element<N,
-            typename ZipIter::iterator_tuple_type>::type result_type;
+        using result_type = typename pika::tuple_element<N,
+            typename ZipIter::iterator_tuple_type>::type;
 
         return pika::make_future<result_type>(
             PIKA_MOVE(zipiter), [](ZipIter zipiter) {
@@ -75,10 +75,9 @@ namespace pika { namespace parallel { inline namespace v1 { namespace detail {
     {
         using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
 
-        typedef std::pair<
+        using result_type = std::pair<
             typename pika::tuple_element<0, iterator_tuple_type>::type,
-            typename pika::tuple_element<1, iterator_tuple_type>::type>
-            result_type;
+            typename pika::tuple_element<1, iterator_tuple_type>::type>;
 
         return pika::make_future<result_type>(PIKA_MOVE(zipiter),
             [](ZipIter zipiter) { return get_iter_pair(PIKA_MOVE(zipiter)); });

--- a/libs/pika/algorithms/tests/regressions/minimal_findend.cpp
+++ b/libs/pika/algorithms/tests/regressions/minimal_findend.cpp
@@ -22,10 +22,9 @@ namespace test {
             IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             decorated_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         decorated_iterator() {}
@@ -59,9 +58,8 @@ namespace test {
 void find_end_failing_test()
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator,
-        std::random_access_iterator_tag>
-        decorated_iterator;
+    using decorated_iterator = test::decorated_iterator<base_iterator,
+        std::random_access_iterator_tag>;
 
     std::vector<std::size_t> c(10007, 0);
     std::size_t h[] = {1, 2};

--- a/libs/pika/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/pika/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -49,7 +49,7 @@ void test_merge_stable(ExPolicy policy, DataType, int rand_base)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::pair<DataType, int> ElemType;
+    using ElemType = typename std::pair<DataType, int>;
 
     using pika::get;
 

--- a/libs/pika/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
@@ -68,8 +68,8 @@ void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::vector<int> d(10007);
 
@@ -101,8 +101,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(10007);
@@ -147,8 +147,8 @@ void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(10007);
@@ -179,8 +179,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(10007);

--- a/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -59,8 +59,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -59,8 +59,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
 
@@ -60,8 +60,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
 
@@ -60,8 +60,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/copy_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/copy_tests.hpp
@@ -99,8 +99,8 @@ template <typename IteratorTag>
 void test_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -135,8 +135,8 @@ void test_copy_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -168,8 +168,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -210,8 +210,8 @@ void test_copy_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -241,8 +241,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/copyif_forward.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/copyif_forward.cpp
@@ -26,8 +26,8 @@ std::uniform_int_distribution<> dis(0, (std::numeric_limits<int>::max)());
 void test_copy_if_seq()
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::forward_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
@@ -63,8 +63,8 @@ void test_copy_if(ExPolicy&& policy)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::forward_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
@@ -97,8 +97,8 @@ template <typename ExPolicy>
 void test_copy_if_async(ExPolicy&& p)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::forward_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/copyif_random.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/copyif_random.cpp
@@ -26,8 +26,8 @@ std::uniform_int_distribution<> dis(0, (std::numeric_limits<int>::max)());
 void test_copy_if_seq()
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
@@ -63,8 +63,8 @@ void test_copy_if(ExPolicy&& policy)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
@@ -97,8 +97,8 @@ template <typename ExPolicy>
 void test_copy_if_async(ExPolicy&& p)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
+    using iterator =
+        test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
     std::vector<int> c(10007);
     std::vector<int> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/copyn_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/copyn_tests.hpp
@@ -100,8 +100,8 @@ template <typename IteratorTag>
 void test_copy_n_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -136,8 +136,8 @@ void test_copy_n_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -169,8 +169,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -212,8 +212,8 @@ void test_copy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -244,8 +244,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/count_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/count_tests.hpp
@@ -98,8 +98,8 @@ template <typename IteratorTag>
 void test_count_exception(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -132,8 +132,8 @@ void test_count_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -164,8 +164,8 @@ void test_count_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using diff_type = std::vector<int>::difference_type;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::fill(std::begin(c), std::end(c), 10);
@@ -205,8 +205,8 @@ void test_count_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -236,8 +236,8 @@ void test_count_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using diff_type = std::vector<int>::difference_type;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/pika/algorithms/tests/unit/algorithms/countif_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/countif_tests.hpp
@@ -102,8 +102,8 @@ template <typename IteratorTag>
 void test_count_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), dis(gen));
@@ -138,8 +138,8 @@ void test_count_if_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), dis(gen));
@@ -172,8 +172,8 @@ void test_count_if_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using diff_type = std::vector<int>::difference_type;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::fill(std::begin(c), std::end(c), 10);
@@ -213,8 +213,8 @@ void test_count_if_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), dis(gen));
@@ -244,8 +244,8 @@ void test_count_if_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using diff_type = std::vector<int>::difference_type;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), dis(gen));

--- a/libs/pika/algorithms/tests/unit/algorithms/destroy_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/destroy_tests.hpp
@@ -48,7 +48,7 @@ std::size_t const data_size = 10007;
 template <typename IteratorTag>
 void test_destroy(IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -74,7 +74,7 @@ void test_destroy(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -98,7 +98,7 @@ void test_destroy(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -125,9 +125,9 @@ template <typename IteratorTag>
 void test_destroy_exception(IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -181,9 +181,9 @@ void test_destroy_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -234,9 +234,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_exception_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -297,9 +297,9 @@ void test_destroy_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -350,9 +350,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 

--- a/libs/pika/algorithms/tests/unit/algorithms/destroyn.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/destroyn.cpp
@@ -47,7 +47,7 @@ std::size_t const data_size = 10007;
 template <typename IteratorTag>
 void test_destroy_n(IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -73,7 +73,7 @@ void test_destroy_n(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -96,7 +96,7 @@ void test_destroy_n(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -144,9 +144,9 @@ template <typename IteratorTag>
 void test_destroy_n_exception(IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -200,9 +200,9 @@ void test_destroy_n_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -253,9 +253,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_exception_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -339,9 +339,9 @@ void test_destroy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -392,9 +392,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 

--- a/libs/pika/algorithms/tests/unit/algorithms/fill_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/fill_tests.hpp
@@ -94,8 +94,8 @@ template <typename IteratorTag>
 void test_fill_exception(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -128,8 +128,8 @@ void test_fill_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -159,8 +159,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_fill_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -200,8 +200,8 @@ void test_fill_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(100007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -230,8 +230,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_fill_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/pika/algorithms/tests/unit/algorithms/filln_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/filln_tests.hpp
@@ -93,8 +93,8 @@ template <typename IteratorTag>
 void test_fill_n_exception(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -127,8 +127,8 @@ void test_fill_n_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -158,8 +158,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -199,8 +199,8 @@ void test_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(100007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -229,8 +229,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/pika/algorithms/tests/unit/algorithms/find.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/find.cpp
@@ -111,8 +111,8 @@ template <typename IteratorTag>
 void test_find_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -146,8 +146,8 @@ void test_find_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -178,8 +178,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -243,8 +243,8 @@ void test_find_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -274,8 +274,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findend.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findend.cpp
@@ -444,8 +444,8 @@ void test_find_end_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -483,8 +483,8 @@ template <typename IteratorTag>
 void test_find_end_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -523,8 +523,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_end_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -593,8 +593,8 @@ void test_find_end_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -627,8 +627,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_end_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findfirstof.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findfirstof.cpp
@@ -121,8 +121,8 @@ template <typename IteratorTag>
 void test_find_first_of_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -158,8 +158,8 @@ void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -192,8 +192,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -259,8 +259,8 @@ void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -292,8 +292,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
@@ -128,8 +128,8 @@ template <typename IteratorTag>
 void test_find_first_of_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -167,8 +167,8 @@ void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -203,8 +203,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -272,8 +272,8 @@ void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -307,8 +307,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findif.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findif.cpp
@@ -114,8 +114,8 @@ template <typename IteratorTag>
 void test_find_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -149,8 +149,8 @@ void test_find_if_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -181,8 +181,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -246,8 +246,8 @@ void test_find_if_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -277,8 +277,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
@@ -29,8 +29,8 @@ void test_find_if_not_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -60,8 +60,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/findifnot_exception.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/findifnot_exception.cpp
@@ -26,8 +26,8 @@ template <typename IteratorTag>
 void test_find_if_not_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -61,8 +61,8 @@ void test_find_if_not_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -93,8 +93,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/generate_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/generate_tests.hpp
@@ -96,8 +96,8 @@ template <typename IteratorTag>
 void test_generate_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -131,8 +131,8 @@ void test_generate_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -163,8 +163,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 
@@ -205,8 +205,8 @@ void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
 
@@ -236,8 +236,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 

--- a/libs/pika/algorithms/tests/unit/algorithms/generaten_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/generaten_tests.hpp
@@ -92,8 +92,8 @@ template <typename IteratorTag>
 void test_generate_n_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -127,8 +127,8 @@ void test_generate_n_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -159,8 +159,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 
@@ -201,8 +201,8 @@ void test_generate_n_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
 
@@ -232,8 +232,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 

--- a/libs/pika/algorithms/tests/unit/algorithms/is_partitioned.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/is_partitioned.cpp
@@ -247,8 +247,8 @@ void test_partitioned_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -283,8 +283,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -346,8 +346,8 @@ void test_partitioned_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -380,8 +380,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half

--- a/libs/pika/algorithms/tests/unit/algorithms/is_sorted_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/is_sorted_tests.hpp
@@ -232,8 +232,8 @@ void test_sorted_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 
@@ -263,8 +263,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_sorted_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -298,8 +298,8 @@ template <typename IteratorTag>
 void test_sorted_exception_seq(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 
@@ -333,8 +333,8 @@ void test_sorted_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -363,8 +363,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_sorted_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -395,8 +395,8 @@ template <typename IteratorTag>
 void test_sorted_bad_alloc_seq(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), 0);

--- a/libs/pika/algorithms/tests/unit/algorithms/is_sorted_until.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/is_sorted_until.cpp
@@ -334,8 +334,8 @@ void test_sorted_until_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -368,8 +368,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -403,8 +403,8 @@ template <typename IteratorTag>
 void test_sorted_until_seq_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -463,8 +463,8 @@ void test_sorted_until_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -496,8 +496,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -531,8 +531,8 @@ template <typename IteratorTag>
 void test_sorted_until_seq_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half

--- a/libs/pika/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
@@ -287,8 +287,8 @@ void test_lexicographical_compare_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -324,8 +324,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::fill(std::begin(c), std::end(c), gen() + 1);
@@ -390,8 +390,8 @@ void test_lexicographical_compare_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::fill(std::begin(c), std::end(c), gen() + 1);
@@ -424,8 +424,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::fill(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -174,8 +174,8 @@ template <typename IteratorTag>
 void test_make_heap_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
 
@@ -206,8 +206,8 @@ void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
 
@@ -236,8 +236,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -294,8 +294,8 @@ template <typename IteratorTag>
 void test_make_heap_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -327,8 +327,8 @@ void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -358,8 +358,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());

--- a/libs/pika/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/max_element.cpp
@@ -132,8 +132,8 @@ template <typename IteratorTag>
 void test_max_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -191,8 +191,8 @@ void test_max_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -247,8 +247,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_max_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -342,8 +342,8 @@ template <typename IteratorTag>
 void test_max_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -397,8 +397,8 @@ void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -451,8 +451,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_max_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -484,10 +484,10 @@ void test_merge_etc(IteratorTag, DataType, int rand_base)
 
     // Test sequential_merge with input_iterator_tag.
     {
-        typedef test::test_iterator<base_iterator, std::input_iterator_tag>
-            input_iterator;
-        typedef test::test_iterator<base_iterator, std::output_iterator_tag>
-            output_iterator;
+        using input_iterator =
+            test::test_iterator<base_iterator, std::input_iterator_tag>;
+        using output_iterator =
+            test::test_iterator<base_iterator, std::output_iterator_tag>;
 
         auto result = pika::parallel::v1::detail::sequential_merge(
             input_iterator(std::begin(src1)), input_iterator(std::end(src1)),
@@ -541,10 +541,10 @@ void test_merge_etc(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 
     // Test sequential_merge with input_iterator_tag.
     {
-        typedef test::test_iterator<base_iterator, std::input_iterator_tag>
-            input_iterator;
-        typedef test::test_iterator<base_iterator, std::output_iterator_tag>
-            output_iterator;
+        using input_iterator =
+            test::test_iterator<base_iterator, std::input_iterator_tag>;
+        using output_iterator =
+            test::test_iterator<base_iterator, std::output_iterator_tag>;
 
         auto result = pika::parallel::v1::detail::sequential_merge(
             input_iterator(std::begin(src1)), input_iterator(std::end(src1)),

--- a/libs/pika/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/min_element.cpp
@@ -133,8 +133,8 @@ template <typename IteratorTag>
 void test_min_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -192,8 +192,8 @@ void test_min_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -248,8 +248,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_min_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -343,8 +343,8 @@ template <typename IteratorTag>
 void test_min_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -398,8 +398,8 @@ void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -452,8 +452,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_min_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -146,8 +146,8 @@ template <typename IteratorTag>
 void test_minmax_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -207,8 +207,8 @@ void test_minmax_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -263,8 +263,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -358,8 +358,8 @@ template <typename IteratorTag>
 void test_minmax_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -413,8 +413,8 @@ void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -467,8 +467,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/move.cpp
@@ -132,8 +132,8 @@ void test_move_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -165,8 +165,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -228,8 +228,8 @@ void test_move_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::vector<std::size_t> d(c.size());
@@ -259,8 +259,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -200,8 +200,8 @@ void test_remove_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -233,8 +233,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -296,8 +296,8 @@ void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -327,8 +327,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -265,8 +265,8 @@ template <typename IteratorTag>
 void test_remove_exception(IteratorTag, bool test_for_remove_if = false)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -310,8 +310,8 @@ void test_remove_exception(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -353,8 +353,8 @@ void test_remove_exception_async(
     ExPolicy policy, IteratorTag, bool test_for_remove_if = false)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -403,8 +403,8 @@ template <typename IteratorTag>
 void test_remove_bad_alloc(IteratorTag, bool test_for_remove_if = false)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -447,8 +447,8 @@ void test_remove_bad_alloc(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -489,8 +489,8 @@ void test_remove_bad_alloc_async(
     ExPolicy policy, IteratorTag, bool test_for_remove_if = false)
 {
     using base_iterator = std::vector<int>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);

--- a/libs/pika/algorithms/tests/unit/algorithms/replace.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/replace.cpp
@@ -131,8 +131,8 @@ template <typename IteratorTag>
 void test_replace_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -166,8 +166,8 @@ void test_replace_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -198,8 +198,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -258,8 +258,8 @@ template <typename IteratorTag>
 void test_replace_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -291,8 +291,8 @@ void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -321,8 +321,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -137,8 +137,8 @@ template <typename IteratorTag>
 void test_replace_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -174,8 +174,8 @@ void test_replace_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -208,8 +208,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -270,8 +270,8 @@ template <typename IteratorTag>
 void test_replace_copy_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -305,8 +305,8 @@ void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -337,8 +337,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/replace_copy_if.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/replace_copy_if.cpp
@@ -152,8 +152,8 @@ template <typename IteratorTag>
 void test_replace_copy_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -189,8 +189,8 @@ void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -223,8 +223,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -285,8 +285,8 @@ template <typename IteratorTag>
 void test_replace_copy_if_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -320,8 +320,8 @@ void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -352,8 +352,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -146,8 +146,8 @@ template <typename IteratorTag>
 void test_replace_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -181,8 +181,8 @@ void test_replace_if_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -213,8 +213,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -273,8 +273,8 @@ template <typename IteratorTag>
 void test_replace_if_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -306,8 +306,8 @@ void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -336,8 +336,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/algorithms/reverse.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/reverse.cpp
@@ -125,8 +125,8 @@ template <typename IteratorTag>
 void test_reverse_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -160,8 +160,8 @@ void test_reverse_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -191,8 +191,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -251,8 +251,8 @@ template <typename IteratorTag>
 void test_reverse_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -283,8 +283,8 @@ void test_reverse_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -312,8 +312,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/algorithms/reverse_copy.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/reverse_copy.cpp
@@ -128,8 +128,8 @@ template <typename IteratorTag>
 void test_reverse_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -165,8 +165,8 @@ void test_reverse_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -198,8 +198,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -259,8 +259,8 @@ template <typename IteratorTag>
 void test_reverse_copy_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -293,8 +293,8 @@ void test_reverse_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -324,8 +324,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/search.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/search.cpp
@@ -365,8 +365,8 @@ void test_search_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
     c[c.size() / 2] = 1;
@@ -404,8 +404,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_search_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
@@ -468,8 +468,8 @@ void test_search_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
@@ -502,8 +502,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_search_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/searchn.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/searchn.cpp
@@ -440,8 +440,8 @@ void test_search_n_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
     c[c.size() / 2] = 1;
@@ -477,8 +477,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_search_n_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
@@ -539,8 +539,8 @@ void test_search_n_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);
@@ -572,8 +572,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_search_n_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand() + 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/set_difference.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/set_difference.cpp
@@ -229,8 +229,8 @@ template <typename IteratorTag>
 void test_set_difference_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -271,8 +271,8 @@ void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -313,8 +313,8 @@ void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -381,8 +381,8 @@ template <typename IteratorTag>
 void test_set_difference_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -421,8 +421,8 @@ void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -462,8 +462,8 @@ void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/set_intersection.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/set_intersection.cpp
@@ -229,8 +229,8 @@ template <typename IteratorTag>
 void test_set_intersection_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -271,8 +271,8 @@ void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -313,8 +313,8 @@ void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -381,8 +381,8 @@ template <typename IteratorTag>
 void test_set_intersection_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -421,8 +421,8 @@ void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -462,8 +462,8 @@ void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
@@ -230,8 +230,8 @@ template <typename IteratorTag>
 void test_set_symmetric_difference_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -273,8 +273,8 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -315,8 +315,8 @@ void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -383,8 +383,8 @@ template <typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -423,8 +423,8 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -464,8 +464,8 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/set_union.cpp
@@ -227,8 +227,8 @@ template <typename IteratorTag>
 void test_set_union_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -269,8 +269,8 @@ void test_set_union_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -311,8 +311,8 @@ void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -379,8 +379,8 @@ template <typename IteratorTag>
 void test_set_union_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -419,8 +419,8 @@ void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -460,8 +460,8 @@ void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/sort_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/sort_tests.hpp
@@ -227,9 +227,8 @@ void test_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -260,9 +259,8 @@ void test_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
@@ -306,9 +304,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -339,9 +336,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
@@ -386,9 +382,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -424,9 +419,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
@@ -475,9 +469,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -513,9 +506,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),

--- a/libs/pika/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
@@ -228,9 +228,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -261,9 +260,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
@@ -307,9 +305,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
@@ -340,9 +337,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
@@ -387,9 +383,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::stable_sort(std::forward<ExPolicy>(policy),
@@ -426,9 +421,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::stable_sort(
                 std::forward<ExPolicy>(policy),
@@ -478,9 +472,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::stable_sort(std::forward<ExPolicy>(policy),
@@ -517,9 +510,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f = pika::stable_sort(
                 std::forward<ExPolicy>(policy),

--- a/libs/pika/algorithms/tests/unit/algorithms/swapranges.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/swapranges.cpp
@@ -150,8 +150,8 @@ void test_swap_ranges_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -184,8 +184,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -248,8 +248,8 @@ void test_swap_ranges_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::vector<std::size_t> d(c.size());
@@ -280,8 +280,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
@@ -22,8 +22,8 @@ template <typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -56,8 +56,8 @@ void test_transform_reduce_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -87,8 +87,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);

--- a/libs/pika/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
@@ -23,8 +23,8 @@ template <typename IteratorTag>
 void test_transform_reduce_binary_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -58,8 +58,8 @@ void test_transform_reduce_binary_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -90,8 +90,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
@@ -79,8 +79,8 @@ void test_uninitialized_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -119,8 +119,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -169,8 +169,8 @@ void test_uninitialized_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -209,8 +209,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
@@ -96,8 +96,8 @@ void test_uninitialized_copy_n_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -136,8 +136,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -207,8 +207,8 @@ void test_uninitialized_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -247,8 +247,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
@@ -44,7 +44,7 @@ void test_uninitialized_default_construct(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef default_constructable* base_iterator;
+    using base_iterator = default_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     default_constructable* p = (default_constructable*) std::malloc(
@@ -68,7 +68,7 @@ void test_uninitialized_default_construct(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef default_constructable* base_iterator;
+    using base_iterator = default_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     default_constructable* p = (default_constructable*) std::malloc(
@@ -96,7 +96,7 @@ void test_uninitialized_default_construct2(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -120,7 +120,7 @@ void test_uninitialized_default_construct2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_async2(ExPolicy&& policy, IteratorTag)
 {
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -151,9 +151,9 @@ void test_uninitialized_default_construct_exception(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -198,9 +198,9 @@ void test_uninitialized_default_construct_exception_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -255,9 +255,9 @@ void test_uninitialized_default_construct_bad_alloc(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -302,9 +302,9 @@ void test_uninitialized_default_construct_bad_alloc_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -42,7 +42,7 @@ void test_uninitialized_default_construct_n(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef default_constructable* base_iterator;
+    using base_iterator = default_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     default_constructable* p = (default_constructable*) std::malloc(
@@ -65,7 +65,7 @@ void test_uninitialized_default_construct_n(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n_async(ExPolicy policy, IteratorTag)
 {
-    typedef default_constructable* base_iterator;
+    using base_iterator = default_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     default_constructable* p = (default_constructable*) std::malloc(
@@ -93,7 +93,7 @@ void test_uninitialized_default_construct_n2(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -116,7 +116,7 @@ void test_uninitialized_default_construct_n2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n_async2(ExPolicy policy, IteratorTag)
 {
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -173,9 +173,9 @@ void test_uninitialized_default_construct_n_exception(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -220,9 +220,9 @@ void test_uninitialized_default_construct_n_exception_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -302,9 +302,9 @@ void test_uninitialized_default_construct_n_bad_alloc(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -349,9 +349,9 @@ void test_uninitialized_default_construct_n_bad_alloc_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<default_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
@@ -112,8 +112,8 @@ void test_uninitialized_fill_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -152,8 +152,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -222,8 +222,8 @@ void test_uninitialized_fill_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(100007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -261,8 +261,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
@@ -110,8 +110,8 @@ void test_uninitialized_fill_n_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -150,8 +150,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -220,8 +220,8 @@ void test_uninitialized_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -259,8 +259,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
@@ -101,8 +101,8 @@ void test_uninitialized_move_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -141,8 +141,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -191,8 +191,8 @@ void test_uninitialized_move_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -231,8 +231,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -120,8 +120,8 @@ void test_uninitialized_move_n_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -160,8 +160,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -231,8 +231,8 @@ void test_uninitialized_move_n_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());
@@ -271,8 +271,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<test::count_instances>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<test::count_instances> c(10007);
     std::vector<test::count_instances> d(c.size());

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
@@ -34,7 +34,7 @@ void test_uninitialized_value_construct(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -58,7 +58,7 @@ void test_uninitialized_value_construct(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -88,9 +88,9 @@ void test_uninitialized_value_construct_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -135,9 +135,9 @@ void test_uninitialized_value_construct_exception_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -191,9 +191,9 @@ void test_uninitialized_value_construct_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -238,9 +238,9 @@ void test_uninitialized_value_construct_bad_alloc_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));

--- a/libs/pika/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
@@ -32,7 +32,7 @@ void test_uninitialized_value_construct_n(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -55,7 +55,7 @@ void test_uninitialized_value_construct_n(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_n_async(ExPolicy policy, IteratorTag)
 {
-    typedef value_constructable* base_iterator;
+    using base_iterator = value_constructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     value_constructable* p = (value_constructable*) std::malloc(
@@ -105,9 +105,9 @@ void test_uninitialized_value_construct_n_exception(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -152,9 +152,9 @@ void test_uninitialized_value_construct_n_exception_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -233,9 +233,9 @@ void test_uninitialized_value_construct_n_bad_alloc(
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));
@@ -280,9 +280,9 @@ void test_uninitialized_value_construct_n_bad_alloc_async(
     ExPolicy policy, IteratorTag)
 {
     using data_type = test::count_instances_v<value_constructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
     std::memset(static_cast<void*>(p), 0xcd, data_size * sizeof(data_type));

--- a/libs/pika/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -391,10 +391,10 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test sequential_unique_copy with input_iterator_tag.
     {
-        typedef test::test_iterator<base_iterator, std::input_iterator_tag>
-            input_iterator;
-        typedef test::test_iterator<base_iterator, std::output_iterator_tag>
-            output_iterator;
+        using input_iterator =
+            test::test_iterator<base_iterator, std::input_iterator_tag>;
+        using output_iterator =
+            test::test_iterator<base_iterator, std::output_iterator_tag>;
 
         auto result = pika::parallel::v1::detail::sequential_unique_copy(
             input_iterator(std::begin(c)), input_iterator(std::end(c)),

--- a/libs/pika/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -382,8 +382,8 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test sequential_unique with input_iterator_tag.
     {
-        typedef test::test_iterator<base_iterator, std::input_iterator_tag>
-            iterator;
+        using iterator =
+            test::test_iterator<base_iterator, std::input_iterator_tag>;
 
         c = d = org;
 

--- a/libs/pika/algorithms/tests/unit/algorithms/util/test_merge_four.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/util/test_merge_four.cpp
@@ -80,7 +80,7 @@ void test1()
 
     // 1 range filled && 3 empty
     X.resize(10, 0);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i);
     RD = range_t(D.begin(), D.end());
     RX = range_t(X.begin(), X.end());
@@ -96,9 +96,9 @@ void test1()
 
     // Two ranges
     D.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 2 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 2);
     X.resize(20, 0);
     RA = range_t(A.begin(), A.end());
@@ -118,11 +118,11 @@ void test1()
     // Three ranges
     A.clear();
     D.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 3 + 2);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i * 3 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 3);
     X.resize(30, 0);
     RA = range_t(A.begin(), A.end());
@@ -145,13 +145,13 @@ void test1()
     C.clear();
     D.clear();
     X.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 4 + 3);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i * 4 + 2);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i * 4 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 4);
 
     X.resize(40, 0);
@@ -175,13 +175,13 @@ void test1()
     C.clear();
     D.clear();
     X.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i + 10);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i + 20);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i + 30);
 
     X.resize(40, 0);
@@ -205,13 +205,13 @@ void test1()
     C.clear();
     D.clear();
     X.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i + 30);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i + 20);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i + 10);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i);
 
     X.resize(40, 0);
@@ -240,7 +240,7 @@ void test2()
     range_t R[4];
     compare comp;
 
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
     {
         A.emplace_back(i, 0);
         B.emplace_back(i, 1);
@@ -299,7 +299,7 @@ void test3()
 
     // 1 range filled && 3 empty
     //X.resize ( 10, 0 );
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i);
     RD = range_t(D.begin(), D.end());
     RX = range<std::uint64_t*>(&X[0], &X[9]);
@@ -315,9 +315,9 @@ void test3()
 
     // Two ranges
     D.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 2 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 2);
     //X.resize ( 20, 0);
     RA = range_t(A.begin(), A.end());
@@ -337,11 +337,11 @@ void test3()
     // Three ranges
     A.clear();
     D.clear();
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 3 + 2);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i * 3 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 3);
     //X.resize ( 30 , 0);
     RA = range_t(A.begin(), A.end());
@@ -364,13 +364,13 @@ void test3()
     C.clear();
     D.clear();
     //X.clear() ;
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i * 4 + 3);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i * 4 + 2);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i * 4 + 1);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i * 4);
 
     //X.resize ( 40 , 0);
@@ -394,13 +394,13 @@ void test3()
     C.clear();
     D.clear();
     //X.clear() ;
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i + 10);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i + 20);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i + 30);
 
     //X.resize ( 40 , 0);
@@ -424,13 +424,13 @@ void test3()
     C.clear();
     D.clear();
     //X.clear() ;
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         A.push_back(i + 30);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         B.push_back(i + 20);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         C.push_back(i + 10);
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
         D.push_back(i);
 
     //X.resize ( 40 , 0);
@@ -460,7 +460,7 @@ void test4()
     range_t R[4];
     compare comp;
 
-    for (std::uint32_t i = 0; i < 10; ++i)
+    for (std::uint64_t i = 0; i < 10; ++i)
     {
         A.emplace_back(i, 0);
         B.emplace_back(i, 1);

--- a/libs/pika/algorithms/tests/unit/algorithms/util/test_merge_vector.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/util/test_merge_vector.cpp
@@ -112,7 +112,8 @@ void test2()
     }
 
     std::vector<rng> Vin, Vout;
-    for (std::uint32_t i = 0; i < 9; ++i)
+    using difference_type = decltype(VA)::difference_type;
+    for (difference_type i = 0; i < 9; ++i)
     {
         Vin.emplace_back(VA.begin() + (i * 10), VA.begin() + ((i + 1) * 10));
     }
@@ -187,7 +188,8 @@ void test4()
 
     std::vector<rng> Vin;
     std::vector<range<xk*>> Vout;
-    for (std::uint32_t i = 0; i < 9; ++i)
+    using difference_type = decltype(VA)::difference_type;
+    for (difference_type i = 0; i < 9; ++i)
     {
         Vin.emplace_back(VA.begin() + (i * 10), VA.begin() + ((i + 1) * 10));
     }
@@ -222,7 +224,8 @@ void test5()
     rng Rout(Y.begin(), Y.end());
 
     std::vector<rng> Vin, Vout;
-    for (std::uint32_t i = 0; i < 10; ++i)
+    using difference_type = decltype(X)::difference_type;
+    for (difference_type i = 0; i < 10; ++i)
     {
         Vin.emplace_back(X.begin() + (i * 10), X.begin() + ((i + 1) * 10));
     }
@@ -255,7 +258,8 @@ void test6()
         VA.emplace_back(2 * k, i / 10);
     }
     std::vector<rng> Vin, Vout;
-    for (std::uint32_t i = 0; i < 16; ++i)
+    using difference_type = decltype(VA)::difference_type;
+    for (difference_type i = 0; i < 16; ++i)
     {
         Vin.emplace_back(VA.begin() + (i * 10), VA.begin() + ((i + 1) * 10));
     }

--- a/libs/pika/algorithms/tests/unit/algorithms/util/test_range.cpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/util/test_range.cpp
@@ -517,7 +517,7 @@ void test7()
 void test8()
 {
     using compare = std::less<std::uint64_t>;
-    typedef range<std::uint64_t*> rng;
+    using rng = range<std::uint64_t*>;
 
     std::vector<std::uint64_t> A, B;
     compare comp;

--- a/libs/pika/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/pika/algorithms/tests/unit/block/task_block_executor.cpp
@@ -36,8 +36,8 @@ void define_task_block_test1(Executor& exec)
     bool task21_flag = false;
     bool task3_flag = false;
 
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
 
     define_task_block(par.on(exec), [&](task_block_type& trh) {
         parent_flag = true;
@@ -87,10 +87,10 @@ void define_task_block_test2(Executor& exec)
     bool task21_flag = false;
     bool task3_flag = false;
 
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type1;
-    typedef task_block<parallel_task_policy_shim<Executor, static_chunk_size>>
-        task_block_type2;
+    using task_block_type1 =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
+    using task_block_type2 =
+        task_block<parallel_task_policy_shim<Executor, static_chunk_size>>;
 
     pika::future<void> f =
         define_task_block(par(task).on(exec), [&](task_block_type2& trh) {
@@ -144,8 +144,8 @@ void define_task_block_test3(Executor& exec)
     bool task21_flag = false;
     bool task3_flag = false;
 
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
 
     define_task_block(par.on(exec), [&](task_block_type& trh) {
         parent_flag = true;
@@ -195,10 +195,10 @@ void define_task_block_test4(Executor& exec)
     bool task21_flag = false;
     bool task3_flag = false;
 
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type1;
-    typedef task_block<parallel_task_policy_shim<Executor, static_chunk_size>>
-        task_block_type2;
+    using task_block_type1 =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
+    using task_block_type2 =
+        task_block<parallel_task_policy_shim<Executor, static_chunk_size>>;
 
     pika::future<void> f =
         define_task_block(par(task).on(exec), [&](task_block_type2& trh) {
@@ -244,8 +244,8 @@ void define_task_block_test4(Executor& exec)
 template <typename Executor>
 void define_task_block_exceptions_test1(Executor& exec)
 {
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
 
     try
     {
@@ -279,8 +279,8 @@ void define_task_block_exceptions_test1(Executor& exec)
 template <typename Executor>
 void define_task_block_exceptions_test2(Executor& exec)
 {
-    typedef task_block<parallel_task_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_task_policy_shim<Executor, static_chunk_size>>;
 
     pika::future<void> f =
         define_task_block(par(task).on(exec), [](task_block_type& trh) {
@@ -316,8 +316,8 @@ void define_task_block_exceptions_test2(Executor& exec)
 template <typename Executor>
 void define_task_block_exceptions_test3(Executor& exec)
 {
-    typedef task_block<parallel_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_policy_shim<Executor, static_chunk_size>>;
 
     try
     {
@@ -351,8 +351,8 @@ void define_task_block_exceptions_test3(Executor& exec)
 template <typename Executor>
 void define_task_block_exceptions_test4(Executor& exec)
 {
-    typedef task_block<parallel_task_policy_shim<Executor, static_chunk_size>>
-        task_block_type;
+    using task_block_type =
+        task_block<parallel_task_policy_shim<Executor, static_chunk_size>>;
 
     pika::future<void> f =
         define_task_block(par(task).on(exec), [&](task_block_type& trh) {

--- a/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_bad_alloc_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_bad_alloc_range.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -59,8 +59,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_binary_bad_alloc_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_binary_bad_alloc_range.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -59,8 +59,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_binary_exception_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_binary_exception_range.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
 
@@ -60,8 +60,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_exception_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/adjacentfind_exception_range.cpp
@@ -29,8 +29,8 @@ void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
 
@@ -60,8 +60,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -111,8 +111,8 @@ template <typename IteratorTag>
 void test_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -149,8 +149,8 @@ void test_copy_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -184,8 +184,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -249,8 +249,8 @@ void test_copy_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -283,8 +283,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/copyn_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/copyn_range.cpp
@@ -121,8 +121,8 @@ template <typename IteratorTag>
 void test_copy_n_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -157,8 +157,8 @@ void test_copy_n_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -190,8 +190,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -256,8 +256,8 @@ void test_copy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -288,8 +288,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
@@ -48,7 +48,7 @@ std::size_t const data_size = 10007;
 template <typename IteratorTag>
 void test_destroy(IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -74,7 +74,7 @@ void test_destroy(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -98,7 +98,7 @@ void test_destroy(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -125,9 +125,9 @@ template <typename IteratorTag>
 void test_destroy_exception(IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -181,9 +181,9 @@ void test_destroy_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -234,9 +234,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_exception_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -297,9 +297,9 @@ void test_destroy_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -350,9 +350,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
@@ -47,7 +47,7 @@ std::size_t const data_size = 10007;
 template <typename IteratorTag>
 void test_destroy_n(IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -73,7 +73,7 @@ void test_destroy_n(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -97,7 +97,7 @@ void test_destroy_n(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_async(ExPolicy&& policy, IteratorTag)
 {
-    typedef destructable* base_iterator;
+    using base_iterator = destructable*;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     destructable* p =
@@ -145,9 +145,9 @@ template <typename IteratorTag>
 void test_destroy_n_exception(IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -201,9 +201,9 @@ void test_destroy_n_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -254,9 +254,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_exception_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -340,9 +340,9 @@ void test_destroy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 
@@ -393,9 +393,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     using data_type = test::count_instances_v<destructable>;
-    typedef data_type* base_iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using base_iterator = data_type*;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     data_type* p = (data_type*) std::malloc(data_size * sizeof(data_type));
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
@@ -475,8 +475,8 @@ void test_find_end_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -514,8 +514,8 @@ template <typename IteratorTag>
 void test_find_end_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -554,8 +554,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_end_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -624,8 +624,8 @@ void test_find_end_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -658,8 +658,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_end_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
@@ -130,8 +130,8 @@ template <typename IteratorTag>
 void test_find_first_of_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -168,8 +168,8 @@ void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 1;
@@ -202,8 +202,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -269,8 +269,8 @@ void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -302,8 +302,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
@@ -26,8 +26,8 @@ template <typename IteratorTag>
 void test_find_if_not_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -62,8 +62,8 @@ void test_find_if_not_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -94,8 +94,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/find_if_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/find_if_range.cpp
@@ -114,8 +114,8 @@ template <typename IteratorTag>
 void test_find_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -149,8 +149,8 @@ void test_find_if_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -181,8 +181,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -246,8 +246,8 @@ void test_find_if_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -277,8 +277,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_if_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/find_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/find_range.cpp
@@ -111,8 +111,8 @@ template <typename IteratorTag>
 void test_find_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -146,8 +146,8 @@ void test_find_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
     c[c.size() / 2] = 0;
@@ -178,8 +178,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -243,8 +243,8 @@ void test_find_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -274,8 +274,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_find_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/generate_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/generate_range.cpp
@@ -69,8 +69,8 @@ void test_generate_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_generate(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
 
@@ -94,8 +94,8 @@ void test_generate(ExPolicy&& policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
 
@@ -119,8 +119,8 @@ void test_generate_async(ExPolicy&& p, IteratorTag)
     using base_iterator = std::vector<std::size_t>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
 
@@ -169,8 +169,8 @@ template <typename IteratorTag>
 void test_generate_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -207,8 +207,8 @@ void test_generate_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
 
     auto gen = []() { return std::size_t(10); };
@@ -241,8 +241,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 
@@ -308,8 +308,8 @@ void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
 
@@ -342,8 +342,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -169,7 +169,7 @@ void test_inplace_merge_stable(
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::pair<DataType, int> ElemType;
+    using ElemType = typename std::pair<DataType, int>;
     using base_iterator = typename std::vector<ElemType>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/is_partitioned_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/is_partitioned_range.cpp
@@ -411,8 +411,8 @@ void test_partitioned_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -447,8 +447,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -510,8 +510,8 @@ void test_partitioned_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half
@@ -544,8 +544,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     //fill first half of array with even numbers and second half

--- a/libs/pika/algorithms/tests/unit/container_algorithms/is_sorted_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/is_sorted_range_tests.hpp
@@ -504,8 +504,8 @@ void test_sorted_exception(ExPolicy policy, IteratorTag)
 
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 
@@ -574,8 +574,8 @@ void test_sorted_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -656,8 +656,8 @@ void test_sorted_exception_seq(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 
@@ -870,8 +870,8 @@ void test_sorted_bad_alloc(ExPolicy policy, IteratorTag)
 
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 
@@ -937,8 +937,8 @@ void test_sorted_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen() + 1);
@@ -1016,8 +1016,8 @@ void test_sorted_bad_alloc_seq(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/is_sorted_until_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/is_sorted_until_range.cpp
@@ -791,8 +791,8 @@ void test_sorted_until_exception(ExPolicy policy, IteratorTag)
 
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     //fill first half of array with even numbers and second half
@@ -864,8 +864,8 @@ void test_sorted_until_async_exception(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -944,8 +944,8 @@ void test_sorted_until_seq_exception(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     //fill first half of array with even numbers and second half
@@ -1199,8 +1199,8 @@ void test_sorted_until_bad_alloc(ExPolicy policy, IteratorTag)
 
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     //fill first half of array with even numbers and second half
@@ -1269,8 +1269,8 @@ void test_sorted_until_async_bad_alloc(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), 0);
@@ -1346,8 +1346,8 @@ void test_sorted_until_seq_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007);
     //fill first half of array with even numbers and second half

--- a/libs/pika/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
@@ -176,8 +176,8 @@ template <typename IteratorTag>
 void test_make_heap_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
 
@@ -209,8 +209,8 @@ void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
 
@@ -240,8 +240,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -299,8 +299,8 @@ template <typename IteratorTag>
 void test_make_heap_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -332,8 +332,8 @@ void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(100007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());
@@ -363,8 +363,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(pika::util::begin(c), pika::util::end(c), gen());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/max_element_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/max_element_range.cpp
@@ -84,8 +84,8 @@ template <typename IteratorTag>
 void test_max_element(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -115,8 +115,8 @@ void test_max_element(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -145,8 +145,8 @@ void test_max_element_async(ExPolicy p, IteratorTag)
     using base_iterator = std::vector<std::size_t>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -200,8 +200,8 @@ template <typename IteratorTag>
 void test_max_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -263,8 +263,8 @@ void test_max_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -321,8 +321,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_max_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -417,8 +417,8 @@ template <typename IteratorTag>
 void test_max_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -475,8 +475,8 @@ void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -532,8 +532,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_max_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -291,7 +291,7 @@ void test_merge_etc(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 template <typename IteratorTag, typename DataType>
 void test_merge_stable(IteratorTag, DataType, int rand_base)
 {
-    typedef typename std::pair<DataType, int> ElemType;
+    using ElemType = typename std::pair<DataType, int>;
     using base_iterator = typename std::vector<ElemType>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
@@ -350,7 +350,7 @@ void test_merge_stable(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::pair<DataType, int> ElemType;
+    using ElemType = typename std::pair<DataType, int>;
     using base_iterator = typename std::vector<ElemType>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/min_element_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/min_element_range.cpp
@@ -84,8 +84,8 @@ template <typename IteratorTag>
 void test_min_element(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -114,8 +114,8 @@ void test_min_element(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -143,8 +143,8 @@ void test_min_element_async(ExPolicy p, IteratorTag)
     using base_iterator = std::vector<std::size_t>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -198,8 +198,8 @@ template <typename IteratorTag>
 void test_min_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -261,8 +261,8 @@ void test_min_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -320,8 +320,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_min_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -418,8 +418,8 @@ template <typename IteratorTag>
 void test_min_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -476,8 +476,8 @@ void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -533,8 +533,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_min_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
@@ -89,8 +89,8 @@ void test_minmax_element(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -124,8 +124,8 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
 
     using base_iterator = std::vector<std::size_t>::iterator;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -156,8 +156,8 @@ void test_minmax_element_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c = test::random_iota(10007);
 
@@ -215,8 +215,8 @@ template <typename IteratorTag>
 void test_minmax_element_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -278,8 +278,8 @@ void test_minmax_element_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -337,8 +337,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -435,8 +435,8 @@ template <typename IteratorTag>
 void test_minmax_element_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -494,8 +494,8 @@ void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 
@@ -551,8 +551,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
 

--- a/libs/pika/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -24,8 +24,8 @@
 template <typename IteratorTag>
 void test_move(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -52,8 +52,8 @@ void test_move(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -76,8 +76,8 @@ void test_move(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_move_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -129,8 +129,8 @@ void test_move_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -164,8 +164,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -229,8 +229,8 @@ void test_move_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -263,8 +263,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -71,8 +71,8 @@ void test_remove_copy_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_remove_copy(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size() / 2);
@@ -100,8 +100,8 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size() / 2);
@@ -126,8 +126,8 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size() / 2);
@@ -156,8 +156,8 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(0);
@@ -185,8 +185,8 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(0);
@@ -244,8 +244,8 @@ void test_remove_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -279,8 +279,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -344,8 +344,8 @@ void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -378,8 +378,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -86,8 +86,8 @@ void test_replace_copy_if_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_replace_copy_if(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -119,8 +119,8 @@ void test_replace_copy_if(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -149,8 +149,8 @@ void test_replace_copy_if(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -206,8 +206,8 @@ template <typename IteratorTag>
 void test_replace_copy_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -245,8 +245,8 @@ void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -280,8 +280,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -343,8 +343,8 @@ template <typename IteratorTag>
 void test_replace_copy_if_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -379,8 +379,8 @@ void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -413,8 +413,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -70,8 +70,8 @@ void test_replace_copy_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_replace_copy(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -102,8 +102,8 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -131,8 +131,8 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -188,8 +188,8 @@ template <typename IteratorTag>
 void test_replace_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -227,8 +227,8 @@ void test_replace_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -262,8 +262,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -325,8 +325,8 @@ template <typename IteratorTag>
 void test_replace_copy_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -361,8 +361,8 @@ void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -395,8 +395,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -81,8 +81,8 @@ void test_replace_if_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_replace_if(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -111,8 +111,8 @@ void test_replace_if(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -138,8 +138,8 @@ void test_replace_if(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -187,8 +187,8 @@ template <typename IteratorTag>
 void test_replace_if_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -225,8 +225,8 @@ void test_replace_if_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -259,8 +259,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -326,8 +326,8 @@ template <typename IteratorTag>
 void test_replace_if_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -361,8 +361,8 @@ void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -394,8 +394,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -70,8 +70,8 @@ void test_replace_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_replace(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -100,8 +100,8 @@ void test_replace(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -127,8 +127,8 @@ void test_replace(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -181,8 +181,8 @@ template <typename IteratorTag>
 void test_replace_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -219,8 +219,8 @@ void test_replace_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -253,8 +253,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -315,8 +315,8 @@ template <typename IteratorTag>
 void test_replace_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -350,8 +350,8 @@ void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -383,8 +383,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
@@ -66,8 +66,8 @@ void test_reverse_copy_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_reverse_copy(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -95,8 +95,8 @@ void test_reverse_copy(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -121,8 +121,8 @@ void test_reverse_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1(c.size());
@@ -174,8 +174,8 @@ template <typename IteratorTag>
 void test_reverse_copy_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -212,8 +212,8 @@ void test_reverse_copy_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -246,8 +246,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -308,8 +308,8 @@ template <typename IteratorTag>
 void test_reverse_copy_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -344,8 +344,8 @@ void test_reverse_copy_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
@@ -377,8 +377,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/reverse_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/reverse_range.cpp
@@ -60,8 +60,8 @@ void test_reverse_sent(ExPolicy policy)
 template <typename IteratorTag>
 void test_reverse(IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1;
@@ -89,8 +89,8 @@ void test_reverse(ExPolicy policy, IteratorTag)
     static_assert(pika::is_execution_policy<ExPolicy>::value,
         "pika::is_execution_policy<ExPolicy>::value");
 
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1;
@@ -115,8 +115,8 @@ void test_reverse(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d1;
@@ -168,8 +168,8 @@ template <typename IteratorTag>
 void test_reverse_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -204,8 +204,8 @@ void test_reverse_exception(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -236,8 +236,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_exception_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -296,8 +296,8 @@ template <typename IteratorTag>
 void test_reverse_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -329,8 +329,8 @@ void test_reverse_bad_alloc(ExPolicy policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
@@ -360,8 +360,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_reverse_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
@@ -230,8 +230,8 @@ template <typename IteratorTag>
 void test_set_difference_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -273,8 +273,8 @@ void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -315,8 +315,8 @@ void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -383,8 +383,8 @@ template <typename IteratorTag>
 void test_set_difference_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -423,8 +423,8 @@ void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -464,8 +464,8 @@ void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
@@ -230,8 +230,8 @@ template <typename IteratorTag>
 void test_set_intersection_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -273,8 +273,8 @@ void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -315,8 +315,8 @@ void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -383,8 +383,8 @@ template <typename IteratorTag>
 void test_set_intersection_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -423,8 +423,8 @@ void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -464,8 +464,8 @@ void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
@@ -230,8 +230,8 @@ template <typename IteratorTag>
 void test_set_symmetric_difference_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -273,8 +273,8 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -315,8 +315,8 @@ void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -383,8 +383,8 @@ template <typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -424,8 +424,8 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -465,8 +465,8 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/set_union_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/set_union_range.cpp
@@ -229,8 +229,8 @@ template <typename IteratorTag>
 void test_set_union_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -271,8 +271,8 @@ void test_set_union_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -313,8 +313,8 @@ void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -381,8 +381,8 @@ template <typename IteratorTag>
 void test_set_union_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -421,8 +421,8 @@ void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());
@@ -462,8 +462,8 @@ void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c1 = test::random_fill(10007);
     std::vector<std::size_t> c2 = test::random_fill(c1.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
@@ -302,9 +302,8 @@ void test_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -336,9 +335,8 @@ void test_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -384,9 +382,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -419,9 +416,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -469,9 +465,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::sort(std::forward<ExPolicy>(policy),
@@ -509,9 +504,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::sort(std::forward<ExPolicy>(policy),
@@ -563,9 +557,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::sort(std::forward<ExPolicy>(policy),
@@ -604,9 +597,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::sort(std::forward<ExPolicy>(policy),

--- a/libs/pika/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
@@ -303,9 +303,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -337,9 +336,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -385,9 +383,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -420,9 +417,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 pika::util::make_iterator_range(
@@ -470,9 +466,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
@@ -510,9 +505,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
@@ -564,9 +558,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::stable_sort(std::forward<ExPolicy>(policy),
@@ -605,9 +598,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         try
         {
             using base_iterator = typename std::vector<T>::iterator;
-            typedef test::decorated_iterator<base_iterator,
-                std::random_access_iterator_tag>
-                decorated_iterator;
+            using decorated_iterator = test::decorated_iterator<base_iterator,
+                std::random_access_iterator_tag>;
 
             pika::future<void> f =
                 pika::ranges::stable_sort(std::forward<ExPolicy>(policy),

--- a/libs/pika/algorithms/tests/unit/container_algorithms/test_utils.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/test_utils.hpp
@@ -70,10 +70,9 @@ namespace test {
             BaseIterator, void, IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             test_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         test_iterator()
@@ -105,11 +104,10 @@ namespace test {
             return *this;
         }
 
-        typedef test_iterator<typename BaseContainer::iterator, IteratorTag>
-            iterator;
-        typedef test_iterator<typename BaseContainer::const_iterator,
-            IteratorTag>
-            const_iterator;
+        using iterator =
+            test_iterator<typename BaseContainer::iterator, IteratorTag>;
+        using const_iterator =
+            test_iterator<typename BaseContainer::const_iterator, IteratorTag>;
 
         iterator begin()
         {
@@ -146,10 +144,9 @@ namespace test {
             IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             decorated_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         decorated_iterator() {}

--- a/libs/pika/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -78,8 +78,8 @@ void test_transform(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/transform_range2.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/transform_range2.cpp
@@ -77,8 +77,8 @@ void test_transform(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_async(ExPolicy p, IteratorTag)
 {
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
+    using test_vector =
+        test::test_container<std::vector<std::size_t>, IteratorTag>;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/pika/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
@@ -22,8 +22,8 @@ template <typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -56,8 +56,8 @@ void test_transform_reduce_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -87,8 +87,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
@@ -23,8 +23,8 @@ template <typename IteratorTag>
 void test_transform_reduce_binary_exception(IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -59,8 +59,8 @@ void test_transform_reduce_binary_exception(ExPolicy&& policy, IteratorTag)
         "pika::is_execution_policy<ExPolicy>::value");
 
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);
@@ -91,8 +91,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_exception_async(ExPolicy&& p, IteratorTag)
 {
     using base_iterator = std::vector<std::size_t>::iterator;
-    typedef test::decorated_iterator<base_iterator, IteratorTag>
-        decorated_iterator;
+    using decorated_iterator =
+        test::decorated_iterator<base_iterator, IteratorTag>;
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d = test::random_iota(10007);

--- a/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
@@ -158,9 +158,8 @@ namespace pika::detail {
             auto ctx = pika::execution_base::this_thread::agent();
             for (std::size_t i = 0; i != size; ++i)
             {
-                typedef
-                    typename traits::detail::shared_state_ptr_for<Future>::type
-                        shared_state_ptr;
+                using shared_state_ptr =
+                    typename traits::detail::shared_state_ptr_for<Future>::type;
                 shared_state_ptr current =
                     traits::detail::get_shared_state(lazy_values_[i]);
 

--- a/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
@@ -103,8 +103,8 @@ namespace pika {
             {
                 pika::detail::try_catch_exception_ptr(
                     [&]() {
-                        typedef
-                            typename traits::future_traits<T>::type result_type;
+                        using result_type =
+                            typename traits::future_traits<T>::type;
                         result_type* result = state->get_result();
                         this->base_type::set_value(
                             PIKA_MOVE(pika::get<I>(*result)));
@@ -118,9 +118,8 @@ namespace pika {
             template <std::size_t I, typename Future>
             void attach(Future& future)
             {
-                typedef
-                    typename traits::detail::shared_state_ptr_for<Future>::type
-                        shared_state_ptr;
+                using shared_state_ptr =
+                    typename traits::detail::shared_state_ptr_for<Future>::type;
 
                 // Bind an on_completed handler to this future which will wait
                 // for the future and will transfer its result to the new
@@ -158,7 +157,7 @@ namespace pika {
             pika::future<typename pika::tuple_element<I, Tuple>::type>
             extract_nth_future(pika::future<Tuple>& future)
         {
-            typedef typename pika::tuple_element<I, Tuple>::type result_type;
+            using result_type = typename pika::tuple_element<I, Tuple>::type;
 
             return pika::traits::future_access<pika::future<result_type>>::
                 create(extract_nth_continuation<result_type, Tuple, I>(future));
@@ -169,7 +168,7 @@ namespace pika {
             pika::future<typename pika::tuple_element<I, Tuple>::type>
             extract_nth_future(pika::shared_future<Tuple>& future)
         {
-            typedef typename pika::tuple_element<I, Tuple>::type result_type;
+            using result_type = typename pika::tuple_element<I, Tuple>::type;
 
             return pika::traits::future_access<pika::future<result_type>>::
                 create(extract_nth_continuation<result_type, Tuple, I>(future));
@@ -240,8 +239,8 @@ namespace pika {
             {
                 pika::detail::try_catch_exception_ptr(
                     [&]() {
-                        typedef
-                            typename traits::future_traits<T>::type result_type;
+                        using result_type =
+                            typename traits::future_traits<T>::type;
                         result_type* result = state->get_result();
                         if (i >= result->size())
                         {
@@ -260,9 +259,8 @@ namespace pika {
             template <typename Future>
             void attach(std::size_t i, Future& future)
             {
-                typedef
-                    typename traits::detail::shared_state_ptr_for<Future>::type
-                        shared_state_ptr;
+                using shared_state_ptr =
+                    typename traits::detail::shared_state_ptr_for<Future>::type;
 
                 // Bind an on_completed handler to this future which will wait
                 // for the future and will transfer its result to the new

--- a/libs/pika/async_combinators/tests/unit/when_all.cpp
+++ b/libs/pika/async_combinators/tests/unit/when_all.cpp
@@ -125,8 +125,8 @@ void test_wait_for_all_three_futures()
     pika::future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>>
-        result_type;
+    using result_type =
+        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3);
 
     result_type result = r.get();
@@ -155,9 +155,8 @@ void test_wait_for_all_four_futures()
     pika::future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-        pika::future<int>>
-        result_type;
+    using result_type = pika::tuple<pika::future<int>, pika::future<int>,
+        pika::future<int>, pika::future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3, f4);
 
     result_type result = r.get();
@@ -191,9 +190,8 @@ void test_wait_for_all_five_futures()
     pika::future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-        pika::future<int>, pika::future<int>>
-        result_type;
+    using result_type = pika::tuple<pika::future<int>, pika::future<int>,
+        pika::future<int>, pika::future<int>, pika::future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3, f4, f5);
 
     result_type result = r.get();

--- a/libs/pika/async_combinators/tests/unit/when_some.cpp
+++ b/libs/pika/async_combinators/tests/unit/when_some.cpp
@@ -43,10 +43,9 @@ void test_wait_for_two_out_of_five_futures()
     pika::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     pika::future<int> f5 = pt5.get_future();
 
-    typedef pika::when_some_result<
-        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-            pika::future<int>, pika::future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::future<int>, pika::future<int>,
+            pika::future<int>, pika::future<int>, pika::future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
@@ -83,10 +82,9 @@ void test_wait_for_three_out_of_five_futures()
     pika::future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef pika::when_some_result<
-        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-            pika::future<int>, pika::future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::future<int>, pika::future<int>,
+            pika::future<int>, pika::future<int>, pika::future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
@@ -120,10 +118,9 @@ void test_wait_for_two_out_of_five_late_futures()
     pika::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     pika::future<int> f5 = pt5.get_future();
 
-    typedef pika::when_some_result<
-        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-            pika::future<int>, pika::future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::future<int>, pika::future<int>,
+            pika::future<int>, pika::future<int>, pika::future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     PIKA_TEST(!f1.valid());
@@ -160,10 +157,9 @@ void test_wait_for_two_out_of_five_deferred_futures()
     pika::future<int> f5 =
         pika::async(pika::launch::deferred, &make_int_slowly);
 
-    typedef pika::when_some_result<
-        pika::tuple<pika::future<int>, pika::future<int>, pika::future<int>,
-            pika::future<int>, pika::future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::future<int>, pika::future<int>,
+            pika::future<int>, pika::future<int>, pika::future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     PIKA_TEST(!f1.valid());

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
@@ -115,7 +115,7 @@ namespace pika { namespace threads { namespace coroutines {
 #else
         struct stack_allocator
         {
-            typedef void* segments_context[PIKA_COROUTINES_SEGMENTS];
+            using segments_context void* [PIKA_COROUTINES_SEGMENTS];
 
             static std::size_t maximum_stacksize()
             {

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
@@ -61,7 +61,7 @@
 
    - ContextImpl must expose the following typedef:
 
-     typedef unspecified-type context_impl_base;
+     using context_impl_base = unspecified-type;
 
      ContextImpl must be convertible to context_impl_base.
      context_impl_base must have conform to the ContextImplBase concept:

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -239,7 +239,7 @@ namespace pika { namespace threads { namespace coroutines {
                 posix::watermark_stack(
                     m_stack, static_cast<std::size_t>(m_stack_size));
 
-                typedef void fun(void*);
+                using fun = void(void*);
                 fun* funp = trampoline<CoroutineImpl>;
 
                 m_sp = (static_cast<void**>(m_stack) +
@@ -375,7 +375,7 @@ namespace pika { namespace threads { namespace coroutines {
                                            sizeof(void*)) -
                                 context_size;
 
-                            typedef void fun(void*);
+                            using fun = void(void*);
                             fun* funp = trampoline<CoroutineImpl>;
                             m_sp[cb_idx] = this;
                             m_sp[funp_idx] = reinterpret_cast<void*>(funp);

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
@@ -144,7 +144,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
             ctx->uc_stack.ss_size = size;
             ctx->uc_link = exitto;
 
-            typedef void (*ctx_main)();
+            using = void (*ctx_main)();
             //makecontext can't fail.
             ::makecontext(ctx, (ctx_main) (startfunc), 1, startarg);
             return 0;

--- a/libs/pika/coroutines/include/pika/coroutines/detail/tss.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/tss.hpp
@@ -116,7 +116,7 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
     class tss_storage
     {
     private:
-        typedef std::map<void const*, tss_data_node> tss_node_data_map;
+        using tss_node_data_map = std::map<void const*, tss_data_node>;
 
         tss_data_node const* find_entry(void const* key) const
         {

--- a/libs/pika/datastructures/tests/unit/tuple.cpp
+++ b/libs/pika/datastructures/tests/unit/tuple.cpp
@@ -122,14 +122,13 @@ public:
 // ----------------------------------------------------------------------------
 
 using t1 = pika::tuple<int>;
-typedef pika::tuple<double&, const double&, const double, double*,
-    const double*>
-    t2;
-typedef pika::tuple<A, int (*)(char, int), C> t3;
+using t2 =
+    pika::tuple<double&, const double&, const double, double*, const double*>;
+using t3 = pika::tuple<A, int (*)(char, int), C>;
 using t4 = pika::tuple<std::string, std::pair<A, B>>;
-typedef pika::tuple<A*, pika::tuple<const A*, const B&, C>, bool, void*> t5;
-typedef pika::tuple<volatile int, const volatile char&, int (&)(float)> t6;
-typedef pika::tuple<B (A::*)(C&), A&> t7;
+using t5 = pika::tuple<A*, pika::tuple<const A*, const B&, C>, bool, void*>;
+using t6 = pika::tuple<volatile int, const volatile char&, int (&)(float)>;
+using t7 = pika::tuple<B (A::*)(C&), A&>;
 
 // -----------------------------------------------------------------------
 // -tuple construction tests ---------------------------------------------

--- a/libs/pika/execution/include/pika/execution/traits/vector_pack_type.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/vector_pack_type.hpp
@@ -24,7 +24,7 @@ namespace pika { namespace parallel { namespace traits {
     template <typename... T, std::size_t N, typename Abi>
     struct vector_pack_type<pika::tuple<T...>, N, Abi>
     {
-        typedef pika::tuple<typename vector_pack_type<T, N, Abi>::type...> type;
+        using type = pika::tuple<typename vector_pack_type<T, N, Abi>::type...>;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/pika/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/pika/execution/tests/unit/minimal_async_executor.cpp
@@ -117,8 +117,8 @@ std::atomic<std::size_t> count_bulk_async(0);
 template <typename Executor>
 void test_executor(std::array<std::size_t, 5> expected)
 {
-    typedef typename pika::traits::executor_execution_category<Executor>::type
-        execution_category;
+    using execution_category =
+        typename pika::traits::executor_execution_category<Executor>::type;
 
     PIKA_TEST((std::is_same<pika::execution::parallel_execution_tag,
         execution_category>::value));

--- a/libs/pika/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/pika/execution/tests/unit/minimal_sync_executor.cpp
@@ -217,8 +217,8 @@ std::atomic<std::size_t> count_bulk_sync(0);
 template <typename Executor>
 void test_executor(std::array<std::size_t, 2> expected)
 {
-    typedef typename pika::traits::executor_execution_category<Executor>::type
-        execution_category;
+    using execution_category =
+        typename pika::traits::executor_execution_category<Executor>::type;
 
     PIKA_TEST((std::is_same<pika::execution::sequenced_execution_tag,
         execution_category>::value));
@@ -270,9 +270,9 @@ struct test_sync_executor2 : test_sync_executor1
         Shape, Ts...>::type
     call(std::false_type, F&& f, Shape const& shape, Ts&&... ts)
     {
-        typedef
+        using result_type =
             typename pika::parallel::execution::detail::bulk_function_result<F,
-                Shape, Ts...>::type result_type;
+                Shape, Ts...>::type;
 
         std::vector<result_type> results;
         for (auto const& elem : shape)
@@ -298,9 +298,9 @@ struct test_sync_executor2 : test_sync_executor1
     {
         ++count_bulk_sync;
 
-        typedef
+        using is_void =
             typename std::is_void<typename pika::parallel::execution::detail::
-                    bulk_function_result<F, Shape, Ts...>::type>::type is_void;
+                    bulk_function_result<F, Shape, Ts...>::type>::type;
 
         return call(
             is_void(), std::forward<F>(f), shape, std::forward<Ts>(ts)...);

--- a/libs/pika/execution/tests/unit/test_utils.hpp
+++ b/libs/pika/execution/tests/unit/test_utils.hpp
@@ -26,10 +26,9 @@ namespace test {
             BaseIterator, void, IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             test_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         test_iterator()
@@ -50,10 +49,9 @@ namespace test {
             IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             decorated_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         decorated_iterator() {}

--- a/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
+++ b/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
@@ -49,9 +49,8 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     {
         PIKA_ASSERT(pool);
 
-        typedef std::vector<pika::future<
-            typename detail::bulk_function_result<F, S, Ts...>::type>>
-            result_type;
+        using result_type = std::vector<pika::future<
+            typename detail::bulk_function_result<F, S, Ts...>::type>>;
 
         result_type results;
         std::size_t const size = pika::util::size(shape);

--- a/libs/pika/executors/include/pika/executors/execution_policy.hpp
+++ b/libs/pika/executors/include/pika/executors/execution_policy.hpp
@@ -213,8 +213,9 @@ namespace pika { namespace execution {
 
         /// The category of the execution agents created by this execution
         /// policy.
-        typedef typename pika::traits::executor_execution_category<
-            executor_type>::type execution_category;
+        using execution_category =
+            typename pika::traits::executor_execution_category<
+                executor_type>::type;
 
         /// Rebind the type of executor used by this execution policy. The
         /// execution category of Executor shall not be weaker than that of

--- a/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
@@ -119,8 +119,9 @@ namespace pika { namespace parallel { namespace execution {
                     debug::str<>("async_schedule"), "domain ", domain);
 
                 // now we must forward the task+hint on to the correct dispatch function
-                typedef typename pika::util::detail::invoke_deferred_result<F,
-                    Ts...>::type result_type;
+                using result_type =
+                    typename pika::util::detail::invoke_deferred_result<F,
+                        Ts...>::type;
 
                 lcos::local::futures_factory<result_type()> p(
                     pika::util::deferred_call(
@@ -181,8 +182,9 @@ namespace pika { namespace parallel { namespace execution {
                 gpx_deb.debug(debug::str<>("then_schedule"), "domain ", domain);
 
                 // now we must forward the task+hint on to the correct dispatch function
-                typedef typename pika::util::detail::invoke_deferred_result<F,
-                    Future, Ts...>::type result_type;
+                using result_type =
+                    typename pika::util::detail::invoke_deferred_result<F,
+                        Future, Ts...>::type;
 
                 lcos::local::futures_factory<result_type()> p(
                     pika::util::deferred_call(PIKA_FORWARD(F, f),
@@ -292,8 +294,9 @@ namespace pika { namespace parallel { namespace execution {
             typename pika::util::detail::invoke_deferred_result<F, Ts...>::type>
         async_execute(F&& f, Ts&&... ts)
         {
-            typedef typename pika::util::detail::invoke_deferred_result<F,
-                Ts...>::type result_type;
+            using result_type =
+                typename pika::util::detail::invoke_deferred_result<F,
+                    Ts...>::type;
 
             gpx_deb.debug(debug::str<>("async execute"), "\n\t",
                 "Function    : ", pika::util::debug::print_type<F>(), "\n\t",
@@ -324,8 +327,9 @@ namespace pika { namespace parallel { namespace execution {
             -> future<typename pika::util::detail::invoke_deferred_result<F,
                 Future, Ts...>::type>
         {
-            typedef typename pika::util::detail::invoke_deferred_result<F,
-                Future, Ts...>::type result_type;
+            using result_type =
+                typename pika::util::detail::invoke_deferred_result<F, Future,
+                    Ts...>::type;
 
             gpx_deb.debug(debug::str<>("then execute"), "\n\t",
                 "Function    : ", pika::util::debug::print_type<F>(), "\n\t",
@@ -388,9 +392,9 @@ namespace pika { namespace parallel { namespace execution {
             auto unwrapped_futures_tuple = pika::util::map_pack(
                 detail::future_extract_value{}, predecessor_value);
 
-            typedef typename pika::util::detail::invoke_deferred_result<F,
-                OuterFuture<pika::tuple<InnerFutures...>>, Ts...>::type
-                result_type;
+            using result_type =
+                typename pika::util::detail::invoke_deferred_result<F,
+                    OuterFuture<pika::tuple<InnerFutures...>>, Ts...>::type;
 
             // clang-format off
             gpx_deb.debug(debug::str<>("when_all(fut) : Predecessor")
@@ -440,8 +444,9 @@ namespace pika { namespace parallel { namespace execution {
             -> future<typename pika::util::detail::invoke_deferred_result<F,
                 pika::tuple<InnerFutures...>>::type>
         {
-            typedef typename pika::util::detail::invoke_deferred_result<F,
-                pika::tuple<InnerFutures...>>::type result_type;
+            using result_type =
+                typename pika::util::detail::invoke_deferred_result<F,
+                    pika::tuple<InnerFutures...>>::type;
 
             // invoke the hint function with the unwrapped tuple futures
 #ifdef GUIDED_POOL_EXECUTOR_FAKE_NOOP
@@ -550,8 +555,9 @@ namespace pika { namespace parallel { namespace execution {
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
             else
             {
-                typedef typename pika::util::detail::invoke_deferred_result<F,
-                    Ts...>::type result_type;
+                using result_type =
+                    typename pika::util::detail::invoke_deferred_result<F,
+                        Ts...>::type;
 
                 lcos::local::futures_factory<result_type()> p(
                     pika::util::deferred_call(
@@ -578,8 +584,9 @@ namespace pika { namespace parallel { namespace execution {
                     PIKA_FORWARD(Future, predecessor), PIKA_FORWARD(Ts, ts)...);
             else
             {
-                typedef typename pika::util::detail::invoke_deferred_result<F,
-                    Future, Ts...>::type result_type;
+                using result_type =
+                    typename pika::util::detail::invoke_deferred_result<F,
+                        Future, Ts...>::type;
 
                 auto func = pika::util::one_shot(pika::util::bind_back(
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...));

--- a/libs/pika/executors/include/pika/executors/sequenced_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/sequenced_executor.hpp
@@ -88,9 +88,9 @@ namespace pika { namespace execution {
                 bulk_function_result<F, S, Ts...>::type>>
         bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            typedef
+            using result_type =
                 typename parallel::execution::detail::bulk_function_result<F, S,
-                    Ts...>::type result_type;
+                    Ts...>::type;
             std::vector<pika::future<result_type>> results;
 
             try

--- a/libs/pika/functional/include/pika/functional/bind_back.hpp
+++ b/libs/pika/functional/include/pika/functional/bind_back.hpp
@@ -150,10 +150,9 @@ namespace pika { namespace util {
         typename util::decay_unwrap<Ts>::type...>
     bind_back(F&& f, Ts&&... vs)
     {
-        typedef detail::bound_back<typename std::decay<F>::type,
+        using result_type = detail::bound_back<typename std::decay<F>::type,
             typename util::make_index_pack<sizeof...(Ts)>::type,
-            typename util::decay_unwrap<Ts>::type...>
-            result_type;
+            typename util::decay_unwrap<Ts>::type...>;
 
         return result_type(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/functional/include/pika/functional/bind_front.hpp
+++ b/libs/pika/functional/include/pika/functional/bind_front.hpp
@@ -152,10 +152,9 @@ namespace pika { namespace util {
         std::decay_t<Ts>...>
     bind_front(F&& f, Ts&&... vs)
     {
-        typedef detail::bound_front<std::decay_t<F>,
+        using result_type = detail::bound_front<std::decay_t<F>,
             typename util::make_index_pack<sizeof...(Ts)>::type,
-            std::decay_t<Ts>...>
-            result_type;
+            std::decay_t<Ts>...>;
 
         return result_type(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/functional/include/pika/functional/one_shot.hpp
+++ b/libs/pika/functional/include/pika/functional/one_shot.hpp
@@ -103,8 +103,8 @@ namespace pika { namespace util {
     constexpr detail::one_shot_wrapper<typename std::decay<F>::type> one_shot(
         F&& f)
     {
-        typedef detail::one_shot_wrapper<typename std::decay<F>::type>
-            result_type;
+        using result_type =
+            detail::one_shot_wrapper<typename std::decay<F>::type>;
 
         return result_type(PIKA_FORWARD(F, f));
     }

--- a/libs/pika/functional/tests/regressions/is_callable_1179.cpp
+++ b/libs/pika/functional/tests/regressions/is_callable_1179.cpp
@@ -32,10 +32,10 @@ int main()
     using pika::is_invocable_v;
     using pika::util::invoke;
 
-    typedef int (s::*mem_fun_ptr)();
+    using mem_fun_ptr = int (s::*)();
     PIKA_TEST_MSG((is_invocable_v<mem_fun_ptr, p> == false), "mem-fun-ptr");
 
-    typedef int (s::*const_mem_fun_ptr)() const;
+    using const_mem_fun_ptr = int (s::*)() const;
     PIKA_TEST_MSG(
         (is_invocable_v<const_mem_fun_ptr, p> == true), "const-mem-fun-ptr");
 

--- a/libs/pika/functional/tests/unit/function_ref.cpp
+++ b/libs/pika/functional/tests/unit/function_ref.cpp
@@ -110,7 +110,7 @@ struct add_to_obj
 
 static void test_zero_args()
 {
-    typedef pika::util::function_ref<void()> func_void_type;
+    using func_void_type = pika::util::function_ref<void()>;
 
     write_five_obj five;
     write_three_obj three;
@@ -417,7 +417,7 @@ static void test_zero_args()
     PIKA_TEST_EQ(global_int, 2);
 
     // Test return values
-    typedef pika::util::function_ref<int()> func_int_type;
+    using func_int_type = pika::util::function_ref<int()>;
     generate_five_obj gen_five;
     generate_three_obj gen_three;
 
@@ -432,7 +432,7 @@ static void test_zero_args()
     PIKA_TEST_EQ(i0(), 3);
 
     // Test return values with compatible types
-    typedef pika::util::function_ref<long()> func_long_type;
+    using func_long_type = pika::util::function_ref<long()>;
     func_long_type i1(gen_five);
 
     PIKA_TEST_EQ(i1(), 5);
@@ -511,8 +511,8 @@ static void test_ref()
 
 static void test_ptr_ref()
 {
-    typedef pika::util::function_ref<void()> func_void_type;
-    typedef pika::util::function_ref<int()> func_int_type;
+    using func_void_type = pika::util::function_ref<void()>;
+    using func_int_type = pika::util::function_ref<int()>;
 
     // Invocation of a function
     void (*void_ptr)() = &write_five;
@@ -575,7 +575,7 @@ struct big_aggregating_structure
 
 static void test_copy_semantics()
 {
-    typedef pika::util::function_ref<void()> f1_type;
+    using f1_type = pika::util::function_ref<void()>;
 
     big_aggregating_structure obj;
 

--- a/libs/pika/functional/tests/unit/function_test.cpp
+++ b/libs/pika/functional/tests/unit/function_test.cpp
@@ -125,7 +125,7 @@ struct add_to_obj
 
 static void test_zero_args()
 {
-    typedef pika::util::function<void()> func_void_type;
+    using func_void_type = pika::util::function<void()>;
 
     write_five_obj five;
     write_three_obj three;
@@ -593,7 +593,7 @@ static void test_zero_args()
     PIKA_TEST(v9np.empty());
 
     // Test return values
-    typedef pika::util::function<int()> func_int_type;
+    using func_int_type = pika::util::function<int()>;
     generate_five_obj gen_five;
     generate_three_obj gen_three;
 
@@ -611,7 +611,7 @@ static void test_zero_args()
     PIKA_TEST(!i0);
 
     // Test return values with compatible types
-    typedef pika::util::function<long()> func_long_type;
+    using func_long_type = pika::util::function<long()>;
     func_long_type i1(gen_five);
 
     PIKA_TEST_EQ(i1(), 5);

--- a/libs/pika/functional/tests/unit/is_invocable.cpp
+++ b/libs/pika/functional/tests/unit/is_invocable.cpp
@@ -41,7 +41,7 @@ struct smart_ptr
 
 void nullary_function()
 {
-    typedef void (*f)();
+    using f = void (*)();
     PIKA_TEST_MSG((pika::is_invocable_v<f> == true), "nullary function");
 }
 
@@ -49,13 +49,13 @@ void lambdas()
 {
     auto lambda = []() {};
 
-    typedef decltype(lambda) f;
+    using f = decltype(lambda);
     PIKA_TEST_MSG((pika::is_invocable_v<f> == true), "lambda");
 }
 
 void functions_byval_params()
 {
-    typedef void (*f)(int);
+    using f = void (*)(int);
     PIKA_TEST_MSG((pika::is_invocable_v<f, int> == true), "fun-value/value");
     PIKA_TEST_MSG((pika::is_invocable_v<f, int&> == true), "fun-value/lvref");
     PIKA_TEST_MSG(
@@ -64,7 +64,7 @@ void functions_byval_params()
     PIKA_TEST_MSG((pika::is_invocable_v<f, int const&&> == true),
         "fun-value/const-rvref");
 
-    typedef void (*fc)(int const);
+    using fc = void (*)(const int);
     PIKA_TEST_MSG(
         (pika::is_invocable_v<fc, int> == true), "fun-const-value/value");
     PIKA_TEST_MSG(
@@ -79,7 +79,7 @@ void functions_byval_params()
 
 void functions_bylvref_params()
 {
-    typedef void (*f)(int&);
+    using f = void (*)(int&);
     PIKA_TEST_MSG((pika::is_invocable_v<f, int> == false), "fun-lvref/value");
     PIKA_TEST_MSG((pika::is_invocable_v<f, int&> == true), "fun-lvref/lvref");
     PIKA_TEST_MSG((pika::is_invocable_v<f, int const&> == false),
@@ -88,7 +88,7 @@ void functions_bylvref_params()
     PIKA_TEST_MSG((pika::is_invocable_v<f, int const&&> == false),
         "fun-lvref/const-rvref");
 
-    typedef void (*fc)(int const&);
+    using fc = void (*)(const int&);
     PIKA_TEST_MSG(
         (pika::is_invocable_v<fc, int> == true), "fun-const-lvref/value");
     PIKA_TEST_MSG(
@@ -103,7 +103,7 @@ void functions_bylvref_params()
 
 void functions_byrvref_params()
 {
-    typedef void (*f)(int&&);
+    using f = void (*)(int&&);
     PIKA_TEST_MSG((pika::is_invocable_v<f, int> == true), "fun-rvref/value");
     PIKA_TEST_MSG((pika::is_invocable_v<f, int&> == false), "fun-rvref/lvref");
     PIKA_TEST_MSG((pika::is_invocable_v<f, int const&> == false),
@@ -114,7 +114,7 @@ void functions_byrvref_params()
         "fun-rvref/const-rvref");
 #endif
 
-    typedef void (*fc)(int const&&);
+    using fc = void (*)(const int&&);
     PIKA_TEST_MSG(
         (pika::is_invocable_v<fc, int> == true), "fun-const-rvref/value");
     PIKA_TEST_MSG(
@@ -129,7 +129,7 @@ void functions_byrvref_params()
 
 void member_function_pointers()
 {
-    typedef int (X::*f)(double);
+    using f = int (X::*)(double);
     PIKA_TEST_MSG(
         (pika::is_invocable_v<f, X*, float> == true), "mem-fun-ptr/ptr");
     PIKA_TEST_MSG((pika::is_invocable_v<f, X const*, float> == false),
@@ -147,7 +147,7 @@ void member_function_pointers()
     PIKA_TEST_MSG((pika::is_invocable_v<f, smart_ptr<X const>, float> == false),
         "mem-fun-ptr/smart-const-ptr");
 
-    typedef int (X::*fc)(double) const;
+    using fc = int (X::*)(double) const;
     PIKA_TEST_MSG(
         (pika::is_invocable_v<fc, X*, float> == true), "const-mem-fun-ptr/ptr");
     PIKA_TEST_MSG((pika::is_invocable_v<fc, X const*, float> == true),
@@ -168,7 +168,7 @@ void member_function_pointers()
 
 void member_object_pointers()
 {
-    typedef int(X::*f);
+    using f = int(X::*);
     PIKA_TEST_MSG((pika::is_invocable_v<f, X*> == true), "mem-obj-ptr/ptr");
     PIKA_TEST_MSG(
         (pika::is_invocable_v<f, X const*> == true), "mem-obj-ptr/const-ptr");

--- a/libs/pika/futures/include/pika/futures/promise.hpp
+++ b/libs/pika/futures/include/pika/futures/promise.hpp
@@ -45,17 +45,17 @@ namespace pika { namespace lcos { namespace local {
               , future_retrieved_(false)
               , shared_future_retrieved_(false)
             {
-                typedef
+                using allocator_shared_state_type =
                     typename traits::detail::shared_state_allocator<SharedState,
-                        Allocator>::type allocator_shared_state_type;
+                        Allocator>::type;
 
-                typedef typename std::allocator_traits<Allocator>::
-                    template rebind_alloc<allocator_shared_state_type>
-                        other_allocator;
+                using other_allocator =
+                    typename std::allocator_traits<Allocator>::
+                        template rebind_alloc<allocator_shared_state_type>;
                 using traits = std::allocator_traits<other_allocator>;
-                typedef std::unique_ptr<allocator_shared_state_type,
-                    pika::detail::allocator_deleter<other_allocator>>
-                    unique_pointer;
+                using unique_pointer =
+                    std::unique_ptr<allocator_shared_state_type,
+                        pika::detail::allocator_deleter<other_allocator>>;
 
                 other_allocator alloc(a);
                 unique_pointer p(traits::allocate(alloc, 1),

--- a/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
@@ -43,7 +43,7 @@ namespace pika { namespace traits {
         template <typename Future, typename F, typename Enable = void>
         struct future_then_result
         {
-            typedef typename continuation_not_callable<Future, F>::type type;
+            using type = typename continuation_not_callable<Future, F>::type;
         };
 
         template <typename Future, typename F>

--- a/libs/pika/futures/tests/regressions/future_range_ambiguity_2032.cpp
+++ b/libs/pika/futures/tests/regressions/future_range_ambiguity_2032.cpp
@@ -11,9 +11,8 @@
 
 #include <vector>
 
-typedef pika::util::iterator_range<
-    std::vector<pika::shared_future<void>>::iterator>
-    future_range;
+using future_range = pika::util::iterator_range<
+    std::vector<pika::shared_future<void>>::iterator>;
 
 using error1 = pika::traits::is_future_range<future_range>::type;
 

--- a/libs/pika/futures/tests/unit/shared_future.cpp
+++ b/libs/pika/futures/tests/unit/shared_future.cpp
@@ -1298,8 +1298,8 @@ void test_wait_for_all_two_futures()
     pika::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
 
-    typedef pika::tuple<pika::shared_future<int>, pika::shared_future<int>>
-        result_type;
+    using result_type =
+        pika::tuple<pika::shared_future<int>, pika::shared_future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2);
 
     result_type result = r.get();
@@ -1322,9 +1322,8 @@ void test_wait_for_all_three_futures()
     pika::shared_future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef pika::tuple<pika::shared_future<int>, pika::shared_future<int>,
-        pika::shared_future<int>>
-        result_type;
+    using result_type = pika::tuple<pika::shared_future<int>,
+        pika::shared_future<int>, pika::shared_future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3);
 
     result_type result = r.get();
@@ -1352,9 +1351,9 @@ void test_wait_for_all_four_futures()
     pika::shared_future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef pika::tuple<pika::shared_future<int>, pika::shared_future<int>,
-        pika::shared_future<int>, pika::shared_future<int>>
-        result_type;
+    using result_type =
+        pika::tuple<pika::shared_future<int>, pika::shared_future<int>,
+            pika::shared_future<int>, pika::shared_future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3, f4);
 
     result_type result = r.get();
@@ -1387,10 +1386,9 @@ void test_wait_for_all_five_futures()
     pika::shared_future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef pika::tuple<pika::shared_future<int>, pika::shared_future<int>,
+    using result_type = pika::tuple<pika::shared_future<int>,
         pika::shared_future<int>, pika::shared_future<int>,
-        pika::shared_future<int>>
-        result_type;
+        pika::shared_future<int>, pika::shared_future<int>>;
     pika::future<result_type> r = pika::when_all(f1, f2, f3, f4, f5);
 
     result_type result = r.get();
@@ -1424,10 +1422,10 @@ void test_wait_for_two_out_of_five_futures()
     pika::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     pika::shared_future<int> f5 = pt5.get_future();
 
-    typedef pika::when_some_result<pika::tuple<pika::shared_future<int>,
-        pika::shared_future<int>, pika::shared_future<int>,
-        pika::shared_future<int>, pika::shared_future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::shared_future<int>,
+            pika::shared_future<int>, pika::shared_future<int>,
+            pika::shared_future<int>, pika::shared_future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
@@ -1464,10 +1462,10 @@ void test_wait_for_three_out_of_five_futures()
     pika::shared_future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef pika::when_some_result<pika::tuple<pika::shared_future<int>,
-        pika::shared_future<int>, pika::shared_future<int>,
-        pika::shared_future<int>, pika::shared_future<int>>>
-        result_type;
+    using result_type =
+        pika::when_some_result<pika::tuple<pika::shared_future<int>,
+            pika::shared_future<int>, pika::shared_future<int>,
+            pika::shared_future<int>, pika::shared_future<int>>>;
     pika::future<result_type> r = pika::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();

--- a/libs/pika/futures/tests/unit/test_allocator.hpp
+++ b/libs/pika/futures/tests/unit/test_allocator.hpp
@@ -34,11 +34,11 @@ public:
     using size_type = std::size_t;
     using difference_type = std::int64_t;
     using value_type = T;
-    typedef value_type* pointer;
-    typedef const value_type* const_pointer;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
     using reference = typename std::add_lvalue_reference<value_type>::type;
-    typedef typename std::add_lvalue_reference<value_type const>::type
-        const_reference;
+    using const_reference =
+        typename std::add_lvalue_reference<const value_type>::type;
 
     template <typename U>
     struct rebind
@@ -133,8 +133,8 @@ public:
     using size_type = std::size_t;
     using difference_type = std::int64_t;
     using value_type = void;
-    typedef value_type* pointer;
-    typedef value_type const* const_pointer;
+    using pointer = value_type*;
+    using const_pointer = value_type const*;
 
     template <typename U>
     struct rebind

--- a/libs/pika/hardware/include/pika/hardware/cpuid.hpp
+++ b/libs/pika/hardware/include/pika/hardware/cpuid.hpp
@@ -28,7 +28,7 @@
 
 namespace pika { namespace util { namespace hardware {
 
-    typedef std::uint32_t cpu_info [4];
+    using cpu_info = std::uint32_t [4];
 
     struct cpu_feature
     {

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -32,8 +32,8 @@ namespace pika { namespace util {
     class PIKA_EXPORT section
     {
     public:
-        typedef util::function<void(std::string const&, std::string const&)>
-            entry_changed_func;
+        using entry_changed_func =
+            util::function<void(const std::string&, const std::string&)>;
         using entry_type = std::pair<std::string, entry_changed_func>;
         using entry_map = std::map<std::string, entry_type>;
         using section_map = std::map<std::string, section>;

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -558,9 +558,8 @@ namespace pika { namespace util {
             return PIKA_FORWARD(F1, f1);
 
         // otherwise create a combined callback
-        typedef compose_callback_impl<typename std::decay<F1>::type,
-            typename std::decay<F2>::type>
-            result_type;
+        using result_type = compose_callback_impl<typename std::decay<F1>::type,
+            typename std::decay<F2>::type>;
         return result_type(PIKA_FORWARD(F1, f1), PIKA_FORWARD(F2, f2));
     }
 

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
@@ -145,9 +145,8 @@ namespace pika { namespace util {
 
     protected:
         // for convenience in derived classes
-        typedef iterator_adaptor<Derived, Base, Value, Category, Reference,
-            Difference, Pointer>
-            iterator_adaptor_;
+        using iterator_adaptor_ = iterator_adaptor<Derived, Base, Value,
+            Category, Reference, Difference, Pointer>;
 
         // lvalue access to the Base object for Derived
         PIKA_HOST_DEVICE PIKA_FORCEINLINE Base const& base_reference() const

--- a/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
@@ -70,8 +70,8 @@ namespace pika { namespace util {
             Value, Category, Difference>::type
     {
     private:
-        typedef typename detail::transform_iterator_base<Iterator, Transformer,
-            Reference, Value, Category, Difference>::type base_type;
+        using base_type = typename detail::transform_iterator_base<Iterator,
+            Transformer, Reference, Value, Category, Difference>::type;
 
     public:
         transform_iterator() {}

--- a/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
@@ -262,12 +262,11 @@ namespace pika { namespace util {
                 typename zip_iterator_category<IteratorTuple>::type,
                 typename zip_iterator_reference<IteratorTuple>::type>
         {
-            typedef pika::util::iterator_facade<
+            using base_type = pika::util::iterator_facade<
                 zip_iterator_base<IteratorTuple, Derived>,
                 typename zip_iterator_value<IteratorTuple>::type,
                 typename zip_iterator_category<IteratorTuple>::type,
-                typename zip_iterator_reference<IteratorTuple>::type>
-                base_type;
+                typename zip_iterator_reference<IteratorTuple>::type>;
 
         public:
             PIKA_HOST_DEVICE zip_iterator_base() {}
@@ -358,9 +357,8 @@ namespace pika { namespace util {
         static_assert(
             sizeof...(Ts) != 0, "zip_iterator must wrap at least one iterator");
 
-        typedef detail::zip_iterator_base<pika::tuple<Ts...>,
-            zip_iterator<Ts...>>
-            base_type;
+        using base_type =
+            detail::zip_iterator_base<pika::tuple<Ts...>, zip_iterator<Ts...>>;
 
     public:
         PIKA_HOST_DEVICE zip_iterator()
@@ -498,7 +496,7 @@ namespace pika { namespace util {
     PIKA_HOST_DEVICE zip_iterator<typename std::decay<Ts>::type...>
     make_zip_iterator(Ts&&... vs)
     {
-        typedef zip_iterator<typename std::decay<Ts>::type...> result_type;
+        using result_type = zip_iterator<typename std::decay<Ts>::type...>;
 
         return result_type(PIKA_FORWARD(Ts, vs)...);
     }
@@ -527,11 +525,10 @@ namespace pika { namespace traits {
         template <typename F, typename... Ts>
         struct lift_zipped_iterators<F, util::zip_iterator<Ts...>>
         {
-            typedef typename util::zip_iterator<Ts...>::iterator_tuple_type
-                tuple_type;
-            typedef pika::tuple<typename element_result_of<
-                typename F::template apply<Ts>, Ts>::type...>
-                result_type;
+            using tuple_type =
+                typename util::zip_iterator<Ts...>::iterator_tuple_type;
+            using result_type = pika::tuple<typename element_result_of<
+                typename F::template apply<Ts>, Ts>::type...>;
 
             template <std::size_t... Is, typename... Ts_>
             static result_type call(

--- a/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iterator_tests.hpp
+++ b/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iterator_tests.hpp
@@ -494,7 +494,7 @@ namespace tests {
             }
         };
 
-        typedef const T* pointer;
+        using pointer = const T*;
         using difference_type = std::ptrdiff_t;
 
         input_output_iterator_archetype() {}
@@ -533,8 +533,8 @@ namespace tests {
     public:
         using iterator_category = std::input_iterator_tag;
         using value_type = T;
-        typedef const T& reference;
-        typedef const T* pointer;
+        using reference = const T&;
+        using pointer = const T*;
         using difference_type = std::ptrdiff_t;
         input_iterator_archetype_no_proxy() {}
         input_iterator_archetype_no_proxy(
@@ -576,8 +576,8 @@ namespace tests {
     public:
         using iterator_category = std::forward_iterator_tag;
         using value_type = T;
-        typedef const T& reference;
-        typedef T const* pointer;
+        using reference = const T&;
+        using pointer = T const*;
         using difference_type = std::ptrdiff_t;
         forward_iterator_archetype() {}
         forward_iterator_archetype(forward_iterator_archetype const&) {}

--- a/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -153,20 +153,19 @@ namespace pika { namespace experimental {
             typename IterValueBegin, typename IterEnd, typename IterValueEnd>
         struct stencil3_iterator_base
         {
-            typedef previous_transformer<IterBegin, IterValueBegin>
-                left_transformer;
+            using left_transformer =
+                previous_transformer<IterBegin, IterValueBegin>;
             using right_transformer = next_transformer<IterEnd, IterValueEnd>;
 
-            typedef util::transform_iterator<Iterator, left_transformer>
-                left_iterator;
-            typedef util::transform_iterator<Iterator, right_transformer>
-                right_iterator;
+            using left_iterator =
+                util::transform_iterator<Iterator, left_transformer>;
+            using right_iterator =
+                util::transform_iterator<Iterator, right_transformer>;
 
-            typedef util::detail::zip_iterator_base<
+            using type = util::detail::zip_iterator_base<
                 pika::tuple<left_iterator, Iterator, right_iterator>,
                 stencil3_iterator_full<Iterator, IterBegin, IterValueBegin,
-                    IterEnd, IterValueEnd>>
-                type;
+                    IterEnd, IterValueEnd>>;
 
             static type create(Iterator const& it, IterBegin const& begin,
                 IterValueBegin const& begin_val, IterEnd const& end,
@@ -197,9 +196,8 @@ namespace pika { namespace experimental {
             IterValueBegin, IterEnd, IterValueEnd>::type
     {
     private:
-        typedef detail::stencil3_iterator_base<Iterator, IterBegin,
-            IterValueBegin, IterEnd, IterValueEnd>
-            base_maker;
+        using base_maker = detail::stencil3_iterator_base<Iterator, IterBegin,
+            IterValueBegin, IterEnd, IterValueEnd>;
         using base_type = typename base_maker::type;
 
     public:
@@ -235,9 +233,8 @@ namespace pika { namespace experimental {
         IterValueBegin const& begin_val, IterEnd const& end,
         IterValueEnd const& end_val)
     {
-        typedef stencil3_iterator_full<Iterator, IterBegin, IterValueBegin,
-            IterEnd, IterValueEnd>
-            result_type;
+        using result_type = stencil3_iterator_full<Iterator, IterBegin,
+            IterValueBegin, IterEnd, IterValueEnd>;
         return result_type(it, begin, begin_val, end, end_val);
     }
 
@@ -271,7 +268,7 @@ std::uint64_t bench_stencil3_iterator_full()
     auto r = pika::experimental::make_stencil3_full_range(
         values.begin(), values.end(), &values.back(), &values.front());
 
-    typedef std::iterator_traits<decltype(r.first)>::reference reference;
+    using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     int result = 0;
 
@@ -293,10 +290,9 @@ namespace pika { namespace experimental {
             stencil3_iterator_v1<Iterator>>
     {
     private:
-        typedef util::detail::zip_iterator_base<
+        using base_type = util::detail::zip_iterator_base<
             pika::tuple<Iterator, Iterator, Iterator>,
-            stencil3_iterator_v1<Iterator>>
-            base_type;
+            stencil3_iterator_v1<Iterator>>;
 
     public:
         stencil3_iterator_v1() {}
@@ -344,7 +340,7 @@ std::uint64_t bench_stencil3_iterator_v1()
     auto r = pika::experimental::make_stencil3_range_v1(
         values.begin() + 1, values.end() - 1);
 
-    typedef std::iterator_traits<decltype(r.first)>::reference reference;
+    using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     // handle boundary elements explicitly
     int result = values.back() + values.front() + values[1];
@@ -369,10 +365,10 @@ namespace pika { namespace experimental {
             template <typename Iterator>
             struct result
             {
-                typedef typename std::iterator_traits<Iterator>::reference
-                    element_type;
-                typedef pika::tuple<element_type, element_type, element_type>
-                    type;
+                using element_type =
+                    typename std::iterator_traits<Iterator>::reference;
+                using type =
+                    pika::tuple<element_type, element_type, element_type>;
             };
 
             // it will dereference tuple(it-1, it, it+1)
@@ -453,7 +449,7 @@ std::uint64_t bench_stencil3_iterator_v2()
     auto r = pika::experimental::make_stencil3_range_v2(
         values.begin() + 1, values.end() - 1);
 
-    typedef std::iterator_traits<decltype(r.first)>::reference reference;
+    using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     // handle boundary elements explicitly
     int result = values.back() + values.front() + values[1];

--- a/libs/pika/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/is_iterator.cpp
@@ -23,10 +23,9 @@ namespace test {
             BaseIterator, void, IteratorTag>
     {
     private:
-        typedef pika::util::iterator_adaptor<
+        using base_type = pika::util::iterator_adaptor<
             test_iterator<BaseIterator, IteratorTag>, BaseIterator, void,
-            IteratorTag>
-            base_type;
+            IteratorTag>;
 
     public:
         test_iterator()

--- a/libs/pika/iterator_support/tests/unit/is_range.cpp
+++ b/libs/pika/iterator_support/tests/unit/is_range.cpp
@@ -13,7 +13,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 void array_range()
 {
-    typedef int range[3];
+    using range = int[3];
 
     PIKA_TEST_MSG((pika::traits::is_range<range>::value == true), "array");
     PIKA_TEST_MSG(

--- a/libs/pika/iterator_support/tests/unit/iterator_adaptor.cpp
+++ b/libs/pika/iterator_support/tests/unit/iterator_adaptor.cpp
@@ -65,7 +65,7 @@ struct one_or_four
 };
 
 using storage = std::deque<int>;
-typedef std::deque<int*> pointer_deque;
+using pointer_deque = std::deque<int*>;
 using iterator_set = std::set<storage::iterator>;
 
 template <class T>
@@ -96,9 +96,8 @@ struct ptr_iterator
         std::random_access_iterator_tag>
 {
 private:
-    typedef pika::util::iterator_adaptor<ptr_iterator<V>, V*, V,
-        std::random_access_iterator_tag>
-        base_adaptor_type;
+    using base_adaptor_type = pika::util::iterator_adaptor<ptr_iterator<V>, V*,
+        V, std::random_access_iterator_tag>;
 
 public:
     ptr_iterator() {}
@@ -131,9 +130,8 @@ struct fwd_iterator
         tests::forward_iterator_archetype<T>>
 {
 private:
-    typedef pika::util::iterator_adaptor<fwd_iterator<T>,
-        tests::forward_iterator_archetype<T>>
-        base_adaptor_type;
+    using base_adaptor_type = pika::util::iterator_adaptor<fwd_iterator<T>,
+        tests::forward_iterator_archetype<T>>;
 
 public:
     fwd_iterator() {}
@@ -150,9 +148,8 @@ struct in_iterator
         tests::input_iterator_archetype_no_proxy<T>>
 {
 private:
-    typedef pika::util::iterator_adaptor<in_iterator<T>,
-        tests::input_iterator_archetype_no_proxy<T>>
-        base_adaptor_type;
+    using base_adaptor_type = pika::util::iterator_adaptor<in_iterator<T>,
+        tests::input_iterator_archetype_no_proxy<T>>;
 
 public:
     in_iterator() {}
@@ -167,9 +164,9 @@ struct constant_iterator
   : pika::util::iterator_adaptor<constant_iterator<Iter>, Iter,
         typename std::iterator_traits<Iter>::value_type const>
 {
-    typedef pika::util::iterator_adaptor<constant_iterator<Iter>, Iter,
-        typename std::iterator_traits<Iter>::value_type const>
-        base_adaptor_type;
+    using base_adaptor_type =
+        pika::util::iterator_adaptor<constant_iterator<Iter>, Iter,
+            const typename std::iterator_traits<Iter>::value_type>;
 
     constant_iterator() {}
     constant_iterator(Iter it)
@@ -216,7 +213,7 @@ int main()
 
     {
         // Test computation of default when the Value is const
-        typedef ptr_iterator<int const> Iter1;
+        using Iter1 = ptr_iterator<const int>;
         PIKA_TEST((std::is_same<Iter1::value_type, int>::value));
         PIKA_TEST((std::is_same<Iter1::reference, const int&>::value));
 
@@ -240,8 +237,8 @@ int main()
         //PIKA_TEST(boost::is_non_const_lvalue_iterator<BaseIter>::value);
         //PIKA_TEST(boost::is_lvalue_iterator<Iter>::value);
 
-        typedef modify_traversal<BaseIter, std::input_iterator_tag>
-            IncrementableIter;
+        using IncrementableIter =
+            modify_traversal<BaseIter, std::input_iterator_tag>;
 
         PIKA_TEST((std::is_same<BaseIter::iterator_category,
             std::random_access_iterator_tag>::value));
@@ -294,8 +291,8 @@ int main()
         PIKA_TEST((std::is_same<constant_iterator<BaseIter>::base_type,
             BaseIter>::value));
 
-        typedef modify_traversal<BaseIter, std::forward_iterator_tag>
-            IncrementableIter;
+        using IncrementableIter =
+            modify_traversal<BaseIter, std::forward_iterator_tag>;
 
         PIKA_TEST(
             (std::is_same<IncrementableIter::base_type, BaseIter>::value));

--- a/libs/pika/iterator_support/tests/unit/stencil3_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/stencil3_iterator.cpp
@@ -37,10 +37,10 @@ namespace test {
             template <typename Iterator>
             struct result
             {
-                typedef typename std::iterator_traits<Iterator>::reference
-                    element_type;
-                typedef pika::tuple<element_type, element_type, element_type>
-                    type;
+                using element_type =
+                    typename std::iterator_traits<Iterator>::reference;
+                using type =
+                    pika::tuple<element_type, element_type, element_type>;
             };
 
             // it will dereference tuple(it-1, it, it+1)
@@ -118,7 +118,7 @@ void test_stencil3_iterator()
 
     auto r = test::make_stencil3_range(values.begin() + 1, values.end() - 1);
 
-    typedef std::iterator_traits<decltype(r.first)>::reference reference;
+    using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     std::ostringstream str;
 
@@ -138,10 +138,10 @@ namespace test {
         template <typename Iterator>
         struct result
         {
-            typedef
-                typename std::iterator_traits<Iterator>::reference element_type;
-            typedef typename pika::util::invoke_result<F, element_type>::type
-                value_type;
+            using element_type =
+                typename std::iterator_traits<Iterator>::reference;
+            using value_type =
+                typename pika::util::invoke_result<F, element_type>::type;
 
             using type = pika::tuple<value_type, element_type, value_type>;
         };
@@ -166,8 +166,8 @@ namespace test {
     inline custom_stencil_transformer<typename std::decay<F>::type>
     make_custom_stencil_transformer(F&& f)
     {
-        typedef custom_stencil_transformer<typename std::decay<F>::type>
-            transformer_type;
+        using transformer_type =
+            custom_stencil_transformer<typename std::decay<F>::type>;
         return transformer_type(std::forward<F>(f));
     }
 }    // namespace test
@@ -181,7 +181,7 @@ void test_stencil3_iterator_custom()
         [](int i) -> int { return 2 * i; });
     auto r = test::make_stencil3_range(values.begin() + 1, values.end() - 1, t);
 
-    typedef std::iterator_traits<decltype(r.first)>::reference reference;
+    using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     std::ostringstream str;
 

--- a/libs/pika/iterator_support/tests/unit/transform_iterator2.cpp
+++ b/libs/pika/iterator_support/tests/unit/transform_iterator2.cpp
@@ -129,8 +129,8 @@ int main()
         for (int k2 = 0; k2 < N; ++k2)
             x[k2] = x[k2] * 2;
 
-        typedef pika::util::transform_iterator<int*, adaptable_mult_functor>
-            iter_t;
+        using iter_t =
+            pika::util::transform_iterator<int*, adaptable_mult_functor>;
         iter_t i(y, adaptable_mult_functor(2));
 
         tests::input_iterator_test(i, x[0], x[1]);
@@ -150,7 +150,7 @@ int main()
         for (int k2 = 0; k2 < N; ++k2)
             x[k2] = x[k2] * 2;
 
-        typedef pika::util::transform_iterator<int*, mult_functor, int> iter_t;
+        using iter_t = pika::util::transform_iterator<int*, mult_functor, int>;
         iter_t i(y, mult_functor(2));
         tests::input_iterator_test(i, x[0], x[1]);
         tests::input_iterator_test(iter_t(&y[0], mult_functor(2)), x[0], x[1]);
@@ -159,27 +159,24 @@ int main()
     }
 
     // Test transform_iterator default argument handling
-    {{typedef pika::util::transform_iterator<int*, adaptable_mult_functor,
-        float>
-            iter_t;
+    {{using iter_t =
+            pika::util::transform_iterator<int*, adaptable_mult_functor, float>;
 
     PIKA_TEST((std::is_same<iter_t::reference, float>::value));
     PIKA_TEST((std::is_same<iter_t::value_type, float>::value));
 }
 
 {
-    typedef pika::util::transform_iterator<int*, adaptable_mult_functor, int&,
-        float>
-        iter_t;
+    using iter_t = pika::util::transform_iterator<int*, adaptable_mult_functor,
+        int&, float>;
 
     PIKA_TEST((std::is_same<iter_t::reference, int&>::value));
     PIKA_TEST((std::is_same<iter_t::value_type, float>::value));
 }
 
 {
-    typedef pika::util::transform_iterator<int*, adaptable_mult_functor, float,
-        double>
-        iter_t;
+    using iter_t = pika::util::transform_iterator<int*, adaptable_mult_functor,
+        float, double>;
 
     PIKA_TEST((std::is_same<iter_t::reference, float>::value));
     PIKA_TEST((std::is_same<iter_t::value_type, double>::value));

--- a/libs/pika/iterator_support/tests/unit/zip_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/zip_iterator.cpp
@@ -67,9 +67,8 @@ int main(void)
     intset.insert(54);
     //
 
-    typedef pika::util::zip_iterator<std::set<int>::iterator,
-        std::vector<double>::iterator>
-        zit_mixed;
+    using zit_mixed = pika::util::zip_iterator<std::set<int>::iterator,
+        std::vector<double>::iterator>;
 
     zit_mixed zip_it_mixed =
         zit_mixed(pika::make_tuple(intset.begin(), vect1.begin()));
@@ -125,27 +124,26 @@ int main(void)
     ve4.push_back(12);
 
     // typedefs for cons lists of iterators.
-    typedef tuple_cat_result_of_t<pika::tuple<std::set<int>::iterator>,
-        pika::tuple<std::vector<int>::iterator, std::list<int>::iterator,
-            std::set<int>::iterator, std::vector<int>::iterator,
-            std::list<int>::iterator, std::set<int>::iterator,
-            std::vector<int>::iterator, std::list<int>::iterator,
-            std::set<int>::iterator, std::vector<int>::const_iterator>>
-        cons_11_its_type;
+    using cons_11_its_type =
+        tuple_cat_result_of_t<pika::tuple<std::set<int>::iterator>,
+            pika::tuple<std::vector<int>::iterator, std::list<int>::iterator,
+                std::set<int>::iterator, std::vector<int>::iterator,
+                std::list<int>::iterator, std::set<int>::iterator,
+                std::vector<int>::iterator, std::list<int>::iterator,
+                std::set<int>::iterator, std::vector<int>::const_iterator>>;
     //
-    typedef tuple_cat_result_of_t<pika::tuple<std::list<int>::const_iterator>,
-        cons_11_its_type>
-        cons_12_its_type;
+    using cons_12_its_type =
+        tuple_cat_result_of_t<pika::tuple<std::list<int>::const_iterator>,
+            cons_11_its_type>;
 
     // typedefs for cons lists for dereferencing the zip iterator
     // made from the cons list above.
-    typedef tuple_cat_result_of_t<pika::tuple<const int&>,
+    using cons_11_refs_type = tuple_cat_result_of_t<pika::tuple<const int&>,
         pika::tuple<int&, int&, const int&, int&, int&, const int&, int&, int&,
-            const int&, const int&>>
-        cons_11_refs_type;
+            const int&, const int&>>;
     //
-    typedef tuple_cat_result_of_t<pika::tuple<const int&>, cons_11_refs_type>
-        cons_12_refs_type;
+    using cons_12_refs_type =
+        tuple_cat_result_of_t<pika::tuple<const int&>, cons_11_refs_type>;
 
     // typedef for zip iterator with 12 elements
     using zip_it_12_type = pika::util::zip_iterator<cons_12_its_type>;
@@ -416,10 +414,9 @@ int main(void)
     // A combining iterator with all vector iterators must have random access
     // traversal.
     //
-    typedef pika::util::zip_iterator<
+    using all_vects_type = pika::util::zip_iterator<
         pika::tuple<std::vector<double>::const_iterator,
-            std::vector<double>::const_iterator>>
-        all_vects_type;
+            std::vector<double>::const_iterator>>;
 
     bool bAllVectsIsRandomAccessIterator = std::is_convertible<
         pika::util::zip_iterator_category<all_vects_type>::type,

--- a/libs/pika/lcos/include/pika/lcos/and_gate.hpp
+++ b/libs/pika/lcos/include/pika/lcos/and_gate.hpp
@@ -32,7 +32,7 @@ namespace pika { namespace lcos { namespace local {
         using mutex_type = Mutex;
 
     private:
-        typedef std::list<conditional_trigger*> condition_list_type;
+        using condition_list_type = std::list<conditional_trigger*>;
 
     public:
         /// \brief This constructor initializes the base_and_gate object from the

--- a/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
+++ b/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
@@ -124,11 +124,11 @@ namespace pika { namespace lcos { namespace local {
 
         struct guard_task;
 
-        typedef std::atomic<guard_task*> guard_atomic;
+        using guard_atomic = std::atomic<guard_task*>;
 
         PIKA_EXPORT void free(guard_task* task);
 
-        typedef util::unique_function<void()> guard_function;
+        using guard_function = util::unique_function<void()>;
     }    // namespace detail
 
     class guard : public detail::debug_object

--- a/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
+++ b/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
@@ -70,8 +70,8 @@ namespace pika { namespace lcos { namespace local {
             bool value_set_;
         };
 
-        typedef std::map<std::size_t, std::shared_ptr<entry_data>>
-            buffer_map_type;
+        using buffer_map_type =
+            std::map<std::size_t, std::shared_ptr<entry_data>>;
         using iterator = typename buffer_map_type::iterator;
 
         struct erase_on_exit
@@ -294,8 +294,8 @@ namespace pika { namespace lcos { namespace local {
             bool value_set_;
         };
 
-        typedef std::map<std::size_t, std::shared_ptr<entry_data>>
-            buffer_map_type;
+        using buffer_map_type =
+            std::map<std::size_t, std::shared_ptr<entry_data>>;
         using iterator = typename buffer_map_type::iterator;
 
         struct erase_on_exit

--- a/libs/pika/lcos/include/pika/lcos/trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/trigger.hpp
@@ -31,7 +31,7 @@ namespace pika { namespace lcos { namespace local {
         using mutex_type = Mutex;
 
     private:
-        typedef std::list<conditional_trigger*> condition_list_type;
+        using condition_list_type = std::list<conditional_trigger*>;
 
     public:
         base_trigger()

--- a/libs/pika/logging/src/format/named_write.cpp
+++ b/libs/pika/logging/src/format/named_write.cpp
@@ -173,6 +173,7 @@ namespace pika { namespace util { namespace logging { namespace detail {
                         m_manipulator = '%';
                 }
                 else if (m_manipulator.empty())
+                // NOLINTNEXTLINE(bugprone-branch-clone)
                 {
                     ;    // ignore this char - not from a manipulator
                 }

--- a/libs/pika/memory/include/pika/memory/detail/sp_convertible.hpp
+++ b/libs/pika/memory/include/pika/memory/detail/sp_convertible.hpp
@@ -18,8 +18,8 @@ namespace pika { namespace memory { namespace detail {
     template <typename Y, typename T>
     struct sp_convertible
     {
-        typedef char (&yes)[1];
-        typedef char (&no)[2];
+        using yes = char (&)[1];
+        using no = char (&)[2];
 
         static yes f(T*);
         static no f(...);

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -195,10 +195,9 @@ namespace pika {
         class async_traversal_frame_allocator
           : public async_traversal_frame<Visitor, Args...>
         {
-            typedef async_traversal_frame<Visitor, Args...> base_type;
-            typedef typename std::allocator_traits<Allocator>::
-                template rebind_alloc<async_traversal_frame_allocator>
-                    other_allocator;
+            using base_type = async_traversal_frame<Visitor, Args...>;
+            using other_allocator = typename std::allocator_traits<Allocator>::
+                template rebind_alloc<async_traversal_frame_allocator>;
 
         public:
             explicit async_traversal_frame_allocator(
@@ -238,9 +237,9 @@ namespace pika {
         struct shared_state_allocator<
             util::detail::async_traversal_frame<Visitor, Args...>, Allocator>
         {
-            typedef util::detail::async_traversal_frame_allocator<Allocator,
-                Visitor, Args...>
-                type;
+            using type =
+                util::detail::async_traversal_frame_allocator<Allocator,
+                    Visitor, Args...>;
         };
     }}    // namespace traits::detail
 

--- a/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
@@ -72,9 +72,8 @@ struct test_async_executor
         template <typename T, template <typename> class Future>
         const T& operator()(const Future<T>& el) const
         {
-            typedef
-                typename traits::detail::shared_state_ptr_for<Future<T>>::type
-                    shared_state_ptr;
+            using shared_state_ptr =
+                typename traits::detail::shared_state_ptr_for<Future<T>>::type;
             shared_state_ptr const& state =
                 traits::detail::get_shared_state(el);
             return *state->get_result();
@@ -89,8 +88,8 @@ struct test_async_executor
     future<typename util::invoke_result<F, Ts...>::type> async_execute(
         F&& f, Ts&&... ts)
     {
-        typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
-            result_type;
+        using result_type =
+            typename util::detail::invoke_deferred_result<F, Ts...>::type;
 
         using namespace pika::util::debug;
         std::cout << "async_execute : Function    : " << print_type<F>()
@@ -116,8 +115,8 @@ struct test_async_executor
     auto then_execute(F&& f, Future&& predecessor, Ts&&... ts) -> future<
         typename util::detail::invoke_deferred_result<F, Future, Ts...>::type>
     {
-        typedef typename util::detail::invoke_deferred_result<F, Future,
-            Ts...>::type result_type;
+        using result_type = typename util::detail::invoke_deferred_result<F,
+            Future, Ts...>::type;
 
         using namespace pika::util::debug;
         std::cout << "then_execute : Function     : " << print_type<F>()
@@ -153,8 +152,8 @@ struct test_async_executor
         -> future<typename util::detail::invoke_deferred_result<F,
             OuterFuture<pika::tuple<InnerFutures...>>, Ts...>::type>
     {
-        typedef typename util::detail::invoke_deferred_result<F,
-            OuterFuture<pika::tuple<InnerFutures...>>, Ts...>::type result_type;
+        using result_type = typename util::detail::invoke_deferred_result<F,
+            OuterFuture<pika::tuple<InnerFutures...>>, Ts...>::type;
 
         // get the tuple of futures from the predecessor future <tuple of futures>
         const auto& predecessor_value =
@@ -205,8 +204,8 @@ struct test_async_executor
         -> future<typename util::detail::invoke_deferred_result<F,
             pika::tuple<InnerFutures...>>::type>
     {
-        typedef typename util::detail::invoke_deferred_result<F,
-            pika::tuple<InnerFutures...>>::type result_type;
+        using result_type = typename util::detail::invoke_deferred_result<F,
+            pika::tuple<InnerFutures...>>::type;
 
         auto unwrapped_futures_tuple =
             util::map_pack(future_extract_value{}, predecessor);

--- a/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
+++ b/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
@@ -40,7 +40,7 @@ namespace pika { namespace threads {
             auto cond = std::make_shared<std::condition_variable_any>();
             bool stopping = false;
 
-            typedef typename util::invoke_result<F, Ts...>::type result_type;
+            using result_type = typename util::invoke_result<F, Ts...>::type;
 
             // Using the optional for storing the returned result value
             // allows to support non-default-constructible and move-only
@@ -141,8 +141,8 @@ namespace pika { namespace threads {
         // This shouldn't be used on a pika-thread
         PIKA_ASSERT(pika::threads::get_self_ptr() == nullptr);
 
-        typedef typename std::is_void<
-            typename util::invoke_result<F, Ts...>::type>::type result_is_void;
+        using result_is_void = typename std::is_void<
+            typename util::invoke_result<F, Ts...>::type>::type;
 
         return detail::run_as_pika_thread(
             result_is_void(), f, PIKA_FORWARD(Ts, vs)...);

--- a/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
@@ -15,7 +15,7 @@
 namespace pika {
     /// The type of a function which is registered to be executed as a
     /// shutdown or pre-shutdown function.
-    typedef util::unique_function<void()> shutdown_function_type;
+    using shutdown_function_type = util::unique_function<void()>;
 
     /// \brief Add a function to be executed by a pika thread during
     /// \a pika::finalize() but guaranteed before any shutdown function is

--- a/libs/pika/runtime/include/pika/runtime/startup_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/startup_function.hpp
@@ -16,7 +16,7 @@ namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     /// The type of a function which is registered to be executed as a
     /// startup or pre-startup function.
-    typedef util::unique_function<void()> startup_function_type;
+    using startup_function_type = util::unique_function<void()>;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add a function to be executed by a pika thread before pika_main

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -1654,8 +1654,8 @@ namespace pika {
     threads::policies::callback_notifier runtime::get_notification_policy(
         char const* prefix, os_thread_type type)
     {
-        typedef bool (runtime::*report_error_t)(
-            std::size_t, std::exception_ptr const&, bool);
+        using report_error_t =
+            bool (runtime::*)(std::size_t, std::exception_ptr const&, bool);
 
         using util::placeholders::_1;
         using util::placeholders::_2;

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -67,9 +67,8 @@ namespace pika { namespace threads { namespace policies {
     public:
         using has_periodic_maintenance = std::false_type;
 
-        typedef thread_queue<Mutex, PendingQueuing, StagedQueuing,
-            TerminatedQueuing>
-            thread_queue_type;
+        using thread_queue_type = thread_queue<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>;
 
         // the scheduler type takes two initialization parameters:
         //    the number of queues

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -59,9 +59,8 @@ namespace pika { namespace threads { namespace policies {
     public:
         using has_periodic_maintenance = std::false_type;
 
-        typedef thread_queue<Mutex, PendingQueuing, StagedQueuing,
-            TerminatedQueuing>
-            thread_queue_type;
+        using thread_queue_type = thread_queue<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>;
 
         struct init_parameter
         {

--- a/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
@@ -52,9 +52,8 @@ namespace pika { namespace threads { namespace policies {
             TerminatedQueuing>
     {
     public:
-        typedef local_queue_scheduler<Mutex, PendingQueuing, StagedQueuing,
-            TerminatedQueuing>
-            base_type;
+        using base_type = local_queue_scheduler<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>;
 
         static_queue_scheduler(
             typename base_type::init_parameter_type const& init,

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -53,11 +53,11 @@ namespace pika { namespace threads { namespace policies {
     // template <typename T>
     // struct queue_backend
     // {
-    //     typedef ... container_type;
-    //     typedef ... value_type;
-    //     typedef ... reference;
-    //     typedef ... const_reference;
-    //     typedef ... size_type;
+    //     using container_type = ...;
+    //     using value_type = ...;
+    //     using reference = ...;
+    //     using const_reference = ...;
+    //     using size_type = ...;
     //
     //     queue_backend(
     //         size_type initial_size = ...
@@ -76,7 +76,7 @@ namespace pika { namespace threads { namespace policies {
     //     template <typename T>
     //     struct apply
     //     {
-    //         typedef ... type;
+    //         using type = ...;
     //     };
     // };
     template <typename Mutex, typename PendingQueuing, typename StagedQueuing,

--- a/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/callback_notifier.hpp
@@ -20,11 +20,10 @@ namespace pika { namespace threads { namespace policies {
     class PIKA_EXPORT callback_notifier
     {
     public:
-        typedef util::function<void(
-            std::size_t, std::size_t, char const*, char const*)>
-            on_startstop_type;
-        typedef util::function<bool(std::size_t, std::exception_ptr const&)>
-            on_error_type;
+        using on_startstop_type = util::function<void(
+            std::size_t, std::size_t, char const*, char const*)>;
+        using on_error_type =
+            util::function<bool(std::size_t, std::exception_ptr const&)>;
 
         callback_notifier()
           : on_start_thread_callbacks_()

--- a/libs/pika/threadmanager/src/threadmanager.cpp
+++ b/libs/pika/threadmanager/src/threadmanager.cpp
@@ -472,9 +472,8 @@ namespace pika { namespace threads {
             case resource::shared_priority:
             {
                 // instantiate the scheduler
-                typedef pika::threads::policies::
-                    shared_priority_queue_scheduler<>
-                        local_sched_type;
+                using local_sched_type =
+                    pika::threads::policies::shared_priority_queue_scheduler<>;
                 local_sched_type::init_parameter_type init(
                     thread_pool_init.num_threads_, {1, 1, 1},
                     thread_pool_init.affinity_data_, thread_queue_init,

--- a/libs/pika/timing/include/pika/timing/high_resolution_clock.hpp
+++ b/libs/pika/timing/include/pika/timing/high_resolution_clock.hpp
@@ -36,8 +36,8 @@ namespace pika { namespace chrono {
         // returned by this clock.
         static constexpr std::uint64_t(min)() noexcept
         {
-            typedef std::chrono::duration_values<std::chrono::nanoseconds>
-                duration_values;
+            using duration_values =
+                std::chrono::duration_values<std::chrono::nanoseconds>;
             return (duration_values::min)().count();
         }
 
@@ -45,8 +45,8 @@ namespace pika { namespace chrono {
         // returned by this clock.
         static constexpr std::uint64_t(max)() noexcept
         {
-            typedef std::chrono::duration_values<std::chrono::nanoseconds>
-                duration_values;
+            using duration_values =
+                std::chrono::duration_values<std::chrono::nanoseconds>;
             return (duration_values::max)().count();
         }
     };

--- a/libs/pika/topology/include/pika/topology/cpu_mask.hpp
+++ b/libs/pika/topology/include/pika/topology/cpu_mask.hpp
@@ -136,10 +136,10 @@ namespace pika::threads::detail {
 #else
 #  if defined(PIKA_HAVE_MAX_CPU_COUNT)
     using mask_type = std::bitset<PIKA_HAVE_MAX_CPU_COUNT>;
-    typedef std::bitset<PIKA_HAVE_MAX_CPU_COUNT> const& mask_cref_type;
+    using mask_cref_type = std::bitset<PIKA_HAVE_MAX_CPU_COUNT> const&;
 #  else
     using mask_type = boost::dynamic_bitset<std::uint64_t>;
-    typedef boost::dynamic_bitset<std::uint64_t> const& mask_cref_type;
+    using mask_cref_type = boost::dynamic_bitset<std::uint64_t> const&;
 #  endif
     // clang-format on
 

--- a/libs/pika/type_support/include/pika/type_support/static.hpp
+++ b/libs/pika/type_support/include/pika/type_support/static.hpp
@@ -42,8 +42,8 @@ namespace pika { namespace util {
     public:
         using value_type = T;
 
-        typedef T& reference;
-        typedef T const& const_reference;
+        using reference = T&;
+        using const_reference = T const&;
 
         static_()
         {
@@ -119,8 +119,8 @@ namespace pika { namespace util {
         };
 
     public:
-        typedef T& reference;
-        typedef T const& const_reference;
+        using reference = T&;
+        using const_reference = T const&;
 
         static_()
         {

--- a/tools/inspect/inspect.cpp
+++ b/tools/inspect/inspect.cpp
@@ -159,7 +159,7 @@ namespace {
 
     //  visit_predicate (determines which directories are visited)  --------------//
 
-    typedef bool (*pred_type)(const std::filesystem::path&);
+    using pred_type = bool (*)(const std::filesystem::path&);
 
     bool visit_predicate(const std::filesystem::path& pth)
     {
@@ -914,7 +914,10 @@ void print_output(std::ostream& out, inspector_list const& inspectors)
             << "\n"
                "Commit: "
             << "<a href = \"https://github.com/pika-org/pika/commit/"
-            << PIKA_HAVE_GIT_COMMIT << "\">"
+            << PIKA_HAVE_GIT_COMMIT
+            << "\">"
+            // The commit hash is intentionally truncated
+            // NOLINTNEXTLINE(bugprone-string-constructor)
             << std::string(PIKA_HAVE_GIT_COMMIT, 10)
             << "</a>\n"
                "\n";
@@ -953,7 +956,10 @@ void print_output(std::ostream& out, inspector_list const& inspectors)
             << "<br>\n"
                "<b>Commit:</b> "
             << "<a href = \"https://github.com/pika-org/pika/commit/"
-            << PIKA_HAVE_GIT_COMMIT << "\">"
+            << PIKA_HAVE_GIT_COMMIT
+            << "\">"
+            // The commit hash is intentionally truncated
+            // NOLINTNEXTLINE(bugprone-string-constructor)
             << std::string(PIKA_HAVE_GIT_COMMIT, 10)
             << "</a>\n"
                "</td>\n"


### PR DESCRIPTION
Fixes #169. Also fixes some additional warnings emitted by clang-tidy that didn't come up in #194 (some tests are not run on CircleCI and will be enabled in #234).