### PR TITLE
Add basic Tracy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1000,6 +1000,21 @@ if(PIKA_WITH_APEX)
   endif()
 endif()
 
+pika_option(
+  PIKA_WITH_TRACY BOOL "Enable Tracy instrumentation support." OFF
+  CATEGORY "Profiling"
+)
+if(PIKA_WITH_TRACY)
+  pika_add_config_define(PIKA_HAVE_TRACY)
+  pika_add_config_define(PIKA_HAVE_THREAD_DESCRIPTION)
+  pika_add_config_define(PIKA_HAVE_THREAD_PARENT_REFERENCE)
+  if(PIKA_WITH_THREAD_DESCRIPTION_FULL)
+    pika_add_config_define(PIKA_HAVE_THREAD_DESCRIPTION_FULL)
+  endif()
+  find_package(Tracy REQUIRED)
+  target_link_libraries(pika_base_libraries INTERFACE Tracy::TracyClient)
+endif()
+
 if(PIKA_WITH_THREAD_DEBUG_INFO)
   pika_add_config_define(PIKA_HAVE_THREAD_PARENT_REFERENCE)
   pika_add_config_define(PIKA_HAVE_THREAD_PHASE_INFORMATION)

--- a/cmake/templates/pika-config.cmake.in
+++ b/cmake/templates/pika-config.cmake.in
@@ -96,6 +96,11 @@ include(pika_setup_mpi)
 set(PIKA_APEX_ROOT "@APEX_ROOT@")
 include(pika_setup_apex)
 
+# Tracy
+if(PIKA_WITH_TRACY)
+  find_dependency(Tracy REQUIRED)
+endif()
+
 set(PIKA_WITH_MALLOC_DEFAULT @PIKA_WITH_MALLOC@)
 
 if(PIKA_WITH_DATAPAR_VC AND NOT Vc_DIR)

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -37,6 +37,10 @@
 #include <pika/util/from_string.hpp>
 #include <pika/version.hpp>
 
+#if defined(PIKA_HAVE_TRACY)
+#include <common/TracySystem.hpp>
+#endif
+
 #include <atomic>
 #include <condition_variable>
 #include <cstddef>
@@ -1689,15 +1693,27 @@ namespace pika {
         char const* pool_name, char const* postfix, bool service_thread,
         error_code& ec)
     {
-        // set the thread's name, if it's not already set
-        PIKA_ASSERT(detail::thread_name().empty());
-
-        std::string fullname;
-        fullname += context;
+        std::ostringstream fullname;
+        fullname << "pika/" << context;
+        if (pool_name && *pool_name)
+        {
+            fullname << "/pool:" << pool_name;
+        }
         if (postfix && *postfix)
-            fullname += postfix;
-        fullname += "#" + std::to_string(global_thread_num);
-        detail::thread_name() = PIKA_MOVE(fullname);
+        {
+            fullname << '/' << postfix;
+        }
+        if (global_thread_num != std::size_t(-1))
+        {
+            fullname << "/global:" + std::to_string(global_thread_num);
+        }
+        if (local_thread_num != std::size_t(-1))
+        {
+            fullname << "/local:" + std::to_string(local_thread_num);
+        }
+
+        PIKA_ASSERT(detail::thread_name().empty());
+        detail::thread_name() = PIKA_MOVE(fullname).str();
 
         char const* name = detail::thread_name().c_str();
 
@@ -1713,6 +1729,10 @@ namespace pika {
 #if defined(PIKA_HAVE_APEX)
         if (std::strstr(name, "worker") != nullptr)
             detail::external_timer::register_thread(name);
+#endif
+
+#ifdef PIKA_HAVE_TRACY
+        tracy::SetThreadName(name);
 #endif
 
         // call thread-specific user-supplied on_start handler


### PR DESCRIPTION
Adds basic Tracy support, fixing part of #64. "basic" means that this can currently only be used with threads that never yield (stackful threads are ok if they don't yield, or stackless threads to be sure that they never yield). This is because of the way scoped annotations work in Tracy (but also in e.g. APEX, where we have to save and restore annotations on suspend and resume). Because of this limitation this is also not enabled in CI.

- `PIKA_WITH_TRACY` enables the use of Tracy. Tracy has to be installed separately, there is no fetchcontent support.
- I've updated the thread names to be of the form `pika/worker-thread/pool:default/global:1/local:1`.
- Every task invocation is wrapped in an annotation of the form `pika/task:0xabcd.../task_name`.

There are two independent next steps from this:
1. Start using stackless threads as much as possible since that is easier to do with senders.
2. Add support for fibers or saving/restoring the annotations on suspend/resume.