### PR TITLE
Add simple `boost::ranges::irange` replacement

### DIFF
--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -21,8 +21,7 @@
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 #include <pika/modules/synchronization.hpp>
-
-#include <boost/range/irange.hpp>
+#include <pika/modules/thread_support.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -159,7 +158,7 @@ struct stepper
 
         // Initial conditions: f(0, i) = i
         std::size_t b = 0;
-        auto range = boost::irange(b, np);
+        auto range = pika::detail::irange(b, np);
         using pika::execution::par;
         pika::ranges::for_each(par, range, [&U, nx](std::size_t i) {
             U[0][i] = pika::make_ready_future(partition_data(nx, double(i)));

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -6,9 +6,8 @@
 
 #include <pika/algorithm.hpp>
 #include <pika/init.hpp>
+#include <pika/modules/iterator_support.hpp>
 #include <pika/numeric.hpp>
-
-#include <boost/range/irange.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -55,7 +54,7 @@ int pika_main(pika::program_options::variables_map& vm)
     const std::uint64_t start = 0;
 
     // Fill the original matrix, set transpose to known garbage value.
-    auto range = boost::irange(start, order);
+    auto range = pika::detail::irange(start, order);
     // parallel for
     for_each(par, range, [&](std::uint64_t i) {
         for (std::uint64_t j = 0; j < order; ++j)
@@ -77,7 +76,8 @@ int pika_main(pika::program_options::variables_map& vm)
         pika::chrono::high_resolution_timer t;
         if (tile_size < order)
         {
-            auto range = boost::irange(start, order + tile_size, tile_size);
+            auto range = pika::detail::strided_irange(
+                start, order + tile_size, tile_size);
             // parallel for
             for_each(par, range, [&](std::uint64_t i) {
                 for (std::uint64_t j = 0; j < order; j += tile_size)
@@ -97,7 +97,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
         else
         {
-            auto range = boost::irange(start, order);
+            auto range = pika::detail::irange(start, order);
             // parallel for
             for_each(par, range, [&](std::uint64_t i) {
                 for (std::uint64_t j = 0; j < order; ++j)
@@ -178,7 +178,7 @@ double test_results(std::uint64_t order, std::vector<double> const& trans)
 
     const std::uint64_t start = 0;
 
-    auto range = boost::irange(start, order);
+    auto range = pika::detail::irange(start, order);
     // parallel reduce
     double errsq = transform_reduce(
         par, std::begin(range), std::end(range), 0.0,

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -6,9 +6,8 @@
 
 #include <pika/algorithm.hpp>
 #include <pika/init.hpp>
+#include <pika/modules/iterator_support.hpp>
 #include <pika/numeric.hpp>
-
-#include <boost/range/irange.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -66,7 +65,7 @@ int pika_main(pika::program_options::variables_map& vm)
     const std::uint64_t start = 0;
 
     // Fill the original matrix, set transpose to known garbage value.
-    auto range = boost::irange(start, num_blocks);
+    auto range = pika::detail::irange(start, num_blocks);
     for_each(par, range, [&](std::uint64_t b) {
         for (std::uint64_t i = 0; i < order; ++i)
         {
@@ -92,7 +91,7 @@ int pika_main(pika::program_options::variables_map& vm)
     {
         pika::chrono::high_resolution_timer t;
 
-        auto range = boost::irange(start, num_blocks);
+        auto range = pika::detail::irange(start, num_blocks);
 
         std::vector<pika::shared_future<void>> transpose_futures;
         transpose_futures.resize(num_blocks);
@@ -224,7 +223,7 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
     const std::uint64_t end = trans.size();
 
     // Fill the original matrix, set transpose to known garbage value.
-    auto range = boost::irange(start, end);
+    auto range = pika::detail::irange(start, end);
     double errsq = transform_reduce(
         par, std::begin(range), std::end(range), 0.0,
         [](double lhs, double rhs) { return lhs + rhs; },

--- a/libs/pika/algorithms/include/pika/parallel/spmd_block.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/spmd_block.hpp
@@ -11,12 +11,11 @@
 #include <pika/functional/first_argument.hpp>
 #include <pika/functional/invoke.hpp>
 #include <pika/futures/future.hpp>
+#include <pika/iterator_support/irange.hpp>
 #include <pika/iterator_support/traits/is_iterator.hpp>
 #include <pika/synchronization/barrier.hpp>
 #include <pika/synchronization/mutex.hpp>
 #include <pika/type_support/pack.hpp>
-
-#include <boost/range/irange.hpp>
 
 #include <cstddef>
 #include <functional>
@@ -198,7 +197,7 @@ namespace pika { namespace lcos { namespace local {
         return pika::parallel::execution::bulk_async_execute(policy.executor(),
             detail::spmd_block_helper<F>{
                 barrier, barriers, mtx, PIKA_FORWARD(F, f), num_images},
-            boost::irange(std::size_t(0), num_images),
+            pika::detail::irange(std::size_t(0), num_images),
             PIKA_FORWARD(Args, args)...);
     }
 
@@ -232,7 +231,7 @@ namespace pika { namespace lcos { namespace local {
         pika::parallel::execution::bulk_sync_execute(policy.executor(),
             detail::spmd_block_helper<F>{
                 barrier, barriers, mtx, PIKA_FORWARD(F, f), num_images},
-            boost::irange(std::size_t(0), num_images),
+            pika::detail::irange(std::size_t(0), num_images),
             PIKA_FORWARD(Args, args)...);
     }
 

--- a/libs/pika/iterator_support/CMakeLists.txt
+++ b/libs/pika/iterator_support/CMakeLists.txt
@@ -5,17 +5,18 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(iterator_support_headers
-    pika/iterator_support/traits/is_iterator.hpp
-    pika/iterator_support/traits/is_range.hpp
-    pika/iterator_support/traits/is_sentinel_for.hpp
     pika/iterator_support/boost_iterator_categories.hpp
     pika/iterator_support/counting_iterator.hpp
     pika/iterator_support/counting_shape.hpp
     pika/iterator_support/generator_iterator.hpp
+    pika/iterator_support/irange.hpp
     pika/iterator_support/iterator_adaptor.hpp
     pika/iterator_support/iterator_facade.hpp
     pika/iterator_support/iterator_range.hpp
     pika/iterator_support/range.hpp
+    pika/iterator_support/traits/is_iterator.hpp
+    pika/iterator_support/traits/is_range.hpp
+    pika/iterator_support/traits/is_sentinel_for.hpp
     pika/iterator_support/transform_iterator.hpp
     pika/iterator_support/zip_iterator.hpp
 )

--- a/libs/pika/iterator_support/include/pika/iterator_support/irange.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/irange.hpp
@@ -1,0 +1,370 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace pika::detail {
+    template <typename T>
+    class irange
+    {
+        static_assert(std::is_integral_v<T>);
+
+    public:
+        constexpr irange(T const b, T const e)
+          : b(b)
+          , e(e)
+        {
+            PIKA_ASSERT(b <= e);
+        }
+        constexpr irange(irange&&) = default;
+        constexpr irange(irange const&) = default;
+        constexpr irange& operator=(irange&&) = default;
+        constexpr irange& operator=(irange const&) = default;
+
+        class iterator
+        {
+        public:
+            constexpr iterator() = default;
+            constexpr explicit iterator(T const v) noexcept
+              : value(v)
+            {
+            }
+            constexpr iterator(iterator&&) = default;
+            constexpr iterator(iterator const&) = default;
+            constexpr iterator& operator=(iterator&&) = default;
+            constexpr iterator& operator=(iterator const&) = default;
+
+            using value_type = T;
+            using difference_type = std::ptrdiff_t;
+            using reference = T&;
+            using pointer = T*;
+            using iterator_category = std::random_access_iterator_tag;
+
+            constexpr reference operator*() noexcept
+            {
+                return value;
+            }
+
+            constexpr iterator& operator++() noexcept
+            {
+                ++value;
+                return *this;
+            }
+
+            constexpr iterator operator++(int) noexcept
+            {
+                iterator r = *this;
+                ++value;
+                return r;
+            }
+
+            constexpr iterator& operator--() noexcept
+            {
+                --value;
+                return *this;
+            }
+
+            constexpr iterator operator--(int) noexcept
+            {
+                iterator r = *this;
+                --value;
+                return r;
+            }
+
+            constexpr iterator& operator+=(difference_type const n) noexcept
+            {
+                value += n;
+                return *this;
+            }
+
+            constexpr friend iterator operator+(
+                iterator const it, difference_type const n) noexcept
+            {
+                return iterator{it.value + n};
+            }
+
+            constexpr friend iterator operator+(
+                difference_type const n, iterator const it) noexcept
+            {
+                return iterator{it.value + n};
+            }
+
+            constexpr friend iterator operator-(
+                iterator const it, difference_type const n) noexcept
+            {
+                return iterator{it.value - n};
+            }
+
+            constexpr iterator& operator-=(difference_type const n) noexcept
+            {
+                value -= n;
+                return *this;
+            }
+
+            constexpr friend difference_type operator-(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return static_cast<difference_type>(lhs.value) -
+                    static_cast<difference_type>(rhs.value);
+            }
+
+            constexpr reference operator[](difference_type d) const noexcept
+            {
+                return static_cast<value_type>(value + d);
+            }
+
+            constexpr friend bool operator==(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value == rhs.value;
+            }
+
+            constexpr friend bool operator!=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value != rhs.value;
+            }
+
+            constexpr friend bool operator<(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value < rhs.value;
+            }
+
+            constexpr friend bool operator>(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value > rhs.value;
+            }
+
+            constexpr friend bool operator<=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value <= rhs.value;
+            }
+
+            constexpr friend bool operator>=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value >= rhs.value;
+            }
+
+        private:
+            T value = 0;
+        };
+
+        constexpr iterator begin() const noexcept
+        {
+            return iterator{b};
+        }
+
+        constexpr iterator end() const noexcept
+        {
+            return iterator{e};
+        }
+
+    private:
+        T b;
+        T e;
+    };
+
+    template <typename T, typename U = T>
+    class strided_irange
+    {
+        static_assert(std::is_integral_v<T>);
+
+    public:
+        constexpr strided_irange(
+            T const b, T const e, T const step = 1) noexcept
+          : b(b)
+          , e(e)
+          , step(step)
+        {
+            PIKA_ASSERT(step != 0);
+            PIKA_ASSERT((b <= e && step > 0) || (e <= b && step < 0));
+        }
+        strided_irange(strided_irange&&) = default;
+        strided_irange(strided_irange const&) = default;
+        strided_irange& operator=(strided_irange&&) = default;
+        strided_irange& operator=(strided_irange const&) = default;
+
+        class iterator
+        {
+        public:
+            constexpr iterator() = default;
+            constexpr iterator(T const v, U const step) noexcept
+              : value(v)
+              , step(step)
+            {
+            }
+            iterator(iterator&&) = default;
+            iterator(iterator const&) = default;
+            iterator& operator=(iterator&&) = default;
+            iterator& operator=(iterator const&) = default;
+
+            using value_type = T;
+            using difference_type = std::ptrdiff_t;
+            using reference = T&;
+            using pointer = T*;
+            using iterator_category = std::random_access_iterator_tag;
+
+            constexpr reference operator*() noexcept
+            {
+                return value;
+            }
+
+            constexpr iterator& operator++() noexcept
+            {
+                value += step;
+                return *this;
+            }
+
+            constexpr iterator operator++(int) noexcept
+            {
+                iterator r = *this;
+                value += step;
+                return r;
+            }
+
+            constexpr iterator& operator--() noexcept
+            {
+                value -= step;
+                return *this;
+            }
+
+            constexpr iterator operator--(int) noexcept
+            {
+                iterator r = *this;
+                value -= step;
+                return r;
+            }
+
+            constexpr iterator& operator+=(difference_type const n) noexcept
+            {
+                value += n * step;
+                return *this;
+            }
+
+            constexpr friend iterator operator+(
+                iterator const it, difference_type const n) noexcept
+            {
+                return iterator{it.value + n * it.step, it.step};
+            }
+
+            constexpr friend iterator operator+(
+                difference_type const n, iterator const it) noexcept
+            {
+                return iterator{it.value + n * it.step, it.step};
+            }
+
+            constexpr friend iterator operator-(
+                iterator const it, difference_type const n) noexcept
+            {
+                return iterator{it.value - n * it.step, it.step};
+            }
+
+            constexpr iterator& operator-=(difference_type const n) noexcept
+            {
+                value -= n * step;
+                return *this;
+            }
+
+            constexpr friend difference_type operator-(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                PIKA_ASSERT(lhs.step == rhs.step);
+                return (static_cast<difference_type>(lhs.value) -
+                           static_cast<difference_type>(rhs.value)) /
+                    lhs.step;
+            }
+
+            constexpr reference operator[](difference_type d) const noexcept
+            {
+                return static_cast<value_type>(value + d * step);
+            }
+
+            constexpr friend bool operator==(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value == rhs.value;
+            }
+
+            constexpr friend bool operator!=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value != rhs.value;
+            }
+
+            constexpr friend bool operator<(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value < rhs.value;
+            }
+
+            constexpr friend bool operator>(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value > rhs.value;
+            }
+
+            constexpr friend bool operator<=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value <= rhs.value;
+            }
+
+            constexpr friend bool operator>=(
+                iterator const lhs, iterator const rhs) noexcept
+            {
+                return lhs.value >= rhs.value;
+            }
+
+        private:
+            T value = 0;
+            U step = 0;
+        };
+
+        constexpr iterator begin() const noexcept
+        {
+            return iterator{b, step};
+        }
+
+        constexpr iterator end() const noexcept
+        {
+            if (b < e)
+            {
+                return iterator{b + ((e - b - 1) / step + 1) * step, step};
+            }
+            else if (b > e)
+            {
+                return iterator{b + ((e - b + 1) / step + 1) * step, step};
+            }
+            else
+            {
+                return iterator{b, step};
+            }
+        }
+
+    private:
+        T b;
+        T e;
+        U step;
+    };
+
+    template <typename T>
+    irange(T const, T const) -> irange<std::decay_t<T>>;
+
+    template <typename T, typename U = T>
+    strided_irange(T const, T const, U const)
+        -> strided_irange<std::decay_t<T>, std::decay_t<U>>;
+}    // namespace pika::detail

--- a/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/range/irange.hpp>
-
 ///////////////////////////////////////////////////////////////////////////////
 int test_count = 100;
 int partition_size = 10000;
@@ -476,7 +474,7 @@ std::uint64_t bench_stencil3_iterator_explicit()
     // handle all elements explicitly
     int result = values.back() + values.front() + values[1];
 
-    auto range = boost::irange(1, partition_size - 1);
+    auto range = pika::detail::irange(1, partition_size - 1);
 
     std::for_each(
         std::begin(range), std::end(range), [&result, &values](std::size_t i) {

--- a/libs/pika/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/pika/iterator_support/tests/unit/CMakeLists.txt
@@ -7,8 +7,11 @@
 set(tests
     boost_iterator_categories
     counting_iterator
+    irange
     is_iterator
     is_range
+    is_sentinel_for
+    is_sized_sentinel_for
     iterator_adaptor
     iterator_facade
     range
@@ -16,8 +19,6 @@ set(tests
     transform_iterator
     transform_iterator2
     zip_iterator
-    is_sentinel_for
-    is_sized_sentinel_for
 )
 
 set(is_range_FLAGS NOLIBS)

--- a/libs/pika/iterator_support/tests/unit/irange.cpp
+++ b/libs/pika/iterator_support/tests/unit/irange.cpp
@@ -1,0 +1,83 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/iterator_support/irange.hpp>
+#include <pika/iterator_support/range.hpp>
+#include <pika/testing.hpp>
+
+#include <vector>
+
+template <typename Range, typename T>
+void test(Range&& rng, T&& ref)
+{
+    auto rb = std::begin(ref);
+    for (auto r : rng)
+    {
+        PIKA_TEST(rb != std::end(ref));
+        PIKA_TEST_EQ(r, *rb++);
+    }
+    PIKA_TEST(rb == std::end(ref));
+    PIKA_TEST_EQ(std::distance(std::begin(rng), std::end(rng)),
+        std::distance(std::begin(ref), std::end(ref)));
+}
+
+template <typename Range>
+void test_unit_stride()
+{
+    test(Range(0, 0), std::vector<int>{});
+    test(Range(-10, -10), std::vector<int>{});
+    test(Range(14, 14), std::vector<int>{});
+    test(Range(0, 1), std::vector<int>{0});
+    test(Range(9, 10), std::vector<int>{9});
+    test(Range(-11, -10), std::vector<int>{-11});
+    test(Range(0, 4), std::vector<int>{0, 1, 2, 3});
+    test(Range(-10, -8), std::vector<int>{-10, -9});
+    test(Range(10, 13), std::vector<int>{10, 11, 12});
+    test(Range(10, 13), std::vector<int>{10, 11, 12});
+}
+
+void test_non_unit_stride()
+{
+    test(pika::detail::strided_irange(0, 0, 1), std::vector<int>{});
+    test(pika::detail::strided_irange(-10, -10, 1), std::vector<int>{});
+    test(pika::detail::strided_irange(14, 14, 1), std::vector<int>{});
+    test(pika::detail::strided_irange(0, 1, 1), std::vector<int>{0});
+    test(pika::detail::strided_irange(9, 10, 1), std::vector<int>{9});
+    test(pika::detail::strided_irange(-11, -10, 1), std::vector<int>{-11});
+    test(pika::detail::strided_irange(0, 4, 1), std::vector<int>{0, 1, 2, 3});
+    test(pika::detail::strided_irange(-10, -8, 1), std::vector<int>{-10, -9});
+    test(pika::detail::strided_irange(10, 13, 1), std::vector<int>{10, 11, 12});
+    test(pika::detail::strided_irange(0, 0, 3), std::vector<int>{});
+    test(pika::detail::strided_irange(-10, -10, 3), std::vector<int>{});
+    test(pika::detail::strided_irange(14, 14, 3), std::vector<int>{});
+    test(pika::detail::strided_irange(0, 0, -3), std::vector<int>{});
+    test(pika::detail::strided_irange(-10, -10, -3), std::vector<int>{});
+    test(pika::detail::strided_irange(14, 14, -3), std::vector<int>{});
+    test(pika::detail::strided_irange(0, 1, 3), std::vector<int>{0});
+    test(pika::detail::strided_irange(9, 10, 3), std::vector<int>{9});
+    test(pika::detail::strided_irange(-11, -10, 3), std::vector<int>{-11});
+    test(pika::detail::strided_irange(0, 4, 3), std::vector<int>{0, 3});
+    test(pika::detail::strided_irange(-10, -8, 3), std::vector<int>{-10});
+    test(pika::detail::strided_irange(10, 12, 3), std::vector<int>{10});
+    test(pika::detail::strided_irange(10, 13, 3), std::vector<int>{10});
+    test(pika::detail::strided_irange(10, 14, 3), std::vector<int>{10, 13});
+    test(pika::detail::strided_irange(10, 15, 3), std::vector<int>{10, 13});
+    test(pika::detail::strided_irange(-10, -12, -3), std::vector<int>{-10});
+    test(pika::detail::strided_irange(-10, -13, -3), std::vector<int>{-10});
+    test(
+        pika::detail::strided_irange(-10, -14, -3), std::vector<int>{-10, -13});
+    test(
+        pika::detail::strided_irange(-10, -15, -3), std::vector<int>{-10, -13});
+}
+
+int main()
+{
+    test_unit_stride<pika::detail::irange<int>>();
+    test_unit_stride<pika::detail::strided_irange<int, int>>();
+    test_non_unit_stride();
+
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
Part of #12. Adds a simple replacement for `boost::ranges::irange` (`pika::detail::irange` and `pika::detail::strided_irange`).