### PR TITLE
Small modifications to P2300 integration

### DIFF
--- a/cmake/pika_setup_p2300.cmake
+++ b/cmake/pika_setup_p2300.cmake
@@ -25,8 +25,8 @@ if(PIKA_WITH_P2300_REFERENCE_IMPLEMENTATION AND NOT PIKA_FIND_PACKAGE)
 
   add_library(P2300 INTERFACE)
   target_include_directories(
-    P2300 INTERFACE "$<BUILD_INTERFACE:${p2300_SOURCE_DIR}/include>"
-                    "$<INSTALL_INTERFACE:include>"
+    P2300 SYSTEM INTERFACE "$<BUILD_INTERFACE:${p2300_SOURCE_DIR}/include>"
+                           "$<INSTALL_INTERFACE:include>"
   )
   target_compile_features(P2300 INTERFACE cxx_std_20)
 

--- a/cmake/pika_setup_p2300.cmake
+++ b/cmake/pika_setup_p2300.cmake
@@ -15,8 +15,8 @@ if(PIKA_WITH_P2300_REFERENCE_IMPLEMENTATION AND NOT PIKA_FIND_PACKAGE)
 
   fetchcontent_declare(
     P2300
-    GIT_REPOSITORY https://github.com/msimberg/wg21_P2300_std_execution.git
-    GIT_TAG misc-fixes
+    GIT_REPOSITORY https://github.com/brycelelbach/wg21_P2300_std_execution.git
+    GIT_TAG 6da4968c0093c188f7d4dfce75a9d401944d8f06
   )
   fetchcontent_getproperties(P2300)
   if(NOT p2300_POPULATED)

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -88,7 +88,6 @@ namespace pika::cuda::experimental {
                 cuda_scheduler scheduler;
                 PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
-                operation_state() = default;
                 operation_state(operation_state&&) = delete;
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state&&) = delete;

--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -178,6 +178,10 @@ int main()
     {
         ex::just() | ex::ensure_started();
     }
+
+    {
+        test_adl_isolation(ex::ensure_started(my_namespace::my_sender{}));
+    }
 #endif
 
     return pika::util::report_errors();

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -105,11 +105,6 @@ struct f_struct_1
 
 struct f_struct_2
 {
-    void operator()(int) noexcept {};
-};
-
-struct f_struct_3
-{
     void operator()(int = 42){};
 };
 
@@ -122,7 +117,7 @@ int main()
     {
         scheduler_1 s1;
         pika::execution::experimental::execute(s1, f_struct_1{});
-        pika::execution::experimental::execute(s1, f_struct_3{});
+        pika::execution::experimental::execute(s1, f_struct_2{});
         pika::execution::experimental::execute(s1, &f_fun_1);
         PIKA_TEST_EQ(friend_tag_invoke_schedule_calls, std::size_t(3));
         PIKA_TEST_EQ(tag_invoke_execute_calls, std::size_t(0));
@@ -131,7 +126,7 @@ int main()
     {
         scheduler_2 s2;
         pika::execution::experimental::execute(s2, f_struct_1{});
-        pika::execution::experimental::execute(s2, f_struct_3{});
+        pika::execution::experimental::execute(s2, f_struct_2{});
         pika::execution::experimental::execute(s2, &f_fun_1);
         PIKA_TEST_EQ(friend_tag_invoke_schedule_calls, std::size_t(3));
         PIKA_TEST_EQ(tag_invoke_execute_calls, std::size_t(3));

--- a/libs/pika/execution/tests/unit/algorithm_then.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_then.cpp
@@ -212,9 +212,7 @@ int main()
         PIKA_TEST(custom_transformer_call_operator_called);
     }
 
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     test_adl_isolation(ex::then(ex::just(), my_namespace::my_type{}));
-#endif
 
     return pika::util::report_errors();
 }


### PR DESCRIPTION
- Use fixed commit from upstream repository
- Add a few more ADL-isolation tests
- Make P2300 includes system includes
- Remove unnecessary default constructor for an operation state
- Remove unused test struct for `execution::then`