### PR TITLE
Add `drop_value` sender adaptor

### DIFF
--- a/libs/pika/execution/CMakeLists.txt
+++ b/libs/pika/execution/CMakeLists.txt
@@ -12,6 +12,7 @@ set(execution_headers
     pika/execution/algorithms/detail/partial_algorithm.hpp
     pika/execution/algorithms/detail/predicates.hpp
     pika/execution/algorithms/detail/single_result.hpp
+    pika/execution/algorithms/drop_value.hpp
     pika/execution/algorithms/ensure_started.hpp
     pika/execution/algorithms/execute.hpp
     pika/execution/algorithms/just.hpp

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -1,0 +1,161 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+
+#include <pika/concepts/concepts.hpp>
+#include <pika/errors/try_catch_exception_ptr.hpp>
+#include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution_base/completion_scheduler.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace pika { namespace execution { namespace experimental {
+    namespace drop_value_detail {
+        template <typename Receiver>
+        struct drop_value_receiver_impl
+        {
+            struct drop_value_receiver_type;
+        };
+
+        template <typename Receiver>
+        using drop_value_receiver = typename drop_value_receiver_impl<
+            Receiver>::drop_value_receiver_type;
+
+        template <typename Receiver>
+        struct drop_value_receiver_impl<Receiver>::drop_value_receiver_type
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+            template <typename Error>
+            friend void tag_invoke(set_error_t, drop_value_receiver_type&& r,
+                Error&& error) noexcept
+            {
+                pika::execution::experimental::set_error(
+                    PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
+            }
+
+            friend void tag_invoke(
+                set_stopped_t, drop_value_receiver_type&& r) noexcept
+            {
+                pika::execution::experimental::set_stopped(
+                    PIKA_MOVE(r.receiver));
+            }
+
+            template <typename... Ts>
+            friend void tag_invoke(
+                set_value_t, drop_value_receiver_type&& r, Ts&&...) noexcept
+            {
+                pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
+            }
+
+            friend constexpr pika::execution::experimental::detail::empty_env
+            tag_invoke(pika::execution::experimental::get_env_t,
+                drop_value_receiver_type const&) noexcept
+            {
+                return {};
+            }
+        };
+
+        template <typename Sender>
+        struct drop_value_sender_impl
+        {
+            struct drop_value_sender_type;
+        };
+
+        template <typename Sender>
+        using drop_value_sender =
+            typename drop_value_sender_impl<Sender>::drop_value_sender_type;
+
+        template <typename Sender>
+        struct drop_value_sender_impl<Sender>::drop_value_sender_type
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+
+#if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
+            template <class...>
+            using empty_set_value = completion_signatures<set_value_t()>;
+
+            using completion_signatures =
+                pika::execution::experimental::make_completion_signatures<
+                    Sender, pika::execution::experimental::detail::empty_env,
+                    pika::execution::experimental::completion_signatures<>,
+                    empty_set_value>;
+#else
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<>>;
+
+            template <template <typename...> class Variant>
+            using error_types =
+                pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                    typename pika::execution::experimental::sender_traits<
+                        Sender>::template error_types<Variant>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+#endif
+
+            template <typename CPO,
+                // clang-format off
+                PIKA_CONCEPT_REQUIRES_(
+                    pika::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    pika::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, std::decay_t<Sender>>)
+                // clang-format on
+                >
+            friend constexpr auto tag_invoke(
+                pika::execution::experimental::get_completion_scheduler_t<CPO>,
+                drop_value_sender_type const& sender)
+            {
+                return pika::execution::experimental::get_completion_scheduler<
+                    CPO>(sender.sender);
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, drop_value_sender_type&& s, Receiver&& receiver)
+            {
+                return pika::execution::experimental::connect(
+                    PIKA_MOVE(s.sender),
+                    drop_value_receiver<Receiver>{
+                        PIKA_FORWARD(Receiver, receiver)});
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, drop_value_sender_type& r, Receiver&& receiver)
+            {
+                return pika::execution::experimental::connect(r.sender,
+                    drop_value_receiver<Receiver>{
+                        PIKA_FORWARD(Receiver, receiver)});
+            }
+        };
+    }    // namespace drop_value_detail
+
+    inline constexpr struct drop_value_t final
+      : pika::functional::detail::tag_fallback<drop_value_t>
+    {
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        constexpr PIKA_FORCEINLINE auto operator()(Sender&& sender) const
+        {
+            return drop_value_detail::drop_value_sender<Sender>{
+                PIKA_FORWARD(Sender, sender)};
+        }
+
+        constexpr PIKA_FORCEINLINE auto operator()() const
+        {
+            return detail::partial_algorithm<drop_value_t>{};
+        }
+    } drop_value{};
+}}}    // namespace pika::execution::experimental

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     algorithm_bulk
+    algorithm_drop_value
     algorithm_ensure_started
     algorithm_execute
     algorithm_just

--- a/libs/pika/execution/tests/unit/algorithm_drop_value.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_drop_value.cpp
@@ -1,0 +1,119 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/modules/execution.hpp>
+#include <pika/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = pika::execution::experimental;
+
+int main()
+{
+    // A drop_value sender will always send nothing
+    constexpr auto f = [] {};
+
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::drop_value(ex::just());
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::drop_value(ex::just(0));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::drop_value(ex::just(std::string("hello")));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::drop_value(ex::just(custom_type_non_default_constructible{0}));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::drop_value(
+            ex::just(custom_type_non_default_constructible_non_copyable{0}));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::drop_value(ex::just());
+        auto s2 = ex::drop_value(std::move(s1));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::drop_value(ex::just(32));
+        auto s2 = ex::drop_value(std::move(s1));
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just() | ex::drop_value() | ex::drop_value();
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), r);
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::drop_value(
+            ex::then(ex::just(), [] { throw std::runtime_error("error"); }));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    test_adl_isolation(ex::drop_value(my_namespace::my_sender{}));
+
+    return pika::util::report_errors();
+}

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1933,6 +1933,58 @@ void test_completion_scheduler()
     }
 }
 
+void test_drop_value()
+{
+    ex::thread_pool_scheduler sched{};
+
+    {
+        tt::sync_wait(ex::drop_value(ex::schedule(sched)));
+        static_assert(std::is_void_v<decltype(tt::sync_wait(
+                ex::drop_value(ex::schedule(sched))))>);
+    }
+
+    {
+        tt::sync_wait(ex::drop_value(ex::transfer_just(sched, 3)));
+        static_assert(std::is_void_v<decltype(tt::sync_wait(
+                ex::drop_value(ex::transfer_just(sched, 3))))>);
+    }
+
+    {
+        tt::sync_wait(
+            ex::drop_value(ex::transfer_just(sched, std::string("hello"))));
+        static_assert(std::is_void_v<decltype(tt::sync_wait(ex::drop_value(
+                ex::transfer_just(sched, std::string("hello")))))>);
+    }
+
+    {
+        tt::sync_wait(ex::drop_value(ex::transfer_just(
+            sched, custom_type_non_default_constructible_non_copyable{0})));
+        static_assert(std::is_void_v<decltype(tt::sync_wait(
+                ex::drop_value(ex::transfer_just(sched,
+                    custom_type_non_default_constructible_non_copyable{0}))))>);
+    }
+
+    {
+        auto s = ex::drop_value(
+            ex::then(ex::just(), [] { throw std::runtime_error("error"); }));
+
+        bool exception_thrown = false;
+
+        try
+        {
+            tt::sync_wait(std::move(s));
+            PIKA_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            PIKA_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+
+        PIKA_TEST(exception_thrown);
+    }
+}
+
 void test_scheduler_queries()
 {
     PIKA_TEST(ex::get_forward_progress_guarantee(ex::thread_pool_scheduler{}) ==
@@ -1969,6 +2021,7 @@ int pika_main()
     test_let_error();
     test_detach();
     test_bulk();
+    test_drop_value();
     test_completion_scheduler();
     test_scheduler_queries();
 


### PR DESCRIPTION
Adds a `drop_value` sender adaptor. It ignores any values sent by a predecessor sender. E.g.:
```
just(1, "hello", Tile{}) | drop_value() | then([](/* nothing here */) {...});
```
This is useful for https://github.com/eth-cscs/DLA-Future/pull/572.

I went for singular `value` instead of `values` to mirror `let_value/error` and `upon_error/stopped` (`then` is "`upon_value`") which all use singular and it mirrors the "channel name" (`value`, `error`, `stopped`). An alternative to `drop` would perhaps be `ignore`.

Note that I'm not adding `drop_error` and `drop_stopped` because 1. I don't want to encourage that and 2. it's not quite clear what they would do (sending no values in `set_value` is fine, but sending no error in `set_error` makes no sense and isn't allowed).

Opinions?