### PR TITLE
Fix inclusion of `-Wno-interference-size` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1341,7 +1341,9 @@ if(PIKA_WITH_P2300_REFERENCE_IMPLEMENTATION AND CMAKE_COMPILER_IS_GNUCXX)
   pika_add_compile_flag_if_available(-Wno-non-template-friend)
 endif()
 
-if(PIKA_WITH_CXX_STANDARD GREATER_EQUAL 20 AND CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION
+                                VERSION_GREATER_EQUAL 12.0
+)
   pika_add_compile_flag_if_available(-Wno-interference-size)
 endif()
 


### PR DESCRIPTION
It does not depend on the C++ standard, but on the GCC version (available from 12 onwards).