### PR TITLE
Fix constness in `init`/`start` overloads

### DIFF
--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -43,7 +43,7 @@ namespace pika::detail {
         }
 
         int call(pika::program_options::options_description const& desc_cmdline,
-            int argc, char** argv);
+            int argc, const char* const* argv);
 
         pika::program_options::variables_map vm_;
         pika::util::runtime_configuration rtcfg_;
@@ -79,7 +79,7 @@ namespace pika::detail {
         void enable_logging_settings(pika::program_options::variables_map& vm,
             std::vector<std::string>& ini_config);
 
-        void store_command_line(int argc, char** argv);
+        void store_command_line(int argc, const char* const* argv);
         void store_unregistered_options(std::string const& cmd_name,
             std::vector<std::string> const& unregistered_options);
         bool handle_help_options(
@@ -88,6 +88,6 @@ namespace pika::detail {
         void handle_attach_debugger();
 
         std::vector<std::string> preprocess_config_settings(
-            int argc, char** argv);
+            int argc, const char* const* argv);
     };
 }    // namespace pika::detail

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -664,7 +664,8 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void command_line_handling::store_command_line(int argc, char** argv)
+    void command_line_handling::store_command_line(
+        int argc, const char* const* argv)
     {
         // Collect the command line for diagnostic purposes.
         std::string command;
@@ -767,7 +768,7 @@ namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     // separate command line arguments from configuration settings
     std::vector<std::string> command_line_handling::preprocess_config_settings(
-        int argc, char** argv)
+        int argc, const char* const* argv)
     {
         std::vector<std::string> options;
         options.reserve(static_cast<std::size_t>(argc) + ini_config_.size());
@@ -823,7 +824,7 @@ namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     int command_line_handling::call(
         pika::program_options::options_description const& desc_cmdline,
-        int argc, char** argv)
+        int argc, const char* const* argv)
     {
         // set the flag signaling that command line parsing has been done
         cmd_line_parsed_ = true;

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -106,11 +106,13 @@ namespace pika {
         PIKA_EXPORT int run_or_start(
             util::function<int(pika::program_options::variables_map& vm)> const&
                 f,
-            int argc, char** argv, init_params const& params, bool blocking);
+            int argc, const char* const* argv, init_params const& params,
+            bool blocking);
 
         inline int init_start_impl(
             util::function<int(pika::program_options::variables_map&)> f,
-            int argc, char** argv, init_params const& params, bool blocking)
+            int argc, const char* const* argv, init_params const& params,
+            bool blocking)
         {
             if (argc == 0 || argv == nullptr)
             {
@@ -132,14 +134,14 @@ namespace pika {
     }    // namespace detail
 
     inline int init(std::function<int(pika::program_options::variables_map&)> f,
-        int const argc, char** const argv,
+        int argc, const char* const* argv,
         init_params const& params = init_params())
     {
         return detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, true);
     }
 
-    inline int init(std::function<int(int, char**)> f, int const argc,
-        char** const argv, init_params const& params = init_params())
+    inline int init(std::function<int(int, char**)> f, int argc,
+        const char* const* argv, init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f =
             pika::util::bind_back(pika::detail::init_helper, f);
@@ -147,7 +149,7 @@ namespace pika {
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    inline int init(std::function<int()> f, int const argc, char** const argv,
+    inline int init(std::function<int()> f, int argc, const char* const* argv,
         init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f =
@@ -156,7 +158,7 @@ namespace pika {
             PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    inline int init(std::nullptr_t, int const argc, char** const argv,
+    inline int init(std::nullptr_t, int argc, const char* const* argv,
         init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f;
@@ -165,16 +167,15 @@ namespace pika {
     }
 
     inline bool start(
-        std::function<int(pika::program_options::variables_map&)> f,
-        int const argc, char** const argv,
-        init_params const& params = init_params())
+        std::function<int(pika::program_options::variables_map&)> f, int argc,
+        const char* const* argv, init_params const& params = init_params())
     {
         return 0 ==
             detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, false);
     }
 
-    inline bool start(std::function<int(int, char**)> f, int argc, char** argv,
-        init_params const& params = init_params())
+    inline bool start(std::function<int(int, char**)> f, int argc,
+        const char* const* argv, init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f =
             pika::util::bind_back(pika::detail::init_helper, f);
@@ -183,7 +184,7 @@ namespace pika {
                 PIKA_MOVE(main_f), argc, argv, params, false);
     }
 
-    inline bool start(std::function<int()> f, int const argc, char** const argv,
+    inline bool start(std::function<int()> f, int argc, const char* const* argv,
         init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f =
@@ -193,7 +194,7 @@ namespace pika {
                 PIKA_MOVE(main_f), argc, argv, params, false);
     }
 
-    inline bool start(std::nullptr_t, int const argc, char** const argv,
+    inline bool start(std::nullptr_t, int argc, const char* const* argv,
         init_params const& params = init_params())
     {
         util::function<int(pika::program_options::variables_map&)> main_f;

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -425,7 +425,8 @@ namespace pika {
         int run_or_start(
             util::function<int(pika::program_options::variables_map& vm)> const&
                 f,
-            int argc, char** argv, init_params const& params, bool blocking)
+            int argc, const char* const* argv, init_params const& params,
+            bool blocking)
         {
             init_environment();
 

--- a/libs/pika/init_runtime/tests/unit/const_args_init.cpp
+++ b/libs/pika/init_runtime/tests/unit/const_args_init.cpp
@@ -3,20 +3,57 @@
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
-// This test checks that the runtime takes into account suspended threads before
-// initiating full shutdown.
 
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
+
+#include <vector>
 
 int pika_main()
 {
     return pika::finalize();
 }
 
-int main(const int argc, char** const argv)
+int main()
 {
-    PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+    int const argc = 1;
+    std::vector<char> name = {'t', 'e', 's', 't'};
+
+    {
+        char* argv[] = {name.data(), nullptr};
+
+        PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+
+        PIKA_TEST(pika::start(pika_main, argc, argv));
+        PIKA_TEST_EQ(pika::stop(), 0);
+    }
+
+    {
+        const char* argv[] = {name.data(), nullptr};
+
+        PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+
+        PIKA_TEST(pika::start(pika_main, argc, argv));
+        PIKA_TEST_EQ(pika::stop(), 0);
+    }
+
+    {
+        char* const argv[] = {name.data(), nullptr};
+
+        PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+
+        PIKA_TEST(pika::start(pika_main, argc, argv));
+        PIKA_TEST_EQ(pika::stop(), 0);
+    }
+
+    {
+        const char* const argv[] = {name.data(), nullptr};
+
+        PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
+
+        PIKA_TEST(pika::start(pika_main, argc, argv));
+        PIKA_TEST_EQ(pika::stop(), 0);
+    }
+
     return pika::util::report_errors();
 }


### PR DESCRIPTION
Removes const on the values themselves passed in `argc` and the pointer for `argv`. Adds `const` to the _pointees_ in `argv`.