### PR TITLE
Eagerly check for MPI request completion in `transform_mpi` and permit throttling

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_executor.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_executor.hpp
@@ -60,8 +60,7 @@ namespace pika { namespace mpi { namespace experimental {
 
         std::size_t in_flight_estimate() const
         {
-            return detail::get_mpi_info().active_requests_vector_size_ +
-                detail::get_mpi_info().requests_queue_size_;
+            return pika::mpi::experimental::get_num_requests_in_flight();
         }
 
     private:

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
@@ -120,7 +120,7 @@ namespace pika { namespace mpi { namespace experimental {
     /// and MPI function that generates an MPI_Request will be suspended.
     /// This should be used with great caution as setting it too low can
     /// cause deadlocks. The default value is size_t(-1) - i.e. unlimited
-    /// The value can be set using an environment variable as folows
+    /// The value can be set using an environment variable as follows
     /// PIKA_MPI_MSG_THROTTLE=512
     /// but user code setting it will override any default or env value
     /// This function returns the previous throttling threshold value
@@ -200,13 +200,4 @@ namespace pika { namespace mpi { namespace experimental {
     private:
         std::string pool_name_;
     };
-
-    // -----------------------------------------------------------------
-    //    template <typename... Args>
-    //    inline void debug(const char *title, Args&&... args)
-    //    {
-    //        if constexpr (mpi_debug.is_enabled())
-    //                mpi_debug.debug(debug::str<>(title),
-    //                                detail::get_mpi_info(), PIKA_FORWARD(Args, args)...);
-    //    }
 }}}    // namespace pika::mpi::experimental

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -191,6 +191,9 @@ namespace pika { namespace mpi { namespace experimental {
                                 }
                                 else
                                 {
+                                    // throttle if too many "in flight"
+                                    wait_for_throttling();
+
                                     pika::util::invoke_fused(
                                         [&](auto&... ts) mutable {
                                             r.op_state.result.template emplace<

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -174,6 +174,9 @@ namespace pika { namespace mpi { namespace experimental {
                                 using invoke_result_type =
                                     mpi_request_invoke_result_t<F, Ts...>;
 
+                                // throttle if too many "in flight"
+                                wait_for_throttling();
+
                                 if constexpr (std::is_void_v<
                                                   invoke_result_type>)
                                 {
@@ -191,9 +194,6 @@ namespace pika { namespace mpi { namespace experimental {
                                 }
                                 else
                                 {
-                                    // throttle if too many "in flight"
-                                    wait_for_throttling();
-
                                     pika::util::invoke_fused(
                                         [&](auto&... ts) mutable {
                                             r.op_state.result.template emplace<

--- a/libs/pika/async_mpi/src/mpi_future.cpp
+++ b/libs/pika/async_mpi/src/mpi_future.cpp
@@ -386,7 +386,9 @@ namespace pika { namespace mpi { namespace experimental {
                 detail::mpi_data_.status_vector_.data());
 
         if (result != MPI_SUCCESS)
-            std::terminate();
+        {
+            throw mpi_exception(result, "Testsome error");
+        }
 
         if constexpr (mpi_debug.is_enabled())
         {
@@ -401,10 +403,6 @@ namespace pika { namespace mpi { namespace experimental {
         for (int i = 0; i < outcount; ++i)
         {
             size_t index = detail::mpi_data_.indices_vector_[i];
-            if (detail::mpi_data_.status_vector_[i].MPI_ERROR != MPI_SUCCESS)
-            {
-                std::terminate();
-            }
 
             if constexpr (mpi_debug.is_enabled())
             {
@@ -420,7 +418,8 @@ namespace pika { namespace mpi { namespace experimental {
 
             // Invoke the callback with the status of the completed
             // operation (status of the request is forwarded to MPI_Testany)
-            detail::mpi_data_.callback_vector_[index](result);
+            detail::mpi_data_.callback_vector_[index](
+                detail::mpi_data_.status_vector_[i].MPI_ERROR);
 
             // Remove the request from our vector to prevent retesting
             detail::mpi_data_.callback_vector_[index].reset();

--- a/libs/pika/async_mpi/src/mpi_future.cpp
+++ b/libs/pika/async_mpi/src/mpi_future.cpp
@@ -11,6 +11,7 @@
 #include <pika/modules/errors.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi_environment.hpp>
+#include <pika/synchronization/condition_variable.hpp>
 #include <pika/synchronization/mutex.hpp>
 
 #include <atomic>
@@ -28,86 +29,190 @@ namespace pika { namespace mpi { namespace experimental {
 
     namespace detail {
 
-        // Holds an MPI_Request and a callback. The callback is intended to be
-        // called when the operation tight to the request handle is finished.
+        // -----------------------------------------------------------------
+        /// Holds an MPI_Request and a callback. The callback is intended to be
+        /// called when the operation tied to the request handle completes.
         struct request_callback
         {
             MPI_Request request;
             request_callback_function_type callback_function;
         };
 
+        // -----------------------------------------------------------------
+        /// When a user first initiates an MPI call, a request is generated
+        /// and a callback associated with it. We place these on a (lock-free) queue
+        /// to avoid taking a lock on every invocation of an MPI function.
+        /// When a thread polls for MPI completions, it moves the request_callback(s)
+        /// into a vector that is passed to the mpi test function
         using request_callback_queue_type =
             concurrency::detail::ConcurrentQueue<request_callback>;
 
-        request_callback_queue_type& get_request_callback_queue()
+        // -----------------------------------------------------------------
+        /// Spinlock is used as it can be called by OS threads or pika tasks
+        using mutex_type = pika::lcos::local::spinlock;
+
+        // -----------------------------------------------------------------
+        /// Queries an environment variable to get/override a default value for
+        /// the number of messages allowed 'in flight' before we throttle a
+        /// thread trying to send more data
+        size_t get_throttling_default();
+
+        // -----------------------------------------------------------------
+        /// a convenience structure to hold state vars in one place
+        struct mpi_data
         {
-            static request_callback_queue_type request_callback_queue;
-            return request_callback_queue;
+            bool error_handler_initialized_ = false;
+            int rank_ = -1;
+            int size_ = -1;
+
+            // requests vector holds the requests that are checked; this
+            // represents the number of active requests in the vector, not the
+            // size of the vector
+            std::atomic<size_t> active_request_vector_size_{0};
+            // requests queue holds the requests recently added
+            std::atomic<size_t> request_queue_size_{0};
+            // The sum of messages in queue + vector
+            std::atomic<size_t> in_flight_{0};
+            // for debugging of code creating/destroying polling handlers
+            std::atomic<size_t> register_polling_count_{0};
+
+            // Principal storage of requests for polling
+            // we track requests and callbacks in two vectors
+            // because we can use MPI_Testany/MPI_Testsome
+            // with a vector of requests to save overheads compared
+            // to testing one by one every item (using a list)
+            request_callback_queue_type request_callback_queue_;
+            std::vector<MPI_Request> request_vector_;
+            std::vector<request_callback_function_type> callback_vector_;
+
+            // mutex needed to protect mpi request vector, note that the
+            // mpi poll function usually takes place inside the main scheduling loop
+            // though poll may also be callled directly by a user task.
+            // we use a spinlock for both cases
+            mutex_type polling_vector_mtx_;
+
+            // variables used when throttling mpi traffic,
+            mutex_type throttling_mtx_;
+            pika::lcos::local::condition_variable throttling_cond_;
+            size_t throttling_limit_ = get_throttling_default();
+        };
+
+        /// a single instance of all the mpi variables initialized once at startup
+        static mpi_data mpi_data_;
+
+        // stream operator to display debug mpi_data
+        PIKA_EXPORT std::ostream& operator<<(
+            std::ostream& os, mpi_data const& info)
+        {
+            // clang-format off
+            os << "R "
+               << debug::dec<3>(info.rank_) << "/" << debug::dec<3>(info.size_)
+               << " vector " << debug::dec<4>(info.active_request_vector_size_)
+               << " queued " << debug::dec<4>(info.request_queue_size_)
+               << " in-flight " << debug::dec<4>(info.in_flight_)
+               << " vec_cb " << debug::dec<3>(info.callback_vector_.size())
+               << " vec_rq " << debug::dec<3>(info.request_vector_.size());
+
+            // clang-format on
+            return os;
         }
 
-        using request_callback_vector_type = std::vector<request_callback>;
-
-        request_callback_vector_type& get_request_callback_vector()
+        // -----------------------------------------------------------------
+        // When debugging, it might be useful to know how many
+        // MPI_REQUEST_NULL messages are currently in our vector
+        inline size_t get_num_null_requests_in_vector()
         {
-            static request_callback_vector_type request_callback_vector;
-            return request_callback_vector;
+            std::vector<MPI_Request>& vec = mpi_data_.request_vector_;
+            return std::count_if(vec.begin(), vec.end(),
+                [](MPI_Request r) { return r == MPI_REQUEST_NULL; });
         }
 
-        std::size_t get_num_active_requests_in_vector()
+        // -----------------------------------------------------------------
+        void wait_for_throttling()
         {
-            return std::count_if(detail::get_requests_vector().begin(),
-                detail::get_requests_vector().end(),
-                [](MPI_Request r) { return r != MPI_REQUEST_NULL; });
+            if (mpi_data_.in_flight_ < mpi_data_.throttling_limit_)
+            {
+                return;
+            }
+            // we don't bother with a condition/predicate, because it would be racy,
+            // (any thread can post more messages between when we are woken and
+            // when we test the "in_flight" condition)
+            // and if we have any spurious wakeup, we don't really care as it just
+            // means an extra message would be posted
+            std::unique_lock lk(mpi_data_.throttling_mtx_);
+            mpi_data_.throttling_cond_.wait(lk);
         }
 
-        // used internally to add an MPI_Request to the lockfree queue
-        // that will be used by the polling routines to check when requests
-        // have completed
+        // -----------------------------------------------------------------
+        size_t get_throttling_default()
+        {
+            size_t def = size_t(-1);    // unlimited
+            char* env = std::getenv("PIKA_MPI_MSG_THROTTLE");
+            if (env)
+            {
+                def = std::atoi(env);
+                // badly formed env var
+                if (def == 0)
+                    def = size_t(-1);    // unlimited
+                mpi_debug.debug(debug::str<>("throttling"), "default", def);
+            }
+            return def;
+        }
+
+        // -----------------------------------------------------------------
+        /// used internally to add an MPI_Request to the lockfree queue
+        /// that will be used by the polling routines to check when requests
+        /// have completed
         void add_to_request_callback_queue(request_callback&& req_callback)
         {
-            get_request_callback_queue().enqueue(PIKA_MOVE(req_callback));
-            ++(get_mpi_info().requests_queue_size_);
+            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
+            ++mpi_data_.request_queue_size_;
+            ++mpi_data_.in_flight_;
 
             if constexpr (mpi_debug.is_enabled())
             {
-                mpi_debug.debug(debug::str<>("request callback queued"),
-                    get_mpi_info(), "request",
+                mpi_debug.debug(debug::str<>("CB queued"), mpi_data_, "request",
                     debug::hex<8>(req_callback.request));
             }
         }
 
-        // used internally to add a request to the main polling vector
-        // that is passed to MPI_Testany
-        void add_to_request_callback_vector(request_callback&& req_callback)
+        // -----------------------------------------------------------------
+        /// used internally to add a request to the main polling vector
+        /// that is passed to MPI_Testany. This is only called inside the
+        /// polling function when a lock is held, so only one thread
+        /// at a time ever enters here
+        inline void add_to_request_callback_vector(
+            request_callback&& req_callback)
         {
-            get_requests_vector().push_back(req_callback.request);
-            get_request_callback_vector().push_back(PIKA_MOVE(req_callback));
-            ++(get_mpi_info().active_requests_vector_size_);
+            mpi_data_.request_vector_.push_back(req_callback.request);
+            mpi_data_.callback_vector_.push_back(
+                PIKA_MOVE(req_callback.callback_function));
+            ++(mpi_data_.active_request_vector_size_);
 
             if constexpr (mpi_debug.is_enabled())
             {
-                mpi_debug.debug(
-                    debug::str<>("request callback moved from queue to vector"),
-                    get_mpi_info(), "request",
-                    debug::hex<8>(req_callback.request), "callbacks in vector",
-                    debug::dec<3>(get_request_callback_vector().size()),
-                    "non null",
-                    debug::dec<3>(get_num_active_requests_in_vector()));
+                // clang-format off
+                mpi_debug.debug(debug::str<>("CB queue => vector"),
+                    mpi_data_,
+                    "request", debug::hex<8>(req_callback.request),
+                    "callbacks", debug::dec<3>(mpi_data_.callback_vector_.size()),
+                    "requests", debug::dec<3>(mpi_data_.request_vector_.size()),
+                    "null", debug::dec<3>(get_num_null_requests_in_vector()));
+                // clang-format on
             }
         }
 
 #if defined(PIKA_DEBUG)
-        std::atomic<std::size_t>& get_register_polling_count()
+        std::atomic<size_t>& get_register_polling_count()
         {
-            static std::atomic<std::size_t> register_polling_count{0};
-            return register_polling_count;
+            return mpi_data_.register_polling_count_;
         }
 #endif
 
         void add_request_callback(
             request_callback_function_type&& callback, MPI_Request request)
         {
-            PIKA_ASSERT_MSG(detail::get_register_polling_count() != 0,
+            PIKA_ASSERT_MSG(get_register_polling_count() != 0,
                 "MPI event polling has not been enabled on any pool. Make sure "
                 "that MPI event polling is enabled on at least one thread "
                 "pool.");
@@ -118,60 +223,42 @@ namespace pika { namespace mpi { namespace experimental {
             int result = MPI_Test(&request, &flag, MPI_STATUS_IGNORE);
             if (flag)
             {
+                mpi_debug.debug(debug::str<>("eager poll"), "success");
                 PIKA_INVOKE(PIKA_MOVE(callback), result);
                 return;
             }
 
-            detail::add_to_request_callback_queue(
+            add_to_request_callback_queue(
                 request_callback{request, PIKA_MOVE(callback)});
-        }
-
-        // mutex needed to protect mpi request vector, note that the
-        // mpi poll function takes place inside the main scheduling loop
-        // of pika and not on an pika worker thread, so we must use std:mutex
-        mutex_type& get_vector_mtx()
-        {
-            static mutex_type vector_mtx;
-            return vector_mtx;
         }
 
         // an MPI error handling type that we can use to intercept
         // MPI errors if we enable the error handler
         MPI_Errhandler pika_mpi_errhandler = 0;
 
-        // an instance of mpi_info that we store data in
-        mpi_info& get_mpi_info()
-        {
-            static mpi_info mpi_info_;
-            return mpi_info_;
-        }
-
-        // stream operator to display debug mpi_info
-        PIKA_EXPORT std::ostream& operator<<(std::ostream& os, mpi_info const&)
-        {
-            os << "R " << debug::dec<3>(get_mpi_info().rank_) << "/"
-               << debug::dec<3>(get_mpi_info().size_)
-               << " active requests in vector "
-               << debug::dec<3>(get_mpi_info().active_requests_vector_size_)
-               << " queued requests "
-               << debug::dec<3>(get_mpi_info().requests_queue_size_);
-            return os;
-        }
-
         // function that converts an MPI error into an exception
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
             mpi_debug.debug(debug::str<>("pika_MPI_Handler"));
-            PIKA_THROW_EXCEPTION(invalid_status, "pika_MPI_Handler",
-                detail::error_message(*errorcode));
-        }
-
-        std::vector<MPI_Request>& get_requests_vector()
-        {
-            static std::vector<MPI_Request> requests_vector;
-            return requests_vector;
+            PIKA_THROW_EXCEPTION(
+                invalid_status, "pika_MPI_Handler", error_message(*errorcode));
         }
     }    // namespace detail
+
+    size_t set_max_requests_in_flight(size_t N)
+    {
+        return std::exchange(detail::mpi_data_.throttling_limit_, N);
+    }
+
+    size_t get_max_requests_in_flight()
+    {
+        return detail::mpi_data_.throttling_limit_;
+    }
+
+    size_t get_num_requests_in_flight()
+    {
+        return detail::mpi_data_.in_flight_;
+    }
 
     // return a future object from a user supplied MPI_Request
     pika::future<void> get_future(MPI_Request request)
@@ -205,6 +292,38 @@ namespace pika { namespace mpi { namespace experimental {
         MPI_Comm_set_errhandler(MPI_COMM_WORLD, detail::pika_mpi_errhandler);
     }
 
+    /// Remove all entries in request and callback vectors that are invalid
+    /// Ideally, would use a zip iterator to do both using remove_if
+    void compact_vectors()
+    {
+        size_t const size = detail::mpi_data_.request_vector_.size();
+        size_t pos = size;
+        // find index of first NULL request
+        for (size_t i = 0; i < size; ++i)
+        {
+            if (detail::mpi_data_.request_vector_[i] == MPI_REQUEST_NULL)
+            {
+                pos = i;
+                break;
+            }
+        }
+        // move all non NULL requests/callbacks towards beginning of vector.
+        for (size_t i = pos + 1; i < size; ++i)
+        {
+            if (detail::mpi_data_.request_vector_[i] != MPI_REQUEST_NULL)
+            {
+                detail::mpi_data_.request_vector_[pos] =
+                    detail::mpi_data_.request_vector_[i];
+                detail::mpi_data_.callback_vector_[pos] =
+                    PIKA_MOVE(detail::mpi_data_.callback_vector_[i]);
+                pos++;
+            }
+        }
+        // and trim off the space we didn't need
+        detail::mpi_data_.request_vector_.resize(pos);
+        detail::mpi_data_.callback_vector_.resize(pos);
+    }
+
     // Background progress function for MPI async operations
     // Checks for completed MPI_Requests and sets mpi::experimental::future
     // ready when found
@@ -212,11 +331,8 @@ namespace pika { namespace mpi { namespace experimental {
     {
         using pika::threads::policies::detail::polling_status;
 
-        auto& request_callback_vector = detail::get_request_callback_vector();
-        auto& requests_vector = detail::get_requests_vector();
-
         std::unique_lock<detail::mutex_type> lk(
-            detail::get_vector_mtx(), std::try_to_lock);
+            detail::mpi_data_.polling_vector_mtx_, std::try_to_lock);
         if (!lk.owns_lock())
         {
             if constexpr (mpi_debug.is_enabled())
@@ -225,7 +341,7 @@ namespace pika { namespace mpi { namespace experimental {
                 static auto poll_deb =
                     mpi_debug.make_timer(1, debug::str<>("Poll - lock failed"));
                 // output mpi debug info every N seconds
-                mpi_debug.timed(poll_deb, detail::get_mpi_info());
+                mpi_debug.timed(poll_deb, detail::mpi_data_);
             }
             return polling_status::idle;
         }
@@ -236,29 +352,38 @@ namespace pika { namespace mpi { namespace experimental {
             static auto poll_deb =
                 mpi_debug.make_timer(1, debug::str<>("Poll - lock success"));
             // output mpi debug info every N seconds
-            mpi_debug.timed(poll_deb, detail::get_mpi_info());
+            mpi_debug.timed(poll_deb, detail::mpi_data_);
         }
 
         {
-            // have any requests been made that need to be handled?
+            // Before moving requests from the queue to the vector
+            compact_vectors();
+
+            // Move requests in the queue (that have not yet been polled for)
+            // into the polling vector ...
+            // number in_flight does not change during this section as one
+            // is popped off the queue and added to the vector
+
             detail::request_callback req_callback;
-            while (
-                detail::get_request_callback_queue().try_dequeue(req_callback))
+            while (detail::mpi_data_.request_callback_queue_.try_dequeue(
+                req_callback))
             {
-                --(detail::get_mpi_info().requests_queue_size_);
+                --detail::mpi_data_.request_queue_size_;
                 add_to_request_callback_vector(PIKA_MOVE(req_callback));
             }
         }
 
-        bool keep_trying = !requests_vector.empty();
+        bool keep_trying = !detail::mpi_data_.request_vector_.empty();
         while (keep_trying)
         {
             int index = 0;
             int flag = false;
             MPI_Status status;
 
-            int result = MPI_Testany(static_cast<int>(requests_vector.size()),
-                requests_vector.data(), &index, &flag, &status);
+            int result = MPI_Testany(
+                static_cast<int>(detail::mpi_data_.request_vector_.size()),
+                detail::mpi_data_.request_vector_.data(), &index, &flag,
+                &status);
 
             if constexpr (mpi_debug.is_enabled())
             {
@@ -267,8 +392,8 @@ namespace pika { namespace mpi { namespace experimental {
                     static auto poll_deb =
                         mpi_debug.make_timer(1, debug::str<>("Poll - success"));
 
-                    mpi_debug.timed(poll_deb, detail::get_mpi_info(),
-                        debug::str<>("Success"), "index",
+                    mpi_debug.timed(poll_deb, detail::mpi_data_, "success",
+                        "index",
                         debug::dec<>(index == MPI_UNDEFINED ? -1 : index),
                         "flag", debug::dec<>(flag), "status",
                         debug::hex(status.MPI_ERROR));
@@ -278,10 +403,9 @@ namespace pika { namespace mpi { namespace experimental {
                     auto poll_deb =
                         mpi_debug.make_timer(1, debug::str<>("Poll - <ERR>"));
 
-                    mpi_debug.error(poll_deb, detail::get_mpi_info(),
-                        debug::str<>("Poll <ERR>"), "MPI_ERROR",
-                        detail::error_message(status.MPI_ERROR), "status",
-                        debug::dec<>(status.MPI_ERROR), "index",
+                    mpi_debug.error(poll_deb, detail::mpi_data_, "Poll <ERR>",
+                        "MPI_ERROR", detail::error_message(status.MPI_ERROR),
+                        "status", debug::dec<>(status.MPI_ERROR), "index",
                         debug::dec<>(index), "flag", debug::dec<>(flag));
                 }
             }
@@ -297,89 +421,57 @@ namespace pika { namespace mpi { namespace experimental {
                 if (keep_trying)
                 {
                     mpi_debug.debug(debug::str<>("MPI_Testany(set)"),
-                        detail::get_mpi_info(), "request",
-                        debug::hex<8>(requests_vector[std::size_t(index)]),
-                        "vector size", debug::dec<3>(requests_vector.size()),
+                        detail::mpi_data_, "request",
+                        debug::hex<8>(
+                            detail::mpi_data_.request_vector_[size_t(index)]),
+                        "vector size",
+                        debug::dec<3>(detail::mpi_data_.request_vector_.size()),
                         "non null",
                         debug::dec<3>(
-                            detail::get_num_active_requests_in_vector()));
+                            detail::get_num_null_requests_in_vector()));
                 }
             }
+
             if (result != MPI_SUCCESS)    // Error and operation not completed
                 keep_trying = false;
+
             if (keep_trying || result != MPI_SUCCESS)
             {
+                // decrement before invoking callback to avoid race
+                // if invoked code checks value
+                size_t inflight = --detail::mpi_data_.in_flight_;
+                --detail::mpi_data_.active_request_vector_size_;
+
                 // Invoke the callback with the status of the completed
                 // operation (status of the request is forwarded to MPI_Testany)
-                request_callback_vector[std::size_t(index)].callback_function(
+                detail::mpi_data_.callback_vector_[size_t(index)].operator()(
                     result);
 
                 // Remove the request from our vector to prevent retesting
-                requests_vector[std::size_t(index)] = MPI_REQUEST_NULL;
-
-                // Could store only the callbacks, right now the request
-                // is only used for an assert
-                request_callback_vector[std::size_t(index)].request =
+                detail::mpi_data_.callback_vector_[size_t(index)].reset();
+                detail::mpi_data_.request_vector_[size_t(index)] =
                     MPI_REQUEST_NULL;
 
-                --(detail::get_mpi_info().active_requests_vector_size_);
-            }
-        }
-
-        // if there are more than 25% NULL request handles in our vector,
-        // compact them
-        if (!requests_vector.empty())
-        {
-            std::size_t nulls = std::count(requests_vector.begin(),
-                requests_vector.end(), MPI_REQUEST_NULL);
-
-            if (nulls > requests_vector.size() / 4)
-            {
-                // compact away any requests that have been replaced by
-                // MPI_REQUEST_NULL
-                auto end1 = std::remove(requests_vector.begin(),
-                    requests_vector.end(), MPI_REQUEST_NULL);
-                requests_vector.resize(
-                    std::distance(requests_vector.begin(), end1));
-
-                auto end2 = std::remove_if(request_callback_vector.begin(),
-                    request_callback_vector.end(),
-                    [](detail::request_callback& req_callback) {
-                        return req_callback.request == MPI_REQUEST_NULL;
-                    });
-                request_callback_vector.resize(
-                    std::distance(request_callback_vector.begin(), end2));
-
-                if (requests_vector.size() != request_callback_vector.size())
+                // wake any thread that is waiting for throttling
+                if (inflight < detail::mpi_data_.throttling_limit_)
                 {
-                    PIKA_THROW_EXCEPTION(invalid_status,
-                        "pika::mpi::experimental::poll",
-                        "Fatal Error: Mismatch in vectors");
-                }
-
-                detail::get_mpi_info().active_requests_vector_size_ =
-                    static_cast<std::uint32_t>(requests_vector.size());
-
-                if constexpr (mpi_debug.is_enabled())
-                {
-                    mpi_debug.debug(debug::str<>("MPI_REQUEST_NULL"),
-                        detail::get_mpi_info(), "nulls ", debug::dec<>(nulls));
+                    mpi_debug.debug(debug::str<>("throttling"), "notify_one",
+                        "in_flight", debug::dec<4>(inflight));
+                    detail::mpi_data_.throttling_cond_.notify_one();
                 }
             }
         }
 
-        return requests_vector.empty() ? polling_status::idle :
-                                         polling_status::busy;
+        return detail::mpi_data_.request_vector_.empty() ?
+            polling_status::idle :
+            polling_status::busy;
     }
 
     namespace detail {
-        std::size_t get_work_count()
+        size_t get_work_count()
         {
-            std::size_t work_count =
-                get_mpi_info().active_requests_vector_size_;
-            work_count += get_mpi_info().requests_queue_size_;
-
-            return work_count;
+            return mpi_data_.active_request_vector_size_ +
+                mpi_data_.request_queue_size_;
         }
 
         // -------------------------------------------------------------
@@ -400,17 +492,17 @@ namespace pika { namespace mpi { namespace experimental {
 #if defined(PIKA_DEBUG)
             {
                 std::unique_lock<pika::mpi::experimental::detail::mutex_type>
-                    lk(detail::get_vector_mtx());
-                bool requests_queue_empty =
-                    get_request_callback_queue().size_approx() == 0;
-                bool requests_vector_empty =
-                    get_num_active_requests_in_vector() == 0;
+                    lk(detail::mpi_data_.polling_vector_mtx_);
+                bool request_queue_empty =
+                    detail::mpi_data_.request_callback_queue_.size_approx() ==
+                    0;
+                bool request_vector_empty = detail::mpi_data_.in_flight_ == 0;
                 lk.unlock();
-                PIKA_ASSERT_MSG(requests_queue_empty,
+                PIKA_ASSERT_MSG(request_queue_empty,
                     "MPI request polling was disabled while there are "
                     "unprocessed MPI requests. Make sure MPI request polling "
                     "is not disabled too early.");
-                PIKA_ASSERT_MSG(requests_vector_empty,
+                PIKA_ASSERT_MSG(request_vector_empty,
                     "MPI request polling was disabled while there are active "
                     "MPI futures. Make sure MPI request polling is not "
                     "disabled too early.");
@@ -444,33 +536,31 @@ namespace pika { namespace mpi { namespace experimental {
                     "pika::mpi::experimental::init",
                     "the MPI installation doesn't allow multiple threads");
             }
-            MPI_Comm_rank(MPI_COMM_WORLD, &detail::get_mpi_info().rank_);
-            MPI_Comm_size(MPI_COMM_WORLD, &detail::get_mpi_info().size_);
+            MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
+            MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
         }
         else
         {
             // Check if MPI_Init has been called previously
-            if (detail::get_mpi_info().size_ == -1)
+            if (detail::mpi_data_.size_ == -1)
             {
                 int is_initialized = 0;
                 MPI_Initialized(&is_initialized);
                 if (is_initialized)
                 {
-                    MPI_Comm_rank(
-                        MPI_COMM_WORLD, &detail::get_mpi_info().rank_);
-                    MPI_Comm_size(
-                        MPI_COMM_WORLD, &detail::get_mpi_info().size_);
+                    MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
+                    MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
                 }
             }
         }
 
-        mpi_debug.debug(debug::str<>("pika::mpi::experimental::init"),
-            detail::get_mpi_info());
+        mpi_debug.debug(
+            debug::str<>("pika::mpi::experimental::init"), detail::mpi_data_);
 
         if (init_errorhandler)
         {
             set_error_handler();
-            detail::get_mpi_info().error_handler_initialized_ = true;
+            detail::mpi_data_.error_handler_initialized_ = true;
         }
 
         // install polling loop on requested thread pool
@@ -489,10 +579,10 @@ namespace pika { namespace mpi { namespace experimental {
 
     void finalize(std::string const& pool_name)
     {
-        if (detail::get_mpi_info().error_handler_initialized_)
+        if (detail::mpi_data_.error_handler_initialized_)
         {
             PIKA_ASSERT(detail::pika_mpi_errhandler != 0);
-            detail::get_mpi_info().error_handler_initialized_ = false;
+            detail::mpi_data_.error_handler_initialized_ = false;
             MPI_Errhandler_free(&detail::pika_mpi_errhandler);
             detail::pika_mpi_errhandler = 0;
         }
@@ -500,7 +590,7 @@ namespace pika { namespace mpi { namespace experimental {
         // clean up if we initialized mpi
         pika::util::mpi_environment::finalize();
 
-        mpi_debug.debug(debug::str<>("Clearing mode"), detail::get_mpi_info(),
+        mpi_debug.debug(debug::str<>("Clearing mode"), detail::mpi_data_,
             "disable_user_polling");
 
         if (pool_name.empty())

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,9 +4,15 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests mpi_ring_async_executor algorithm_transform_mpi)
+set(tests mpi_ring_async_executor algorithm_transform_mpi
+          mpi_ring_async_sender_receiver mpi_async_storage
+)
 
 set(mpi_ring_async_executor_PARAMETERS THREADS 4 LOCALITIES 2 RUNWRAPPER mpi)
+set(mpi_ring_async_sender_receiver_PARAMETERS THREADS 4 LOCALITIES 2 RUNWRAPPER
+                                              mpi
+)
+set(mpi_async_storage_PARAMETERS THREADS 4 LOCALITIES 2 RUNWRAPPER mpi)
 
 set(algorithm_transform_mpi_PARAMETERS LOCALITIES 2 RUNWRAPPER mpi)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -1,0 +1,545 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
+#include <pika/init.hpp>
+#include <pika/mpi.hpp>
+#include <pika/program_options.hpp>
+#include <pika/testing.hpp>
+
+#include <pika/config.hpp>
+#include <pika/execution_base/this_thread.hpp>
+#include <pika/modules/format.hpp>
+#include <pika/mpi_base/mpi_environment.hpp>
+#include <pika/threading_base/print.hpp>
+//
+#define RANK_OUTPUT (rank == 0)
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <string>
+#include <vector>
+
+// a debug level of zero disables messages with a priority>0
+// a debug level of N shows messages with priority<N
+constexpr int debug_level = 0;
+
+// cppcheck-suppress ConfigurationNotChecked
+template <int Level>
+static pika::debug::print_threshold<Level, debug_level> nws_deb("STORAGE");
+
+//----------------------------------------------------------------------------
+// #defines to control program
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+#define TEST_SUCCESS 0
+#define TEST_FAIL 1
+
+//----------------------------------------------------------------------------
+//
+// Each locality allocates a buffer of memory which is used to host transfers
+//
+static pika::util::detail::spinlock storage_mutex;
+using local_storage_type = std::vector<char>;
+static local_storage_type local_send_storage;
+static local_storage_type local_recv_storage;
+
+//----------------------------------------------------------------------------
+// namespace aliases
+//----------------------------------------------------------------------------
+namespace ex = pika::execution::experimental;
+namespace mpi = pika::mpi::experimental;
+namespace tt = pika::this_thread::experimental;
+namespace deb = pika::debug;
+
+//----------------------------------------------------------------------------
+// namespace aliases
+//----------------------------------------------------------------------------
+struct test_options
+{
+    std::uint64_t local_storage_MB;
+    std::uint64_t global_storage_MB;
+    std::uint64_t transfer_size_B;
+    std::uint64_t threads;
+    std::uint64_t num_seconds;
+    std::uint64_t in_flight_limit;
+
+    bool warmup;
+    bool final;
+    bool auto_throttling;
+    bool yield;
+};
+
+//----------------------------------------------------------------------------
+struct perf
+{
+    size_t rank;
+    size_t nranks;
+    double dataMB;
+    double time;
+    double IOPs;
+    std::string mode;
+};
+
+//----------------------------------------------------------------------------
+void display(perf const& data, const test_options& options)
+{
+    std::stringstream temp;
+    double IOPs_s = data.IOPs / data.time;
+    double BW = data.dataMB / data.time;
+    if (data.rank == 0 && !options.warmup)
+    {
+        temp << "\n";
+        temp << "Rank                 : " << data.rank << " / " << data.nranks
+             << "\n";
+        temp << "Total time           : " << data.time << "\n";
+        temp << "Memory Transferred   : " << data.dataMB << " MB\n";
+        temp << "Number of local IOPs : " << data.IOPs << "\n";
+        temp << "IOPs/s (local)       : " << IOPs_s << "\n";
+        temp << "Aggregate BW         : " << BW << " MB/s";
+        temp << "\n";
+        // a complete set of results that our python matplotlib script will ingest
+        char const* msg =
+            "CSVData, {8}, network, "
+            "{1}, ranks, {2}, threads, {3}, Memory, {4}, IOPsize, {5}, "
+            "IOPS/s, {6}, BW(MB/s), {7}, ";
+        if (/*options.final && */ !options.warmup)
+        {
+            pika::util::format_to(temp, msg, "mpi", data.nranks,
+                options.threads, data.dataMB, options.transfer_size_B, IOPs_s,
+                BW, data.mode.c_str())
+                << std::endl;
+        }
+        std::cout << temp.str() << std::endl;
+    }
+}
+
+//----------------------------------------------------------------------------
+static std::vector<perf> performance_figures;
+static std::atomic<size_t> results_received{0};
+static test_options options;
+
+//----------------------------------------------------------------------------
+static std::atomic<uint32_t> sends_in_flight;
+static std::atomic<uint32_t> recvs_in_flight;
+
+//----------------------------------------------------------------------------
+// Test speed of write/put
+void test_send_recv(uint32_t rank, uint32_t nranks, std::mt19937& gen,
+    std::uniform_int_distribution<uint64_t>& random_offset,
+    std::uniform_int_distribution<uint64_t>& random_slot, test_options& options)
+{
+    static deb::print_threshold<1, debug_level> write_arr(" WRITE ");
+
+    // this needs to scope all uses of mpi::experimental::executor
+    mpi::enable_user_polling enable_polling;
+
+    pika::scoped_annotation annotate("test_write");
+    std::stringstream temp;
+    temp << deb::detail::hostname_print_helper();
+    std::string name = temp.str() + "-test-write.prof";
+    std::replace(name.begin(), name.end(), ':', '-');
+
+    results_received = 0;
+    sends_in_flight = 0;
+    recvs_in_flight = 0;
+    uint64_t messages_sent = 0;
+    //
+    if (rank == 0)
+    {
+        std::cout << (options.warmup ? "Warmup   " : "Progress ");
+    }
+
+    // generate an array of location offsets where we are going to send data
+    constexpr size_t array_size = 1024;
+    std::array<std::size_t, array_size> offsets, sends, recvs;
+    std::generate(
+        offsets.begin(), offsets.end(), [&]() { return random_offset(gen); });
+    std::transform(offsets.begin(), offsets.end(), sends.begin(),
+        [&](std::size_t& offset) { return (rank + offset) % nranks; });
+    std::transform(offsets.begin(), offsets.end(), recvs.begin(),
+        [&](std::size_t& offset) { return (rank - offset) % nranks; });
+
+    std::string tempstr = "rank " + std::to_string(rank);
+    write_arr.array(
+        tempstr + " # offset  ", &offsets[0], std::min(array_size, 32ul));
+    write_arr.array(
+        tempstr + " # send    ", &sends[0], std::min(array_size, 32ul));
+    write_arr.array(
+        tempstr + " # recv    ", &recvs[0], std::min(array_size, 32ul));
+
+    // ----------------------------------------------------------------
+    nws_deb<2>.debug("Entering Barrier at start of write on rank", rank);
+    MPI_Barrier(MPI_COMM_WORLD);
+    nws_deb<2>.debug("Passed Barrier at start of write on rank", rank);
+    // ----------------------------------------------------------------
+
+    // create a timer object with a 1s tick
+    auto debug_timer = nws_deb<0>.make_timer(1);
+    int debug_tick = 0;
+
+    std::vector<MPI_Request> recvsr(nranks);
+    std::vector<MPI_Request> sendsr(nranks);
+    std::vector<MPI_Status> recvss(nranks);
+    std::vector<MPI_Status> sendss(nranks);
+    recvsr[rank] = MPI_REQUEST_NULL;
+    sendsr[rank] = MPI_REQUEST_NULL;
+    std::vector<uint64_t> counts(nranks, 0);
+
+    //
+    // Start main message sending loop
+    //
+    pika::chrono::high_resolution_timer exec_timer;
+    uint64_t final_count = std::numeric_limits<uint64_t>().max();
+    bool count_complete = false;
+    bool time_up;
+    // loop for allowed time : sending and receiving
+    do
+    {
+        // read from a random slot on this node
+        // (and ideally write to a random slot on remote node)
+        int read_slot = random_slot(gen);
+        int write_slot = random_slot(gen);
+
+        uint32_t memory_offset_recv =
+            static_cast<uint32_t>(read_slot * options.transfer_size_B);
+        uint32_t memory_offset_send =
+            static_cast<uint32_t>(write_slot * options.transfer_size_B);
+
+        // next message to recv from here
+        uint32_t recv_rank = recvs[messages_sent % array_size];
+        // next message to send goes here
+        uint32_t send_rank = sends[messages_sent % array_size];
+        //
+        int tag = messages_sent & 0xffff;
+        {
+            // we are about to recv, so increment our counter
+            ++recvs_in_flight;
+            // clang-format off
+            nws_deb<5>.debug(deb::str<>("posting recv"),
+                             "Rank ", deb::dec<3>(rank),
+                             "recv block ", deb::hex<8>(read_slot),
+                             "<- rank", deb::dec<4>(recv_rank),
+                             "tag", deb::hex<4>(tag),
+                             "recv in flight", deb::dec<4>(recvs_in_flight),
+                             "send in flight", deb::dec<4>(sends_in_flight));
+            // clang-format on
+            void* buffer_to_recv = &local_recv_storage[memory_offset_recv];
+            auto rsnd1 = mpi::transform_mpi(
+                ex::just(buffer_to_recv, options.transfer_size_B,
+                    MPI_UNSIGNED_CHAR, recv_rank, tag, MPI_COMM_WORLD),
+                MPI_Irecv);
+            auto rsnd2 = rsnd1 | ex::then([&](int result) {
+                --recvs_in_flight;
+                nws_deb<5>.debug(deb::str<>("recv complete"), "recv in flight",
+                    recvs_in_flight, "send in flight", sends_in_flight);
+                return result;
+            });
+            ex::start_detached(rsnd2);
+
+            // we are about to send, so increment our counter
+            ++sends_in_flight;
+            // clang-format off
+            nws_deb<5>.debug(deb::str<>("posting send"),
+                             "Rank ", deb::dec<3>(rank),
+                             "send block ", deb::hex<8>(write_slot),
+                             "-> rank", deb::dec<4>(send_rank),
+                             "tag", deb::hex<4>(tag),
+                             "recv in flight", deb::dec<4>(recvs_in_flight),
+                             "send in flight", deb::dec<4>(sends_in_flight));
+            // clang-format on
+            void* buffer_to_send = &local_send_storage[memory_offset_send];
+            auto ssnd1 = mpi::transform_mpi(
+                ex::just(buffer_to_send, options.transfer_size_B,
+                    MPI_UNSIGNED_CHAR, send_rank, tag, MPI_COMM_WORLD),
+                MPI_Isend);
+            auto ssnd2 = ssnd1 | ex::then([&](int result) {
+                --sends_in_flight;
+                nws_deb<5>.debug(deb::str<>("send complete"), "recv in flight",
+                    recvs_in_flight, "send in flight", sends_in_flight);
+                return result;
+            });
+            ex::start_detached(ssnd2);
+        }
+        messages_sent++;
+        //
+        if (RANK_OUTPUT && debug_timer.trigger())
+        {
+            std::cout << ((debug_tick++ % 10 == 9) ? "x" : ".") << std::flush;
+        }
+
+        time_up = (exec_timer.elapsed() >= options.num_seconds);
+
+        //
+        if (time_up && !count_complete)
+        {
+            for (uint32_t i = 0; i < nranks; ++i)
+            {
+                if (i != rank)
+                {
+                    MPI_Irecv(&counts[i], 1, MPI_INT32_T, i, 0, MPI_COMM_WORLD,
+                        &recvsr[i]);
+                    MPI_Isend(&messages_sent, 1, MPI_INT32_T, i, 0,
+                        MPI_COMM_WORLD, &sendsr[i]);
+                }
+            }
+            for (uint32_t i = 0; i < nranks; ++i)
+            {
+                MPI_Waitall(nranks, sendsr.data(), sendss.data());
+                MPI_Waitall(nranks, recvsr.data(), recvss.data());
+            }
+            // reduction step
+            final_count = messages_sent;
+            std::for_each(counts.begin(), counts.end(),
+                [&](uint64_t c) { final_count = std::max(final_count, c); });
+            nws_deb<2>.debug(
+                "Rank ", rank, "count max", deb::dec<8>(final_count));
+            //
+            count_complete = true;
+        }
+
+    } while (messages_sent < final_count);
+
+    nws_deb<2>.debug(
+        "Time elapsed", "on rank", rank, "counter", deb::dec<8>(messages_sent));
+
+    // block until no messages are in flight
+    nws_deb<2>.debug(deb::str<>("pre final"), "Rank ", rank, "recvs in flight",
+        deb::dec<>(recvs_in_flight), "sends in flight",
+        deb::dec<>(sends_in_flight));
+    //
+    while ((sends_in_flight.load() + recvs_in_flight.load()) > 0)
+    {
+        mpi::poll();
+        if (debug_timer.trigger())
+            nws_deb<5>.debug(
+                "Rank ", rank, "yield", "counter", deb::dec<8>(messages_sent));
+    }
+    //
+    nws_deb<2>.debug(deb::str<>("final"), "Rank ", rank, "recvs in flight",
+        deb::dec<>(recvs_in_flight), "sends in flight",
+        deb::dec<>(sends_in_flight));
+
+    // ----------------------------------------------------------------
+    double MB = nranks *
+        static_cast<double>(messages_sent * options.transfer_size_B) /
+        (1024 * 1024);
+    double IOPs = static_cast<double>(messages_sent);
+    double Time = exec_timer.elapsed();
+
+    if (rank == 0)
+        std::cout << std::endl;
+
+    // ----------------------------------------------------------------
+    nws_deb<2>.debug(
+        "Entering Barrier before update_performance on rank", rank);
+    MPI_Barrier(MPI_COMM_WORLD);
+    nws_deb<2>.debug("Passed Barrier before update_performance on rank", rank);
+    // ----------------------------------------------------------------
+
+    perf p{rank, nranks, MB, Time, IOPs, options.warmup ? "warmup" : "write "};
+    display(p, options);
+}
+
+//----------------------------------------------------------------------------
+// Main test loop which randomly sends packets of data from one locality to
+// another looping over the entire buffer address space and timing the total
+// transmit/receive time to see how well we're doing.
+int pika_main(pika::program_options::variables_map& vm)
+{
+    pika::util::mpi_environment mpi_env;
+    pika::runtime* rt = pika::get_runtime_ptr();
+    pika::util::runtime_configuration cfg = rt->get_config();
+    mpi_env.init(nullptr, nullptr, cfg);
+
+    pika::chrono::high_resolution_timer timer_main;
+    nws_deb<2>.debug(deb::str<>("PIKA main"));
+    //
+    std::string name = mpi_env.get_processor_name();
+    uint64_t rank = mpi_env.rank();
+    uint64_t nranks = mpi_env.size();
+    std::size_t current = pika::get_worker_thread_num();
+
+    if (rank == 0)
+    {
+        char const* msg = "hello world from OS-thread {:02} on locality "
+                          "{:04} rank {:04} hostname {}";
+        pika::util::format_to(std::cout, msg, current, pika::get_locality_id(),
+            rank, name.c_str())
+            << std::endl
+            << std::endl;
+    }
+
+    // extract command line argument
+    options.transfer_size_B =
+        static_cast<uint64_t>(vm["transferKB"].as<double>() * 1024);
+    options.local_storage_MB = vm["localMB"].as<std::uint64_t>();
+    options.global_storage_MB = vm["globalMB"].as<std::uint64_t>();
+    options.num_seconds = vm["seconds"].as<std::uint64_t>();
+    options.in_flight_limit = vm["in-flight-limit"].as<std::uint64_t>();
+    options.threads = pika::get_os_thread_count();
+    options.auto_throttling = vm["auto-throttling"].as<bool>();
+    options.yield = vm.count("yield") > 0;
+    options.warmup = false;
+    options.final = false;
+
+    size_t throttling = pika::mpi::experimental::get_max_requests_in_flight();
+    if (throttling == size_t(-1))
+    {
+        pika::mpi::experimental::set_max_requests_in_flight(
+            options.in_flight_limit);
+    }
+
+    //
+    if (options.global_storage_MB > 0)
+    {
+        options.local_storage_MB = options.global_storage_MB / nranks;
+    }
+
+    nws_deb<1>.debug("Allocating local storage on rank", rank);
+    local_send_storage.resize(options.local_storage_MB * 1024 * 1024);
+    local_recv_storage.resize(options.local_storage_MB * 1024 * 1024);
+    for (uint64_t i = 0; i < local_send_storage.size(); i += sizeof(uint64_t))
+    {
+        // each block is filled with the block number
+        uint64_t temp = (rank << 32) + i / options.transfer_size_B;
+        *reinterpret_cast<uint64_t*>(&local_send_storage[i]) = temp;
+        *reinterpret_cast<uint64_t*>(&local_recv_storage[i]) = temp;
+    }
+    //
+    uint64_t num_slots =
+        1024 * 1024 * options.local_storage_MB / options.transfer_size_B;
+    nws_deb<6>.debug(
+        "num ranks ", nranks, ", num_slots ", num_slots, " on rank", rank);
+    //
+    int64_t random_number = 0;
+    if (rank == 0)
+    {
+        std::random_device rand;
+        random_number = rand();
+        nws_deb<1>.debug("Sending Seed", deb::dec<8>(random_number));
+        for (uint i = 1; i < nranks; ++i)
+        {
+            MPI_Send(&random_number, 1, MPI_INT64_T, i, 0, MPI_COMM_WORLD);
+        }
+    }
+    else
+    {
+        MPI_Recv(&random_number, 1, MPI_INT64_T, 0, 0, MPI_COMM_WORLD,
+            MPI_STATUS_IGNORE);
+        nws_deb<1>.debug("Received Seed", deb::dec<8>(random_number));
+    }
+    std::mt19937 gen(random_number);
+    std::uniform_int_distribution<uint64_t> random_offset(1, (int) nranks - 1);
+    std::uniform_int_distribution<uint64_t> random_slot(0, (int) num_slots - 1);
+
+    // ----------------------------------------------------------------
+    if (rank == 0)
+        nws_deb<1>.debug("Completed initialization on", rank);
+    // ----------------------------------------------------------------
+    nws_deb<1>.debug("Entering startup_barrier on rank", rank);
+    MPI_Barrier(MPI_COMM_WORLD);
+    nws_deb<1>.debug("Passed startup_barrier on rank", rank);
+    // ----------------------------------------------------------------
+
+    test_options warmup = options;
+    warmup.num_seconds = 1;
+    warmup.warmup = true;
+
+    if (rank == 0)
+        nws_deb<1>.debug("Starting warmup", rank);
+    nws_deb<1>.debug("test_write warmup on rank", rank);
+
+    test_send_recv(rank, nranks, gen, random_offset, random_slot, warmup);
+    nws_deb<1>.debug("warmup complete on rank", rank);
+
+    test_send_recv(rank, nranks, gen, random_offset, random_slot, options);
+
+    // ----------------------------------------------------------------
+    nws_deb<1>.debug("Entering end_barrier on rank", rank);
+    MPI_Barrier(MPI_COMM_WORLD);
+    nws_deb<1>.debug("Passed end_barrier on rank", rank);
+    // ----------------------------------------------------------------
+
+    nws_deb<2>.debug("Deleting local storage ", rank);
+    // free up any allocated memory (clear() does not free memory)
+    local_recv_storage.clear();
+    local_recv_storage.shrink_to_fit();
+    local_send_storage.clear();
+    local_send_storage.shrink_to_fit();
+
+    nws_deb<2>.debug("Calling finalize ", rank);
+    return pika::finalize();
+}
+
+//----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    // Init MPI
+    int provided = MPI_THREAD_MULTIPLE;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    if (provided != MPI_THREAD_MULTIPLE)
+    {
+        std::cout << "Provided MPI is not : MPI_THREAD_MULTIPLE " << provided
+                  << std::endl;
+    }
+
+    // Configure application-specific options
+    // some of these are not used currently but left for future tweaking
+    pika::program_options::options_description cmdline(
+        "Usage: " PIKA_APPLICATION_STRING " [options]");
+
+    cmdline.add_options()("localMB",
+        pika::program_options::value<std::uint64_t>()->default_value(256),
+        "Sets the storage capacity (in MB) on each node.\n"
+        "The total storage will be num_ranks * localMB");
+
+    cmdline.add_options()("globalMB",
+        pika::program_options::value<std::uint64_t>()->default_value(0),
+        "Sets the storage capacity (in MB) for the entire job.\n"
+        "The storage per node will be globalMB / num_ranks\n"
+        "By default, localMB is used, setting this overrides localMB value.");
+
+    cmdline.add_options()("in-flight-limit",
+        pika::program_options::value<std::uint64_t>()->default_value(64),
+        "Apply a limit to then number of messages in flight.");
+
+    cmdline.add_options()("transferKB",
+        pika::program_options::value<double>()->default_value(512),
+        "Sets the default block transfer size (in KB).\n"
+        "Each put/get IOP will be this size");
+
+    cmdline.add_options()("seconds",
+        pika::program_options::value<std::uint64_t>()->default_value(5),
+        "The number of seconds to run each iteration for.\n");
+
+    cmdline.add_options()("auto-throttling",
+        pika::program_options::value<bool>()->default_value(false),
+        "When set, throttling of messages is enabled");
+
+    cmdline.add_options()(
+        "yield", "When set, throttling uses a yield instead of a poll");
+
+    nws_deb<6>.debug(3, "Calling pika::init");
+    pika::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    auto res = pika::init(pika_main, argc, argv, init_args);
+    MPI_Finalize();
+    return res;
+}

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <mutex>
 #include <random>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -113,13 +114,13 @@ void display(perf const& data, const test_options& options)
         temp << "IOPs/s (local)       : " << IOPs_s << "\n";
         temp << "Aggregate BW         : " << BW << " MB/s";
         temp << "\n";
-        // a complete set of results that our python matplotlib script will ingest
-        char const* msg =
-            "CSVData, {8}, network, "
-            "{1}, ranks, {2}, threads, {3}, Memory, {4}, IOPsize, {5}, "
-            "IOPS/s, {6}, BW(MB/s), {7}, ";
         if (/*options.final && */ !options.warmup)
         {
+            // a complete set of results that our python matplotlib script will ingest
+            char const* msg =
+                "CSVData, {8}, network, "
+                "{1}, ranks, {2}, threads, {3}, Memory, {4}, IOPsize, {5}, "
+                "IOPS/s, {6}, BW(MB/s), {7}, ";
             pika::util::format_to(temp, msg, "mpi", data.nranks,
                 options.threads, data.dataMB, options.transfer_size_B, IOPs_s,
                 BW, data.mode.c_str())
@@ -177,11 +178,11 @@ void test_send_recv(uint32_t rank, uint32_t nranks, std::mt19937& gen,
 
     std::string tempstr = "rank " + std::to_string(rank);
     write_arr.array(
-        tempstr + " # offset  ", &offsets[0], std::min(array_size, 32ul));
+        tempstr + " # offset  ", &offsets[0], (std::min)(array_size, 32ul));
     write_arr.array(
-        tempstr + " # send    ", &sends[0], std::min(array_size, 32ul));
+        tempstr + " # send    ", &sends[0], (std::min)(array_size, 32ul));
     write_arr.array(
-        tempstr + " # recv    ", &recvs[0], std::min(array_size, 32ul));
+        tempstr + " # recv    ", &recvs[0], (std::min)(array_size, 32ul));
 
     // ----------------------------------------------------------------
     nws_deb<2>.debug("Entering Barrier at start of write on rank", rank);
@@ -205,9 +206,8 @@ void test_send_recv(uint32_t rank, uint32_t nranks, std::mt19937& gen,
     // Start main message sending loop
     //
     pika::chrono::high_resolution_timer exec_timer;
-    uint64_t final_count = std::numeric_limits<uint64_t>().max();
+    uint64_t final_count = (std::numeric_limits<uint64_t>().max)();
     bool count_complete = false;
-    bool time_up;
     // loop for allowed time : sending and receiving
     do
     {
@@ -283,7 +283,7 @@ void test_send_recv(uint32_t rank, uint32_t nranks, std::mt19937& gen,
             std::cout << ((debug_tick++ % 10 == 9) ? "x" : ".") << std::flush;
         }
 
-        time_up = (exec_timer.elapsed() >= options.num_seconds);
+        bool time_up = (exec_timer.elapsed() >= options.num_seconds);
 
         //
         if (time_up && !count_complete)
@@ -306,7 +306,7 @@ void test_send_recv(uint32_t rank, uint32_t nranks, std::mt19937& gen,
             // reduction step
             final_count = messages_sent;
             std::for_each(counts.begin(), counts.end(),
-                [&](uint64_t c) { final_count = std::max(final_count, c); });
+                [&](uint64_t c) { final_count = (std::max)(final_count, c); });
             nws_deb<2>.debug(
                 "Rank ", rank, "count max", deb::dec<8>(final_count));
             //

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/assert.hpp>
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/assert.hpp>
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
@@ -155,7 +156,7 @@ int pika_main(pika::program_options::variables_map& vm)
                                         [=, &tokens, &counter](int /*result*/) {
                                             msg_send(rank, size, rank_to,
                                                 rank_from, tokens[tag], tag);
-                                            // ranks > 0 are done when they have sent their token
+                                            // ranks > 0 are done after sending token
                                             --counter;
                                         });
                                 ex::start_detached(s4);

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -69,6 +69,8 @@ namespace pika { namespace debug {
             std::ostream&, std::atomic<int> const&, int);
         template PIKA_EXPORT void print_dec(
             std::ostream&, std::atomic<unsigned int> const&, int);
+        template PIKA_EXPORT void print_dec(
+            std::ostream&, std::atomic<unsigned long> const&, int);
     }    // namespace detail
 
     // ------------------------------------------------------------------

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -82,7 +82,9 @@ namespace pika { namespace debug {
             {
                 pika::threads::detail::thread_data* dummy =
                     pika::threads::detail::get_self_id_data();
-                os << dummy << " ";
+                os << hex<12, std::uintptr_t>(
+                          reinterpret_cast<std::uintptr_t>(dummy))
+                   << " ";
             }
             os << hex<12, std::thread::id>(std::this_thread::get_id())
 #ifdef DEBUGGING_PRINT_LINUX


### PR DESCRIPTION
Fixes part of #184.

This extends and replaces PR #204 (this PR is rebased onto current main branch)
 
Eager checks on send/recv calls are a useful improvement as mpi implementations may make use of `inject` semantics on some messages, which can complete immediately and therefore do not need to be polled for, including this does not impost a significant cost and can save time overall.

This PR adds throttling of MPI traffic to help prevent excessive message queues which can happen when a loop spwans many send or recv calls.

I addition, the PR includes a major cleanup of the mpi handling/polling code and also adds `testsome` in place of `testany` - which ought to be a slight performance improvement, but in timings does not seem to make any difference. 