### PR TITLE
Fix handling on reference types in sent by predecessors to `ensure_started` and `schedule_from`

### DIFF
--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -98,6 +98,18 @@ int main()
         PIKA_TEST(set_value_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        int x = 42;
+        auto s1 = const_reference_sender<int>{x};
+        auto s2 = ex::ensure_started(std::move(s1));
+        auto f = [](auto&& x) { PIKA_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -315,6 +315,25 @@ int main()
         PIKA_TEST(scheduler_schedule_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        int x = 3;
+        auto s = ex::transfer(const_reference_sender<int>{x},
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
+        auto f = [](int x) { PIKA_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+        PIKA_TEST(!tag_invoke_overload_called);
+        PIKA_TEST(!scheduler_execute_called);
+        PIKA_TEST(scheduler_schedule_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};


### PR DESCRIPTION
Fixes handling of reference types sent to `ensure_started` and `schedule_from`. Other algorithms also need to be checked for the same problem, but I'm doing it in separate PRs.