### PR TITLE
Enable tests for P2300 reference implementation split

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -457,7 +457,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 pika::execution::experimental::value_types_of_t<
                     std::decay_t<Sender>,
                     pika::execution::experimental::detail::empty_env,
-                    pika::tuple, pika::variant>,
+                    std::tuple, pika::detail::variant>,
                 pika::detail::monostate>;
 #else
             using ts_type = pika::util::detail::prepend_t<

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -98,7 +98,9 @@ namespace pika::this_thread::experimental {
             // variant.
             using error_type =
                 pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    predecessor_error_types<pika::detail::variant>,
+                    pika::util::detail::transform_t<
+                        predecessor_error_types<pika::detail::variant>,
+                        std::decay>,
                     std::exception_ptr>>;
 #else
             // value and error_types of the predecessor sender
@@ -138,7 +140,9 @@ namespace pika::this_thread::experimental {
             // variant.
             using error_type =
                 pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    predecessor_error_types<pika::detail::variant>,
+                    pika::util::detail::transform_t<
+                        predecessor_error_types<pika::detail::variant>,
+                        std::decay>,
                     std::exception_ptr>>;
 #endif
 

--- a/libs/pika/execution/tests/include/algorithm_test_utils.hpp
+++ b/libs/pika/execution/tests/include/algorithm_test_utils.hpp
@@ -109,6 +109,7 @@ struct const_reference_error_sender
 
     using completion_signatures =
         pika::execution::experimental::completion_signatures<
+            pika::execution::experimental::set_value_t(),
             pika::execution::experimental::set_error_t(std::exception_ptr&)>;
 
     template <typename R>

--- a/libs/pika/execution/tests/unit/algorithm_split.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_split.cpp
@@ -77,6 +77,18 @@ int main()
         PIKA_TEST(set_value_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        int x = 42;
+        auto s1 = const_reference_sender<int>{x};
+        auto s2 = ex::split(std::move(s1));
+        auto f = [](auto& x) { PIKA_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};
@@ -116,6 +128,16 @@ int main()
     {
         std::atomic<bool> set_error_called{false};
         auto s = error_sender{} | ex::split() | ex::split() | ex::split();
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::split(const_reference_error_sender{});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));

--- a/libs/pika/execution/tests/unit/algorithm_split.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_split.cpp
@@ -31,9 +31,6 @@ auto tag_invoke(
 
 int main()
 {
-    // TODO: split doesn't have a default implementation in the reference
-    // implementation.
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     // Success path
     {
         std::atomic<bool> set_value_called{false};
@@ -126,7 +123,10 @@ int main()
         PIKA_TEST(set_error_called);
     }
 
-    // Chained split calls do not create new shared states
+    // Chained split calls do not create new shared states. This is an
+    // implementation detail of our own implementation. We can't test this for
+    // the reference implementation.
+#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     {
         std::atomic<bool> receiver_set_value_called{false};
         auto s1 = ex::just() | ex::split();
@@ -154,6 +154,7 @@ int main()
         ex::start(os);
         PIKA_TEST(receiver_set_value_called);
     }
+#endif
 
     {
         auto s = ex::split(my_namespace::my_sender{});
@@ -164,7 +165,6 @@ int main()
         // the sender has been connected and started before being released.
         tt::sync_wait(std::move(s));
     }
-#endif
 
     return pika::util::report_errors();
 }

--- a/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
@@ -61,6 +61,12 @@ int pika_main()
             42);
     }
 
+    {
+        int x = 42;
+        PIKA_TEST_EQ(
+            tt::sync_wait(ex::just(const_reference_sender<int>{x})).x, 42);
+    }
+
     // operator| overload
     {
         std::atomic<bool> start_called{false};
@@ -96,6 +102,21 @@ int pika_main()
         try
         {
             tt::sync_wait(error_sender{});
+            PIKA_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            PIKA_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+        PIKA_TEST(exception_thrown);
+    }
+
+    {
+        bool exception_thrown = false;
+        try
+        {
+            tt::sync_wait(const_reference_error_sender{});
             PIKA_TEST(false);
         }
         catch (std::runtime_error const& e)


### PR DESCRIPTION
We already had it enabled in the header, but I had forgotten to remove the ifdefs in the test file. This also fixes part of #284 for `sync_wait` and `split` since those were broken after updating the test.

To do:
- [x] Add tests for the error channel with `const_reference_error_sender` from #307.