### PR TITLE
Add priorities for CUDA polling

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <pika/config.hpp>
+#include <pika/async_cuda/cuda_stream.hpp>
 #include <pika/async_cuda/custom_gpu_api.hpp>
 #include <pika/functional/unique_function.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
@@ -26,7 +27,7 @@ namespace pika::cuda::experimental::detail {
         pika::util::unique_function<void(cudaError_t)>;
 
     PIKA_EXPORT void add_event_callback(
-        event_callback_function_type&& f, cudaStream_t stream);
+        event_callback_function_type&& f, cuda_stream const& stream);
 
     PIKA_EXPORT void register_polling(pika::threads::thread_pool_base& pool);
     PIKA_EXPORT void unregister_polling(pika::threads::thread_pool_base& pool);

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -110,7 +110,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 set_value_event_callback_helper(
                     status, PIKA_MOVE(op_state.receiver));
             },
-            op_state.stream.value().get().get());
+            op_state.stream.value().get());
     }
 
     template <typename Result, typename OperationState>
@@ -123,7 +123,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                     PIKA_MOVE(op_state.receiver),
                     PIKA_MOVE(pika::get<Result>(op_state.result)));
             },
-            op_state.stream.value().get().get());
+            op_state.stream.value().get());
     }
 
     template <typename Sender, typename F>


### PR DESCRIPTION
Slight refactoring of the CUDA polling implementation. The actual polling mechanism is completely unchanged. I've only refactored the queues and free functions into a class so that it's easier to create multiple instances. There are now two polling queues, one for normal priority streams and one for high priority streams. The interface for adding callbacks is almost unchanged. The only difference is that it now requires a `cuda_stream` which has an embedded `pika::execution::thread_priority` instead of having to query a `cudaStream_t`.

Performance is minimally improved with small blocksizes in DLA-Future, so this is primarily about refactoring the code to be slightly more manageable, not a performance improvement.