### PR TITLE
Fix `--pika:ignore-process-mask`

### DIFF
--- a/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
+++ b/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
@@ -31,7 +31,7 @@ namespace pika::detail {
             std::size_t pu_offset = 0, std::size_t pu_step = 1,
             std::size_t used_cores = 0, std::string affinity_domain = "pu",
             std::string const& affinity_description = "balanced",
-            bool use_process_mask = false);
+            bool use_process_mask = true);
 
         void set_num_threads(size_t num_threads)
         {

--- a/libs/pika/affinity/src/affinity_data.cpp
+++ b/libs/pika/affinity/src/affinity_data.cpp
@@ -40,7 +40,7 @@ namespace pika::detail {
       , affinity_masks_()
       , pu_nums_()
       , no_affinity_()
-      , use_process_mask_(false)
+      , use_process_mask_(true)
       , num_pus_needed_(0)
     {
         threads::detail::resize(

--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -35,7 +35,7 @@ namespace pika::detail {
           , pu_step_(1)
           , pu_offset_(std::size_t(-1))
           , numa_sensitive_(0)
-          , ignore_process_mask_(false)
+          , use_process_mask_(true)
           , cmd_line_parsed_(false)
           , info_printed_(false)
           , version_printed_(false)
@@ -60,7 +60,7 @@ namespace pika::detail {
         std::string affinity_domain_;
         std::string affinity_bind_;
         std::size_t numa_sensitive_;
-        bool ignore_process_mask_;
+        bool use_process_mask_;
         bool cmd_line_parsed_;
         bool info_printed_;
         bool version_printed_;

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -462,8 +462,8 @@ namespace pika {
                             cmdline.rtcfg_, "pika.pu_step", 0),
                         0, cmdline.rtcfg_.get_entry("pika.affinity", ""),
                         cmdline.rtcfg_.get_entry("pika.bind", ""),
-                        pika::util::get_entry_as<bool>(
-                            cmdline.rtcfg_, "pika.use_process_mask", 0));
+                        !pika::util::get_entry_as<bool>(
+                            cmdline.rtcfg_, "pika.ignore_process_mask", false));
 
                     pika::resource::partitioner rp =
                         pika::resource::detail::make_partitioner(


### PR DESCRIPTION
The process mask was being taken into account for the _number_ of threads, but not for the actual affinity data (in `affinity_data`). This lead me to believe that things were working ok, but things were apparently slightly off. This meant that e.g. multiple ranks on a single node had overlapping thread bindings.

In an attempt to simplify things I've renamed some variables back to what they were before #242. Now everything internal is again called `use_process_mask` whereas _only_ the command line and configuration options are called `ignore_process_mask`, and the given options are translated to `use_process_mask` as soon as possible. I prefer `use_process_mask` internally since it's the "positive" form.