### PR TITLE
Fix Tracy integration

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -10,6 +10,7 @@ status = [
   "github/linux/fetchcontent/fast",
   "github/linux/hip/fast",
   "github/linux/sanitizers/fast",
+  "github/linux/tracy/fast",
   "github/macos/debug/core",
   "github/macos/debug/tests/examples_regressions",
   "github/macos/debug/tests/performance",

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -1,0 +1,90 @@
+# Copyright (c) 2022 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Tracy)
+
+on:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/tracy/fast
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:7
+
+    steps:
+    - name: Check out Tracy
+      uses: actions/checkout@v3
+      with:
+        repository: wolfpld/tracy
+        ref: v0.8.2
+        path: tracy
+    - name: Install Tracy
+      shell: bash
+      working-directory: tracy
+      run: |
+          # TRACY_TIMER_FALLBACK is set to ON to silence Tracy complaining with:
+          #   Tracy Profiler initialization failure: CPU doesn't support invariant TSC.
+          #   Define TRACY_NO_INVARIANT_CHECK=1 to ignore this error, *if you know what you are doing*.
+          #   Alternatively you may rebuild the application with the TRACY_TIMER_FALLBACK define to use lower resolution timer.
+          # Since we only want to check that the executables run, we don't care
+          # about having a lower precision timer.
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DBUILD_SHARED_LIBS=ON \
+              -DTRACY_TIMER_FALLBACK=ON
+          cmake --build build --target install
+
+    - name: Check out pika
+      uses: actions/checkout@v3
+      with:
+        path: pika
+    - name: Configure
+      shell: bash
+      working-directory: pika
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_TRACY=ON \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_COMPILER_WARNINGS=ON \
+              -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
+              -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
+    - name: Build
+      shell: bash
+      working-directory: pika
+      run: |
+          cmake --build build --target all
+          cmake --build build --target examples
+    - name: Test
+      shell: bash
+      working-directory: pika/build
+      run: |
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.examples.quickstart.hello_world
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.unit.build

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -748,9 +748,10 @@ namespace pika { namespace threads { namespace detail {
                                 task_annotation
                                     << "pika/task:" << thrd << "/"
                                     << (desc.kind() ==
-                                                   pika::util::thread_description::
-                                                       data_type::
-                                                           data_type_description ?
+                                                   pika::util::detail::
+                                                       thread_description::
+                                                           data_type::
+                                                               data_type_description ?
                                                desc.get_description() :
                                                "<unknown>");
                                 auto task_annotation_str =

--- a/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
@@ -68,7 +68,7 @@ namespace pika {
         pika::util::itt::task task_;
     };
 #elif defined(PIKA_HAVE_TRACY)
-    struct PIKA_NODISCARD scoped_annotation
+    struct [[nodiscard]] scoped_annotation
     {
         PIKA_NON_COPYABLE(scoped_annotation);
 
@@ -86,13 +86,16 @@ namespace pika {
             typename =
                 std::enable_if_t<!std::is_same_v<std::decay_t<F>, std::string>>>
         explicit scoped_annotation(F&& f)
-          : annotation(
-                pika::traits::get_function_annotation<std::decay_t<F>>::call(f))
         {
+            if (auto f_annotation = pika::traits::get_function_annotation<
+                    std::decay_t<F>>::call(f))
+            {
+                annotation = f_annotation;
+            }
         }
 
     private:
-        char const* annotation;
+        char const* annotation = "<unknown>";
 
         // We don't use a Zone* macro from Tracy here because they are only
         // meant to be used in function scopes. The Zone* macros make use of


### PR DESCRIPTION
Fixes the build with Tracy, and since I managed to break the build in record time I'm also adding a simple GitHub actions workflow which builds examples and runs `hello_world`. We still can't run all executables because threads can't yield with the Tracy integration.