### PR TITLE
Fix compilation of `mpi_async_storage` test

### DIFF
--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -423,8 +423,9 @@ int pika_main(pika::program_options::variables_map& vm)
         *reinterpret_cast<uint64_t*>(&local_recv_storage[i]) = temp;
     }
     //
-    uint64_t num_slots =
-        1024 * 1024 * options.local_storage_MB / options.transfer_size_B;
+    std::uint64_t num_slots = static_cast<std::uint64_t>(1024) *
+        static_cast<std::uint64_t>(1024) * options.local_storage_MB /
+        options.transfer_size_B;
     nws_deb<6>.debug(
         "num ranks ", nranks, ", num_slots ", num_slots, " on rank", rank);
     //

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -45,14 +45,6 @@ template <int Level>
 static pika::debug::print_threshold<Level, debug_level> nws_deb("STORAGE");
 
 //----------------------------------------------------------------------------
-// #defines to control program
-//----------------------------------------------------------------------------
-
-//----------------------------------------------------------------------------
-#define TEST_SUCCESS 0
-#define TEST_FAIL 1
-
-//----------------------------------------------------------------------------
 //
 // Each locality allocates a buffer of memory which is used to host transfers
 //

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -73,7 +73,6 @@ struct test_options
 
     bool warmup;
     bool final;
-    bool yield;
 };
 
 //----------------------------------------------------------------------------
@@ -321,7 +320,7 @@ void test_send_recv(std::uint32_t rank, std::uint32_t nranks, std::mt19937& gen,
         mpi::poll();
         if (debug_timer.trigger())
             nws_deb<5>.debug(
-                "Rank ", rank, "yield", "counter", deb::dec<8>(messages_sent));
+                "Rank ", rank, "counter", deb::dec<8>(messages_sent));
     }
     //
     nws_deb<2>.debug(deb::str<>("final"), "Rank ", rank, "recvs in flight",
@@ -390,7 +389,6 @@ int pika_main(pika::program_options::variables_map& vm)
     options.num_seconds = vm["seconds"].as<std::uint64_t>();
     options.in_flight_limit = vm["in-flight-limit"].as<std::uint64_t>();
     options.threads = pika::get_os_thread_count();
-    options.yield = vm.count("yield") > 0;
     options.warmup = false;
     options.final = false;
 
@@ -549,9 +547,6 @@ int main(int argc, char* argv[])
     cmdline.add_options()("seconds",
         pika::program_options::value<std::uint64_t>()->default_value(5),
         "The number of seconds to run each iteration for.\n");
-
-    cmdline.add_options()(
-        "yield", "When set, throttling uses a yield instead of a poll");
 
     nws_deb<6>.debug(3, "Calling pika::init");
     pika::init_params init_args;

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -538,7 +538,7 @@ int main(int argc, char* argv[])
         "The total storage will be num_ranks * localMB");
 
     cmdline.add_options()("in-flight-limit",
-        pika::program_options::value<std::uint64_t>()->default_value(64),
+        pika::program_options::value<std::uint64_t>()->default_value(256),
         "Apply a limit to then number of messages in flight.");
 
     cmdline.add_options()("transferKB",

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -56,7 +56,6 @@ static pika::debug::print_threshold<Level, debug_level> nws_deb("STORAGE");
 //
 // Each locality allocates a buffer of memory which is used to host transfers
 //
-static pika::util::detail::spinlock storage_mutex;
 using local_storage_type = std::vector<char>;
 static local_storage_type local_send_storage;
 static local_storage_type local_recv_storage;


### PR DESCRIPTION
Fixes things that were missed in #277.

@biddisco can you confirm that the mutex really was intended to be unused?