### PR TITLE
Eagerly check completion of CUDA kernels

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/custom_gpu_api.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/custom_gpu_api.hpp
@@ -70,6 +70,7 @@
     #define cudaStreamGetFlags hipStreamGetFlags
     #define cudaStreamNonBlocking hipStreamNonBlocking
     #define cudaStreamSynchronize hipStreamSynchronize
+    #define cudaStreamQuery hipStreamQuery
     #define cudaSuccess hipSuccess
 
 #elif defined(PIKA_HAVE_CUDA)


### PR DESCRIPTION
Fixes the CUDA part of #184. However, this is untested and if it doesn't show any improvement (or worse, a performance drop) this shouldn't be merged.

Based on #286.