### PR TITLE
Move ccache directory to `jenkssl` scratch in Jenkins jobs

### DIFF
--- a/.jenkins/cscs-perftests/Jenkinsfile
+++ b/.jenkins/cscs-perftests/Jenkinsfile
@@ -23,7 +23,6 @@ pipeline {
         )
     }
     environment {
-        SPACK_ROOT = '/apps/daint/SSL/pika/spack'
         GITHUB_TOKEN = credentials('PIKA_BOT_GITHUB_TOKEN')
     }
     stages {

--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -23,7 +23,6 @@ pipeline {
         )
     }
     environment {
-        SPACK_ROOT = '/apps/daint/SSL/pika/spack'
         GITHUB_TOKEN = credentials('PIKA_BOT_GITHUB_TOKEN')
     }
     stages {

--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -6,6 +6,7 @@
 
 module load daint-gpu spack-config
 
+export SPACK_ROOT="/apps/daint/SSL/pika/spack"
 export SPACK_USER_CONFIG_PATH="${SPACK_ROOT}/../spack-user-config"
 export SPACK_USER_CACHE_PATH="/scratch/snx3000/simbergm/spack-user-cache-jenkins"
 source "${SPACK_ROOT}/share/spack/setup-env.sh"

--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -15,7 +15,7 @@ spack load ccache@4.5.1 %gcc@10.3.0
 
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 export CMAKE_GENERATOR=Ninja
-export CCACHE_DIR=/scratch/snx3000/simbergm/ccache-jenkins-pika
+export CCACHE_DIR="${SCRATCH}/jenkins-pika-ccache"
 export CCACHE_MAXSIZE=100G
 export CCACHE_MAXFILES=50000
 export CCACHE_COMPILERCHECK="%compiler% -v"


### PR DESCRIPTION
Fixes half of #299.

I've also moved the `SPACK_ROOT` definition to `env-common.sh` to 1. have it only in one place and 2. to have it together with the rest of the environment. It doesn't actually need to be set in the `Jenkinsfile`, unlike the GitHub credentials.

Edit: I updated this to only move the ccache directory for the moment. The spack user cache directory seems to be a bit more complicated...