### PR TITLE
Clean up debugging module

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_debug.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_debug.hpp
@@ -12,6 +12,6 @@
 #include <pika/debugging/print.hpp>
 
 namespace pika::cuda::experimental::detail {
-    using print_on = debug::enable_print<false>;
+    using print_on = debug::detail::enable_print<false>;
     static constexpr print_on cud_debug("CUDA");
 }    // namespace pika::cuda::experimental::detail

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -69,11 +69,11 @@ namespace pika::cuda::experimental::detail {
                 if (cud_debug.is_enabled())
                 {
                     static auto poll_deb = cud_debug.make_timer(
-                        1, debug::str<>("Poll - lock failed"));
+                        1, debug::detail::str<>("Poll - lock failed"));
                     cud_debug.timed(poll_deb, "enqueued events",
-                        debug::dec<3>(get_number_of_enqueued_events()),
+                        debug::detail::dec<3>(get_number_of_enqueued_events()),
                         "active events",
-                        debug::dec<3>(get_number_of_active_events()));
+                        debug::detail::dec<3>(get_number_of_active_events()));
                 }
                 return polling_status::idle;
             }
@@ -81,11 +81,11 @@ namespace pika::cuda::experimental::detail {
             if (cud_debug.is_enabled())
             {
                 static auto poll_deb = cud_debug.make_timer(
-                    1, debug::str<>("Poll - lock success"));
+                    1, debug::detail::str<>("Poll - lock success"));
                 cud_debug.timed(poll_deb, "enqueued events",
-                    debug::dec<3>(get_number_of_enqueued_events()),
+                    debug::detail::dec<3>(get_number_of_enqueued_events()),
                     "active events",
-                    debug::dec<3>(get_number_of_active_events()));
+                    debug::detail::dec<3>(get_number_of_active_events()));
             }
 
             // Grab the handle to the event pool so we can return completed events
@@ -103,12 +103,15 @@ namespace pika::cuda::experimental::detail {
                             return false;
                         }
 
-                        cud_debug.debug(debug::str<>("set ready vector"),
-                            "event", debug::hex<8>(continuation.event),
+                        cud_debug.debug(
+                            debug::detail::str<>("set ready vector"), "event",
+                            debug::detail::hex<8>(continuation.event),
                             "enqueued events",
-                            debug::dec<3>(get_number_of_enqueued_events()),
+                            debug::detail::dec<3>(
+                                get_number_of_enqueued_events()),
                             "active events",
-                            debug::dec<3>(get_number_of_active_events()));
+                            debug::detail::dec<3>(
+                                get_number_of_active_events()));
                         continuation.f(status);
                         pool.push(PIKA_MOVE(continuation.event));
                         return true;
@@ -127,11 +130,12 @@ namespace pika::cuda::experimental::detail {
                 }
                 else
                 {
-                    cud_debug.debug(debug::str<>("set ready queue"), "event",
-                        debug::hex<8>(continuation.event), "enqueued events",
-                        debug::dec<3>(get_number_of_enqueued_events()),
+                    cud_debug.debug(debug::detail::str<>("set ready queue"),
+                        "event", debug::detail::hex<8>(continuation.event),
+                        "enqueued events",
+                        debug::detail::dec<3>(get_number_of_enqueued_events()),
                         "active events",
-                        debug::dec<3>(get_number_of_active_events()));
+                        debug::detail::dec<3>(get_number_of_active_events()));
                     continuation.f(status);
                     pool.push(PIKA_MOVE(continuation.event));
                 }
@@ -162,10 +166,11 @@ namespace pika::cuda::experimental::detail {
 
             event_callback_queue.enqueue(PIKA_MOVE(continuation));
 
-            cud_debug.debug(debug::str<>("event queued"), "event",
-                debug::hex<8>(continuation.event), "enqueued events",
-                debug::dec<3>(get_number_of_enqueued_events()), "active events",
-                debug::dec<3>(get_number_of_active_events()));
+            cud_debug.debug(debug::detail::str<>("event queued"), "event",
+                debug::detail::hex<8>(continuation.event), "enqueued events",
+                debug::detail::dec<3>(get_number_of_enqueued_events()),
+                "active events",
+                debug::detail::dec<3>(get_number_of_active_events()));
         }
 
         std::size_t get_work_count() const noexcept
@@ -192,11 +197,13 @@ namespace pika::cuda::experimental::detail {
             event_callback_vector.push_back(PIKA_MOVE(continuation));
             ++active_events_counter;
 
-            cud_debug.debug(
-                debug::str<>("event callback moved from queue to vector"),
-                "event", debug::hex<8>(continuation.event), "enqueued events",
-                debug::dec<3>(get_number_of_enqueued_events()), "active events",
-                debug::dec<3>(get_number_of_active_events()));
+            cud_debug.debug(debug::detail::str<>(
+                                "event callback moved from queue to vector"),
+                "event", debug::detail::hex<8>(continuation.event),
+                "enqueued events",
+                debug::detail::dec<3>(get_number_of_enqueued_events()),
+                "active events",
+                debug::detail::dec<3>(get_number_of_active_events()));
         }
 
         event_callback_queue_type event_callback_queue;
@@ -272,7 +279,7 @@ namespace pika::cuda::experimental::detail {
 #if defined(PIKA_DEBUG)
         ++get_register_polling_count();
 #endif
-        cud_debug.debug(debug::str<>("enable polling"));
+        cud_debug.debug(debug::detail::str<>("enable polling"));
         auto* sched = pool.get_scheduler();
         sched->set_cuda_polling_functions(
             &pika::cuda::experimental::detail::poll, &get_work_count);
@@ -289,7 +296,7 @@ namespace pika::cuda::experimental::detail {
                 "early.");
         }
 #endif
-        cud_debug.debug(debug::str<>("disable polling"));
+        cud_debug.debug(debug::detail::str<>("disable polling"));
         auto* sched = pool.get_scheduler();
         sched->clear_cuda_polling_function();
     }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_future.hpp
@@ -29,7 +29,7 @@ namespace pika { namespace mpi { namespace experimental {
 
     // -----------------------------------------------------------------
     // by convention the title is 7 chars (for alignment)
-    using print_on = debug::enable_print<false>;
+    using print_on = pika::debug::detail::enable_print<false>;
     static constexpr print_on mpi_debug("MPI_FUT");
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/src/mpi_future.cpp
+++ b/libs/pika/async_mpi/src/mpi_future.cpp
@@ -108,12 +108,13 @@ namespace pika { namespace mpi { namespace experimental {
         {
             // clang-format off
             os << "R "
-               << debug::dec<3>(info.rank_) << "/" << debug::dec<3>(info.size_)
-               << " vector " << debug::dec<4>(info.active_request_vector_size_)
-               << " queued " << debug::dec<4>(info.request_queue_size_)
-               << " in-flight " << debug::dec<4>(info.in_flight_)
-               << " vec_cb " << debug::dec<3>(info.callback_vector_.size())
-               << " vec_rq " << debug::dec<3>(info.request_vector_.size());
+               << debug::detail::dec<3>(info.rank_) << "/"
+               << debug::detail::dec<3>(info.size_)
+               << " vector " << debug::detail::dec<4>(info.active_request_vector_size_)
+               << " queued " << debug::detail::dec<4>(info.request_queue_size_)
+               << " in-flight " << debug::detail::dec<4>(info.in_flight_)
+               << " vec_cb " << debug::detail::dec<3>(info.callback_vector_.size())
+               << " vec_rq " << debug::detail::dec<3>(info.request_vector_.size());
 
             // clang-format on
             return os;
@@ -156,7 +157,8 @@ namespace pika { namespace mpi { namespace experimental {
                 // badly formed env var
                 if (def == 0)
                     def = size_t(-1);    // unlimited
-                mpi_debug.debug(debug::str<>("throttling"), "default", def);
+                mpi_debug.debug(
+                    debug::detail::str<>("throttling"), "default", def);
             }
             return def;
         }
@@ -173,8 +175,8 @@ namespace pika { namespace mpi { namespace experimental {
 
             if constexpr (mpi_debug.is_enabled())
             {
-                mpi_debug.debug(debug::str<>("CB queued"), mpi_data_, "request",
-                    debug::hex<8>(req_callback.request));
+                mpi_debug.debug(debug::detail::str<>("CB queued"), mpi_data_,
+                    "request", debug::detail::hex<8>(req_callback.request));
             }
         }
 
@@ -194,12 +196,12 @@ namespace pika { namespace mpi { namespace experimental {
             if constexpr (mpi_debug.is_enabled())
             {
                 // clang-format off
-                mpi_debug.debug(debug::str<>("CB queue => vector"),
+                mpi_debug.debug(debug::detail::str<>("CB queue => vector"),
                     mpi_data_,
-                    "request", debug::hex<8>(req_callback.request),
-                    "callbacks", debug::dec<3>(mpi_data_.callback_vector_.size()),
-                    "requests", debug::dec<3>(mpi_data_.request_vector_.size()),
-                    "null", debug::dec<3>(get_num_null_requests_in_vector()));
+                    "request", debug::detail::hex<8>(req_callback.request),
+                    "callbacks", debug::detail::dec<3>(mpi_data_.callback_vector_.size()),
+                    "requests", debug::detail::dec<3>(mpi_data_.request_vector_.size()),
+                    "null", debug::detail::dec<3>(get_num_null_requests_in_vector()));
                 // clang-format on
             }
         }
@@ -225,7 +227,7 @@ namespace pika { namespace mpi { namespace experimental {
             int result = MPI_Test(&request, &flag, MPI_STATUS_IGNORE);
             if (flag)
             {
-                mpi_debug.debug(debug::str<>("eager poll"), "success");
+                mpi_debug.debug(debug::detail::str<>("eager poll"), "success");
                 PIKA_INVOKE(PIKA_MOVE(callback), result);
                 return;
             }
@@ -241,7 +243,7 @@ namespace pika { namespace mpi { namespace experimental {
         // function that converts an MPI error into an exception
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
-            mpi_debug.debug(debug::str<>("pika_MPI_Handler"));
+            mpi_debug.debug(debug::detail::str<>("pika_MPI_Handler"));
             PIKA_THROW_EXCEPTION(
                 invalid_status, "pika_MPI_Handler", error_message(*errorcode));
         }
@@ -287,7 +289,7 @@ namespace pika { namespace mpi { namespace experimental {
     // on any error instead of the default behavior of program termination
     void set_error_handler()
     {
-        mpi_debug.debug(debug::str<>("set_error_handler"));
+        mpi_debug.debug(debug::detail::str<>("set_error_handler"));
 
         MPI_Comm_create_errhandler(
             detail::pika_MPI_Handler, &detail::pika_mpi_errhandler);
@@ -343,8 +345,8 @@ namespace pika { namespace mpi { namespace experimental {
             if constexpr (mpi_debug.is_enabled())
             {
                 // for debugging, create a timer
-                static auto poll_deb =
-                    mpi_debug.make_timer(1, debug::str<>("Poll - lock failed"));
+                static auto poll_deb = mpi_debug.make_timer(
+                    1, debug::detail::str<>("Poll - lock failed"));
                 // output mpi debug info every N seconds
                 mpi_debug.timed(poll_deb, detail::mpi_data_);
             }
@@ -354,8 +356,8 @@ namespace pika { namespace mpi { namespace experimental {
         if constexpr (mpi_debug.is_enabled())
         {
             // for debugging, create a timer
-            static auto poll_deb =
-                mpi_debug.make_timer(1, debug::str<>("Poll - lock success"));
+            static auto poll_deb = mpi_debug.make_timer(
+                1, debug::detail::str<>("Poll - lock success"));
             // output mpi debug info every N seconds
             mpi_debug.timed(poll_deb, detail::mpi_data_);
         }
@@ -394,9 +396,9 @@ namespace pika { namespace mpi { namespace experimental {
         {
             // output a heartbeat every seconds
             static auto poll_deb =
-                mpi_debug.make_timer(1, debug::str<>("Poll - success"));
+                mpi_debug.make_timer(1, debug::detail::str<>("Poll - success"));
             mpi_debug.timed(poll_deb, detail::mpi_data_, "outcount", outcount,
-                debug::dec<4>(outcount));
+                debug::detail::dec<4>(outcount));
         }
 
         // for each completed request
@@ -406,9 +408,10 @@ namespace pika { namespace mpi { namespace experimental {
 
             if constexpr (mpi_debug.is_enabled())
             {
-                mpi_debug.debug(debug::str<>("MPI_Testsome (set)"),
+                mpi_debug.debug(debug::detail::str<>("MPI_Testsome (set)"),
                     detail::mpi_data_, "request",
-                    debug::hex<8>(detail::mpi_data_.request_vector_[index]));
+                    debug::detail::hex<8>(
+                        detail::mpi_data_.request_vector_[index]));
             }
 
             // decrement before invoking callback to avoid race
@@ -428,8 +431,8 @@ namespace pika { namespace mpi { namespace experimental {
             // wake any thread that is waiting for throttling
             if (inflight < detail::mpi_data_.throttling_limit_)
             {
-                mpi_debug.debug(debug::str<>("throttling"), "notify_one",
-                    "in_flight", debug::dec<4>(inflight));
+                mpi_debug.debug(debug::detail::str<>("throttling"),
+                    "notify_one", "in_flight", debug::detail::dec<4>(inflight));
                 detail::mpi_data_.throttling_cond_.notify_one();
             }
         }
@@ -453,7 +456,7 @@ namespace pika { namespace mpi { namespace experimental {
 #if defined(PIKA_DEBUG)
             ++get_register_polling_count();
 #endif
-            mpi_debug.debug(debug::str<>("enable polling"));
+            mpi_debug.debug(debug::detail::str<>("enable polling"));
             auto* sched = pool.get_scheduler();
             sched->set_mpi_polling_functions(
                 &pika::mpi::experimental::poll, &get_work_count);
@@ -482,7 +485,7 @@ namespace pika { namespace mpi { namespace experimental {
             }
 #endif
             if constexpr (mpi_debug.is_enabled())
-                mpi_debug.debug(debug::str<>("disable polling"));
+                mpi_debug.debug(debug::detail::str<>("disable polling"));
             auto* sched = pool.get_scheduler();
             sched->clear_mpi_polling_function();
         }
@@ -503,7 +506,8 @@ namespace pika { namespace mpi { namespace experimental {
                 nullptr, nullptr, required, minimal, provided);
             if (provided < MPI_THREAD_FUNNELED)
             {
-                mpi_debug.error(debug::str<>("pika::mpi::experimental::init"),
+                mpi_debug.error(
+                    debug::detail::str<>("pika::mpi::experimental::init"),
                     "init failed");
                 PIKA_THROW_EXCEPTION(invalid_status,
                     "pika::mpi::experimental::init",
@@ -527,8 +531,8 @@ namespace pika { namespace mpi { namespace experimental {
             }
         }
 
-        mpi_debug.debug(
-            debug::str<>("pika::mpi::experimental::init"), detail::mpi_data_);
+        mpi_debug.debug(debug::detail::str<>("pika::mpi::experimental::init"),
+            detail::mpi_data_);
 
         if (init_errorhandler)
         {
@@ -563,8 +567,8 @@ namespace pika { namespace mpi { namespace experimental {
         // clean up if we initialized mpi
         pika::util::mpi_environment::finalize();
 
-        mpi_debug.debug(debug::str<>("Clearing mode"), detail::mpi_data_,
-            "disable_user_polling");
+        mpi_debug.debug(debug::detail::str<>("Clearing mode"),
+            detail::mpi_data_, "disable_user_polling");
 
         if (pool_name.empty())
         {

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -42,7 +42,8 @@ constexpr int debug_level = 0;
 
 // cppcheck-suppress ConfigurationNotChecked
 template <int Level>
-static pika::debug::print_threshold<Level, debug_level> nws_deb("STORAGE");
+static pika::debug::detail::print_threshold<Level, debug_level> nws_deb(
+    "STORAGE");
 
 //----------------------------------------------------------------------------
 //
@@ -58,7 +59,7 @@ static local_storage_type local_recv_storage;
 namespace ex = pika::execution::experimental;
 namespace mpi = pika::mpi::experimental;
 namespace tt = pika::this_thread::experimental;
-namespace deb = pika::debug;
+namespace deb = pika::debug::detail;
 
 //----------------------------------------------------------------------------
 // namespace aliases

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -755,7 +755,7 @@ namespace pika::detail {
             else
             {
                 if (option == "startup")
-                    util::attach_debugger();
+                    debug::detail::attach_debugger();
 
                 ini_config_.emplace_back("pika.attach_debugger!=" + option);
             }

--- a/libs/pika/debugging/include/pika/debugging/attach_debugger.hpp
+++ b/libs/pika/debugging/include/pika/debugging/attach_debugger.hpp
@@ -8,10 +8,9 @@
 #pragma once
 
 #include <pika/config.hpp>
-#include <string>
 
-namespace pika { namespace util {
+namespace pika::debug::detail {
     /// Tries to break an attached debugger, if not supported a loop is
     /// invoked which gives enough time to attach a debugger manually.
     PIKA_EXPORT void attach_debugger();
-}}    // namespace pika::util
+}    // namespace pika::debug::detail

--- a/libs/pika/debugging/include/pika/debugging/backtrace.hpp
+++ b/libs/pika/debugging/include/pika/debugging/backtrace.hpp
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::debug::detail {
     class backtrace
     {
     };
@@ -25,6 +25,6 @@ namespace pika { namespace util {
     {
         return "";
     }
-}}    // namespace pika::util
+}    // namespace pika::debug::detail
 
 #endif

--- a/libs/pika/debugging/include/pika/debugging/backtrace/backtrace.hpp
+++ b/libs/pika/debugging/include/pika/debugging/backtrace/backtrace.hpp
@@ -18,7 +18,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::debug::detail {
     namespace stack_trace {
         PIKA_EXPORT std::size_t trace(void** addresses, std::size_t size);
         PIKA_EXPORT void write_symbols(
@@ -88,37 +88,34 @@ namespace pika { namespace util {
         std::vector<void*> frames_;
     };
 
-    namespace details {
-        class trace_manip
+    class trace_manip
+    {
+    public:
+        trace_manip(backtrace const* tr)
+          : tr_(tr)
         {
-        public:
-            trace_manip(backtrace const* tr)
-              : tr_(tr)
-            {
-            }
-            std::ostream& write(std::ostream& out) const
-            {
-                if (tr_)
-                    tr_->trace(out);
-                return out;
-            }
-
-        private:
-            backtrace const* tr_;
-        };
-
-        inline std::ostream& operator<<(
-            std::ostream& out, details::trace_manip const& t)
-        {
-            return t.write(out);
         }
-    }    // namespace details
+        std::ostream& write(std::ostream& out) const
+        {
+            if (tr_)
+                tr_->trace(out);
+            return out;
+        }
+
+    private:
+        backtrace const* tr_;
+    };
+
+    inline std::ostream& operator<<(std::ostream& out, trace_manip const& t)
+    {
+        return t.write(out);
+    }
 
     template <typename E>
-    inline details::trace_manip trace(E const& e)
+    inline trace_manip trace(E const& e)
     {
         backtrace const* tr = dynamic_cast<backtrace const*>(&e);
-        return details::trace_manip(tr);
+        return trace_manip(tr);
     }
 
     inline std::string trace(
@@ -126,4 +123,4 @@ namespace pika { namespace util {
     {
         return backtrace(frames_no).trace();
     }
-}}    // namespace pika::util
+}    // namespace pika::debug::detail

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -16,7 +16,7 @@
 // --------------------------------------------------------------------
 // Always present regardless of compiler : used by serialization code
 // --------------------------------------------------------------------
-namespace pika { namespace util { namespace debug {
+namespace pika::debug::detail {
     template <typename T>
     struct demangle_helper
     {
@@ -25,7 +25,7 @@ namespace pika { namespace util { namespace debug {
             return typeid(T).name();
         }
     };
-}}}    // namespace pika::util::debug
+}    // namespace pika::debug::detail
 
 #if defined(__GNUG__)
 
@@ -36,7 +36,7 @@ namespace pika { namespace util { namespace debug {
 // --------------------------------------------------------------------
 // if available : demangle an arbitrary c++ type using gnu utility
 // --------------------------------------------------------------------
-namespace pika { namespace util { namespace debug {
+namespace pika::debug::detail {
     template <typename T>
     class cxxabi_demangle_helper
     {
@@ -56,20 +56,19 @@ namespace pika { namespace util { namespace debug {
     private:
         std::unique_ptr<char, void (*)(void*)> demangled_;
     };
-
-}}}    // namespace pika::util::debug
+}    // namespace pika::debug::detail
 
 #else
 
-namespace pika { namespace util { namespace debug {
+namespace pika::debug::detail {
     template <typename T>
     using cxxabi_demangle_helper = demangle_helper<T>;
-}}}    // namespace pika::util::debug
+}    // namespace pika::debug::detail
 
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util { namespace debug {
+namespace pika::debug::detail {
     template <typename T>
     struct type_id
     {
@@ -118,4 +117,4 @@ namespace pika { namespace util { namespace debug {
         std::string temp(cxx_type_id<T>::typeid_.type_id());
         return temp + delim + print_type<Args...>(delim);
     }
-}}}    // namespace pika::util::debug
+}    // namespace pika::debug::detail

--- a/libs/pika/debugging/src/attach_debugger.cpp
+++ b/libs/pika/debugging/src/attach_debugger.cpp
@@ -18,7 +18,7 @@
 #include <Windows.h>
 #endif    // PIKA_WINDOWS
 
-namespace pika { namespace util {
+namespace pika::debug::detail {
     void attach_debugger()
     {
 #if defined(_POSIX_VERSION) && defined(PIKA_HAVE_UNISTD_H)
@@ -35,4 +35,4 @@ namespace pika { namespace util {
         DebugBreak();
 #endif
     }
-}}    // namespace pika::util
+}    // namespace pika::debug::detail

--- a/libs/pika/debugging/src/backtrace.cpp
+++ b/libs/pika/debugging/src/backtrace.cpp
@@ -15,8 +15,6 @@
 
 #include <pika/debugging/backtrace/backtrace.hpp>
 
-#include <boost/config.hpp>
-
 #if (defined(__linux) || defined(__APPLE__) || defined(__sun)) &&              \
     (!defined(__ANDROID__) || !defined(ANDROID))
 #define PIKA_HAVE_EXECINFO
@@ -64,7 +62,7 @@
 #include <winbase.h>
 #endif
 
-namespace pika { namespace util { namespace stack_trace {
+namespace pika::debug::detail::stack_trace {
 #if defined(PIKA_HAVE_EXECINFO) && defined(PIKA_HAVE_UNWIND)
     struct trace_data
     {
@@ -480,6 +478,6 @@ namespace pika { namespace util { namespace stack_trace {
     }
 
 #endif
-}}}    // namespace pika::util::stack_trace
+}    // namespace pika::debug::detail::stack_trace
 
 #endif

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -37,41 +37,38 @@ PIKA_EXPORT char** freebsd_environ = nullptr;
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace pika { namespace debug {
+namespace NS_DEBUG {
 
     // ------------------------------------------------------------------
     // format as zero padded int
     // ------------------------------------------------------------------
-    namespace detail {
+    template <typename Int>
+    PIKA_EXPORT void print_dec(std::ostream& os, Int const& v, int N)
+    {
+        os << std::right << std::setfill('0') << std::setw(N) << std::noshowbase
+           << std::dec << v;
+    }
 
-        template <typename Int>
-        PIKA_EXPORT void print_dec(std::ostream& os, Int const& v, int N)
-        {
-            os << std::right << std::setfill('0') << std::setw(N)
-               << std::noshowbase << std::dec << v;
-        }
+    template PIKA_EXPORT void print_dec(std::ostream&, bool const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::int16_t const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::uint16_t const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::int32_t const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::uint32_t const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::int64_t const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::uint64_t const&, int);
 
-        template PIKA_EXPORT void print_dec(std::ostream&, bool const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::int16_t const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::uint16_t const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::int32_t const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::uint32_t const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::int64_t const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::uint64_t const&, int);
-
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::atomic<int> const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::atomic<unsigned int> const&, int);
-        template PIKA_EXPORT void print_dec(
-            std::ostream&, std::atomic<unsigned long> const&, int);
-    }    // namespace detail
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::atomic<int> const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::atomic<unsigned int> const&, int);
+    template PIKA_EXPORT void print_dec(
+        std::ostream&, std::atomic<unsigned long> const&, int);
 
     // ------------------------------------------------------------------
     // format as pointer
@@ -96,73 +93,62 @@ namespace pika { namespace debug {
     // ------------------------------------------------------------------
     // format as zero padded hex
     // ------------------------------------------------------------------
-    namespace detail {
+    template <typename Int>
+    void print_hex(std::ostream& os, Int v, int N)
+    {
+        os << std::right << "0x" << std::setfill('0') << std::setw(N)
+           << std::noshowbase << std::hex << v;
+    }
 
-        template <typename Int>
-        void print_hex(std::ostream& os, Int v, int N)
-        {
-            os << std::right << "0x" << std::setfill('0') << std::setw(N)
-               << std::noshowbase << std::hex << v;
-        }
+    template PIKA_EXPORT void print_hex(std::ostream&, std::thread::id, int);
+    template PIKA_EXPORT void print_hex(std::ostream&, unsigned long, int);
+    template PIKA_EXPORT void print_hex(std::ostream&, long, int);
+    template PIKA_EXPORT void print_hex(std::ostream&, int, int);
+    template PIKA_EXPORT void print_hex(std::ostream&, unsigned int, int);
+    template PIKA_EXPORT void print_hex(std::ostream&, void*, int);
 
-        template PIKA_EXPORT void print_hex(
-            std::ostream&, std::thread::id, int);
-        template PIKA_EXPORT void print_hex(std::ostream&, unsigned long, int);
-        template PIKA_EXPORT void print_hex(std::ostream&, long, int);
-        template PIKA_EXPORT void print_hex(std::ostream&, int, int);
-        template PIKA_EXPORT void print_hex(std::ostream&, unsigned int, int);
-        template PIKA_EXPORT void print_hex(std::ostream&, void*, int);
+    template <typename Int>
+    void print_ptr(std::ostream& os, Int v, int N)
+    {
+        os << std::right << std::setw(N) << std::noshowbase << std::hex << v;
+    }
 
-        template <typename Int>
-        void print_ptr(std::ostream& os, Int v, int N)
-        {
-            os << std::right << std::setw(N) << std::noshowbase << std::hex
-               << v;
-        }
-
-        template PIKA_EXPORT void print_ptr(std::ostream&, void*, int);
-        template PIKA_EXPORT void print_ptr(std::ostream&, int, int);
-        template PIKA_EXPORT void print_ptr(std::ostream&, long, int);
-
-    }    // namespace detail
+    template PIKA_EXPORT void print_ptr(std::ostream&, void*, int);
+    template PIKA_EXPORT void print_ptr(std::ostream&, int, int);
+    template PIKA_EXPORT void print_ptr(std::ostream&, long, int);
 
     // ------------------------------------------------------------------
     // format as binary bits
     // ------------------------------------------------------------------
-    namespace detail {
+    template <typename Int>
+    PIKA_EXPORT void print_bin(std::ostream& os, Int v, int N)
+    {
+        char const* beg = reinterpret_cast<char const*>(&v);
+        char const* end = beg + sizeof(v);
 
-        template <typename Int>
-        PIKA_EXPORT void print_bin(std::ostream& os, Int v, int N)
+        N = (N + CHAR_BIT - 1) / CHAR_BIT;
+        while (beg != end && N-- > 0)
         {
-            char const* beg = reinterpret_cast<char const*>(&v);
-            char const* end = beg + sizeof(v);
-
-            N = (N + CHAR_BIT - 1) / CHAR_BIT;
-            while (beg != end && N-- > 0)
-            {
-                os << std::bitset<CHAR_BIT>(*beg++);
-            }
+            os << std::bitset<CHAR_BIT>(*beg++);
         }
+    }
 
-        template PIKA_EXPORT void print_bin(std::ostream&, unsigned char, int);
-        template PIKA_EXPORT void print_bin(std::ostream&, std::uint32_t, int);
-        template PIKA_EXPORT void print_bin(std::ostream&, std::uint64_t, int);
+    template PIKA_EXPORT void print_bin(std::ostream&, unsigned char, int);
+    template PIKA_EXPORT void print_bin(std::ostream&, std::uint32_t, int);
+    template PIKA_EXPORT void print_bin(std::ostream&, std::uint64_t, int);
 
 #if defined(__APPLE__)
-        // Explicit instantiation necessary to solve undefined symbol for MacOS
-        template PIKA_EXPORT void print_bin(std::ostream&, unsigned long, int);
+    // Explicit instantiation necessary to solve undefined symbol for MacOS
+    template PIKA_EXPORT void print_bin(std::ostream&, unsigned long, int);
 #endif
-    }    // namespace detail
 
     // ------------------------------------------------------------------
     // format as padded string
     // ------------------------------------------------------------------
-    namespace detail {
-        void print_str(std::ostream& os, char const* v, int N)
-        {
-            os << std::left << std::setfill(' ') << std::setw(N) << v;
-        }
-    }    // namespace detail
+    void print_str(std::ostream& os, char const* v, int N)
+    {
+        os << std::left << std::setfill(' ') << std::setw(N) << v;
+    }
 
     // ------------------------------------------------------------------
     // format as ip address
@@ -189,58 +175,50 @@ namespace pika { namespace debug {
     // ------------------------------------------------------------------
     // helper class for printing time since start
     // ------------------------------------------------------------------
-    namespace detail {
-        std::ostream& operator<<(
-            std::ostream& os, current_time_print_helper const&)
-        {
-            static std::chrono::steady_clock::time_point log_t_start =
-                std::chrono::steady_clock::now();
+    std::ostream& operator<<(std::ostream& os, current_time_print_helper const&)
+    {
+        static std::chrono::steady_clock::time_point log_t_start =
+            std::chrono::steady_clock::now();
 
-            auto now = std::chrono::steady_clock::now();
-            auto nowt = std::chrono::duration_cast<std::chrono::microseconds>(
-                now - log_t_start)
-                            .count();
+        auto now = std::chrono::steady_clock::now();
+        auto nowt = std::chrono::duration_cast<std::chrono::microseconds>(
+            now - log_t_start)
+                        .count();
 
-            os << debug::dec<10>(nowt) << " ";
-            return os;
-        }
-    }    // namespace detail
+        os << dec<10>(nowt) << " ";
+        return os;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+    std::function<void(std::ostream&)> print_info;
 
-        std::function<void(std::ostream&)> print_info;
+    void register_print_info(void (*printer)(std::ostream&))
+    {
+        print_info = printer;
+    }
 
-        void register_print_info(void (*printer)(std::ostream&))
+    void generate_prefix(std::ostream& os)
+    {
+        os << detail::current_time_print_helper();
+        if (print_info)
         {
-            print_info = printer;
+            print_info(os);
         }
-
-        void generate_prefix(std::ostream& os)
-        {
-            os << detail::current_time_print_helper();
-            if (print_info)
-            {
-                print_info(os);
-            }
-            os << detail::hostname_print_helper();
-        }
-    }    // namespace detail
+        os << detail::hostname_print_helper();
+    }
 
     // ------------------------------------------------------------------
     // helper function for printing short memory dump and crc32
     // useful for debugging corruptions in buffers during
     // rma or other transfers
     // ------------------------------------------------------------------
-    namespace detail {
-        std::uint32_t crc32(void const* ptr, std::size_t size)
-        {
-            boost::crc_32_type result;
-            result.process_bytes(ptr, size);
-            return result.checksum();
-            return 0;
-        }
-    }    // namespace detail
+    std::uint32_t crc32(void const* ptr, std::size_t size)
+    {
+        boost::crc_32_type result;
+        result.process_bytes(ptr, size);
+        return result.checksum();
+        return 0;
+    }
 
     mem_crc32::mem_crc32(void const* a, std::size_t len)
       : addr_(reinterpret_cast<const uint64_t*>(a))
@@ -253,89 +231,80 @@ namespace pika { namespace debug {
         std::uint64_t const* uintBuf =
             static_cast<std::uint64_t const*>(p.addr_);
         os << "Memory:";
-        os << " address " << pika::debug::ptr(p.addr_) << " length "
-           << pika::debug::hex<6>(p.len_)
-           << " CRC32:" << pika::debug::hex<8>(detail::crc32(p.addr_, p.len_))
-           << "\n";
+        os << " address " << ptr(p.addr_) << " length " << hex<6>(p.len_)
+           << " CRC32:" << hex<8>(detail::crc32(p.addr_, p.len_)) << "\n";
 
         for (std::size_t i = 0; i <
              (std::min)(size_t(std::ceil(static_cast<double>(p.len_) / 8.0)),
                  std::size_t(128));
              i++)
         {
-            os << pika::debug::hex<16>(*uintBuf++) << " ";
+            os << hex<16>(*uintBuf++) << " ";
         }
         return os;
     }
 
-    namespace detail {
-
-        // ------------------------------------------------------------------
-        // helper class for printing time since start
-        // ------------------------------------------------------------------
-        char const* hostname_print_helper::get_hostname() const
+    // ------------------------------------------------------------------
+    // helper class for printing time since start
+    // ------------------------------------------------------------------
+    char const* hostname_print_helper::get_hostname() const
+    {
+        static bool initialized = false;
+        static char hostname_[20] = {'\0'};
+        if (!initialized)
         {
-            static bool initialized = false;
-            static char hostname_[20] = {'\0'};
-            if (!initialized)
-            {
-                initialized = true;
+            initialized = true;
 #if !defined(__FreeBSD__)
-                gethostname(hostname_, std::size_t(12));
+            gethostname(hostname_, std::size_t(12));
 #endif
-                std::ostringstream temp;
-                temp << '(' << std::to_string(guess_rank()) << ')';
-                std::strcat(hostname_, temp.str().c_str());
-            }
-            return hostname_;
+            std::ostringstream temp;
+            temp << '(' << std::to_string(guess_rank()) << ')';
+            std::strcat(hostname_, temp.str().c_str());
         }
+        return hostname_;
+    }
 
-        int hostname_print_helper::guess_rank() const
-        {
+    int hostname_print_helper::guess_rank() const
+    {
 #if defined(__FreeBSD__)
-            char** env = freebsd_environ;
+        char** env = freebsd_environ;
 #else
-            char** env = environ;
+        char** env = environ;
 #endif
-            std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
-            for (char** current = env; *current; current++)
+        std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
+        for (char** current = env; *current; current++)
+        {
+            auto e = std::string(*current);
+            for (auto s : env_strings)
             {
-                auto e = std::string(*current);
-                for (auto s : env_strings)
+                auto pos = e.find(s);
+                if (pos != std::string::npos)
                 {
-                    auto pos = e.find(s);
-                    if (pos != std::string::npos)
-                    {
-                        //std::cout << "Got a rank string : " << e << std::endl;
-                        return std::stoi(e.substr(pos + s.size(), 5));
-                    }
+                    //std::cout << "Got a rank string : " << e << std::endl;
+                    return std::stoi(e.substr(pos + s.size(), 5));
                 }
             }
-            return -1;
         }
+        return -1;
+    }
 
-        std::ostream& operator<<(
-            std::ostream& os, hostname_print_helper const& h)
-        {
-            os << debug::str<13>(h.get_hostname()) << " ";
-            return os;
-        }
+    std::ostream& operator<<(std::ostream& os, hostname_print_helper const& h)
+    {
+        os << str<13>(h.get_hostname()) << " ";
+        return os;
+    }
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        PIKA_EXPORT void print_array(
-            std::string const& name, T const* data, std::size_t size)
-        {
-            std::cout << str<20>(name.c_str()) << ": {" << debug::dec<4>(size)
-                      << "} : ";
-            std::copy(
-                data, data + size, std::ostream_iterator<T>(std::cout, ", "));
-            std::cout << "\n";
-        }
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T>
+    PIKA_EXPORT void print_array(
+        std::string const& name, T const* data, std::size_t size)
+    {
+        std::cout << str<20>(name.c_str()) << ": {" << dec<4>(size) << "} : ";
+        std::copy(data, data + size, std::ostream_iterator<T>(std::cout, ", "));
+        std::cout << "\n";
+    }
 
-        template PIKA_EXPORT void print_array(
-            std::string const&, std::size_t const*, std::size_t);
-
-    }    // namespace detail
-}}       // namespace pika::debug
+    template PIKA_EXPORT void print_array(
+        std::string const&, std::size_t const*, std::size_t);
+}    // namespace NS_DEBUG
 /// \endcond

--- a/libs/pika/debugging/tests/unit/print.cpp
+++ b/libs/pika/debugging/tests/unit/print.cpp
@@ -20,9 +20,9 @@
 
 namespace pika {
     // this is an enabled debug object that should output messages
-    static pika::debug::enable_print<true> p_enabled("PRINT  ");
+    static pika::debug::detail::enable_print<true> p_enabled("PRINT  ");
     // this is disabled and we want it to have zero footprint
-    static pika::debug::enable_print<false> p_disabled("PRINT  ");
+    static pika::debug::detail::enable_print<false> p_disabled("PRINT  ");
 }    // namespace pika
 
 int increment(std::atomic<int>& counter)
@@ -37,7 +37,7 @@ int main()
     std::atomic<int> disabled_counter(0);
 
     using namespace pika;
-    using namespace pika::debug;
+    using namespace pika::debug::detail;
 
     // ---------------------------------------------------------
     // Test if normal debug messages trigger argument evaluation
@@ -87,9 +87,11 @@ int main()
     (void) var2;    // silenced unused var when optimized out
 
     p_enabled.debug("var 1",
-        pika::debug::dec<>(PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
+        pika::debug::detail::dec<>(
+            PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
     p_disabled.debug("var 2",
-        pika::debug::dec<>(PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
+        pika::debug::detail::dec<>(
+            PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
 
     PIKA_TEST_EQ(enabled_counter, 10);
     PIKA_TEST_EQ(disabled_counter, 0);
@@ -98,9 +100,11 @@ int main()
     p_disabled.set(var2, 5);
 
     p_enabled.debug("var 1",
-        pika::debug::dec<>(PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
+        pika::debug::detail::dec<>(
+            PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
     p_disabled.debug("var 2",
-        pika::debug::dec<>(PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
+        pika::debug::detail::dec<>(
+            PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
 
     PIKA_TEST_EQ(enabled_counter, 15);
     PIKA_TEST_EQ(disabled_counter, 0);
@@ -108,9 +112,9 @@ int main()
     // ---------------------------------------------------------
     // Test that timed log messages behave as expected
     static auto t_enabled =
-        p_enabled.make_timer(1, debug::str<>("Timed (enabled)"));
+        p_enabled.make_timer(1, debug::detail::str<>("Timed (enabled)"));
     static auto t_disabled =
-        p_disabled.make_timer(1, debug::str<>("Timed (disabled)"));
+        p_disabled.make_timer(1, debug::detail::str<>("Timed (disabled)"));
 
     // run a loop for 2 seconds with a timed print every 1 sec
     auto start = std::chrono::system_clock::now();
@@ -120,10 +124,11 @@ int main()
         2)
     {
         p_enabled.timed(t_enabled, "enabled",
-            debug::dec<3>(PIKA_DP_LAZY(p_enabled, ++enabled_counter)));
+            debug::detail::dec<3>(PIKA_DP_LAZY(p_enabled, ++enabled_counter)));
 
         p_disabled.timed(t_disabled, "disabled",
-            debug::dec<3>(PIKA_DP_LAZY(p_disabled, ++disabled_counter)));
+            debug::detail::dec<3>(
+                PIKA_DP_LAZY(p_disabled, ++disabled_counter)));
         end = std::chrono::system_clock::now();
     }
     PIKA_TEST_EQ(enabled_counter > 10, true);

--- a/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
@@ -32,8 +32,8 @@
 
 namespace pika {
     // cppcheck-suppress ConfigurationNotChecked
-    static pika::debug::enable_print<GUIDED_POOL_EXECUTOR_DEBUG> gpx_deb(
-        "GP_EXEC");
+    static pika::debug::detail::enable_print<GUIDED_POOL_EXECUTOR_DEBUG>
+        gpx_deb("GP_EXEC");
 }    // namespace pika
 
 // --------------------------------------------------------------------
@@ -117,7 +117,7 @@ namespace pika { namespace parallel { namespace execution {
 #endif
 
                 gpx_deb.debug(
-                    debug::str<>("async_schedule"), "domain ", domain);
+                    debug::detail::str<>("async_schedule"), "domain ", domain);
 
                 // now we must forward the task+hint on to the correct dispatch function
                 using result_type =
@@ -128,8 +128,8 @@ namespace pika { namespace parallel { namespace execution {
                     pika::util::deferred_call(
                         PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...));
 
-                gpx_deb.debug(
-                    debug::str<>("triggering apply"), "domain ", domain);
+                gpx_deb.debug(debug::detail::str<>("triggering apply"),
+                    "domain ", domain);
                 if (hp_sync_ &&
                     executor_.priority_ ==
                         pika::execution::thread_priority::high)
@@ -183,7 +183,8 @@ namespace pika { namespace parallel { namespace execution {
                 int domain = numa_function_(predecessor_value, ts...);
 #endif
 
-                gpx_deb.debug(debug::str<>("then_schedule"), "domain ", domain);
+                gpx_deb.debug(
+                    debug::detail::str<>("then_schedule"), "domain ", domain);
 
                 // now we must forward the task+hint on to the correct dispatch function
                 using result_type =
@@ -305,13 +306,13 @@ namespace pika { namespace parallel { namespace execution {
                 typename pika::util::detail::invoke_deferred_result<F,
                     Ts...>::type;
 
-            gpx_deb.debug(debug::str<>("async execute"), "\n\t",
-                "Function    : ", pika::util::debug::print_type<F>(), "\n\t",
-                "Arguments   : ", pika::util::debug::print_type<Ts...>(" | "),
-                "\n\t",
-                "Result      : ", pika::util::debug::print_type<result_type>(),
-                "\n\t", "Numa Hint   : ",
-                pika::util::debug::print_type<pool_numa_hint<Tag>>());
+            gpx_deb.debug(debug::detail::str<>("async execute"), "\n\t",
+                "Function    : ", pika::debug::detail::print_type<F>(), "\n\t",
+                "Arguments   : ", pika::debug::detail::print_type<Ts...>(" | "),
+                "\n\t", "Result      : ",
+                pika::debug::detail::print_type<result_type>(), "\n\t",
+                "Numa Hint   : ",
+                pika::debug::detail::print_type<pool_numa_hint<Tag>>());
 
             // hold onto the function until all futures have become ready
             // by using a dataflow operation, then call the scheduling hint
@@ -338,18 +339,18 @@ namespace pika { namespace parallel { namespace execution {
                 typename pika::util::detail::invoke_deferred_result<F, Future,
                     Ts...>::type;
 
-            gpx_deb.debug(debug::str<>("then execute"), "\n\t",
-                "Function    : ", pika::util::debug::print_type<F>(), "\n\t",
-                "Predecessor  : ", pika::util::debug::print_type<Future>(),
+            gpx_deb.debug(debug::detail::str<>("then execute"), "\n\t",
+                "Function    : ", pika::debug::detail::print_type<F>(), "\n\t",
+                "Predecessor  : ", pika::debug::detail::print_type<Future>(),
                 "\n\t", "Future       : ",
-                pika::util::debug::print_type<typename pika::traits::
+                pika::debug::detail::print_type<typename pika::traits::
                         future_traits<Future>::result_type>(),
                 "\n\t",
-                "Arguments   : ", pika::util::debug::print_type<Ts...>(" | "),
-                "\n\t",
-                "Result      : ", pika::util::debug::print_type<result_type>(),
-                "\n\t", "Numa Hint   : ",
-                pika::util::debug::print_type<pool_numa_hint<Tag>>());
+                "Arguments   : ", pika::debug::detail::print_type<Ts...>(" | "),
+                "\n\t", "Result      : ",
+                pika::debug::detail::print_type<result_type>(), "\n\t",
+                "Numa Hint   : ",
+                pika::debug::detail::print_type<pool_numa_hint<Tag>>());
 
             // Note 1 : The Ts &&... args are not actually used in a continuation since
             // only the future becoming ready (predecessor) is actually passed onwards.
@@ -404,18 +405,18 @@ namespace pika { namespace parallel { namespace execution {
                     OuterFuture<std::tuple<InnerFutures...>>, Ts...>::type;
 
             // clang-format off
-            gpx_deb.debug(debug::str<>("when_all(fut) : Predecessor")
-                , pika::util::debug::print_type<
+            gpx_deb.debug(debug::detail::str<>("when_all(fut) : Predecessor")
+                , pika::debug::detail::print_type<
                        OuterFuture<std::tuple<InnerFutures...>>>()
                 , "\n"
                 , "when_all(fut) : unwrapped   : "
-                , pika::util::debug::print_type<decltype(unwrapped_futures_tuple)>(
+                , pika::debug::detail::print_type<decltype(unwrapped_futures_tuple)>(
                        " | ")
                 , "\n"
                 , "then_execute  : Arguments   : "
-                , pika::util::debug::print_type<Ts...>(" | ") , "\n"
+                , pika::debug::detail::print_type<Ts...>(" | ") , "\n"
                 , "when_all(fut) : Result      : "
-                , pika::util::debug::print_type<result_type>() , "\n"
+                , pika::debug::detail::print_type<result_type>() , "\n"
             );
             // clang-format on
 #endif
@@ -468,11 +469,11 @@ namespace pika { namespace parallel { namespace execution {
 
 #ifndef GUIDED_EXECUTOR_DEBUG
             // clang-format off
-            gpx_deb.debug(debug::str<>("dataflow      : Predecessor")
-                      , pika::util::debug::print_type<std::tuple<InnerFutures...>>()
+            gpx_deb.debug(debug::detail::str<>("dataflow      : Predecessor")
+                      , debug::detail::print_type<std::tuple<InnerFutures...>>()
                       , "\n"
                       , "dataflow      : unwrapped   : "
-                      , pika::util::debug::print_type<
+                      , pika::debug::detail::print_type<
 #ifdef GUIDED_POOL_EXECUTOR_FAKE_NOOP
                              int>(" | ")
 #else
@@ -480,7 +481,8 @@ namespace pika { namespace parallel { namespace execution {
 #endif
                       , "\n");
 
-            gpx_deb.debug(debug::str<>("dataflow hint"), debug::dec<>(domain));
+            gpx_deb.debug(debug::detail::str<>("dataflow hint"),
+                          debug::detail::dec<>(domain));
             // clang-format on
 #endif
 

--- a/libs/pika/executors/include/pika/executors/limiting_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/limiting_executor.hpp
@@ -30,7 +30,7 @@
 namespace pika { namespace execution { namespace experimental {
 
     // by convention the title is 7 chars (for alignment)
-    using print_on = pika::debug::enable_print<false>;
+    using print_on = pika::debug::detail::enable_print<false>;
     static constexpr print_on lim_debug("LIMEXEC");
 
     ///////////////////////////////////////////////////////////////////////////
@@ -54,7 +54,7 @@ namespace pika { namespace execution { namespace experimental {
             }
             ~on_exit()
             {
-                lim_debug.debug(pika::debug::str<>("Count Down"));
+                lim_debug.debug(pika::debug::detail::str<>("Count Down"));
                 executor_.count_down();
             }
             limiting_executor const& executor_;
@@ -79,9 +79,10 @@ namespace pika { namespace execution { namespace experimental {
                 limiting_.count_up();
                 if (exceeds_upper())
                 {
-                    lim_debug.debug(pika::debug::str<>("Exceeds_upper"));
+                    lim_debug.debug(
+                        pika::debug::detail::str<>("Exceeds_upper"));
                     pika::util::yield_while([&]() { return exceeds_lower(); });
-                    lim_debug.debug(pika::debug::str<>("Below_lower"));
+                    lim_debug.debug(pika::debug::detail::str<>("Below_lower"));
                 }
             }
 
@@ -128,14 +129,14 @@ namespace pika { namespace execution { namespace experimental {
             {
                 if (exceeds_upper(base))
                 {
-                    lim_debug.debug(pika::debug::str<>("Exceeds_upper"),
+                    lim_debug.debug(pika::debug::detail::str<>("Exceeds_upper"),
                         "in_flight",
-                        pika::debug::dec<4>(base.in_flight_estimate()));
+                        pika::debug::detail::dec<4>(base.in_flight_estimate()));
                     pika::util::yield_while(
                         [&]() { return exceeds_lower(base); });
-                    lim_debug.debug(pika::debug::str<>("Below_lower"),
+                    lim_debug.debug(pika::debug::detail::str<>("Below_lower"),
                         "in_flight",
-                        pika::debug::dec<4>(base.in_flight_estimate()));
+                        pika::debug::detail::dec<4>(base.in_flight_estimate()));
                 }
             }
 

--- a/libs/pika/lock_registration/src/register_locks.cpp
+++ b/libs/pika/lock_registration/src/register_locks.cpp
@@ -27,7 +27,7 @@ namespace pika { namespace util {
           : ignore_(false)
           , user_data_(nullptr)
 #ifdef PIKA_HAVE_VERIFY_LOCKS_BACKTRACE
-          , backtrace_(pika::util::trace(trace_depth))
+          , backtrace_(pika::debug::detail::trace(trace_depth))
 #endif
         {
 #ifndef PIKA_HAVE_VERIFY_LOCKS_BACKTRACE

--- a/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
@@ -91,7 +91,7 @@ struct test_async_executor
         using result_type =
             typename util::detail::invoke_deferred_result<F, Ts...>::type;
 
-        using namespace pika::util::debug;
+        using namespace pika::debug::detail;
         std::cout << "async_execute : Function    : " << print_type<F>()
                   << "\n";
         std::cout << "async_execute : Arguments   : "
@@ -118,7 +118,7 @@ struct test_async_executor
         using result_type = typename util::detail::invoke_deferred_result<F,
             Future, Ts...>::type;
 
-        using namespace pika::util::debug;
+        using namespace pika::debug::detail;
         std::cout << "then_execute : Function     : " << print_type<F>()
                   << "\n";
         std::cout << "then_execute : Predecessor  : " << print_type<Future>()
@@ -163,7 +163,7 @@ struct test_async_executor
         auto unwrapped_futures_tuple =
             util::map_pack(future_extract_value{}, predecessor_value);
 
-        using namespace pika::util::debug;
+        using namespace pika::debug::detail;
         std::cout << "when_all(fut) : Predecessor : "
                   << print_type<OuterFuture<std::tuple<InnerFutures...>>>()
                   << "\n";
@@ -209,7 +209,7 @@ struct test_async_executor
         auto unwrapped_futures_tuple =
             util::map_pack(future_extract_value{}, predecessor);
 
-        using namespace pika::util::debug;
+        using namespace pika::debug::detail;
         std::cout << "dataflow      : Predecessor : "
                   << print_type<std::tuple<InnerFutures...>>() << "\n";
         std::cout << "dataflow      : unwrapped   : "

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
@@ -26,7 +26,7 @@
 
 namespace pika {
     // use <true>/<false> to enable/disable debug printing
-    using sbc_print_on = pika::debug::enable_print<false>;
+    using sbc_print_on = pika::debug::detail::enable_print<false>;
     static sbc_print_on deb_schbin("SCHBIND");
 }    // namespace pika
 
@@ -54,10 +54,10 @@ void threadLoop()
         dec_counter dec(count_down);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         std::size_t thread_actual = pika::get_worker_thread_num();
-        pika::deb_schbin.debug(pika::debug::str<10>("Iteration"),
-            pika::debug::dec<4>(iteration),
-            pika::debug::str<20>("Running on thread"), thread_actual,
-            pika::debug::str<10>("Expected"), thread_expected);
+        pika::deb_schbin.debug(pika::debug::detail::str<10>("Iteration"),
+            pika::debug::detail::dec<4>(iteration),
+            pika::debug::detail::str<20>("Running on thread"), thread_actual,
+            pika::debug::detail::str<10>("Expected"), thread_expected);
         PIKA_TEST_EQ(thread_actual, thread_expected);
     };
 
@@ -75,12 +75,12 @@ void threadLoop()
     do
     {
         pika::this_thread::yield();
-        pika::deb_schbin.debug(pika::debug::str<15>("count_down"),
-            pika::debug::dec<4>(count_down));
+        pika::deb_schbin.debug(pika::debug::detail::str<15>("count_down"),
+            pika::debug::detail::dec<4>(count_down));
     } while (count_down > 0);
 
-    pika::deb_schbin.debug(
-        pika::debug::str<15>("complete"), pika::debug::dec<4>(count_down));
+    pika::deb_schbin.debug(pika::debug::detail::str<15>("complete"),
+        pika::debug::detail::dec<4>(count_down));
     PIKA_TEST_EQ(count_down, 0);
 }
 
@@ -98,7 +98,7 @@ int pika_main()
     threadLoop();
 
     pika::finalize();
-    pika::deb_schbin.debug(pika::debug::str<15>("Finalized"));
+    pika::deb_schbin.debug(pika::debug::detail::str<15>("Finalized"));
     return pika::util::report_errors();
 }
 

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -378,7 +378,7 @@ namespace pika {
                 util::from_string<std::size_t>(get_config_entry(
                     "pika.trace_depth", PIKA_HAVE_THREAD_BACKTRACE_DEPTH));
 
-            pika::util::backtrace bt(trace_depth);
+            pika::debug::detail::backtrace bt(trace_depth);
             std::string back_trace = bt.trace();
 
             std::string state_name("not running");

--- a/libs/pika/runtime/src/debugging.cpp
+++ b/libs/pika/runtime/src/debugging.cpp
@@ -17,7 +17,7 @@ namespace pika { namespace util {
     {
         if (get_config_entry("pika.attach_debugger", "") == category)
         {
-            attach_debugger();
+            debug::detail::attach_debugger();
         }
     }
 }}    // namespace pika::util

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -70,7 +70,7 @@ namespace pika {
     {
         if (get_config_entry("pika.attach_debugger", "") == "exception")
         {
-            util::attach_debugger();
+            debug::detail::attach_debugger();
         }
 
         if (get_config_entry("pika.diagnostics_on_terminate", "1") == "1")
@@ -89,8 +89,8 @@ namespace pika {
                 std::size_t const trace_depth =
                     util::from_string<std::size_t>(get_config_entry(
                         "pika.trace_depth", PIKA_HAVE_THREAD_BACKTRACE_DEPTH));
-                std::cerr << "{stack-trace}: " << pika::util::trace(trace_depth)
-                          << "\n";
+                std::cerr << "{stack-trace}: "
+                          << pika::debug::detail::trace(trace_depth) << "\n";
             }
 #endif
 
@@ -143,7 +143,7 @@ namespace pika {
         if (signum != SIGINT &&
             get_config_entry("pika.attach_debugger", "") == "exception")
         {
-            util::attach_debugger();
+            debug::detail::attach_debugger();
         }
 
         if (get_config_entry("pika.diagnostics_on_terminate", "1") == "1")
@@ -164,8 +164,8 @@ namespace pika {
                 std::size_t const trace_depth =
                     util::from_string<std::size_t>(get_config_entry(
                         "pika.trace_depth", PIKA_HAVE_THREAD_BACKTRACE_DEPTH));
-                std::cerr << "{stack-trace}: " << pika::util::trace(trace_depth)
-                          << "\n";
+                std::cerr << "{stack-trace}: "
+                          << pika::debug::detail::trace(trace_depth) << "\n";
             }
 #endif
 

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -84,7 +84,7 @@ namespace pika { namespace detail {
 #if defined(PIKA_HAVE_VERIFY_LOCKS)
     void registered_locks_error_handler()
     {
-        std::string back_trace = pika::util::trace(std::size_t(128));
+        std::string back_trace = pika::debug::detail::trace(std::size_t(128));
 
         // throw or log, depending on config options
         if (get_config_entry("pika.throw_on_held_lock", "1") == "0")

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
@@ -43,7 +43,8 @@
 #endif
 
 namespace pika {
-    static pika::debug::enable_print<QUEUE_HOLDER_NUMA_DEBUG> nq_deb("QH_NUMA");
+    static pika::debug::detail::enable_print<QUEUE_HOLDER_NUMA_DEBUG> nq_deb(
+        "QH_NUMA");
 }
 
 // ------------------------------------------------------------////////
@@ -108,13 +109,13 @@ namespace pika { namespace threads { namespace policies {
                         thrd, (stealing || (i > 0)), i == 0))
                 {
                     // clang-format off
-                    nq_deb.debug(debug::str<>("HP/BP get_next")
-                         , "D", debug::dec<2>(domain_)
-                         , "Q",  debug::dec<3>(q)
-                         , "Qidx",  debug::dec<3>(qidx)
+                    nq_deb.debug(debug::detail::str<>("HP/BP get_next")
+                         , "D", debug::detail::dec<2>(domain_)
+                         , "Q",  debug::detail::dec<3>(q)
+                         , "Qidx",  debug::detail::dec<3>(qidx)
                          , ((i==0 && !stealing) ? "taken" : "stolen from")
                          , typename ThreadQueue::queue_data_print(queues_[q])
-                         , debug::threadinfo<
+                         , debug::detail::threadinfo<
                                  threads::detail::thread_id_ref_type*>(&thrd));
                     // clang-format on
                     return true;
@@ -140,13 +141,14 @@ namespace pika { namespace threads { namespace policies {
                 // if we got a thread, return it, only allow stealing if i>0
                 if (queues_[q]->get_next_thread(thrd, (stealing || (i > 0))))
                 {
-                    nq_deb.debug(debug::str<>("get_next"), "D",
-                        debug::dec<2>(domain_), "Q", debug::dec<3>(q), "Qidx",
-                        debug::dec<3>(qidx),
+                    nq_deb.debug(debug::detail::str<>("get_next"), "D",
+                        debug::detail::dec<2>(domain_), "Q",
+                        debug::detail::dec<3>(q), "Qidx",
+                        debug::detail::dec<3>(qidx),
                         ((i == 0 && !stealing) ? "taken" : "stolen from"),
                         typename ThreadQueue::queue_data_print(queues_[q]),
-                        debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                            &thrd));
+                        debug::detail::threadinfo<
+                            threads::detail::thread_id_ref_type*>(&thrd));
                     return true;
                 }
                 // if stealing disabled, do not check other queues
@@ -170,11 +172,11 @@ namespace pika { namespace threads { namespace policies {
                 if (added > 0)
                 {
                     // clang-format off
-                    nq_deb.debug(debug::str<>("HP/BP add_new")
-                        , "added", debug::dec<>(added)
-                        , "D", debug::dec<2>(domain_)
-                        , "Q",  debug::dec<3>(q)
-                        , "Qidx",  debug::dec<3>(qidx)
+                    nq_deb.debug(debug::detail::str<>("HP/BP add_new")
+                        , "added", debug::detail::dec<>(added)
+                        , "D", debug::detail::dec<2>(domain_)
+                        , "Q",  debug::detail::dec<3>(q)
+                        , "Qidx",  debug::detail::dec<3>(qidx)
                         , ((i==0 && !stealing) ? "taken" : "stolen from")
                         , typename ThreadQueue::queue_data_print(queues_[q]));
                     // clang-format on
@@ -201,11 +203,11 @@ namespace pika { namespace threads { namespace policies {
                 if (added > 0)
                 {
                     // clang-format off
-                    nq_deb.debug(debug::str<>("add_new")
-                         , "added", debug::dec<>(added)
-                         , "D", debug::dec<2>(domain_)
-                         , "Q",  debug::dec<3>(q)
-                         , "Qidx",  debug::dec<3>(qidx)
+                    nq_deb.debug(debug::detail::str<>("add_new")
+                         , "added", debug::detail::dec<>(added)
+                         , "D", debug::detail::dec<2>(domain_)
+                         , "Q",  debug::detail::dec<3>(q)
+                         , "Qidx",  debug::detail::dec<3>(qidx)
                          , ((i==0 && !stealing) ? "taken" : "stolen from")
                          , typename ThreadQueue::queue_data_print(queues_[q]));
                     // clang-format on

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -44,7 +44,7 @@
 #endif
 
 namespace pika {
-    static pika::debug::enable_print<QUEUE_HOLDER_THREAD_DEBUG> tq_deb(
+    static pika::debug::detail::enable_print<QUEUE_HOLDER_THREAD_DEBUG> tq_deb(
         "QH_THRD");
 }
 
@@ -168,8 +168,10 @@ namespace pika { namespace threads { namespace policies {
             friend std::ostream& operator<<(
                 std::ostream& os, const queue_mc_print& d)
             {
-                os << "n " << debug::dec<3>(d.q_->new_tasks_count_.data_)
-                   << " w " << debug::dec<3>(d.q_->work_items_count_.data_);
+                os << "n "
+                   << debug::detail::dec<3>(d.q_->new_tasks_count_.data_)
+                   << " w "
+                   << debug::detail::dec<3>(d.q_->work_items_count_.data_);
                 return os;
             }
         };
@@ -185,14 +187,16 @@ namespace pika { namespace threads { namespace policies {
             friend std::ostream& operator<<(
                 std::ostream& os, const queue_data_print& d)
             {
-                os << "D " << debug::dec<2>(d.q_->domain_index_) << " Q "
-                   << debug::dec<3>(d.q_->queue_index_) << " TM "
-                   << debug::dec<3>(d.q_->thread_map_count_.data_) << " [BP "
-                   << queue_mc_print(d.q_->bp_queue_) << "] [HP "
+                os << "D " << debug::detail::dec<2>(d.q_->domain_index_)
+                   << " Q " << debug::detail::dec<3>(d.q_->queue_index_)
+                   << " TM "
+                   << debug::detail::dec<3>(d.q_->thread_map_count_.data_)
+                   << " [BP " << queue_mc_print(d.q_->bp_queue_) << "] [HP "
                    << queue_mc_print(d.q_->hp_queue_) << "] [NP "
                    << queue_mc_print(d.q_->np_queue_) << "] [LP "
                    << queue_mc_print(d.q_->lp_queue_) << "] T "
-                   << debug::dec<3>(d.q_->terminated_items_count_.data_);
+                   << debug::detail::dec<3>(
+                          d.q_->terminated_items_count_.data_);
                 return os;
             }
         };
@@ -221,11 +225,11 @@ namespace pika { namespace threads { namespace policies {
         {
             rollover_counters_.data_ =
                 std::make_tuple(queue_index_, round_robin_rollover);
-            tq_deb.debug(debug::str<>("construct"), "D",
-                debug::dec<2>(domain_index_), "Q", debug::dec<3>(queue_index_),
-                "Rollover counter",
-                debug::dec<>(std::get<0>(rollover_counters_.data_)),
-                debug::dec<>(std::get<1>(rollover_counters_.data_)));
+            tq_deb.debug(debug::detail::str<>("construct"), "D",
+                debug::detail::dec<2>(domain_index_), "Q",
+                debug::detail::dec<3>(queue_index_), "Rollover counter",
+                debug::detail::dec<>(std::get<0>(rollover_counters_.data_)),
+                debug::detail::dec<>(std::get<1>(rollover_counters_.data_)));
             thread_map_count_.data_ = 0;
             terminated_items_count_.data_ = 0;
             if (bp_queue_)
@@ -295,10 +299,11 @@ namespace pika { namespace threads { namespace policies {
         // using a batching of N per worker before incrementing
         inline std::size_t worker_next(std::size_t const workers) const
         {
-            tq_deb.debug(debug::str<>("worker_next"), "Rollover counter ",
-                debug::dec<4>(std::get<0>(rollover_counters_.data_)),
-                debug::dec<4>(std::get<1>(rollover_counters_.data_)), "workers",
-                debug::dec<4>(workers));
+            tq_deb.debug(debug::detail::str<>("worker_next"),
+                "Rollover counter ",
+                debug::detail::dec<4>(std::get<0>(rollover_counters_.data_)),
+                debug::detail::dec<4>(std::get<1>(rollover_counters_.data_)),
+                "workers", debug::detail::dec<4>(workers));
             if (--std::get<1>(rollover_counters_.data_) == 0)
             {
                 std::get<1>(rollover_counters_.data_) = round_robin_rollover;
@@ -314,10 +319,10 @@ namespace pika { namespace threads { namespace policies {
         {
             if (bp_queue_ && (priority == execution::thread_priority::bound))
             {
-                tq_deb.debug(debug::str<>("schedule_thread"),
+                tq_deb.debug(debug::detail::str<>("schedule_thread"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "queueing execution::thread_priority::bound");
                 bp_queue_->schedule_work(PIKA_MOVE(thrd), other_end);
             }
@@ -326,28 +331,28 @@ namespace pika { namespace threads { namespace policies {
                     priority == execution::thread_priority::high_recursive ||
                     priority == execution::thread_priority::boost))
             {
-                tq_deb.debug(debug::str<>("schedule_thread"),
+                tq_deb.debug(debug::detail::str<>("schedule_thread"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "queueing execution::thread_priority::high");
                 hp_queue_->schedule_work(PIKA_MOVE(thrd), other_end);
             }
             else if (lp_queue_ && (priority == execution::thread_priority::low))
             {
-                tq_deb.debug(debug::str<>("schedule_thread"),
+                tq_deb.debug(debug::detail::str<>("schedule_thread"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "queueing execution::thread_priority::low");
                 lp_queue_->schedule_work(PIKA_MOVE(thrd), other_end);
             }
             else
             {
-                tq_deb.debug(debug::str<>("schedule_thread"),
+                tq_deb.debug(debug::detail::str<>("schedule_thread"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "queueing execution::thread_priority::normal");
                 np_queue_->schedule_work(PIKA_MOVE(thrd), other_end);
             }
@@ -358,7 +363,7 @@ namespace pika { namespace threads { namespace policies {
         {
             // clang-format off
             if (thread_num!=thread_num_) {
-                tq_deb.error(debug::str<>("assertion fail")
+                tq_deb.error(debug::detail::str<>("assertion fail")
                              , "thread_num", thread_num
                              , "thread_num_", thread_num_
                              , "queue_index_", queue_index_
@@ -381,10 +386,10 @@ namespace pika { namespace threads { namespace policies {
                 while (terminated_items_.pop(todelete))
                 {
                     --terminated_items_count_.data_;
-                    tq_deb.debug(debug::str<>("cleanup"), "delete",
+                    tq_deb.debug(debug::detail::str<>("cleanup"), "delete",
                         queue_data_print(this),
-                        debug::threadinfo<threads::detail::thread_data*>(
-                            todelete));
+                        debug::detail::threadinfo<
+                            threads::detail::thread_data*>(todelete));
                     threads::detail::thread_id_type tid(todelete);
                     remove_from_thread_map(tid, true);
                 }
@@ -397,8 +402,8 @@ namespace pika { namespace threads { namespace policies {
                         std::memory_order_relaxed) /
                     2);
 
-                tq_deb.debug(debug::str<>("cleanup"), "recycle", "delete_count",
-                    debug::dec<3>(delete_count));
+                tq_deb.debug(debug::detail::str<>("cleanup"), "recycle",
+                    "delete_count", debug::detail::dec<3>(delete_count));
 
                 threads::detail::thread_data* todelete;
                 while (delete_count && terminated_items_.pop(todelete))
@@ -406,10 +411,10 @@ namespace pika { namespace threads { namespace policies {
                     threads::detail::thread_id_type tid(todelete);
                     --terminated_items_count_.data_;
                     remove_from_thread_map(tid, false);
-                    tq_deb.debug(debug::str<>("cleanup"), "recycle",
+                    tq_deb.debug(debug::detail::str<>("cleanup"), "recycle",
                         queue_data_print(this),
-                        debug::threadinfo<threads::detail::thread_id_type*>(
-                            &tid));
+                        debug::detail::threadinfo<
+                            threads::detail::thread_id_type*>(&tid));
                     recycle_thread(tid);
                     --delete_count;
                 }
@@ -433,7 +438,7 @@ namespace pika { namespace threads { namespace policies {
             // create the thread using priority to select queue
             if (data.priority == execution::thread_priority::normal)
             {
-                tq_deb.debug(debug::str<>("create_thread "),
+                tq_deb.debug(debug::detail::str<>("create_thread "),
                     queue_data_print(this),
                     "execution::thread_priority::normal", "run_now ",
                     data.run_now);
@@ -442,7 +447,7 @@ namespace pika { namespace threads { namespace policies {
             else if (bp_queue_ &&
                 (data.priority == execution::thread_priority::bound))
             {
-                tq_deb.debug(debug::str<>("create_thread "),
+                tq_deb.debug(debug::detail::str<>("create_thread "),
                     queue_data_print(this), "execution::thread_priority::bound",
                     "run_now ", data.run_now);
                 return bp_queue_->create_thread(data, tid, ec);
@@ -458,7 +463,7 @@ namespace pika { namespace threads { namespace policies {
                 {
                     data.priority = execution::thread_priority::normal;
                 }
-                tq_deb.debug(debug::str<>("create_thread "),
+                tq_deb.debug(debug::detail::str<>("create_thread "),
                     queue_data_print(this), "execution::thread_priority::high",
                     "run_now ", data.run_now);
                 return hp_queue_->create_thread(data, tid, ec);
@@ -466,13 +471,13 @@ namespace pika { namespace threads { namespace policies {
             else if (lp_queue_ &&
                 (data.priority == execution::thread_priority::low))
             {
-                tq_deb.debug(debug::str<>("create_thread "),
+                tq_deb.debug(debug::detail::str<>("create_thread "),
                     queue_data_print(this), "execution::thread_priority::low",
                     "run_now ", data.run_now);
                 return lp_queue_->create_thread(data, tid, ec);
             }
 
-            tq_deb.error(debug::str<>("create_thread "), "priority?");
+            tq_deb.error(debug::detail::str<>("create_thread "), "priority?");
             std::terminate();
         }
 
@@ -536,10 +541,10 @@ namespace pika { namespace threads { namespace policies {
                 tid = heap->front();
                 heap->pop_front();
                 threads::detail::get_thread_id_data(tid)->rebind(data);
-                tq_deb.debug(debug::str<>("create_thread_object"), "rebind",
-                    queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &tid));
+                tq_deb.debug(debug::detail::str<>("create_thread_object"),
+                    "rebind", queue_data_print(this),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&tid));
             }
             else
 #endif
@@ -559,9 +564,10 @@ namespace pika { namespace threads { namespace policies {
                 tid = threads::detail::thread_id_ref_type(
                     p, threads::detail::thread_id_addref::no);
 
-                tq_deb.debug(debug::str<>("create_thread_object"), "new",
-                    queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_data*>(p));
+                tq_deb.debug(debug::detail::str<>("create_thread_object"),
+                    "new", queue_data_print(this),
+                    debug::detail::threadinfo<threads::detail::thread_data*>(
+                        p));
             }
         }
 
@@ -623,10 +629,11 @@ namespace pika { namespace threads { namespace policies {
                 //     threads::detail::get_thread_id_data(tid2);
                 // std::string prev = pika::util::format("{}", td);
 
-                tq_deb.error(debug::str<>("map add"),
+                tq_deb.error(debug::detail::str<>("map add"),
                     "Couldn't add new thread to the thread map",
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_type*>(&tid));
+                    debug::detail::threadinfo<threads::detail::thread_id_type*>(
+                        &tid));
 
                 lk.unlock();
                 PIKA_THROW_EXCEPTION(pika::out_of_memory,
@@ -636,8 +643,10 @@ namespace pika { namespace threads { namespace policies {
 
             ++thread_map_count_.data_;
 
-            tq_deb.debug(debug::str<>("map add"), queue_data_print(this),
-                debug::threadinfo<threads::detail::thread_id_type*>(&tid));
+            tq_deb.debug(debug::detail::str<>("map add"),
+                queue_data_print(this),
+                debug::detail::threadinfo<threads::detail::thread_id_type*>(
+                    &tid));
 
             // this thread has to be in the map now
             PIKA_ASSERT(thread_map_.find(tid) != thread_map_.end());
@@ -656,8 +665,10 @@ namespace pika { namespace threads { namespace policies {
             PIKA_ASSERT(deleted);
             (void) deleted;
 
-            tq_deb.debug(debug::str<>("map remove"), queue_data_print(this),
-                debug::threadinfo<threads::detail::thread_id_type*>(&tid));
+            tq_deb.debug(debug::detail::str<>("map remove"),
+                queue_data_print(this),
+                debug::detail::threadinfo<threads::detail::thread_id_type*>(
+                    &tid));
 
             if (dealloc)
             {
@@ -674,10 +685,10 @@ namespace pika { namespace threads { namespace policies {
             if (!stealing && bp_queue_ &&
                 bp_queue_->get_next_thread(thrd, stealing, check_new))
             {
-                tq_deb.debug(debug::str<>("next_thread_BP"),
+                tq_deb.debug(debug::detail::str<>("next_thread_BP"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "execution::thread_priority::bound");
                 return true;
             }
@@ -685,10 +696,10 @@ namespace pika { namespace threads { namespace policies {
             if (hp_queue_ &&
                 hp_queue_->get_next_thread(thrd, stealing, check_new))
             {
-                tq_deb.debug(debug::str<>("get_next_thread_HP"),
+                tq_deb.debug(debug::detail::str<>("get_next_thread_HP"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "execution::thread_priority::high");
                 return true;
             }
@@ -703,20 +714,20 @@ namespace pika { namespace threads { namespace policies {
         {
             if (np_queue_->get_next_thread(thrd, stealing))
             {
-                tq_deb.debug(debug::str<>("next_thread_NP"),
+                tq_deb.debug(debug::detail::str<>("next_thread_NP"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "execution::thread_priority::normal");
                 return true;
             }
 
             if (lp_queue_ && lp_queue_->get_next_thread(thrd, stealing))
             {
-                tq_deb.debug(debug::str<>("next_thread_LP"),
+                tq_deb.debug(debug::detail::str<>("next_thread_LP"),
                     queue_data_print(this),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd),
                     "execution::thread_priority::low");
                 return true;
             }
@@ -770,8 +781,8 @@ namespace pika { namespace threads { namespace policies {
             }
             //
             static auto an_timed =
-                tq_deb.make_timer(1, debug::str<>("add_new"));
-            tq_deb.timed(an_timed, "add", debug::dec<3>(add_count),
+                tq_deb.make_timer(1, debug::detail::str<>("add_new"));
+            tq_deb.timed(an_timed, "add", debug::detail::dec<3>(add_count),
                 "owns bp, hp, np, lp", owns_bp_queue(), owns_hp_queue(),
                 owns_np_queue(), owns_lp_queue(), "this",
                 queue_data_print(this), "from", queue_data_print(addfrom));
@@ -944,9 +955,10 @@ namespace pika { namespace threads { namespace policies {
             // the thread must be destroyed by the same queue holder that created it
             PIKA_ASSERT(&thrd->get_queue<queue_holder_thread>() == this);
             //
-            tq_deb.debug(debug::str<>("destroy"), "terminated_items push",
-                "xthread", xthread, queue_data_print(this),
-                debug::threadinfo<threads::detail::thread_data*>(thrd));
+            tq_deb.debug(debug::detail::str<>("destroy"),
+                "terminated_items push", "xthread", xthread,
+                queue_data_print(this),
+                debug::detail::threadinfo<threads::detail::thread_data*>(thrd));
             terminated_items_.push(thrd);
             std::int64_t count = ++terminated_items_count_.data_;
 
@@ -1039,24 +1051,25 @@ namespace pika { namespace threads { namespace policies {
         // ------------------------------------------------------------
         void debug_info()
         {
-            tq_deb.debug(debug::str<>("details"), "owner_mask_",
-                debug::bin<8>(owner_mask_), "D", debug::dec<2>(domain_index_),
-                "Q", debug::dec<3>(queue_index_));
-            tq_deb.debug(debug::str<>("bp_queue"),
-                debug::hex<12, void*>(bp_queue_), "holder",
-                debug::hex<12, void*>(
+            tq_deb.debug(debug::detail::str<>("details"), "owner_mask_",
+                debug::detail::bin<8>(owner_mask_), "D",
+                debug::detail::dec<2>(domain_index_), "Q",
+                debug::detail::dec<3>(queue_index_));
+            tq_deb.debug(debug::detail::str<>("bp_queue"),
+                debug::detail::hex<12, void*>(bp_queue_), "holder",
+                debug::detail::hex<12, void*>(
                     bp_queue_->holder_ ? bp_queue_->holder_ : nullptr));
-            tq_deb.debug(debug::str<>("hp_queue"),
-                debug::hex<12, void*>(hp_queue_), "holder",
-                debug::hex<12, void*>(
+            tq_deb.debug(debug::detail::str<>("hp_queue"),
+                debug::detail::hex<12, void*>(hp_queue_), "holder",
+                debug::detail::hex<12, void*>(
                     hp_queue_->holder_ ? hp_queue_->holder_ : nullptr));
-            tq_deb.debug(debug::str<>("np_queue"),
-                debug::hex<12, void*>(np_queue_), "holder",
-                debug::hex<12, void*>(
+            tq_deb.debug(debug::detail::str<>("np_queue"),
+                debug::detail::hex<12, void*>(np_queue_), "holder",
+                debug::detail::hex<12, void*>(
                     np_queue_->holder_ ? np_queue_->holder_ : nullptr));
-            tq_deb.debug(debug::str<>("lp_queue"),
-                debug::hex<12, void*>(lp_queue_), "holder",
-                debug::hex<12, void*>(
+            tq_deb.debug(debug::detail::str<>("lp_queue"),
+                debug::detail::hex<12, void*>(lp_queue_), "holder",
+                debug::detail::hex<12, void*>(
                     lp_queue_->holder_ ? lp_queue_->holder_ : nullptr));
         }
 
@@ -1064,7 +1077,7 @@ namespace pika { namespace threads { namespace policies {
         void debug_queues(const char* prefix)
         {
             static auto deb_queues =
-                tq_deb.make_timer(1, debug::str<>("debug_queues"));
+                tq_deb.make_timer(1, debug::detail::str<>("debug_queues"));
             //
             tq_deb.timed(deb_queues, prefix, queue_data_print(this));
         }

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -56,8 +56,9 @@ namespace pika {
     constexpr int debug_level = 0;
 
     template <int Level>
-    static debug::print_threshold<Level, debug_level> spq_deb("SPQUEUE");
-    static debug::print_threshold<1, 1> spq_arr("SPQUEUE");
+    static debug::detail::print_threshold<Level, debug_level> spq_deb(
+        "SPQUEUE");
+    static debug::detail::print_threshold<1, 1> spq_arr("SPQUEUE");
 #define DEBUG(printer, Expr) PIKA_DP_ONLY(printer, Expr)
 }    // namespace pika
 
@@ -175,7 +176,7 @@ namespace pika { namespace threads { namespace policies {
             core_stealing_ = mode & policies::enable_stealing;
             numa_stealing_ = mode & policies::enable_stealing_numa;
             // clang-format off
-            DEBUG(spq_deb<5>,debug(debug::str<>("scheduler_mode")
+            DEBUG(spq_deb<5>,debug(debug::detail::str<>("scheduler_mode")
                 , round_robin_ ? "round_robin" : "thread parent"
                 , ','
                 , steal_hp_first_ ? "steal_hp_first" : "steal after local"
@@ -220,7 +221,7 @@ namespace pika { namespace threads { namespace policies {
         bool cleanup_terminated(bool delete_all) override
         {
             static auto cleanup = spq_deb<5>.make_timer(
-                1, debug::str<>("Cleanup"), "Global version");
+                1, debug::detail::str<>("Cleanup"), "Global version");
             DEBUG(spq_deb<5>, timed(cleanup));
 
             // check calling thread number has queues to clean
@@ -230,7 +231,7 @@ namespace pika { namespace threads { namespace policies {
             {
                 // clang-format off
                 using namespace pika::threads::detail;
-                DEBUG(spq_deb<5>,debug(debug::str<>("cleanup_terminated")
+                DEBUG(spq_deb<5>,debug(debug::detail::str<>("cleanup_terminated")
                     , "v1 aborted"
                     , "num_workers_", num_workers_
                     , "thread_number"
@@ -248,9 +249,10 @@ namespace pika { namespace threads { namespace policies {
             std::size_t q_index = q_lookup_[local_num];
 
             DEBUG(spq_deb<5>,
-                debug(debug::str<>("cleanup_terminated"), "v1", "D",
-                    debug::dec<2>(domain_num), "Q", debug::dec<3>(q_index),
-                    "thread_num", debug::dec<3>(local_num)));
+                debug(debug::detail::str<>("cleanup_terminated"), "v1", "D",
+                    debug::detail::dec<2>(domain_num), "Q",
+                    debug::detail::dec<3>(q_index), "thread_num",
+                    debug::detail::dec<3>(local_num)));
 
             return numa_holder_[domain_num]
                 .thread_queue(static_cast<std::size_t>(q_index))
@@ -297,7 +299,7 @@ namespace pika { namespace threads { namespace policies {
                 {
                     // clang-format off
                     using namespace pika::threads::detail;
-                    DEBUG(spq_deb<7>,debug(debug::str<>("create_thread")
+                    DEBUG(spq_deb<7>,debug(debug::detail::str<>("create_thread")
                         , "x-pool", "num_workers_", num_workers_
                         , "thread_number"
                         , "global", get_global_thread_num_tss()
@@ -319,7 +321,7 @@ namespace pika { namespace threads { namespace policies {
                         q_index = q_lookup_[thread_num];
                     }
                     DEBUG(spq_deb<7>,
-                        debug(debug::str<>("create_thread"),
+                        debug(debug::detail::str<>("create_thread"),
                             "assign_work_thread_parent", "thread_num",
                             thread_num, "pool", parent_pool_->get_pool_name()));
                 }
@@ -328,7 +330,7 @@ namespace pika { namespace threads { namespace policies {
                     domain_num = d_lookup_[thread_num];
                     q_index = q_lookup_[thread_num];
                     DEBUG(spq_deb<7>,
-                        debug(debug::str<>("create_thread"),
+                        debug(debug::detail::str<>("create_thread"),
                             "assign_work_round_robin", "thread_num", thread_num,
                             "pool", parent_pool_->get_pool_name(),
                             typename thread_holder_type::queue_data_print(
@@ -395,20 +397,21 @@ namespace pika { namespace threads { namespace policies {
             {
                 data.run_now = false;
                 DEBUG(spq_deb<6>,
-                    debug(debug::str<>("create_thread"), "run_now OVERRIDE "));
+                    debug(debug::detail::str<>("create_thread"),
+                        "run_now OVERRIDE "));
             }
             // clang-format off
-            DEBUG(spq_deb<5>,debug(debug::str<>("create_thread")
+            DEBUG(spq_deb<5>,debug(debug::detail::str<>("create_thread")
                 , "pool", parent_pool_->get_pool_name()
                 , "hint", msg
                 , "dest"
-                , "D", debug::dec<2>(domain_num)
-                , "Q", debug::dec<3>(q_index)
+                , "D", debug::detail::dec<2>(domain_num)
+                , "Q", debug::detail::dec<3>(q_index)
                 , "this"
-                , "D", debug::dec<2>(d_lookup_[thread_num])
-                , "Q", debug::dec<3>(thread_num)
+                , "D", debug::detail::dec<2>(d_lookup_[thread_num])
+                , "Q", debug::detail::dec<3>(thread_num)
                 , "run_now ", data.run_now
-                , debug::threadinfo<threads::detail::thread_init_data>(data)));
+                , debug::detail::threadinfo<threads::detail::thread_init_data>(data)));
             // clang-format on
             numa_holder_[domain_num]
                 .thread_queue(static_cast<std::size_t>(q_index))
@@ -448,9 +451,9 @@ namespace pika { namespace threads { namespace policies {
                 if (result)
                 {
                     DEBUG(spq_deb<7>,
-                        debug(debug::str<>(prefix), "local no stealing", "D",
-                            debug::dec<2>(domain), "Q",
-                            debug::dec<3>(q_index)));
+                        debug(debug::detail::str<>(prefix), "local no stealing",
+                            "D", debug::detail::dec<2>(domain), "Q",
+                            debug::detail::dec<3>(q_index)));
                     return result;
                 }
             }
@@ -466,11 +469,11 @@ namespace pika { namespace threads { namespace policies {
                     if (result)
                     {
                         DEBUG(spq_deb<5>,
-                            debug(debug::str<>(prefix),
+                            debug(debug::detail::str<>(prefix),
                                 "steal_high_priority_first BP/HP",
                                 (d == 0 ? "taken" : "stolen"), "D",
-                                debug::dec<2>(domain), "Q",
-                                debug::dec<3>(q_index)));
+                                debug::detail::dec<2>(domain), "Q",
+                                debug::detail::dec<3>(q_index)));
                         return result;
                     }
                     // if no numa stealing, skip other domains
@@ -486,11 +489,11 @@ namespace pika { namespace threads { namespace policies {
                     if (result)
                     {
                         DEBUG(spq_deb<5>,
-                            debug(debug::str<>(prefix),
+                            debug(debug::detail::str<>(prefix),
                                 "steal_high_priority_first NP/LP",
                                 (d == 0 ? "taken" : "stolen"), "D",
-                                debug::dec<2>(domain), "Q",
-                                debug::dec<3>(q_index)));
+                                debug::detail::dec<2>(domain), "Q",
+                                debug::detail::dec<3>(q_index)));
                         return result;
                     }
                     // if no numa stealing, skip other domains
@@ -508,10 +511,10 @@ namespace pika { namespace threads { namespace policies {
                 if (result)
                 {
                     DEBUG(spq_deb<5>,
-                        debug(debug::str<>(prefix),
+                        debug(debug::detail::str<>(prefix),
                             "steal_after_local local taken", "D",
-                            debug::dec<2>(domain), "Q",
-                            debug::dec<3>(q_index)));
+                            debug::detail::dec<2>(domain), "Q",
+                            debug::detail::dec<3>(q_index)));
                     return result;
                 }
 
@@ -529,10 +532,10 @@ namespace pika { namespace threads { namespace policies {
                         if (result)
                         {
                             DEBUG(spq_deb<5>,
-                                debug(debug::str<>(prefix),
+                                debug(debug::detail::str<>(prefix),
                                     "steal_after_local this numa", "stolen",
-                                    "D", debug::dec<2>(domain), "Q",
-                                    debug::dec<3>(q_index)));
+                                    "D", debug::detail::dec<2>(domain), "Q",
+                                    debug::detail::dec<3>(q_index)));
                             return result;
                         }
                     }
@@ -550,11 +553,11 @@ namespace pika { namespace threads { namespace policies {
                         if (result)
                         {
                             DEBUG(spq_deb<5>,
-                                debug(debug::str<>(prefix),
+                                debug(debug::detail::str<>(prefix),
                                     "steal_after_local other numa BP/HP",
                                     (d == 0 ? "taken" : "stolen"), "D",
-                                    debug::dec<2>(domain), "Q",
-                                    debug::dec<3>(q_index)));
+                                    debug::detail::dec<2>(domain), "Q",
+                                    debug::detail::dec<3>(q_index)));
                             return result;
                         }
                     }
@@ -568,11 +571,11 @@ namespace pika { namespace threads { namespace policies {
                         if (result)
                         {
                             DEBUG(spq_deb<5>,
-                                debug(debug::str<>(prefix),
+                                debug(debug::detail::str<>(prefix),
                                     "steal_after_local other numa NP/LP",
                                     (d == 0 ? "taken" : "stolen"), "D",
-                                    debug::dec<2>(domain), "Q",
-                                    debug::dec<3>(q_index)));
+                                    debug::detail::dec<2>(domain), "Q",
+                                    debug::detail::dec<3>(q_index)));
                             return result;
                         }
                     }
@@ -591,10 +594,11 @@ namespace pika { namespace threads { namespace policies {
             PIKA_ASSERT(this_thread < num_workers_);
 
             // just cleanup the thread we were called by rather than all threads
-            static auto getnext =
-                spq_deb<5>.make_timer(1, debug::str<>("get_next_thread"));
+            static auto getnext = spq_deb<5>.make_timer(
+                1, debug::detail::str<>("get_next_thread"));
             //
-            DEBUG(spq_deb<5>, timed(getnext, debug::dec<>(this_thread)));
+            DEBUG(
+                spq_deb<5>, timed(getnext, debug::detail::dec<>(this_thread)));
 
             auto get_next_thread_function_HP =
                 [&](std::size_t domain, std::size_t q_index,
@@ -654,7 +658,7 @@ namespace pika { namespace threads { namespace policies {
             PIKA_ASSERT(this_thread < num_workers_);
 
             static auto w_or_add_n =
-                spq_deb<5>.make_timer(1, debug::str<>("just_add_new"));
+                spq_deb<5>.make_timer(1, debug::detail::str<>("just_add_new"));
 
             added = 0;
 
@@ -730,7 +734,7 @@ namespace pika { namespace threads { namespace policies {
                     q_index = 0;
                     // clang-format off
                     using namespace pika::threads::detail;
-                    DEBUG(spq_deb<5>,debug(debug::str<>("schedule_thread")
+                    DEBUG(spq_deb<5>,debug(debug::detail::str<>("schedule_thread")
                         , "x-pool thread schedule"
                         , "num_workers_", num_workers_
                         , "thread_number"
@@ -738,8 +742,9 @@ namespace pika { namespace threads { namespace policies {
                         , "local", get_local_thread_num_tss()
                         , "pool", get_thread_pool_num_tss()
                         , "parent offset", parent_pool_->get_thread_offset()
-                        , parent_pool_->get_pool_name(),
-                        debug::threadinfo<threads::detail::thread_id_ref_type*>(&thrd)));
+                        , parent_pool_->get_pool_name()
+                        , debug::detail::threadinfo<threads::detail::thread_id_ref_type*>(
+                            &thrd)));
                     // clang-format on
                 }
                 else if (!round_robin_) /*assign_parent*/
@@ -747,10 +752,10 @@ namespace pika { namespace threads { namespace policies {
                     domain_num = d_lookup_[thread_num];
                     q_index = q_lookup_[thread_num];
                     DEBUG(spq_deb<5>,
-                        debug(debug::str<>("schedule_thread"),
+                        debug(debug::detail::str<>("schedule_thread"),
                             "assign_work_thread_parent", "thread_num",
                             thread_num,
-                            debug::threadinfo<
+                            debug::detail::threadinfo<
                                 threads::detail::thread_id_ref_type*>(&thrd)));
                 }
                 else /*(round_robin_)*/
@@ -761,9 +766,9 @@ namespace pika { namespace threads { namespace policies {
                                      .thread_queue(q_index)
                                      ->worker_next(num_workers_);
                     DEBUG(spq_deb<5>,
-                        debug(debug::str<>("schedule_thread"),
+                        debug(debug::detail::str<>("schedule_thread"),
                             "assign_work_round_robin", "thread_num", thread_num,
-                            debug::threadinfo<
+                            debug::detail::threadinfo<
                                 threads::detail::thread_id_ref_type*>(&thrd)));
                 }
                 thread_num =
@@ -776,11 +781,11 @@ namespace pika { namespace threads { namespace policies {
                 // Create thread on requested worker thread
                 DEBUG(spq_deb<5>, set(msg, (const char*) "HINT_THREAD"));
                 DEBUG(spq_deb<5>,
-                    debug(debug::str<>("schedule_thread"),
+                    debug(debug::detail::str<>("schedule_thread"),
                         "received HINT_THREAD",
-                        debug::dec<3>(schedulehint.hint),
-                        debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                            &thrd)));
+                        debug::detail::dec<3>(schedulehint.hint),
+                        debug::detail::threadinfo<
+                            threads::detail::thread_id_ref_type*>(&thrd)));
                 thread_num = select_active_pu(
                     l, schedulehint.hint, true /*allow_fallback*/);
                 domain_num = d_lookup_[thread_num];
@@ -815,9 +820,10 @@ namespace pika { namespace threads { namespace policies {
             }
 
             DEBUG(spq_deb<5>,
-                debug(debug::str<>("thread scheduled"), msg, "Thread",
-                    debug::dec<3>(thread_num), "D", debug::dec<2>(domain_num),
-                    "Q", debug::dec<3>(q_index)));
+                debug(debug::detail::str<>("thread scheduled"), msg, "Thread",
+                    debug::detail::dec<3>(thread_num), "D",
+                    debug::detail::dec<2>(domain_num), "Q",
+                    debug::detail::dec<3>(q_index)));
 
             numa_holder_[domain_num].thread_queue(q_index)->schedule_thread(
                 thrd, priority, other_end);
@@ -839,7 +845,8 @@ namespace pika { namespace threads { namespace policies {
             execution::thread_priority priority =
                 execution::thread_priority::normal) override
         {
-            DEBUG(spq_deb<5>, debug(debug::str<>("schedule_thread_last")));
+            DEBUG(spq_deb<5>,
+                debug(debug::detail::str<>("schedule_thread_last")));
             schedule_work(thrd, schedulehint, allow_fallback, true,
                 priority = execution::thread_priority::normal);
         }
@@ -860,7 +867,7 @@ namespace pika { namespace threads { namespace policies {
             if (this_thread == std::size_t(-1))
             {
                 this_thread = thrd->get_last_worker_thread_num();
-                spq_arr.debug(debug::str<>("Alert"), this_thread);
+                spq_arr.debug(debug::detail::str<>("Alert"), this_thread);
             }
             PIKA_ASSERT(this_thread < num_workers_);
 
@@ -868,11 +875,12 @@ namespace pika { namespace threads { namespace policies {
             auto q2 = q_lookup_[this_thread];
             bool xthread = ((q1 != q2) || (d1 != d2));
             DEBUG(spq_deb<7>,
-                debug(debug::str<>("destroy_thread"), "xthread", xthread,
-                    "task owned by", "D", debug::dec<2>(d1), "Q",
-                    debug::dec<3>(q1), "this thread", "D", debug::dec<2>(d2),
-                    "Q", debug::dec<3>(q2),
-                    debug::threadinfo<threads::detail::thread_data*>(thrd)));
+                debug(debug::detail::str<>("destroy_thread"), "xthread",
+                    xthread, "task owned by", "D", debug::detail::dec<2>(d1),
+                    "Q", debug::detail::dec<3>(q1), "this thread", "D",
+                    debug::detail::dec<2>(d2), "Q", debug::detail::dec<3>(q2),
+                    debug::detail::threadinfo<threads::detail::thread_data*>(
+                        thrd)));
             // the cleanup of a task should be done by the original owner
             // of the task, so return it to the queue it came from before it
             // was stolen
@@ -888,8 +896,8 @@ namespace pika { namespace threads { namespace policies {
             std::size_t thread_num = std::size_t(-1)) const override
         {
             DEBUG(spq_deb<5>,
-                debug(debug::str<>("get_queue_length"), "thread_num ",
-                    debug::dec<>(thread_num)));
+                debug(debug::detail::str<>("get_queue_length"), "thread_num ",
+                    debug::detail::dec<>(thread_num)));
 
             PIKA_ASSERT(thread_num != std::size_t(-1));
 
@@ -928,9 +936,9 @@ namespace pika { namespace threads { namespace policies {
                                          .thread_queue(q_index)
                                          ->get_thread_count(state, priority);
                 DEBUG(spq_deb<6>,
-                    debug(debug::str<>("get_thread_count"), "thread_num ",
-                        debug::dec<3>(thread_num), "count ",
-                        debug::dec<4>(count)));
+                    debug(debug::detail::str<>("get_thread_count"),
+                        "thread_num ", debug::detail::dec<3>(thread_num),
+                        "count ", debug::detail::dec<4>(count)));
                 return count;
             }
             else
@@ -941,9 +949,9 @@ namespace pika { namespace threads { namespace policies {
                     count += numa_holder_[d].get_thread_count(state, priority);
                 }
                 DEBUG(spq_deb<6>,
-                    debug(debug::str<>("get_thread_count"), "thread_num ",
-                        debug::dec<3>(thread_num), "count ",
-                        debug::dec<4>(count)));
+                    debug(debug::detail::str<>("get_thread_count"),
+                        "thread_num ", debug::detail::dec<3>(thread_num),
+                        "count ", debug::detail::dec<4>(count)));
                 return count;
             }
         }
@@ -967,7 +975,7 @@ namespace pika { namespace threads { namespace policies {
         {
             bool result = true;
 
-            DEBUG(spq_deb<5>, debug(debug::str<>("enumerate_threads")));
+            DEBUG(spq_deb<5>, debug(debug::detail::str<>("enumerate_threads")));
 
             for (std::size_t d = 0; d < num_domains_; ++d)
             {
@@ -980,7 +988,7 @@ namespace pika { namespace threads { namespace policies {
         void on_start_thread(std::size_t local_thread) override
         {
             DEBUG(spq_deb<5>,
-                debug(debug::str<>("start_thread"), "local_thread",
+                debug(debug::detail::str<>("start_thread"), "local_thread",
                     local_thread));
 
             auto const& topo = ::pika::threads::detail::create_topology();
@@ -1200,9 +1208,10 @@ namespace pika { namespace threads { namespace policies {
                     }
 
                     DEBUG(spq_deb<5>,
-                        debug(debug::str<>("thread holder"), "local_thread",
-                            local_thread, "domain", domain, "index", index,
-                            "local_id", local_id, "owner_mask", owner_mask));
+                        debug(debug::detail::str<>("thread holder"),
+                            "local_thread", local_thread, "domain", domain,
+                            "index", index, "local_id", local_id, "owner_mask",
+                            owner_mask));
 
                     thread_holder = new queue_holder_thread<thread_queue_type>(
                         bp_queue, hp_queue, np_queue, lp_queue,

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
@@ -43,7 +43,7 @@
 #include <vector>
 
 namespace pika {
-    static pika::debug::enable_print<false> tqmc_deb("_TQ_MC_");
+    static pika::debug::detail::enable_print<false> tqmc_deb("_TQ_MC_");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -79,9 +79,10 @@ namespace pika { namespace threads { namespace policies {
         std::size_t add_new(
             std::int64_t add_count, thread_queue_type* addfrom, bool stealing)
         {
-            [[maybe_unused]] auto scp = tqmc_deb.scope(debug::ptr(this),
-                __func__, "from", debug::ptr(addfrom), "std::thread::id",
-                debug::hex<6>(holder_->owner_id_), stealing);
+            [[maybe_unused]] auto scp =
+                tqmc_deb.scope(debug::detail::ptr(this), __func__, "from",
+                    debug::detail::ptr(addfrom), "std::thread::id",
+                    debug::detail::hex<6>(holder_->owner_id_), stealing);
             PIKA_ASSERT(holder_->owner_id_ == std::this_thread::get_id());
 
             if (addfrom->new_tasks_count_.data_.load(
@@ -104,9 +105,10 @@ namespace pika { namespace threads { namespace policies {
                 // Decrement only after thread_map_count_ has been incremented
                 --addfrom->new_tasks_count_.data_;
 
-                tqmc_deb.debug(debug::str<>("add_new"), "stealing", stealing,
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &tid));
+                tqmc_deb.debug(debug::detail::str<>("add_new"), "stealing",
+                    stealing,
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&tid));
 
                 // insert the thread into work-items queue assuming it is in
                 // pending state
@@ -139,9 +141,9 @@ namespace pika { namespace threads { namespace policies {
         void set_holder(queue_holder_thread<thread_queue_type>* holder)
         {
             holder_ = holder;
-            tqmc_deb.debug(debug::str<>("set_holder"), "D",
-                debug::dec<2>(holder_->domain_index_), "Q",
-                debug::dec<3>(queue_index_));
+            tqmc_deb.debug(debug::detail::str<>("set_holder"), "D",
+                debug::detail::dec<2>(holder_->domain_index_), "Q",
+                debug::detail::dec<3>(queue_index_));
         }
 
         // ----------------------------------------------------------------
@@ -254,7 +256,7 @@ namespace pika { namespace threads { namespace policies {
             bool other_end, bool check_new = false) PIKA_HOT
         {
             [[maybe_unused]] auto scp =
-                tqmc_deb.scope(debug::ptr(this), __func__);
+                tqmc_deb.scope(debug::detail::ptr(this), __func__);
             std::int64_t work_items_count_count =
                 work_items_count_.data_.load(std::memory_order_relaxed);
 
@@ -262,13 +264,14 @@ namespace pika { namespace threads { namespace policies {
             if (0 != work_items_count_count && work_items_.pop(thrd, other_end))
             {
                 --work_items_count_.data_;
-                tqmc_deb.debug(debug::str<>("get_next_thread"), "stealing",
-                    other_end, "D", debug::dec<2>(holder_->domain_index_), "Q",
-                    debug::dec<3>(queue_index_), "n",
-                    debug::dec<4>(new_tasks_count_.data_), "w",
-                    debug::dec<4>(work_items_count_.data_),
-                    debug::threadinfo<threads::detail::thread_id_ref_type*>(
-                        &thrd));
+                tqmc_deb.debug(debug::detail::str<>("get_next_thread"),
+                    "stealing", other_end, "D",
+                    debug::detail::dec<2>(holder_->domain_index_), "Q",
+                    debug::detail::dec<3>(queue_index_), "n",
+                    debug::detail::dec<4>(new_tasks_count_.data_), "w",
+                    debug::detail::dec<4>(work_items_count_.data_),
+                    debug::detail::threadinfo<
+                        threads::detail::thread_id_ref_type*>(&thrd));
                 return true;
             }
 
@@ -289,12 +292,13 @@ namespace pika { namespace threads { namespace policies {
             threads::detail::thread_id_ref_type thrd, bool other_end)
         {
             ++work_items_count_.data_;
-            tqmc_deb.debug(debug::str<>("schedule_work"), "stealing", other_end,
-                "D", debug::dec<2>(holder_->domain_index_), "Q",
-                debug::dec<3>(queue_index_), "n",
-                debug::dec<4>(new_tasks_count_.data_), "w",
-                debug::dec<4>(work_items_count_.data_),
-                debug::threadinfo<threads::detail::thread_id_ref_type*>(&thrd));
+            tqmc_deb.debug(debug::detail::str<>("schedule_work"), "stealing",
+                other_end, "D", debug::detail::dec<2>(holder_->domain_index_),
+                "Q", debug::detail::dec<3>(queue_index_), "n",
+                debug::detail::dec<4>(new_tasks_count_.data_), "w",
+                debug::detail::dec<4>(work_items_count_.data_),
+                debug::detail::threadinfo<threads::detail::thread_id_ref_type*>(
+                    &thrd));
             //
             work_items_.push(PIKA_MOVE(thrd), other_end);
 #ifdef DEBUG_QUEUE_EXTRA
@@ -320,21 +324,25 @@ namespace pika { namespace threads { namespace policies {
             work_items_type work_items_copy_;
             int x = 0;
             thread_description* thrd;
-            tqmc_deb.debug(debug::str<>("debug_queue"), "Pop work items");
+            tqmc_deb.debug(
+                debug::detail::str<>("debug_queue"), "Pop work items");
             while (q.pop(thrd))
             {
-                tqmc_deb.debug(debug::str<>("debug_queue"), x++,
-                    debug::threadinfo<threads::detail::thread_data*>(thrd));
+                tqmc_deb.debug(debug::detail::str<>("debug_queue"), x++,
+                    debug::detail::threadinfo<threads::detail::thread_data*>(
+                        thrd));
                 work_items_copy_.push(thrd);
             }
-            tqmc_deb.debug(debug::str<>("debug_queue"), "Push work items");
+            tqmc_deb.debug(
+                debug::detail::str<>("debug_queue"), "Push work items");
             while (work_items_copy_.pop(thrd))
             {
                 q.push(thrd);
-                tqmc_deb.debug(debug::str<>("debug_queue"), --x,
-                    debug::threadinfo<threads::detail::thread_data*>(thrd));
+                tqmc_deb.debug(debug::detail::str<>("debug_queue"), --x,
+                    debug::detail::threadinfo<threads::detail::thread_data*>(
+                        thrd));
             }
-            tqmc_deb.debug(debug::str<>("debug_queue"), "Finished");
+            tqmc_deb.debug(debug::detail::str<>("debug_queue"), "Finished");
         }
 #endif
 

--- a/libs/pika/threading_base/include/pika/threading_base/detail/reset_backtrace.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/reset_backtrace.hpp
@@ -24,7 +24,7 @@ namespace pika::threads::detail {
         PIKA_EXPORT ~reset_backtrace();
 
         thread_id_type id_;
-        std::unique_ptr<pika::util::backtrace> backtrace_;
+        std::unique_ptr<pika::debug::detail::backtrace> backtrace_;
 #ifdef PIKA_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
         std::string full_backtrace_;
 #endif

--- a/libs/pika/threading_base/include/pika/threading_base/print.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/print.hpp
@@ -14,7 +14,7 @@
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace pika { namespace debug {
+namespace pika::debug::detail {
     // ------------------------------------------------------------------
     // safely dump thread pointer/description
     // ------------------------------------------------------------------
@@ -81,5 +81,5 @@ namespace pika { namespace debug {
         PIKA_EXPORT friend std::ostream& operator<<(
             std::ostream& os, threadinfo const& d);
     };
-}}    // namespace pika::debug
+}    // namespace pika::debug::detail
 /// \endcond

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -365,11 +365,12 @@ namespace pika::threads::detail {
             return nullptr;
         }
 #else
-        constexpr util::backtrace const* get_backtrace() const noexcept
+        constexpr debug::detail::backtrace const* get_backtrace() const noexcept
         {
             return nullptr;
         }
-        util::backtrace const* set_backtrace(util::backtrace const*) noexcept
+        debug::detail::backtrace const* set_backtrace(
+            debug::detail::backtrace const*) noexcept
         {
             return nullptr;
         }
@@ -394,19 +395,19 @@ namespace pika::threads::detail {
             return bt;
         }
 #else
-        util::backtrace const* get_backtrace() const noexcept
+        debug::detail::backtrace const* get_backtrace() const noexcept
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
             return backtrace_;
         }
-        util::backtrace const* set_backtrace(
-            util::backtrace const* value) noexcept
+        debug::detail::backtrace const* set_backtrace(
+            debug::detail::backtrace const* value) noexcept
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
 
-            util::backtrace const* bt = backtrace_;
+            debug::detail::backtrace const* bt = backtrace_;
             backtrace_ = value;
             return bt;
         }
@@ -601,7 +602,7 @@ namespace pika::threads::detail {
 #ifdef PIKA_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
         char const* backtrace_;
 #else
-        util::backtrace const* backtrace_;
+        debug::detail::backtrace const* backtrace_;
 #endif
 #endif
         ///////////////////////////////////////////////////////////////////////

--- a/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
@@ -186,10 +186,10 @@ namespace pika::threads::detail {
         char const* bt = nullptr, error_code& ec = throws);
 #else
 #if !defined(DOXYGEN)
-    PIKA_EXPORT util::backtrace const* get_thread_backtrace(
+    PIKA_EXPORT debug::detail::backtrace const* get_thread_backtrace(
         thread_id_type const& id, error_code& ec = throws);
-    PIKA_EXPORT util::backtrace const* set_thread_backtrace(
-        thread_id_type const& id, util::backtrace const* bt = nullptr,
+    PIKA_EXPORT debug::detail::backtrace const* set_thread_backtrace(
+        thread_id_type const& id, debug::detail::backtrace const* bt = nullptr,
         error_code& ec = throws);
 #endif
 #endif

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -13,7 +13,7 @@
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace pika { namespace debug {
+namespace pika::debug::detail {
 
     std::ostream& operator<<(
         std::ostream& os, threadinfo<threads::detail::thread_data*> const& d)
@@ -88,7 +88,7 @@ namespace pika { namespace debug {
             }
             os << hex<12, std::thread::id>(std::this_thread::get_id())
 #ifdef DEBUGGING_PRINT_LINUX
-               << " cpu " << debug::dec<3, int>(sched_getcpu()) << " ";
+               << " cpu " << debug::detail::dec<3, int>(sched_getcpu()) << " ";
 #else
                << " cpu "
                << "--- ";
@@ -99,7 +99,7 @@ namespace pika { namespace debug {
         {
             current_thread_print_helper()
             {
-                detail::register_print_info(&detail::print_thread_info);
+                debug::detail::register_print_info(&detail::print_thread_info);
             }
 
             static current_thread_print_helper helper_;
@@ -107,5 +107,5 @@ namespace pika { namespace debug {
 
         current_thread_print_helper current_thread_print_helper::helper_{};
     }    // namespace detail
-}}       // namespace pika::debug
+}    // namespace pika::debug::detail
 /// \endcond

--- a/libs/pika/threading_base/src/reset_backtrace.cpp
+++ b/libs/pika/threading_base/src/reset_backtrace.cpp
@@ -18,7 +18,7 @@
 namespace pika::threads::detail {
     reset_backtrace::reset_backtrace(thread_id_type const& id, error_code& ec)
       : id_(id)
-      , backtrace_(new pika::util::backtrace())
+      , backtrace_(new pika::debug::detail::backtrace())
 #ifdef PIKA_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
       , full_backtrace_(backtrace_->trace())
 #endif

--- a/libs/pika/threading_base/src/thread_helpers.cpp
+++ b/libs/pika/threading_base/src/thread_helpers.cpp
@@ -287,7 +287,7 @@ namespace pika::threads::detail {
 #ifdef PIKA_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
     char const* get_thread_backtrace(thread_id_type const& id, error_code& ec)
 #else
-    util::backtrace const* get_thread_backtrace(
+    debug::detail::backtrace const* get_thread_backtrace(
         thread_id_type const& id, error_code& ec)
 #endif
     {
@@ -309,8 +309,9 @@ namespace pika::threads::detail {
     char const* set_thread_backtrace(
         thread_id_type const& id, char const* bt, error_code& ec)
 #else
-    util::backtrace const* set_thread_backtrace(
-        thread_id_type const& id, util::backtrace const* bt, error_code& ec)
+    debug::detail::backtrace const* set_thread_backtrace(
+        thread_id_type const& id, debug::detail::backtrace const* bt,
+        error_code& ec)
 #endif
     {
         if (PIKA_UNLIKELY(!id))

--- a/tools/VS/backtrace.natvis
+++ b/tools/VS/backtrace.natvis
@@ -7,7 +7,7 @@
 <!-- or copy at http://www.boost.org/LICENSE_1_0.txt)                       -->
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-    <Type Name="pika::util::backtrace">
+    <Type Name="pika::debug::detail::backtrace">
         <DisplayString>{{ size={frames_._Mysize} }}</DisplayString>
         <Expand>
             <ExpandedItem>frames_._Myfirst,[frames_._Mysize]stackTrace</ExpandedItem>


### PR DESCRIPTION
Part of #16.

I've kept the sub-namespace `pika::debug` and put everything in `pika::debug::detail` to avoid polluting `pika::detail` with short names like `ptr`.