### PR TITLE
Add back overload taking a raw `cudaStream_t` for `add_event_callback`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
@@ -26,6 +26,10 @@ namespace pika::cuda::experimental::detail {
     using event_callback_function_type =
         pika::util::unique_function<void(cudaError_t)>;
 
+    PIKA_EXPORT void add_event_callback(event_callback_function_type&& f,
+        cudaStream_t stream,
+        pika::execution::thread_priority =
+            pika::execution::thread_priority::default_);
     PIKA_EXPORT void add_event_callback(
         event_callback_function_type&& f, cuda_stream const& stream);
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -457,7 +457,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 pika::execution::experimental::value_types_of_t<
                     std::decay_t<Sender>,
                     pika::execution::experimental::detail::empty_env,
-                    pika::tuple, pika::variant>,
+                    std::tuple, pika::detail::variant>,
                 pika::detail::monostate>;
 #else
             using ts_type = pika::util::detail::prepend_t<


### PR DESCRIPTION
Unfortunately we still use `add_event_callback` for special purposes in DLA-Future. Until we decide if we make `add_event_callback` public or come up with another solution in DLA-Future I'm adding back an overload that takes a raw `cudaStream_t`. I changed it to take our wrapper `cuda_stream` in #286, but since `cuda_stream` is owning one can't use a self-created `cudaStream_t` with it. This allows that again for the time being.