### PR TITLE
Fix use of `tuple` and `variant` in `then_with_stream`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -457,7 +457,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 pika::execution::experimental::value_types_of_t<
                     std::decay_t<Sender>,
                     pika::execution::experimental::detail::empty_env,
-                    pika::tuple, pika::variant>,
+                    std::tuple, pika::detail::variant>,
                 pika::detail::monostate>;
 #else
             using ts_type = pika::util::detail::prepend_t<


### PR DESCRIPTION
Leftover from #315. It didn't affect any builds since CUDA with the P2300 reference implementation is still untested and unsupported.