### PR TITLE
Increase timeout for container algorithms tests on macOS CI configuration

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -289,6 +289,6 @@ jobs:
           ctest \
             -j3 \
             --output-on-failure \
-            --timeout 120 \
+            --timeout 300 \
             --tests-regex tests.unit.modules.algorithms.container_algorithms \
             --exclude-regex tests.unit.modules.algorithms.container_algorithms.inplace_merge_range


### PR DESCRIPTION
I'm increasing the timeout to check if these timeouts https://github.com/pika-org/pika/runs/7692289838?check_suite_focus=true#step:6:237 are simply due to the test taking long to complete or if it really hangs. `partial_sort_copy_range` is one of the longer running tests so it's possible that it indeed just doesn't have enough time to finish (the timeout is 120 seconds and one of the later runs finished in 101 seconds: https://github.com/pika-org/pika/runs/7691710341?check_suite_focus=true#step:6:237).