### PR TITLE
Use ccache in GitHub actions workflows

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -11,12 +11,7 @@ status = [
   "github/linux/hip/fast",
   "github/linux/sanitizers/fast",
   "github/linux/tracy/fast",
-  "github/macos/debug/core",
-  "github/macos/debug/tests/examples_regressions",
-  "github/macos/debug/tests/performance",
-  "github/macos/debug/tests/unit",
-  "github/macos/debug/tests/unit/algorithms",
-  "github/macos/debug/tests/unit/container_algorithms",
+  "github/macos/debug",
 
   # CircleCI static checks
   "ci/circleci: check_circular_deps",

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -20,6 +20,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-coverage
     - name: Configure
       shell: bash
       run: |
@@ -27,6 +33,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_CXX_FLAGS="--coverage" \
               -DCMAKE_EXE_LINKER_FLAGS="--coverage" \

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -15,7 +15,6 @@ on:
       # Bors branches
       - trying
       - staging
-  pull_request:
 
 jobs:
   build:
@@ -25,6 +24,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-debug
     - name: Configure
       shell: bash
       run: |
@@ -32,6 +37,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -24,6 +24,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-hip
     - name: Configure
       shell: bash
       run: |
@@ -31,6 +37,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -24,6 +24,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-release-fetchcontent
     - name: Configure
       shell: bash
       run: |
@@ -31,6 +37,7 @@ jobs:
               tests/unit/build/fetchcontent \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Release \
               -DPIKA_REPOSITORY="file:////$(pwd)" \
               -DPIKA_TAG="$GITHUB_SHA" \

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -24,6 +24,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-sanitizers
     - name: Configure
       shell: bash
       run: |
@@ -31,6 +37,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -29,6 +29,12 @@ jobs:
         repository: wolfpld/tracy
         ref: v0.8.2
         path: tracy
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-tracy
     - name: Install Tracy
       shell: bash
       working-directory: tracy
@@ -43,6 +49,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_SHARED_LIBS=ON \
               -DTRACY_TIMER_FALLBACK=ON
           cmake --build build --target install
@@ -59,6 +66,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_MALLOC=system \

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -47,6 +47,10 @@ jobs:
         brew update
         brew install boost cmake hwloc ninja
     - uses: actions/checkout@v2
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Configure
       shell: bash
       run: |
@@ -54,6 +58,7 @@ jobs:
               -H. \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_EXAMPLES=ON \
@@ -104,6 +109,10 @@ jobs:
       shell: bash
       run: |
           tar --extract --file artifact.tar.gz
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Build tests
       shell: bash
       run: |
@@ -150,6 +159,10 @@ jobs:
       shell: bash
       run: |
           tar --extract --file artifact.tar.gz
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Build tests
       shell: bash
       run: |
@@ -187,6 +200,10 @@ jobs:
       shell: bash
       run: |
           tar --extract --file artifact.tar.gz
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Build tests
       shell: bash
       run: |
@@ -233,6 +250,10 @@ jobs:
       shell: bash
       run: |
           tar --extract --file artifact.tar.gz
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Build tests
       shell: bash
       run: |
@@ -278,6 +299,10 @@ jobs:
       shell: bash
       run: |
           tar --extract --file artifact.tar.gz
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-macos
     - name: Build tests
       shell: bash
       run: |

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -16,25 +16,9 @@ on:
       - trying
       - staging
 
-# Note that this file contains a lot of duplication between the workflow steps.
-# That is because GitHub actions doesn't support YAML anchors:
-# https://github.community/t/support-for-yaml-anchors/16128. If GitHub ever
-# supports that in the future this file should absolutely be updated to make use
-# of them. In the meantime the duplication stays as GitHub's other options for
-# reusing steps seem overkill in this situation.
-
-# This defines in initial job for configuring pika and building the core
-# library. Following that are parallel steps for building and running tests. The
-# tests have been split to roughly have equal running time.
-#
-# Note that dependencies are reinstalled on every step as this seems to be
-# faster than trying to package the dependencies from the first step and reusing
-# them in later steps. This does open the door for occasional failures with
-# later steps installing different versions of packages.
-
 jobs:
   build_core:
-    name: github/macos/debug/core
+    name: github/macos/debug
     runs-on: macos-latest
 
     steps:
@@ -70,54 +54,11 @@ jobs:
               -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON \
               -DPIKA_WITH_COMPILER_WARNINGS=ON \
               -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=On
-    - name: Build pika
+    - name: Build
       shell: bash
       run: |
-          cmake --build build --target pika
-    # Packaging the build artifacts from the first step into an archive is
-    # faster than letting upload-artifact upload the directory directory.
-    - name: Package artifacts into a single file
-      shell: bash
-      run: |
-          tar --create --file artifact.tar.gz .
-    - name: Store results for test stage
-      uses: actions/upload-artifact@v3
-      with:
-        path: artifact.tar.gz
-        if-no-files-found: error
-        retention-days: 7
-
-  build_and_run_tests_examples_regressions:
-    name: github/macos/debug/tests/examples_regressions
-    needs: build_core
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/2322
-        rm -rf /usr/local/bin/2to3
-        export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-        brew upgrade
-        brew update
-        brew install boost cmake hwloc ninja
-    - name: Load build artifacts from core stage
-      uses: actions/download-artifact@v3
-      with:
-        name: artifact
-    - name: Unpack artifacts
-      shell: bash
-      run: |
-          tar --extract --file artifact.tar.gz
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ccache-macos
-    - name: Build tests
-      shell: bash
-      run: |
-          cmake --build build --target examples
-          cmake --build build --target tests.regressions
+          cmake --build build --target all
+          cmake --build build --target tests
     - name: Test
       shell: bash
       run: |
@@ -125,9 +66,15 @@ jobs:
           ctest \
             -j3 \
             --output-on-failure \
-            --timeout 120 \
-            --tests-regex tests.examples \
-            --tests-regex tests.regressions
+            --timeout 300 \
+            --exclude-regex \
+          "tests.unit.modules.algorithms.default_construct|\
+          tests.unit.modules.algorithms.destroy|\
+          tests.unit.modules.algorithms.foreach_executors|\
+          tests.unit.modules.algorithms.max_element|\
+          tests.unit.modules.algorithms.replace_copy_if|\
+          tests.unit.modules.execution.standalone_thread_pool_executor|\
+          tests.unit.modules.resource_partitioner.used_pus"
     - name: Install
       shell: bash
       run: |
@@ -136,184 +83,3 @@ jobs:
       shell: bash
       run: |
           hello_world
-
-  build_and_run_tests_performance:
-    name: github/macos/debug/tests/performance
-    needs: build_core
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/2322
-        rm -rf /usr/local/bin/2to3
-        export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-        brew upgrade
-        brew update
-        brew install boost cmake hwloc ninja
-    - name: Load build artifacts from core stage
-      uses: actions/download-artifact@v3
-      with:
-        name: artifact
-    - name: Unpack artifacts
-      shell: bash
-      run: |
-          tar --extract --file artifact.tar.gz
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ccache-macos
-    - name: Build tests
-      shell: bash
-      run: |
-          cmake --build build --target tests.performance
-    - name: Test
-      shell: bash
-      run: |
-          cd build
-          ctest \
-            -j3 \
-            --output-on-failure \
-            --timeout 120 \
-            --tests-regex tests.performance
-
-  # All unit tests except algorithms and container_algorithms
-  build_and_run_tests_unit:
-    name: github/macos/debug/tests/unit
-    needs: build_core
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/2322
-        rm -rf /usr/local/bin/2to3
-        export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-        brew upgrade
-        brew update
-        brew install boost cmake hwloc ninja
-    - name: Load build artifacts from core stage
-      uses: actions/download-artifact@v3
-      with:
-        name: artifact
-    - name: Unpack artifacts
-      shell: bash
-      run: |
-          tar --extract --file artifact.tar.gz
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ccache-macos
-    - name: Build tests
-      shell: bash
-      run: |
-          cd build
-          targets=$(ninja help | \
-            grep '^tests.unit.modules\.' | \
-            grep -v '^tests.unit.modules.algorithms' | \
-            awk -F':' '{ print $1 }')
-          ninja ${targets}
-    - name: Test
-      shell: bash
-      run: |
-          cd build
-          ctest \
-            -j3 \
-            --output-on-failure \
-            --timeout 120 \
-            --tests-regex tests.unit \
-            --exclude-regex \
-          "tests.unit.modules.algorithms|\
-          tests.unit.modules.execution.standalone_thread_pool_executor|\
-          tests.unit.modules.resource_partitioner.used_pus"
-
-  # algorithms unit tests
-  build_and_run_tests_unit_algorithms:
-    name: github/macos/debug/tests/unit/algorithms
-    needs: build_core
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/2322
-        rm -rf /usr/local/bin/2to3
-        export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-        brew upgrade
-        brew update
-        brew install boost cmake hwloc ninja
-    - name: Load build artifacts from core stage
-      uses: actions/download-artifact@v3
-      with:
-        name: artifact
-    - name: Unpack artifacts
-      shell: bash
-      run: |
-          tar --extract --file artifact.tar.gz
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ccache-macos
-    - name: Build tests
-      shell: bash
-      run: |
-          cd build
-          ninja tests.unit.modules.algorithms.{algorithms,block}
-    - name: Test
-      shell: bash
-      run: |
-          cd build
-          ctest \
-            -j3 \
-            --output-on-failure \
-            --timeout 300 \
-            --tests-regex tests.unit.modules.algorithms \
-            --exclude-regex \
-          "tests.unit.modules.algorithms.container_algorithms|\
-          tests.unit.modules.algorithms.default_construct|\
-          tests.unit.modules.algorithms.destroy|\
-          tests.unit.modules.algorithms.foreach_executors|\
-          tests.unit.modules.algorithms.max_element|\
-          tests.unit.modules.algorithms.replace_copy_if"
-
-  # container_algorithms unit tests
-  build_and_run_tests_unit_container_algorithms:
-    name: github/macos/debug/tests/unit/container_algorithms
-    needs: build_core
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/2322
-        rm -rf /usr/local/bin/2to3
-        export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-        brew upgrade
-        brew update
-        brew install boost cmake hwloc ninja
-    - name: Load build artifacts from core stage
-      uses: actions/download-artifact@v3
-      with:
-        name: artifact
-    - name: Unpack artifacts
-      shell: bash
-      run: |
-          tar --extract --file artifact.tar.gz
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ccache-macos
-    - name: Build tests
-      shell: bash
-      run: |
-          cmake --build build --target tests.unit.modules.algorithms.container_algorithms
-    - name: Test
-      shell: bash
-      run: |
-          cd build
-          ctest \
-            -j3 \
-            --output-on-failure \
-            --timeout 300 \
-            --tests-regex tests.unit.modules.algorithms.container_algorithms \
-            --exclude-regex tests.unit.modules.algorithms.container_algorithms.inplace_merge_range


### PR DESCRIPTION
This uses https://github.com/hendrikmuhs/ccache-action. Note that an explicit key is given for the cache since caches are otherwise shared between workflows.