### PR TITLE
Fix use of `--pika:ignore-process-mask` command line option

### DIFF
--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -455,8 +455,8 @@ namespace pika::detail {
 #if defined(__APPLE__)
             false;
 #else
-            !(cfgmap.get_value<int>("pika.ignore_process_mask", 0) > 0) ||
-            (vm.count("pika:ignore-process-mask") > 0);
+            !((cfgmap.get_value<int>("pika.ignore_process_mask", 0) > 0) ||
+                (vm.count("pika:ignore-process-mask") > 0));
 #endif
 
         ini_config.emplace_back(

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -125,6 +125,7 @@ namespace pika { namespace util {
             "${PIKA_EXPECT_CONNECTING_LOCALITIES:0}",
 
             // add placeholders for keys to be added by command line handling
+            "ignore_process_mask = 0",
             "os_threads = cores",
             "cores = all",
             "localities = 1",


### PR DESCRIPTION
Fixes the condition used for checking if a process mask should be used or not. Also adds a default `pika.ignore_process_mask = 0` option to the runtime configuration so that adding the option manually doesn't error out complaining about a nonexistent entry in the configuration.

Thanks @aurianer for noticing this.