### PR TITLE
Attempt to fix `program_options` visibility issue

### DIFF
--- a/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
@@ -91,7 +91,7 @@ namespace pika { namespace program_options {
       : public value_semantic
     {
     private:    // base overrides
-        void parse(std::any& value_store,
+        PIKA_EXPORT void parse(std::any& value_store,
             const std::vector<std::string>& new_tokens,
             bool utf8) const override;
 
@@ -112,7 +112,7 @@ namespace pika { namespace program_options {
       : public value_semantic
     {
     private:    // base overrides
-        void parse(std::any& value_store,
+        PIKA_EXPORT void parse(std::any& value_store,
             const std::vector<std::string>& new_tokens,
             bool utf8) const override;
 


### PR DESCRIPTION
Fixes #350. It's slightly unclear to me why this is required as I assumed that a visibility attribute on the class itself would be enough, but it may be that the ruls for template specializations are different or something in that direction...