### PR TITLE
Increase algorithms tests timeout in macOS workflow

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -245,7 +245,7 @@ jobs:
           ctest \
             -j3 \
             --output-on-failure \
-            --timeout 120 \
+            --timeout 300 \
             --tests-regex tests.unit.modules.algorithms \
             --exclude-regex \
           "tests.unit.modules.algorithms.container_algorithms|\


### PR DESCRIPTION
Follow-up to #352. Also increase the timeout for the algorithms tests. `partial_sort_copy` (like `partial_sort_copy_range`) takes long to complete, most likely just due to insufficient time.