### PR TITLE
Only run coverage on `main` branch

### DIFF
--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Changing coverage CI job to only run on `main`.