### PR TITLE
Clean up `errors` module

### DIFF
--- a/examples/quickstart/channel_example.cpp
+++ b/examples/quickstart/channel_example.cpp
@@ -113,7 +113,7 @@ void dispatch_work()
     pika::apply([jobs, done]() mutable {
         while (true)
         {
-            pika::error_code ec(pika::lightweight);
+            pika::error_code ec(pika::throwmode::lightweight);
             int value = jobs.get(pika::launch::sync, ec);
             if (!ec)
             {

--- a/libs/pika/affinity/src/affinity_data.cpp
+++ b/libs/pika/affinity/src/affinity_data.cpp
@@ -110,7 +110,7 @@ namespace pika::detail {
             std::size_t num_initialized = count_initialized(affinity_masks_);
             if (num_initialized != num_threads_)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "affinity_data::affinity_data",
                     "The number of OS threads requested ({1}) does not match "
                     "the number of threads to bind ({2})",

--- a/libs/pika/affinity/src/parse_affinity_options.cpp
+++ b/libs/pika/affinity/src/parse_affinity_options.cpp
@@ -45,7 +45,8 @@ namespace pika::detail {
         }
         else
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "parse_affinity_options",
                 "failed to parse affinity specification: \"" + spec + "\"");
         }
 
@@ -125,7 +126,8 @@ namespace pika::detail {
 
             if (num_threads > num_pus_proc_mask)
             {
-                PIKA_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                    "check_num_threads",
                     "specified number of threads ({1}) is larger than number "
                     "of processing units available in process mask ({2})",
                     num_threads, num_pus_proc_mask);
@@ -138,7 +140,8 @@ namespace pika::detail {
 
             if (num_threads > num_threads_available)
             {
-                PIKA_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                    "check_num_threads",
                     "specified number of threads ({1}) is larger than number "
                     "of available processing units ({2})",
                     num_threads, num_threads_available);
@@ -184,7 +187,7 @@ namespace pika::detail {
 
                     if (threads::detail::any(affinities[num_thread]))
                     {
-                        PIKA_THROWS_IF(ec, bad_parameter,
+                        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                             "decode_compact_distribution",
                             "affinity mask for thread {1} has already been set",
                             num_thread);
@@ -232,7 +235,7 @@ namespace pika::detail {
             {
                 if (threads::detail::any(affinities[num_thread]))
                 {
-                    PIKA_THROWS_IF(ec, bad_parameter,
+                    PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                         "decode_scatter_distribution",
                         "affinity mask for thread {1} has already been set",
                         num_thread);
@@ -349,7 +352,7 @@ namespace pika::detail {
             {
                 if (threads::detail::any(affinities[num_thread]))
                 {
-                    PIKA_THROWS_IF(ec, bad_parameter,
+                    PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                         "decode_balanced_distribution",
                         "affinity mask for thread {1} has already been set",
                         num_thread);
@@ -499,7 +502,7 @@ namespace pika::detail {
                 {
                     if (threads::detail::any(affinities[num_thread]))
                     {
-                        PIKA_THROWS_IF(ec, bad_parameter,
+                        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                             "decode_numabalanced_distribution",
                             "affinity mask for thread {1} has already been set",
                             num_thread);

--- a/libs/pika/algorithms/include/pika/parallel/task_block.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/task_block.hpp
@@ -41,7 +41,7 @@ namespace pika { namespace parallel { inline namespace v2 {
     {
     public:
         task_canceled_exception() noexcept
-          : pika::exception(pika::task_canceled_exception)
+          : pika::exception(pika::error::task_canceled_exception)
         {
         }
     };
@@ -182,8 +182,8 @@ namespace pika { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::detail::get_self_id())
             {
-                PIKA_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                PIKA_THROW_EXCEPTION(pika::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
             }
 
             tasks_.run(policy_.executor(), PIKA_FORWARD(F, f),
@@ -232,8 +232,8 @@ namespace pika { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::detail::get_self_id())
             {
-                PIKA_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                PIKA_THROW_EXCEPTION(pika::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
             }
 
             tasks_.run(PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f),
@@ -272,8 +272,8 @@ namespace pika { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::detail::get_self_id())
             {
-                PIKA_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                PIKA_THROW_EXCEPTION(pika::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
                 return;
             }
 

--- a/libs/pika/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/pika/algorithms/tests/unit/block/task_block.cpp
@@ -206,7 +206,8 @@ void define_task_block_exceptions_test3()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(int(e.get_error()), int(pika::task_block_not_active));
+        PIKA_TEST_EQ(
+            int(e.get_error()), int(pika::error::task_block_not_active));
     }
     catch (...)
     {
@@ -235,7 +236,8 @@ void define_task_block_exceptions_test4()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(int(e.get_error()), int(pika::task_block_not_active));
+        PIKA_TEST_EQ(
+            int(e.get_error()), int(pika::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/pika/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/pika/algorithms/tests/unit/block/task_block_executor.cpp
@@ -340,7 +340,8 @@ void define_task_block_exceptions_test3(Executor& exec)
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(int(e.get_error()), int(pika::task_block_not_active));
+        PIKA_TEST_EQ(
+            int(e.get_error()), int(pika::error::task_block_not_active));
     }
     catch (...)
     {
@@ -373,7 +374,8 @@ void define_task_block_exceptions_test4(Executor& exec)
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(int(e.get_error()), int(pika::task_block_not_active));
+        PIKA_TEST_EQ(
+            int(e.get_error()), int(pika::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/pika/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/pika/algorithms/tests/unit/block/task_block_par.cpp
@@ -118,7 +118,8 @@ void define_task_block_exceptions_test2()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(int(e.get_error()), int(pika::task_block_not_active));
+        PIKA_TEST_EQ(
+            int(e.get_error()), int(pika::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
@@ -69,7 +69,7 @@ namespace pika::detail {
         {
             if (lazy_values_[i].has_value())
             {
-                if (success_counter_)
+                if (pika::error::success_counter_)
                     ++*success_counter_;
                 // invoke callback function
                 f_(i, lazy_values_[i].get());
@@ -85,7 +85,7 @@ namespace pika::detail {
         {
             if (lazy_values_[i].has_value())
             {
-                if (success_counter_)
+                if (pika::error::success_counter_)
                     ++*success_counter_;
                 // invoke callback function
                 f_(i);
@@ -104,7 +104,7 @@ namespace pika::detail {
           : lazy_values_(lazy_values)
           , ready_count_(0)
           , f_(PIKA_FORWARD(F, f))
-          , success_counter_(success_counter)
+          , success_counter_(pika::error::success_counter)
           , goal_reached_on_calling_thread_(false)
         {
         }
@@ -115,7 +115,7 @@ namespace pika::detail {
           : lazy_values_(PIKA_MOVE(lazy_values))
           , ready_count_(0)
           , f_(PIKA_FORWARD(F, f))
-          , success_counter_(success_counter)
+          , success_counter_(pika::error::success_counter)
           , goal_reached_on_calling_thread_(false)
         {
         }

--- a/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
@@ -225,7 +225,7 @@ namespace pika {
                         result_type* result = state->get_result();
                         if (i >= result->size())
                         {
-                            PIKA_THROW_EXCEPTION(length_error,
+                            PIKA_THROW_EXCEPTION(pika::error::length_error,
                                 "split_continuation::on_ready",
                                 "index out of bounds");
                         }

--- a/libs/pika/async_combinators/include/pika/async_combinators/wait_some.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/wait_some.hpp
@@ -334,7 +334,7 @@ namespace pika {
 
         if (n > values.size())
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -395,7 +395,7 @@ namespace pika {
 
         if (n > values.size())
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -489,7 +489,7 @@ namespace pika {
     {
         if (n != 0)
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
         }
     }
@@ -505,7 +505,7 @@ namespace pika {
     {
         if (n != 1)
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -525,7 +525,7 @@ namespace pika {
     {
         if (n != 1)
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -551,7 +551,7 @@ namespace pika {
 
         if (n > sizeof...(Ts))
         {
-            PIKA_THROW_EXCEPTION(pika::bad_parameter, "pika::wait_some",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "pika::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }

--- a/libs/pika/async_combinators/include/pika/async_combinators/when_some.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/when_some.hpp
@@ -429,7 +429,8 @@ namespace pika {
         if (n > values.size())
         {
             return pika::make_exceptional_future<when_some_result<result_type>>(
-                PIKA_GET_EXCEPTION(pika::bad_parameter, "pika::when_some",
+                PIKA_GET_EXCEPTION(pika::error::bad_parameter,
+                    "pika::when_some",
                     "number of results to wait for is out of bounds"));
         }
 
@@ -494,7 +495,7 @@ namespace pika {
         }
 
         return pika::make_exceptional_future<when_some_result<result_type>>(
-            PIKA_GET_EXCEPTION(pika::bad_parameter, "pika::when_some",
+            PIKA_GET_EXCEPTION(pika::error::bad_parameter, "pika::when_some",
                 "number of results to wait for is out of bounds"));
     }
 
@@ -518,7 +519,8 @@ namespace pika {
         if (n > 1 + sizeof...(Ts))
         {
             return pika::make_exceptional_future<when_some_result<result_type>>(
-                PIKA_GET_EXCEPTION(pika::bad_parameter, "pika::when_some",
+                PIKA_GET_EXCEPTION(pika::error::bad_parameter,
+                    "pika::when_some",
                     "number of results to wait for is out of bounds"));
         }
 

--- a/libs/pika/async_cuda/src/cublas_exception.cpp
+++ b/libs/pika/async_cuda/src/cublas_exception.cpp
@@ -56,7 +56,7 @@ namespace pika::cuda::experimental {
     }    // namespace detail
 
     cublas_exception::cublas_exception(cublasStatus_t err)
-      : pika::exception(pika::bad_function_call,
+      : pika::exception(pika::error::bad_function_call,
             std::string("cuBLAS function returned error code ") +
                 std::to_string(err) + " (" +
                 detail::cublas_get_error_string(err) + ")")
@@ -66,7 +66,7 @@ namespace pika::cuda::experimental {
 
     cublas_exception::cublas_exception(
         const std::string& msg, cublasStatus_t err)
-      : pika::exception(pika::bad_function_call, msg)
+      : pika::exception(pika::error::bad_function_call, msg)
       , err_(err)
     {
     }

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -161,7 +161,7 @@ namespace pika::cuda::experimental::detail {
             cudaEvent_t event;
             if (!cuda_event_pool::get_event_pool().pop(event))
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "add_to_event_callback_queue", "could not get an event");
             }
             check_cuda_error(cudaEventRecord(event, stream));

--- a/libs/pika/async_cuda/src/cuda_exception.cpp
+++ b/libs/pika/async_cuda/src/cuda_exception.cpp
@@ -13,7 +13,7 @@
 
 namespace pika::cuda::experimental {
     cuda_exception::cuda_exception(cudaError_t err)
-      : pika::exception(pika::bad_function_call,
+      : pika::exception(pika::error::bad_function_call,
             std::string("CUDA function returned error code ") +
                 std::to_string(err) + " (" + cudaGetErrorString(err) + ")")
       , err_(err)
@@ -21,7 +21,7 @@ namespace pika::cuda::experimental {
     }
 
     cuda_exception::cuda_exception(const std::string& msg, cudaError_t err)
-      : pika::exception(pika::bad_function_call, msg)
+      : pika::exception(pika::error::bad_function_call, msg)
       , err_(err)
     {
     }

--- a/libs/pika/async_cuda/src/cusolver_exception.cpp
+++ b/libs/pika/async_cuda/src/cusolver_exception.cpp
@@ -102,7 +102,7 @@ namespace pika::cuda::experimental {
     }    // namespace detail
 
     cusolver_exception::cusolver_exception(cusolverStatus_t err)
-      : pika::exception(pika::bad_function_call,
+      : pika::exception(pika::error::bad_function_call,
             std::string("cuSOLVER function returned error code ") +
                 std::to_string(err) + " (" +
                 detail::cusolver_get_error_string(err) + ")")
@@ -112,7 +112,7 @@ namespace pika::cuda::experimental {
 
     cusolver_exception::cusolver_exception(
         const std::string& msg, cusolverStatus_t err)
-      : pika::exception(pika::bad_function_call, msg)
+      : pika::exception(pika::error::bad_function_call, msg)
       , err_(err)
     {
     }

--- a/libs/pika/async_mpi/src/mpi_exception.cpp
+++ b/libs/pika/async_mpi/src/mpi_exception.cpp
@@ -31,7 +31,7 @@ namespace pika::mpi::experimental {
     // -------------------------------------------------------------------------
     // exception type for failed launch of MPI functions
     mpi_exception::mpi_exception(int err_code, const std::string& msg)
-      : pika::exception(pika::bad_function_call,
+      : pika::exception(pika::error::bad_function_call,
             msg + std::string(" MPI returned with error: ") +
                 detail::error_message(err_code))
       , err_code_(err_code)

--- a/libs/pika/async_mpi/src/mpi_future.cpp
+++ b/libs/pika/async_mpi/src/mpi_future.cpp
@@ -244,8 +244,8 @@ namespace pika { namespace mpi { namespace experimental {
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
             mpi_debug.debug(debug::detail::str<>("pika_MPI_Handler"));
-            PIKA_THROW_EXCEPTION(
-                invalid_status, "pika_MPI_Handler", error_message(*errorcode));
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika_MPI_Handler", error_message(*errorcode));
         }
     }    // namespace detail
 
@@ -509,7 +509,7 @@ namespace pika { namespace mpi { namespace experimental {
                 mpi_debug.error(
                     debug::detail::str<>("pika::mpi::experimental::init"),
                     "init failed");
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "pika::mpi::experimental::init",
                     "the MPI installation doesn't allow multiple threads");
             }

--- a/libs/pika/coroutines/src/detail/tss.cpp
+++ b/libs/pika/coroutines/src/detail/tss.cpp
@@ -67,7 +67,7 @@ namespace pika::threads::coroutines::detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::coroutines::detail::get_tss_thread_data",
                 "null thread id encountered");
             return 0;
@@ -96,7 +96,7 @@ namespace pika::threads::coroutines::detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::coroutines::detail::set_tss_thread_data",
                 "null thread id encountered");
             return 0;
@@ -136,7 +136,7 @@ namespace pika::threads::coroutines::detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::coroutines::detail::find_tss_data",
                 "null thread id encountered");
             return nullptr;
@@ -174,7 +174,7 @@ namespace pika::threads::coroutines::detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::coroutines::detail::add_new_tss_node",
                 "null thread id encountered");
             return;
@@ -201,7 +201,7 @@ namespace pika::threads::coroutines::detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::coroutines::detail::erase_tss_node",
                 "null thread id encountered");
             return;

--- a/libs/pika/errors/README.rst
+++ b/libs/pika/errors/README.rst
@@ -6,8 +6,8 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-===
+======
 errors
-===
+======
 
 This library is part of pika.

--- a/libs/pika/errors/include/pika/errors/error.hpp
+++ b/libs/pika/errors/include/pika/errors/error.hpp
@@ -22,123 +22,84 @@ namespace pika {
     ///
     /// This enumeration lists all possible error conditions which can be
     /// reported from any of the API functions.
-    enum error
+    enum class error
     {
+        /// The operation was successful
         success = 0,
-        ///< The operation was successful
+        /// The operation failed, but not in an unexpected manner
         no_success = 1,
-        ///< The operation did failed, but not in an unexpected manner
+        /// The operation is not implemented
         not_implemented = 2,
-        ///< The operation is not implemented
+        /// The operation caused an out of memory condition
         out_of_memory = 3,
-        ///< The operation caused an out of memory condition
-        bad_action_code = 4,
-        ///<
-        bad_component_type = 5,
-        ///< The specified component type is not known or otherwise invalid
-        network_error = 6,
-        ///< A generic network error occurred
-        version_too_new = 7,
-        ///< The version of the network representation for this object is too new
-        version_too_old = 8,
-        ///< The version of the network representation for this object is too old
-        version_unknown = 9,
-        ///< The version of the network representation for this object is unknown
-        unknown_component_address = 10,
-        ///<
-        duplicate_component_address = 11,
-        ///< The given global id has already been registered
-        invalid_status = 12,
-        ///< The operation was executed in an invalid status
-        bad_parameter = 13,
-        ///< One of the supplied parameters is invalid
-        internal_server_error = 14,
-        ///<
-        service_unavailable = 15,
-        ///<
-        bad_request = 16,
-        ///<
-        repeated_request = 17,
-        ///<
-        lock_error = 18,
-        ///<
-        duplicate_console = 19,
-        ///< There is more than one console locality
-        no_registered_console = 20,
-        ///< There is no registered console locality available
-        startup_timed_out = 21,
-        ///<
-        uninitialized_value = 22,
-        ///<
-        bad_response_type = 23,
-        ///<
-        deadlock = 24,
-        ///<
-        assertion_failure = 25,
-        ///<
-        null_thread_id = 26,
-        ///< Attempt to invoke a API function from a non-pika thread
-        invalid_data = 27,
-        ///<
-        yield_aborted = 28,
-        ///< The yield operation was aborted
-        dynamic_link_failure = 29,
-        ///<
-        commandline_option_error = 30,
-        ///< One of the options given on the command line is erroneous
-        serialization_error = 31,
-        ///< There was an error during serialization of this object
-        unhandled_exception = 32,
-        ///< An unhandled exception has been caught
-        kernel_error = 33,
-        ///< The OS kernel reported an error
-        broken_task = 34,
-        ///< The task associated with this future object is not available anymore
-        task_moved = 35,
-        ///< The task associated with this future object has been moved
-        task_already_started = 36,
-        ///< The task associated with this future object has already been started
-        future_already_retrieved = 37,
-        ///< The future object has already been retrieved
-        promise_already_satisfied = 38,
-        ///< The value for this future object has already been set
-        future_does_not_support_cancellation = 39,
-        ///< The future object does not support cancellation
-        future_can_not_be_cancelled = 40,
-        ///< The future can't be canceled at this time
-        no_state = 41,
-        ///< The future object has no valid shared state
-        broken_promise = 42,
-        ///< The promise has been deleted
-        thread_resource_error = 43,
-        ///<
-        future_cancelled = 44,
-        ///<
-        thread_cancelled = 45,
-        ///<
-        thread_not_interruptable = 46,
-        ///<
-        duplicate_component_id = 47,
-        ///< The component type has already been registered
-        unknown_error = 48,
-        ///< An unknown error occurred
-        bad_plugin_type = 49,
-        ///< The specified plugin type is not known or otherwise invalid
-        filesystem_error = 50,
-        ///< The specified file does not exist or other filesystem related error
-        bad_function_call = 51,
-        ///< equivalent of std::bad_function_call
-        task_canceled_exception = 52,
-        ///< parallel::v2::task_canceled_exception
-        task_block_not_active = 53,
-        ///< task_region is not active
-        out_of_range = 54,
-        ///< Equivalent to std::out_of_range
-        length_error = 55,
-        ///< Equivalent to std::length_error
-
-        migration_needs_retry = 56,    ///< migration failed because of global
-                                       ///< race, retry
+        /// The operation was executed in an invalid status
+        invalid_status = 4,
+        /// One of the supplied parameters is invalid
+        bad_parameter = 5,
+        ///
+        lock_error = 6,
+        ///
+        startup_timed_out = 7,
+        ///
+        uninitialized_value = 8,
+        ///
+        bad_response_type = 9,
+        ///
+        deadlock = 10,
+        ///
+        assertion_failure = 11,
+        /// Attempt to invoke a function that requires a pika thread from a non-pika thread
+        null_thread_id = 12,
+        ///
+        invalid_data = 13,
+        /// The yield operation was aborted
+        yield_aborted = 14,
+        ///
+        dynamic_link_failure = 15,
+        /// One of the options given on the command line is erroneous
+        commandline_option_error = 16,
+        /// An unhandled exception has been caught
+        unhandled_exception = 17,
+        /// The OS kernel reported an error
+        kernel_error = 18,
+        /// The task associated with this future object is not available anymore
+        broken_task = 19,
+        /// The task associated with this future object has been moved
+        task_moved = 20,
+        /// The task associated with this future object has already been started
+        task_already_started = 21,
+        /// The future object has already been retrieved
+        future_already_retrieved = 22,
+        /// The value for this future object has already been set
+        promise_already_satisfied = 23,
+        /// The future object does not support cancellation
+        future_does_not_support_cancellation = 24,
+        /// The future can't be canceled at this time
+        future_can_not_be_cancelled = 25,
+        /// The future object has no valid shared state
+        no_state = 26,
+        /// The promise has been deleted
+        broken_promise = 27,
+        ///
+        thread_resource_error = 28,
+        ///
+        future_cancelled = 29,
+        ///
+        thread_cancelled = 30,
+        ///
+        thread_not_interruptable = 31,
+        /// An unknown error occurred
+        unknown_error = 32,
+        /// equivalent of std::bad_function_call
+        bad_function_call = 33,
+        /// parallel::v2::task_canceled_exception
+        task_canceled_exception = 34,
+        /// task_region is not active
+        task_block_not_active = 35,
+        /// Equivalent to std::out_of_range
+        out_of_range = 36,
+        /// Equivalent to std::length_error
+        length_error = 37,
 
         /// \cond NOINTERNAL
         last_error,
@@ -149,68 +110,56 @@ namespace pika {
         /// \endcond
     };
 
-    /// \cond NOINTERNAL
-    char const* const error_names[] = {
-        /*  0 */ "success",
-        /*  1 */ "no_success",
-        /*  2 */ "not_implemented",
-        /*  3 */ "out_of_memory",
-        /*  4 */ "bad_action_code",
-        /*  5 */ "bad_component_type",
-        /*  6 */ "network_error",
-        /*  7 */ "version_too_new",
-        /*  8 */ "version_too_old",
-        /*  9 */ "version_unknown",
-        /* 10 */ "unknown_component_address",
-        /* 11 */ "duplicate_component_address",
-        /* 12 */ "invalid_status",
-        /* 13 */ "bad_parameter",
-        /* 14 */ "internal_server_error",
-        /* 15 */ "service_unavailable",
-        /* 16 */ "bad_request",
-        /* 17 */ "repeated_request",
-        /* 18 */ "lock_error",
-        /* 19 */ "duplicate_console",
-        /* 20 */ "no_registered_console",
-        /* 21 */ "startup_timed_out",
-        /* 22 */ "uninitialized_value",
-        /* 23 */ "bad_response_type",
-        /* 24 */ "deadlock",
-        /* 25 */ "assertion_failure",
-        /* 26 */ "null_thread_id",
-        /* 27 */ "invalid_data",
-        /* 28 */ "yield_aborted",
-        /* 29 */ "dynamic_link_failure",
-        /* 30 */ "commandline_option_error",
-        /* 31 */ "serialization_error",
-        /* 32 */ "unhandled_exception",
-        /* 33 */ "kernel_error",
-        /* 34 */ "broken_task",
-        /* 35 */ "task_moved",
-        /* 36 */ "task_already_started",
-        /* 37 */ "future_already_retrieved",
-        /* 38 */ "promise_already_satisfied",
-        /* 39 */ "future_does_not_support_cancellation",
-        /* 40 */ "future_can_not_be_cancelled",
-        /* 41 */ "no_state",
-        /* 42 */ "broken_promise",
-        /* 43 */ "thread_resource_error",
-        /* 44 */ "future_cancelled",
-        /* 45 */ "thread_cancelled",
-        /* 46 */ "thread_not_interruptable",
-        /* 47 */ "duplicate_component_id",
-        /* 48 */ "unknown_error",
-        /* 49 */ "bad_plugin_type",
-        /* 50 */ "filesystem_error",
-        /* 51 */ "bad_function_call",
-        /* 52 */ "task_canceled_exception",
-        /* 53 */ "task_block_not_active",
-        /* 54 */ "out_of_range",
-        /* 55 */ "length_error",
-        /* 56 */ "migration_needs_retry",
+    namespace detail {
+        /// \cond NOINTERNAL
+        char const* const error_names[] = {
+            /*  0 */ "success",
+            /*  1 */ "no_success",
+            /*  2 */ "not_implemented",
+            /*  3 */ "out_of_memory",
+            /*  4 */ "invalid_status",
+            /*  5 */ "bad_parameter",
+            /*  6 */ "lock_error",
+            /*  7 */ "startup_timed_out",
+            /*  8 */ "uninitialized_value",
+            /*  9 */ "bad_response_type",
+            /* 10 */ "deadlock",
+            /* 11 */ "assertion_failure",
+            /* 12 */ "null_thread_id",
+            /* 13 */ "invalid_data",
+            /* 14 */ "yield_aborted",
+            /* 15 */ "dynamic_link_failure",
+            /* 16 */ "commandline_option_error",
+            /* 17 */ "unhandled_exception",
+            /* 18 */ "kernel_error",
+            /* 19 */ "broken_task",
+            /* 20 */ "task_moved",
+            /* 21 */ "task_already_started",
+            /* 22 */ "future_already_retrieved",
+            /* 23 */ "promise_already_satisfied",
+            /* 24 */ "future_does_not_support_cancellation",
+            /* 25 */ "future_can_not_be_cancelled",
+            /* 26 */ "no_state",
+            /* 27 */ "broken_promise",
+            /* 28 */ "thread_resource_error",
+            /* 29 */ "future_cancelled",
+            /* 30 */ "thread_cancelled",
+            /* 31 */ "thread_not_interruptable",
+            /* 32 */ "unknown_error",
+            /* 33 */ "bad_function_call",
+            /* 34 */ "task_canceled_exception",
+            /* 35 */ "task_block_not_active",
+            /* 36 */ "out_of_range",
+            /* 37 */ "length_error",
 
-        /*    */ ""};
-    /// \endcond
+            /*    */ ""};
+
+        inline bool error_code_has_system_error(int e)
+        {
+            return e & static_cast<int>(pika::error::system_error_flag);
+        }
+        /// \endcond
+    }    // namespace detail
 }    // namespace pika
 
 /// \cond NOEXTERNAL

--- a/libs/pika/errors/include/pika/errors/error_code.hpp
+++ b/libs/pika/errors/include/pika/errors/error_code.hpp
@@ -49,22 +49,27 @@ namespace pika {
     PIKA_EXPORT std::error_category const& get_pika_rethrow_category();
 
     /// \cond NOINTERNAL
-    PIKA_EXPORT std::error_category const& get_lightweight_pika_category();
+    namespace detail {
+        PIKA_EXPORT std::error_category const& get_lightweight_pika_category();
 
-    PIKA_EXPORT std::error_category const& get_pika_category(throwmode mode);
+        PIKA_EXPORT std::error_category const& get_pika_category(
+            throwmode mode);
 
-    inline std::error_code make_system_error_code(
-        error e, throwmode mode = plain)
-    {
-        return std::error_code(static_cast<int>(e), get_pika_category(mode));
-    }
+        inline std::error_code make_system_error_code(
+            error e, throwmode mode = throwmode::plain)
+        {
+            return std::error_code(
+                static_cast<int>(e), get_pika_category(mode));
+        }
 
-    ///////////////////////////////////////////////////////////////////////////
-    inline std::error_condition make_error_condition(error e, throwmode mode)
-    {
-        return std::error_condition(
-            static_cast<int>(e), get_pika_category(mode));
-    }
+        ///////////////////////////////////////////////////////////////////////////
+        inline std::error_condition make_error_condition(
+            error e, throwmode mode)
+        {
+            return std::error_condition(
+                static_cast<int>(e), get_pika_category(mode));
+        }
+    }    // namespace detail
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
@@ -84,13 +89,14 @@ namespace pika {
         ///
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
         ///
         /// \throws nothing
-        explicit error_code(throwmode mode = plain)
-          : std::error_code(make_system_error_code(success, mode))
+        explicit error_code(throwmode mode = throwmode::plain)
+          : std::error_code(
+                detail::make_system_error_code(pika::error::success, mode))
         {
         }
 
@@ -100,12 +106,13 @@ namespace pika {
         ///               exception should encapsulate.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
         ///
         /// \throws nothing
-        PIKA_EXPORT explicit error_code(error e, throwmode mode = plain);
+        PIKA_EXPORT explicit error_code(
+            error e, throwmode mode = throwmode::plain);
 
         /// Construct an object of type error_code.
         ///
@@ -117,13 +124,13 @@ namespace pika {
         ///               raised.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
         ///
         /// \throws nothing
         PIKA_EXPORT error_code(error e, char const* func, char const* file,
-            long line, throwmode mode = plain);
+            long line, throwmode mode = throwmode::plain);
 
         /// Construct an object of type error_code.
         ///
@@ -133,14 +140,14 @@ namespace pika {
         ///               exception should encapsulate.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
         ///
         /// \throws std#bad_alloc (if allocation of a copy of
         ///         the passed string fails).
         PIKA_EXPORT error_code(
-            error e, char const* msg, throwmode mode = plain);
+            error e, char const* msg, throwmode mode = throwmode::plain);
 
         /// Construct an object of type error_code.
         ///
@@ -154,14 +161,14 @@ namespace pika {
         ///               raised.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
+        ///               \a pika_category (if mode is \a throwmode::plain, this is the
         ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               (if mode is \a throwmode::rethrow).
         ///
         /// \throws std#bad_alloc (if allocation of a copy of
         ///         the passed string fails).
         PIKA_EXPORT error_code(error e, char const* msg, char const* func,
-            char const* file, long line, throwmode mode = plain);
+            char const* file, long line, throwmode mode = throwmode::plain);
 
         /// Construct an object of type error_code.
         ///
@@ -171,14 +178,14 @@ namespace pika {
         ///               exception should encapsulate.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
+        ///               \a pika_category (if mode is \a throwmode::plain, this is the
         ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               (if mode is \a throwmode::rethrow).
         ///
         /// \throws std#bad_alloc (if allocation of a copy of
         ///         the passed string fails).
         PIKA_EXPORT error_code(
-            error e, std::string const& msg, throwmode mode = plain);
+            error e, std::string const& msg, throwmode mode = throwmode::plain);
 
         /// Construct an object of type error_code.
         ///
@@ -192,15 +199,15 @@ namespace pika {
         ///               raised.
         /// \param mode   The parameter \p mode specifies whether the constructed
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
         ///
         /// \throws std#bad_alloc (if allocation of a copy of
         ///         the passed string fails).
         PIKA_EXPORT error_code(error e, std::string const& msg,
             char const* func, char const* file, long line,
-            throwmode mode = plain);
+            throwmode mode = throwmode::plain);
 
         /// Return a reference to the error message stored in the pika::error_code.
         ///
@@ -209,10 +216,11 @@ namespace pika {
 
         /// \brief Clear this error_code object.
         /// The postconditions of invoking this method are
-        /// * value() == pika::success and category() == pika::get_pika_category()
+        /// * value() == pika::error::success and category() == pika::get_pika_category()
         void clear()
         {
-            this->std::error_code::assign(success, get_pika_category());
+            this->std::error_code::assign(
+                static_cast<int>(pika::error::success), get_pika_category());
             exception_ = std::exception_ptr();
         }
 
@@ -241,36 +249,39 @@ namespace pika {
 
     /// @{
     /// \brief Returns a new error_code constructed from the given parameters.
-    inline error_code make_error_code(error e, throwmode mode = plain)
+    inline error_code make_error_code(
+        error e, throwmode mode = throwmode::plain)
     {
         return error_code(e, mode);
     }
     inline error_code make_error_code(error e, char const* func,
-        char const* file, long line, throwmode mode = plain)
+        char const* file, long line, throwmode mode = throwmode::plain)
     {
         return error_code(e, func, file, line, mode);
     }
 
     /// \brief Returns error_code(e, msg, mode).
     inline error_code make_error_code(
-        error e, char const* msg, throwmode mode = plain)
+        error e, char const* msg, throwmode mode = throwmode::plain)
     {
         return error_code(e, msg, mode);
     }
     inline error_code make_error_code(error e, char const* msg,
-        char const* func, char const* file, long line, throwmode mode = plain)
+        char const* func, char const* file, long line,
+        throwmode mode = throwmode::plain)
     {
         return error_code(e, msg, func, file, line, mode);
     }
 
     /// \brief Returns error_code(e, msg, mode).
     inline error_code make_error_code(
-        error e, std::string const& msg, throwmode mode = plain)
+        error e, std::string const& msg, throwmode mode = throwmode::plain)
     {
         return error_code(e, msg, mode);
     }
     inline error_code make_error_code(error e, std::string const& msg,
-        char const* func, char const* file, long line, throwmode mode = plain)
+        char const* func, char const* file, long line,
+        throwmode mode = throwmode::plain)
     {
         return error_code(e, msg, func, file, line, mode);
     }
@@ -280,8 +291,8 @@ namespace pika {
     }
     ///@}
 
-    /// \brief Returns error_code(pika::success, "success", mode).
-    inline error_code make_success_code(throwmode mode = plain)
+    /// \brief Returns error_code(pika::error:success, "success", mode).
+    inline error_code make_success_code(throwmode mode = throwmode::plain)
     {
         return error_code(mode);
     }

--- a/libs/pika/errors/include/pika/errors/exception.hpp
+++ b/libs/pika/errors/include/pika/errors/exception.hpp
@@ -42,7 +42,7 @@ namespace pika {
         ///
         /// \param e    The parameter \p e holds the pika::error code the new
         ///             exception should encapsulate.
-        explicit exception(error e = success);
+        explicit exception(error e = pika::error::success);
 
         /// Construct a pika::exception from a std#system_error.
         explicit exception(std::system_error const& e);
@@ -60,10 +60,10 @@ namespace pika {
         ///               exception should encapsulate.
         /// \param mode   The parameter \p mode specifies whether the returned
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
-        exception(error e, char const* msg, throwmode mode = plain);
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
+        exception(error e, char const* msg, throwmode mode = throwmode::plain);
 
         /// Construct a pika::exception from a \a pika::error and an error message.
         ///
@@ -73,10 +73,11 @@ namespace pika {
         ///               exception should encapsulate.
         /// \param mode   The parameter \p mode specifies whether the returned
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
-        exception(error e, std::string const& msg, throwmode mode = plain);
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
+        exception(
+            error e, std::string const& msg, throwmode mode = throwmode::plain);
 
         /// Destruct a pika::exception
         ///
@@ -96,22 +97,26 @@ namespace pika {
         ///
         /// \param mode   The parameter \p mode specifies whether the returned
         ///               pika::error_code belongs to the error category
-        ///               \a pika_category (if mode is \a plain, this is the
-        ///               default) or to the category \a pika_category_rethrow
-        ///               (if mode is \a rethrow).
-        error_code get_error_code(throwmode mode = plain) const noexcept;
+        ///               \a pika_category (if mode is \a throwmode::plain, this
+        ///               is the default) or to the category \a
+        ///               pika_category_rethrow (if mode is \a throwmode::rethrow).
+        error_code get_error_code(
+            throwmode mode = throwmode::plain) const noexcept;
     };
 
-    using custom_exception_info_handler_type =
-        std::function<pika::exception_info(
-            std::string const&, std::string const&, long, std::string const&)>;
+    namespace detail {
+        using custom_exception_info_handler_type =
+            std::function<pika::exception_info(std::string const&,
+                std::string const&, long, std::string const&)>;
 
-    PIKA_EXPORT void set_custom_exception_info_handler(
-        custom_exception_info_handler_type f);
+        PIKA_EXPORT void set_custom_exception_info_handler(
+            custom_exception_info_handler_type f);
 
-    using pre_exception_handler_type = std::function<void()>;
+        using pre_exception_handler_type = std::function<void()>;
 
-    PIKA_EXPORT void set_pre_exception_handler(pre_exception_handler_type f);
+        PIKA_EXPORT void set_pre_exception_handler(
+            pre_exception_handler_type f);
+    }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief A pika::thread_interrupted is the exception type used by pika to
@@ -351,7 +356,7 @@ namespace pika {
     inline std::string get_error_what(pika::error_code const& e)
     {
         // if this is a lightweight error_code, return canned response
-        if (e.category() == pika::get_lightweight_pika_category())
+        if (e.category() == detail::get_lightweight_pika_category())
             return e.message();
 
         return get_error_what<pika::error_code>(e);

--- a/libs/pika/errors/include/pika/errors/exception_fwd.hpp
+++ b/libs/pika/errors/include/pika/errors/exception_fwd.hpp
@@ -16,15 +16,13 @@ namespace pika {
     /// \cond NOINTERNAL
     // forward declaration
     class error_code;
-
     class PIKA_EXPORT exception;
-
     struct PIKA_EXPORT thread_interrupted;
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Encode error category for new error_code.
-    enum throwmode
+    enum class throwmode
     {
         plain = 0,
         rethrow = 1,

--- a/libs/pika/errors/include/pika/errors/throw_exception.hpp
+++ b/libs/pika/errors/include/pika/errors/throw_exception.hpp
@@ -25,7 +25,7 @@
 #include <pika/config/warnings_prefix.hpp>
 
 /// \cond NODETAIL
-namespace pika { namespace detail {
+namespace pika::detail {
     template <typename Exception>
     [[noreturn]] PIKA_EXPORT void throw_exception(Exception const& e,
         std::string const& func, std::string const& file, long line);
@@ -63,7 +63,7 @@ namespace pika { namespace detail {
         pika::error_code& ec, exception const& e, std::string const& func);
 
     [[noreturn]] PIKA_EXPORT void throw_thread_interrupted_exception();
-}}    // namespace pika::detail
+}    // namespace pika::detail
 /// \endcond
 
 namespace pika {
@@ -99,7 +99,7 @@ namespace pika {
         PIKA_GET_EXCEPTION_, PIKA_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))         \
 /**/
 #define PIKA_GET_EXCEPTION_3(errcode, f, msg)                                  \
-    PIKA_GET_EXCEPTION_4(errcode, pika::plain, f, msg)                         \
+    PIKA_GET_EXCEPTION_4(errcode, pika::throwmode::plain, f, msg)              \
 /**/
 #define PIKA_GET_EXCEPTION_4(errcode, mode, f, msg)                            \
     pika::detail::get_exception(errcode, msg, mode, f, __FILE__, __LINE__) /**/
@@ -151,7 +151,7 @@ namespace pika {
 ///          // Throw a pika::exception initialized from the given parameters.
 ///          // Additionally associate with this exception some detailed
 ///          // diagnostic information about the throw-site.
-///          PIKA_THROW_EXCEPTION(pika::no_success, "raise_exception", "simulated error");
+///          PIKA_THROW_EXCEPTION(pika::error:no_success, "raise_exception", "simulated error");
 ///      }
 /// \endcode
 ///

--- a/libs/pika/errors/include/pika/errors/try_catch_exception_ptr.hpp
+++ b/libs/pika/errors/include/pika/errors/try_catch_exception_ptr.hpp
@@ -11,7 +11,7 @@
 #include <exception>
 #include <utility>
 
-namespace pika { namespace detail {
+namespace pika::detail {
     /// Helper function for a try-catch block where what would normally go in
     /// the catch block should be called after the catch block. This is useful
     /// for situations where the catch-block may yield, since the catch block
@@ -41,4 +41,4 @@ namespace pika { namespace detail {
         }
         return c(PIKA_MOVE(ep));
     }
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/errors/src/exception_list.cpp
+++ b/libs/pika/errors/src/exception_list.cpp
@@ -55,7 +55,7 @@ namespace pika {
                           // to take its address for comparison purposes.
 
     exception_list::exception_list()
-      : pika::exception(pika::success)
+      : pika::exception(pika::error::success)
       , mtx_()
     {
     }
@@ -68,7 +68,8 @@ namespace pika {
     }
 
     exception_list::exception_list(exception_list_type&& l)
-      : pika::exception(!l.empty() ? pika::get_error(l.front()) : success)
+      : pika::exception(
+            !l.empty() ? pika::get_error(l.front()) : pika::error::success)
       , exceptions_(PIKA_MOVE(l))
       , mtx_()
     {
@@ -115,7 +116,7 @@ namespace pika {
     {
         std::lock_guard<mutex_type> l(mtx_);
         if (exceptions_.empty())
-            return pika::no_success;
+            return pika::error::no_success;
         return pika::get_error(exceptions_.front());
     }
 

--- a/libs/pika/errors/src/throw_exception.cpp
+++ b/libs/pika/errors/src/throw_exception.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <system_error>
 
-namespace pika { namespace detail {
+namespace pika::detail {
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     [[noreturn]] void throw_exception(error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line)
@@ -22,15 +22,16 @@ namespace pika { namespace detail {
     {
         std::filesystem::path p(file);
         pika::detail::throw_exception(
-            pika::exception(errcode, msg, pika::plain), func, p.string(), line);
+            pika::exception(errcode, msg, pika::throwmode::plain), func,
+            p.string(), line);
     }
 
     [[noreturn]] void rethrow_exception(
         exception const& e, std::string const& func)
     {
         pika::detail::throw_exception(
-            pika::exception(e.get_error(), e.what(), pika::rethrow), func,
-            pika::get_error_file_name(e), pika::get_error_line_number(e));
+            pika::exception(e.get_error(), e.what(), pika::throwmode::rethrow),
+            func, pika::get_error_file_name(e), pika::get_error_line_number(e));
     }
 
     std::exception_ptr get_exception(error errcode, std::string const& msg,
@@ -62,9 +63,9 @@ namespace pika { namespace detail {
         {
             ec = make_error_code(static_cast<pika::error>(errcode), msg,
                 func.c_str(), file.c_str(), line,
-                (ec.category() == pika::get_lightweight_pika_category()) ?
-                    pika::lightweight :
-                    pika::plain);
+                (ec.category() == get_lightweight_pika_category()) ?
+                    pika::throwmode::lightweight :
+                    pika::throwmode::plain);
         }
     }
 
@@ -80,9 +81,9 @@ namespace pika { namespace detail {
             ec = make_error_code(e.get_error(), e.what(), func.c_str(),
                 pika::get_error_file_name(e).c_str(),
                 pika::get_error_line_number(e),
-                (ec.category() == pika::get_lightweight_pika_category()) ?
-                    pika::lightweight_rethrow :
-                    pika::rethrow);
+                (ec.category() == get_lightweight_pika_category()) ?
+                    pika::throwmode::lightweight_rethrow :
+                    pika::throwmode::rethrow);
         }
     }
 
@@ -90,4 +91,4 @@ namespace pika { namespace detail {
     {
         throw pika::thread_interrupted();
     }
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/errors/tests/unit/exception.cpp
+++ b/libs/pika/errors/tests/unit/exception.cpp
@@ -16,7 +16,8 @@
 
 void throw_always()
 {
-    PIKA_THROW_EXCEPTION(pika::no_success, "throw_always", "simulated error");
+    PIKA_THROW_EXCEPTION(
+        pika::error::no_success, "throw_always", "simulated error");
 }
 
 std::exception_ptr test_transport()

--- a/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
@@ -39,7 +39,7 @@ namespace pika { namespace execution { namespace experimental {
 
                         if (!state)
                         {
-                            PIKA_THROW_EXCEPTION(no_state,
+                            PIKA_THROW_EXCEPTION(pika::error::no_state,
                                 "operation_state::start",
                                 "the future has no valid shared state");
                         }

--- a/libs/pika/execution/src/execution_parameter_callbacks.cpp
+++ b/libs/pika/execution/src/execution_parameter_callbacks.cpp
@@ -34,7 +34,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         }
         else
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::parallel::execution::detail::get_os_thread_count",
                 "No fallback handler for get_os_thread_count is installed. "
                 "Please start the runtime if you haven't done so. If you "
@@ -66,7 +66,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         }
         else
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::parallel::execution::detail::get_pu_mask",
                 "No fallback handler for get_pu_mask is installed. Please "
                 "start the runtime if you haven't done so. If you intended "

--- a/libs/pika/execution/src/polymorphic_executor.cpp
+++ b/libs/pika/execution/src/polymorphic_executor.cpp
@@ -21,7 +21,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     [[noreturn]] void throw_bad_polymorphic_executor()
     {
-        pika::throw_exception(bad_function_call,
+        pika::throw_exception(pika::error::bad_function_call,
             "empty polymorphic_executor object should not be used",
             "polymorphic_executor::operator()");
     }

--- a/libs/pika/execution_base/src/any_sender.cpp
+++ b/libs/pika/execution_base/src/any_sender.cpp
@@ -17,7 +17,7 @@
 namespace pika::execution::experimental::detail {
     void empty_any_operation_state::start() & noexcept
     {
-        PIKA_THROW_EXCEPTION(pika::bad_function_call,
+        PIKA_THROW_EXCEPTION(pika::error::bad_function_call,
             "attempted to call start on empty any_operation_state",
             "any_operation_state::start");
     }
@@ -35,7 +35,7 @@ namespace pika::execution::experimental::detail {
 
     void throw_bad_any_call(char const* class_name, char const* function_name)
     {
-        PIKA_THROW_EXCEPTION(pika::bad_function_call,
+        PIKA_THROW_EXCEPTION(pika::error::bad_function_call,
             pika::util::format(
                 "attempted to call {} on empty {}", function_name, class_name),
             pika::util::format("{}::{}", class_name, function_name));

--- a/libs/pika/execution_base/src/this_thread.cpp
+++ b/libs/pika/execution_base/src/this_thread.cpp
@@ -156,7 +156,7 @@ namespace pika { namespace execution_base {
 
             if (aborted_)
             {
-                PIKA_THROW_EXCEPTION(yield_aborted, "suspend",
+                PIKA_THROW_EXCEPTION(pika::error::yield_aborted, "suspend",
                     "std::thread({}) aborted (yield returned wait_abort)", id_);
             }
         }
@@ -275,7 +275,7 @@ namespace pika { namespace execution_base {
                     pika::util::detail::get_spinlock_deadlock_detection_limit();
                 if (k >= deadlock_detection_limit)
                 {
-                    PIKA_THROW_EXCEPTION(deadlock, desc,
+                    PIKA_THROW_EXCEPTION(pika::error::deadlock, desc,
                         pika::util::format(
                             "yield_k yielded {} times. This may indicate a "
                             "deadlock in your application or a bug in pika. "

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -398,7 +398,7 @@ void test_any_sender(F&& f, Ts&&... ts)
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {
@@ -419,7 +419,7 @@ void test_any_sender(F&& f, Ts&&... ts)
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {
@@ -459,7 +459,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {
@@ -519,7 +519,7 @@ void test_any_sender_set_error()
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {
@@ -540,7 +540,7 @@ void test_any_sender_set_error()
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {
@@ -578,7 +578,7 @@ void test_unique_any_sender_set_error()
         }
         catch (pika::exception const& e)
         {
-            PIKA_TEST_EQ(e.get_error(), pika::bad_function_call);
+            PIKA_TEST_EQ(e.get_error(), pika::error::bad_function_call);
         }
         catch (...)
         {

--- a/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
@@ -653,7 +653,7 @@ namespace pika { namespace execution { namespace experimental {
         {
             if (stacksize == execution::thread_stacksize::nostack)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "fork_join_executor::fork_join_executor",
                     "The fork_join_executor does not support using "
                     "thread_stacksize::nostack as the stacksize (stackful "

--- a/libs/pika/executors/src/current_executor.cpp
+++ b/libs/pika/executors/src/current_executor.cpp
@@ -13,8 +13,8 @@ namespace pika::threads {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id, "pika::threads::get_executor",
-                "null thread id encountered");
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
+                "pika::threads::get_executor", "null thread id encountered");
             return parallel::execution::current_executor();
         }
 

--- a/libs/pika/functional/src/empty_function.cpp
+++ b/libs/pika/functional/src/empty_function.cpp
@@ -13,7 +13,7 @@
 namespace pika { namespace util { namespace detail {
     [[noreturn]] void throw_bad_function_call()
     {
-        pika::throw_exception(bad_function_call,
+        pika::throw_exception(pika::error::bad_function_call,
             "empty function object should not be used",
             "empty_function::operator()");
     }

--- a/libs/pika/futures/include/pika/futures/detail/future_data.hpp
+++ b/libs/pika/futures/include/pika/futures/detail/future_data.hpp
@@ -266,7 +266,8 @@ namespace pika { namespace lcos { namespace detail {
         }
         virtual void cancel()
         {
-            PIKA_THROW_EXCEPTION(future_does_not_support_cancellation,
+            PIKA_THROW_EXCEPTION(
+                pika::error::future_does_not_support_cancellation,
                 "future_data_base::cancel",
                 "this future does not support cancellation");
         }
@@ -305,19 +306,19 @@ namespace pika { namespace lcos { namespace detail {
 
         virtual std::string const& get_registered_name() const
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "future_data_base::get_registered_name",
                 "this future does not support name registration");
         }
         virtual void set_registered_name(std::string /*name*/)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "future_data_base::set_registered_name",
                 "this future does not support name registration");
         }
         virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "future_data_base::register_as",
                 "this future does not support name registration");
         }
@@ -462,7 +463,7 @@ namespace pika { namespace lcos { namespace detail {
                 // this future should be 'empty' still (it can't be made ready
                 // more than once).
                 l.unlock();
-                PIKA_THROW_EXCEPTION(promise_already_satisfied,
+                PIKA_THROW_EXCEPTION(pika::error::promise_already_satisfied,
                     "future_data_base::set_value",
                     "data has already been set for this future");
                 return;
@@ -521,7 +522,7 @@ namespace pika { namespace lcos { namespace detail {
                 // this future should be 'empty' still (it can't be made ready
                 // more than once).
                 l.unlock();
-                PIKA_THROW_EXCEPTION(promise_already_satisfied,
+                PIKA_THROW_EXCEPTION(pika::error::promise_already_satisfied,
                     "future_data_base::set_exception",
                     "data has already been set for this future");
                 return;
@@ -875,7 +876,7 @@ namespace pika { namespace lcos { namespace detail {
             if (started_)
             {
                 l.unlock();
-                PIKA_THROW_EXCEPTION(task_already_started,
+                PIKA_THROW_EXCEPTION(pika::error::task_already_started,
                     "task_base::check_started",
                     "this task has already been started");
                 return;
@@ -1016,14 +1017,15 @@ namespace pika { namespace lcos { namespace detail {
                         this->started_ = true;
 
                         l.unlock();
-                        this->set_error(future_cancelled,
+                        this->set_error(pika::error::future_cancelled,
                             "task_base<Result>::cancel",
                             "future has been canceled");
                     }
                     else
                     {
                         l.unlock();
-                        PIKA_THROW_EXCEPTION(future_can_not_be_cancelled,
+                        PIKA_THROW_EXCEPTION(
+                            pika::error::future_can_not_be_cancelled,
                             "task_base<Result>::cancel",
                             "future can't be canceled at this time");
                     }

--- a/libs/pika/futures/include/pika/futures/future.hpp
+++ b/libs/pika/futures/include/pika/futures/future.hpp
@@ -276,7 +276,8 @@ namespace pika { namespace lcos { namespace detail {
 
                     if (!state)
                     {
-                        PIKA_THROW_EXCEPTION(no_state, "operation_state::start",
+                        PIKA_THROW_EXCEPTION(pika::error::no_state,
+                            "operation_state::start",
                             "the future has no valid shared state");
                     }
 
@@ -421,14 +422,14 @@ namespace pika { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                PIKA_THROW_EXCEPTION(no_state,
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
                     "future_base<R>::get_exception_ptr",
                     "this future has no valid shared state");
             }
 
             using result_type = typename shared_state_type::result_type;
 
-            error_code ec(lightweight);
+            error_code ec(throwmode::lightweight);
             lcos::detail::future_get_result<result_type>::call(
                 this->shared_state_, ec);
             if (!ec)
@@ -482,7 +483,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future_base<R>::then",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "future_base<R>::then",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -502,7 +504,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future_base<R>::then",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "future_base<R>::then",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -523,7 +526,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future_base<R>::then_alloc",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "future_base<R>::then_alloc",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -537,7 +541,8 @@ namespace pika { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future_base<R>::wait",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "future_base<R>::wait",
                     "this future has no valid shared state");
                 return;
             }
@@ -561,7 +566,8 @@ namespace pika { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future_base<R>::wait_until",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "future_base<R>::wait_until",
                     "this future has no valid shared state");
                 return pika::future_status::uninitialized;
             }
@@ -772,7 +778,7 @@ namespace pika {
         {
             if (!this->shared_state_)
             {
-                PIKA_THROW_EXCEPTION(no_state, "future<R>::get",
+                PIKA_THROW_EXCEPTION(pika::error::no_state, "future<R>::get",
                     "this future has no valid shared state");
             }
 
@@ -792,7 +798,7 @@ namespace pika {
         {
             if (!this->shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "future<R>::get",
+                PIKA_THROWS_IF(ec, pika::error::no_state, "future<R>::get",
                     "this future has no valid shared state");
                 return lcos::detail::future_value<R>::get_default();
             }
@@ -1072,7 +1078,8 @@ namespace pika {
         {
             if (!this->shared_state_)
             {
-                PIKA_THROW_EXCEPTION(no_state, "shared_future<R>::get",
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
+                    "shared_future<R>::get",
                     "this future has no valid shared state");
             }
 
@@ -1091,7 +1098,8 @@ namespace pika {
             using result_type = typename shared_state_type::result_type;
             if (!this->shared_state_)
             {
-                PIKA_THROWS_IF(ec, no_state, "shared_future<R>::get",
+                PIKA_THROWS_IF(ec, pika::error::no_state,
+                    "shared_future<R>::get",
                     "this future has no valid shared state");
                 static result_type res(
                     lcos::detail::future_value<R>::get_default());

--- a/libs/pika/futures/include/pika/futures/futures_factory.hpp
+++ b/libs/pika/futures/include/pika/futures/futures_factory.hpp
@@ -718,7 +718,7 @@ namespace pika { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                PIKA_THROW_EXCEPTION(task_moved,
+                PIKA_THROW_EXCEPTION(pika::error::task_moved,
                     "futures_factory<Result()>::operator()",
                     "futures_factory invalid (has it been moved?)");
                 return;
@@ -742,7 +742,7 @@ namespace pika { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                PIKA_THROW_EXCEPTION(task_moved,
+                PIKA_THROW_EXCEPTION(pika::error::task_moved,
                     "futures_factory<Result()>::apply()",
                     "futures_factory invalid (has it been moved?)");
                 return threads::detail::invalid_thread_id;
@@ -756,14 +756,14 @@ namespace pika { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                PIKA_THROWS_IF(ec, task_moved,
+                PIKA_THROWS_IF(ec, pika::error::task_moved,
                     "futures_factory<Result()>::get_future",
                     "futures_factory invalid (has it been moved?)");
                 return pika::future<Result>();
             }
             if (future_obtained_)
             {
-                PIKA_THROWS_IF(ec, future_already_retrieved,
+                PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                     "futures_factory<Result()>::get_future",
                     "future already has been retrieved from this factory");
                 return pika::future<Result>();
@@ -785,7 +785,7 @@ namespace pika { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                PIKA_THROW_EXCEPTION(task_moved,
+                PIKA_THROW_EXCEPTION(pika::error::task_moved,
                     "futures_factory<Result()>::set_exception",
                     "futures_factory invalid (has it been moved?)");
                 return;

--- a/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
@@ -102,7 +102,8 @@ namespace pika { namespace lcos { namespace detail {
 
                 if (ptr == nullptr)
                 {
-                    PIKA_THROW_EXCEPTION(no_state, "invoke_continuation",
+                    PIKA_THROW_EXCEPTION(pika::error::no_state,
+                        "invoke_continuation",
                         "the inner future has no valid shared state");
                 }
 
@@ -207,7 +208,7 @@ namespace pika { namespace lcos { namespace detail {
                 std::lock_guard<mutex_type> l(mtx_);
                 if (started_)
                 {
-                    PIKA_THROWS_IF(ec, task_already_started,
+                    PIKA_THROWS_IF(ec, pika::error::task_already_started,
                         "continuation::run",
                         "this task has already been started");
                     return;
@@ -228,7 +229,7 @@ namespace pika { namespace lcos { namespace detail {
                 std::lock_guard<mutex_type> l(mtx_);
                 if (started_)
                 {
-                    PIKA_THROWS_IF(ec, task_already_started,
+                    PIKA_THROWS_IF(ec, pika::error::task_already_started,
                         "continuation::run_nounwrap",
                         "this task has already been started");
                     return;
@@ -274,7 +275,7 @@ namespace pika { namespace lcos { namespace detail {
                 if (started_)
                 {
                     l.unlock();
-                    PIKA_THROWS_IF(ec, task_already_started,
+                    PIKA_THROWS_IF(ec, pika::error::task_already_started,
                         "continuation::async",
                         "this task has already been started");
                     return;
@@ -304,7 +305,7 @@ namespace pika { namespace lcos { namespace detail {
                 if (started_)
                 {
                     l.unlock();
-                    PIKA_THROWS_IF(ec, task_already_started,
+                    PIKA_THROWS_IF(ec, pika::error::task_already_started,
                         "continuation::async_nounwrap",
                         "this task has already been started");
                     return;
@@ -350,14 +351,15 @@ namespace pika { namespace lcos { namespace detail {
                         this->started_ = true;
 
                         l.unlock();
-                        this->set_error(future_cancelled,
+                        this->set_error(pika::error::future_cancelled,
                             "continuation<Future, ContResult>::cancel",
                             "future has been canceled");
                     }
                     else
                     {
                         l.unlock();
-                        PIKA_THROW_EXCEPTION(future_can_not_be_cancelled,
+                        PIKA_THROW_EXCEPTION(
+                            pika::error::future_can_not_be_cancelled,
                             "continuation<Future, ContResult>::cancel",
                             "future can't be canceled at this time");
                     }
@@ -388,7 +390,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                PIKA_THROW_EXCEPTION(no_state, "continuation::attach",
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
+                    "continuation::attach",
                     "the future to attach has no valid shared state");
             }
 
@@ -424,7 +427,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                PIKA_THROW_EXCEPTION(no_state, "continuation::attach",
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
+                    "continuation::attach",
                     "the future to attach has no valid shared state");
             }
 
@@ -461,7 +465,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                PIKA_THROW_EXCEPTION(no_state, "continuation::attach_nounwrap",
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
+                    "continuation::attach_nounwrap",
                     "the future to attach has no valid shared state");
             }
 
@@ -497,7 +502,8 @@ namespace pika { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                PIKA_THROW_EXCEPTION(no_state, "continuation::attach_nounwrap",
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
+                    "continuation::attach_nounwrap",
                     "the future to attach has no valid shared state");
             }
 
@@ -616,7 +622,7 @@ namespace pika { namespace lcos { namespace detail {
 
                     if (ptr == nullptr)
                     {
-                        PIKA_THROW_EXCEPTION(no_state,
+                        PIKA_THROW_EXCEPTION(pika::error::no_state,
                             "unwrap_continuation<ContResult>::on_outer_ready",
                             "the inner future has no valid shared state");
                     }
@@ -662,7 +668,7 @@ namespace pika { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                PIKA_THROW_EXCEPTION(no_state,
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
                     "unwrap_continuation<ContResult>::attach",
                     "the future has no valid shared state");
             }

--- a/libs/pika/futures/include/pika/futures/packaged_task.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_task.hpp
@@ -71,7 +71,7 @@ namespace pika { namespace lcos { namespace local {
         {
             if (function_.empty())
             {
-                PIKA_THROW_EXCEPTION(no_state,
+                PIKA_THROW_EXCEPTION(pika::error::no_state,
                     "packaged_task<Signature>::operator()",
                     "this packaged_task has no valid shared state");
                 return;
@@ -101,7 +101,7 @@ namespace pika { namespace lcos { namespace local {
         {
             if (function_.empty())
             {
-                PIKA_THROWS_IF(ec, no_state,
+                PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                     "packaged_task<Signature>::get_future",
                     "this packaged_task has no valid shared state");
                 return pika::future<R>();
@@ -118,7 +118,8 @@ namespace pika { namespace lcos { namespace local {
         {
             if (function_.empty())
             {
-                PIKA_THROWS_IF(ec, no_state, "packaged_task<Signature>::reset",
+                PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
+                    "packaged_task<Signature>::reset",
                     "this packaged_task has no valid shared state");
                 return;
             }

--- a/libs/pika/futures/include/pika/futures/promise.hpp
+++ b/libs/pika/futures/include/pika/futures/promise.hpp
@@ -118,7 +118,7 @@ namespace pika { namespace lcos { namespace local {
             {
                 if (future_retrieved_ || shared_future_retrieved_)
                 {
-                    PIKA_THROWS_IF(ec, future_already_retrieved,
+                    PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                         "local::detail::promise_base<R>::get_future",
                         "future or shared future has already been retrieved "
                         "from this promise");
@@ -127,7 +127,7 @@ namespace pika { namespace lcos { namespace local {
 
                 if (shared_state_ == nullptr)
                 {
-                    PIKA_THROWS_IF(ec, no_state,
+                    PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                         "local::detail::promise_base<R>::get_future",
                         "this promise has no valid shared state");
                     return pika::future<R>();
@@ -142,7 +142,7 @@ namespace pika { namespace lcos { namespace local {
             {
                 if (future_retrieved_)
                 {
-                    PIKA_THROWS_IF(ec, future_already_retrieved,
+                    PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                         "local::detail::promise_base<R>::get_shared_future",
                         "future has already been retrieved from this promise");
                     return pika::shared_future<R>();
@@ -150,7 +150,7 @@ namespace pika { namespace lcos { namespace local {
 
                 if (shared_state_ == nullptr)
                 {
-                    PIKA_THROWS_IF(ec, no_state,
+                    PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
                         "local::detail::promise_base<R>::get_shared_future",
                         "this promise has no valid shared state");
                     return pika::shared_future<R>();
@@ -168,7 +168,7 @@ namespace pika { namespace lcos { namespace local {
             {
                 if (shared_state_ == nullptr)
                 {
-                    PIKA_THROW_EXCEPTION(no_state,
+                    PIKA_THROW_EXCEPTION(pika::error::no_state,
                         "local::detail::promise_base<R>::set_value",
                         "this promise has no valid shared state");
                     return;
@@ -176,7 +176,7 @@ namespace pika { namespace lcos { namespace local {
 
                 if (shared_state_->is_ready())
                 {
-                    PIKA_THROW_EXCEPTION(promise_already_satisfied,
+                    PIKA_THROW_EXCEPTION(pika::error::promise_already_satisfied,
                         "local::detail::promise_base<R>::set_value",
                         "result has already been stored for this promise");
                     return;
@@ -190,7 +190,7 @@ namespace pika { namespace lcos { namespace local {
             {
                 if (shared_state_ == nullptr)
                 {
-                    PIKA_THROW_EXCEPTION(no_state,
+                    PIKA_THROW_EXCEPTION(pika::error::no_state,
                         "local::detail::promise_base<R>::set_exception",
                         "this promise has no valid shared state");
                     return;
@@ -198,7 +198,7 @@ namespace pika { namespace lcos { namespace local {
 
                 if (shared_state_->is_ready())
                 {
-                    PIKA_THROW_EXCEPTION(promise_already_satisfied,
+                    PIKA_THROW_EXCEPTION(pika::error::promise_already_satisfied,
                         "local::detail::promise_base<R>::set_exception",
                         "result has already been stored for this promise");
                     return;
@@ -214,7 +214,7 @@ namespace pika { namespace lcos { namespace local {
                     (future_retrieved_ || shared_future_retrieved_) &&
                     !shared_state_->is_ready())
                 {
-                    shared_state_->set_error(broken_promise, fun,
+                    shared_state_->set_error(pika::error::broken_promise, fun,
                         "abandoning not ready shared state");
                 }
             }

--- a/libs/pika/futures/src/future_data.cpp
+++ b/libs/pika/futures/src/future_data.cpp
@@ -125,7 +125,8 @@ namespace pika { namespace lcos { namespace detail {
         if (s == empty)
         {
             // the value has already been moved out of this future
-            PIKA_THROWS_IF(ec, no_state, "future_data_base::get_result",
+            PIKA_THROWS_IF(ec, pika::error::future_already_retrieved,
+                "future_data_base::get_result",
                 "this future has no valid shared state");
             return nullptr;
         }

--- a/libs/pika/futures/tests/regressions/exception_from_continuation_1613.cpp
+++ b/libs/pika/futures/tests/regressions/exception_from_continuation_1613.cpp
@@ -25,7 +25,7 @@ void test_exception_from_continuation1()
     pika::future<void> f2 = f1.then([](pika::future<void>&& f1) {
         PIKA_TEST(f1.has_value());
         PIKA_THROW_EXCEPTION(
-            pika::invalid_status, "lambda", "testing exceptions");
+            pika::error::invalid_status, "lambda", "testing exceptions");
     });
 
     p.set_value();
@@ -54,8 +54,8 @@ void test_exception_from_continuation2()
                 f.get();    // rethrow, if has exception
 
                 ++exceptions_thrown;
-                PIKA_THROW_EXCEPTION(
-                    pika::invalid_status, "lambda", "testing exceptions");
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status, "lambda",
+                    "testing exceptions");
             }));
     }
 

--- a/libs/pika/futures/tests/regressions/future_unwrap_878.cpp
+++ b/libs/pika/futures/tests/regressions/future_unwrap_878.cpp
@@ -22,7 +22,7 @@ int pika_main()
     try
     {
         //promise.set_value(42);
-        throw pika::bad_parameter;
+        throw pika::error::bad_parameter;
     }
     catch (...)
     {

--- a/libs/pika/futures/tests/unit/future.cpp
+++ b/libs/pika/futures/tests/unit/future.cpp
@@ -114,7 +114,7 @@ void test_initial_state()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::no_state);
+        PIKA_TEST_EQ(e.get_error(), pika::error::no_state);
     }
     catch (...)
     {
@@ -150,7 +150,7 @@ void test_cannot_get_future_twice()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::future_already_retrieved);
+        PIKA_TEST_EQ(e.get_error(), pika::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -247,7 +247,7 @@ void test_invoking_a_packaged_task_twice_throws()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::promise_already_satisfied);
+        PIKA_TEST_EQ(e.get_error(), pika::error::promise_already_satisfied);
     }
     catch (...)
     {
@@ -272,7 +272,7 @@ void test_cannot_get_future_twice_from_task()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::future_already_retrieved);
+        PIKA_TEST_EQ(e.get_error(), pika::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -490,7 +490,7 @@ void test_packaged_task_can_be_moved()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::no_state);
+        PIKA_TEST_EQ(e.get_error(), pika::error::no_state);
     }
     catch (...)
     {
@@ -522,7 +522,7 @@ void test_destroying_a_promise_stores_broken_promise()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::broken_promise);
+        PIKA_TEST_EQ(e.get_error(), pika::error::broken_promise);
     }
     catch (...)
     {
@@ -548,7 +548,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::broken_promise);
+        PIKA_TEST_EQ(e.get_error(), pika::error::broken_promise);
     }
     catch (...)
     {

--- a/libs/pika/futures/tests/unit/shared_future.cpp
+++ b/libs/pika/futures/tests/unit/shared_future.cpp
@@ -96,7 +96,7 @@ void test_initial_state()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::no_state);
+        PIKA_TEST_EQ(e.get_error(), pika::error::no_state);
     }
     catch (...)
     {
@@ -132,7 +132,7 @@ void test_cannot_get_future_twice()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::future_already_retrieved);
+        PIKA_TEST_EQ(e.get_error(), pika::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -227,7 +227,7 @@ void test_invoking_a_packaged_task_twice_throws()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::promise_already_satisfied);
+        PIKA_TEST_EQ(e.get_error(), pika::error::promise_already_satisfied);
     }
     catch (...)
     {
@@ -252,7 +252,7 @@ void test_cannot_get_future_twice_from_task()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::future_already_retrieved);
+        PIKA_TEST_EQ(e.get_error(), pika::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -556,7 +556,7 @@ void test_packaged_task_can_be_moved()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::no_state);
+        PIKA_TEST_EQ(e.get_error(), pika::error::no_state);
     }
     catch (...)
     {
@@ -588,7 +588,7 @@ void test_destroying_a_promise_stores_broken_promise()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::broken_promise);
+        PIKA_TEST_EQ(e.get_error(), pika::error::broken_promise);
     }
     catch (...)
     {
@@ -614,7 +614,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::broken_promise);
+        PIKA_TEST_EQ(e.get_error(), pika::error::broken_promise);
     }
     catch (...)
     {

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -360,8 +360,9 @@ namespace pika { namespace util {
             if (name.empty())
                 name = "<root>";
 
-            PIKA_THROW_EXCEPTION(bad_parameter, "section::get_section",
-                "No such section ({}) in section: {}", sec_name, name);
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "section::get_section", "No such section ({}) in section: {}",
+                sec_name, name);
             return nullptr;
         }
 
@@ -369,7 +370,7 @@ namespace pika { namespace util {
         if (it != sections_.end())
             return &((*it).second);
 
-        PIKA_THROW_EXCEPTION(bad_parameter, "section::get_section",
+        PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "section::get_section",
             "No such section ({}) in section: {}", sec_name, get_name());
         return nullptr;
     }
@@ -393,8 +394,9 @@ namespace pika { namespace util {
             if (name.empty())
                 name = "<root>";
 
-            PIKA_THROW_EXCEPTION(bad_parameter, "section::get_section",
-                "No such section ({}) in section: {}", sec_name, name);
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "section::get_section", "No such section ({}) in section: {}",
+                sec_name, name);
             return nullptr;
         }
 
@@ -402,7 +404,7 @@ namespace pika { namespace util {
         if (it != sections_.end())
             return &((*it).second);
 
-        PIKA_THROW_EXCEPTION(bad_parameter, "section::get_section",
+        PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "section::get_section",
             "No such section ({}) in section: {}", sec_name, get_name());
         return nullptr;
     }
@@ -640,8 +642,9 @@ namespace pika { namespace util {
                 return (*cit).second.get_entry(sub_key);
             }
 
-            PIKA_THROW_EXCEPTION(bad_parameter, "section::get_entry",
-                "No such key ({}) in section: {}", key, get_name());
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "section::get_entry", "No such key ({}) in section: {}", key,
+                get_name());
             return "";
         }
 
@@ -652,7 +655,7 @@ namespace pika { namespace util {
             return expand(l, (*cit).second.first);
         }
 
-        PIKA_THROW_EXCEPTION(bad_parameter, "section::get_entry",
+        PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "section::get_entry",
             "No such section ({}) in section: {}", key, get_name());
         return "";
     }
@@ -804,7 +807,7 @@ namespace pika { namespace util {
         if (!line.empty())
             msg += " (offending entry: " + line + ")";
 
-        PIKA_THROW_EXCEPTION(no_success, "section::line_msg", msg);
+        PIKA_THROW_EXCEPTION(pika::error::no_success, "section::line_msg", msg);
     }
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -123,14 +123,14 @@ namespace pika {
     {
         if (!threads::detail::get_self_ptr())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::finalize",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::finalize",
                 "this function can be called from an pika thread only");
             return -1;
         }
 
         if (!is_running())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::finalize",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::finalize",
                 "the runtime system is not active (did you already "
                 "call finalize?)");
             return -1;
@@ -142,7 +142,7 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::finalize",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::finalize",
                 "the runtime system is not active (did you already "
                 "call pika::stop?)");
             return -1;
@@ -157,7 +157,7 @@ namespace pika {
     {
         if (threads::detail::get_self_ptr())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::stop",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::stop",
                 "this function cannot be called from an pika thread");
             return -1;
         }
@@ -165,7 +165,7 @@ namespace pika {
         std::unique_ptr<runtime> rt(get_runtime_ptr());    // take ownership!
         if (nullptr == rt.get())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::stop",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::stop",
                 "the runtime system is not active (did you already "
                 "call pika::stop?)");
             return -1;
@@ -184,7 +184,7 @@ namespace pika {
     {
         if (threads::detail::get_self_ptr())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::suspend",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::suspend",
                 "this function cannot be called from an pika thread");
             return -1;
         }
@@ -192,7 +192,7 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::suspend",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::suspend",
                 "the runtime system is not active (did you already "
                 "call pika::stop?)");
             return -1;
@@ -206,7 +206,7 @@ namespace pika {
     {
         if (threads::detail::get_self_ptr())
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::resume",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::resume",
                 "this function cannot be called from an pika thread");
             return -1;
         }
@@ -214,7 +214,7 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROWS_IF(ec, invalid_status, "pika::resume",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::resume",
                 "the runtime system is not active (did you already "
                 "call pika::stop?)");
             return -1;
@@ -362,9 +362,9 @@ namespace pika {
 
             pika::detail::set_assertion_handler(
                 &pika::detail::assertion_handler);
-            pika::set_custom_exception_info_handler(
+            pika::detail::set_custom_exception_info_handler(
                 &pika::detail::custom_exception_info);
-            pika::set_pre_exception_handler(
+            pika::detail::set_pre_exception_handler(
                 &pika::detail::pre_exception_handler);
             pika::set_thread_termination_handler(
                 [](std::exception_ptr const& e) { report_error(e); });

--- a/libs/pika/lcos/include/pika/lcos/and_gate.hpp
+++ b/libs/pika/lcos/include/pika/lcos/and_gate.hpp
@@ -75,7 +75,7 @@ namespace pika { namespace lcos { namespace local {
             bool triggered = false;
             if (!conditions_.empty())
             {
-                error_code rc(lightweight);
+                error_code rc(throwmode::lightweight);
                 for (conditional_trigger* c : conditions_)
                 {
                     triggered |= c->set(rc);
@@ -195,7 +195,8 @@ namespace pika { namespace lcos { namespace local {
                 // out of bounds index
                 l.unlock();
                 outer_lock.unlock();
-                PIKA_THROWS_IF(ec, bad_parameter, "base_and_gate<>::set",
+                PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                    "base_and_gate<>::set",
                     "index is out of range for this base_and_gate");
                 return false;
             }
@@ -204,7 +205,8 @@ namespace pika { namespace lcos { namespace local {
                 // segment already filled, logic error
                 l.unlock();
                 outer_lock.unlock();
-                PIKA_THROWS_IF(ec, bad_parameter, "base_and_gate<>::set",
+                PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                    "base_and_gate<>::set",
                     "input with the given index has already been triggered");
                 return false;
             }
@@ -297,7 +299,7 @@ namespace pika { namespace lcos { namespace local {
             if (generation_value < generation_)
             {
                 l.unlock();
-                PIKA_THROWS_IF(ec, pika::invalid_status, function_name,
+                PIKA_THROWS_IF(ec, pika::error::invalid_status, function_name,
                     "sequencing error, generational counter too small");
                 return;
             }
@@ -349,7 +351,8 @@ namespace pika { namespace lcos { namespace local {
                 // reset happens while part of the slots are filled
                 l.unlock();
                 outer_lock.unlock();
-                PIKA_THROWS_IF(ec, bad_parameter, "base_and_gate<>::init",
+                PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                    "base_and_gate<>::init",
                     "initializing this base_and_gate while slots are filled");
                 return;
             }

--- a/libs/pika/lcos/include/pika/lcos/channel.hpp
+++ b/libs/pika/lcos/include/pika/lcos/channel.hpp
@@ -121,7 +121,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::channel::get",
                                 "this channel is empty and was closed"));
                     }
@@ -130,7 +130,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::channel::get",
                                 "this channel is empty and is not accessible "
                                 "by any other thread causing a deadlock"));
@@ -150,7 +150,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::channel::get",
                                 "this channel is closed and the requested value"
                                 "has not been received yet"));
@@ -185,7 +185,7 @@ namespace pika { namespace lcos { namespace local {
                 {
                     l.unlock();
                     return pika::make_exceptional_future<void>(
-                        PIKA_GET_EXCEPTION(pika::invalid_status,
+                        PIKA_GET_EXCEPTION(pika::error::invalid_status,
                             "pika::lcos::local::channel::set",
                             "attempting to write to a closed channel"));
                 }
@@ -204,7 +204,7 @@ namespace pika { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    PIKA_THROW_EXCEPTION(pika::invalid_status,
+                    PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                         "pika::lcos::local::channel::close",
                         "attempting to close an already closed channel");
                     return 0;
@@ -219,8 +219,9 @@ namespace pika { namespace lcos { namespace local {
 
                 {
                     util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
-                    e = PIKA_GET_EXCEPTION(pika::future_cancelled,
-                        pika::lightweight, "pika::lcos::local::close",
+                    e = PIKA_GET_EXCEPTION(pika::error::future_cancelled,
+                        pika::throwmode::lightweight,
+                        "pika::lcos::local::close",
                         "canceled waiting on this entry");
                 }
 
@@ -306,7 +307,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<void>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::detail::"
                                 "one_element_queue_async::push",
                                 "attempting to write to a busy queue"));
@@ -352,7 +353,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::detail::"
                                 "one_element_queue_async::pop",
                                 "attempting to read from an empty queue"));
@@ -424,7 +425,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::channel::get",
                                 "this channel is empty and was closed"));
                     }
@@ -433,7 +434,7 @@ namespace pika { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return pika::make_exceptional_future<T>(
-                            PIKA_GET_EXCEPTION(pika::invalid_status,
+                            PIKA_GET_EXCEPTION(pika::error::invalid_status,
                                 "pika::lcos::local::channel::get",
                                 "this channel is empty and is not accessible "
                                 "by any other thread causing a deadlock"));
@@ -446,10 +447,11 @@ namespace pika { namespace lcos { namespace local {
                     // the requested item must be available, otherwise this
                     // would create a deadlock
                     l.unlock();
-                    return pika::make_exceptional_future<T>(PIKA_GET_EXCEPTION(
-                        pika::invalid_status, "pika::lcos::local::channel::get",
-                        "this channel is closed and the requested value"
-                        "has not been received yet"));
+                    return pika::make_exceptional_future<T>(
+                        PIKA_GET_EXCEPTION(pika::error::invalid_status,
+                            "pika::lcos::local::channel::get",
+                            "this channel is closed and the requested value"
+                            "has not been received yet"));
                 }
 
                 return f;
@@ -480,7 +482,7 @@ namespace pika { namespace lcos { namespace local {
                 {
                     l.unlock();
                     return pika::make_exceptional_future<void>(
-                        PIKA_GET_EXCEPTION(pika::invalid_status,
+                        PIKA_GET_EXCEPTION(pika::error::invalid_status,
                             "pika::lcos::local::channel::set",
                             "attempting to write to a closed channel"));
                 }
@@ -495,7 +497,7 @@ namespace pika { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    PIKA_THROW_EXCEPTION(pika::invalid_status,
+                    PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                         "pika::lcos::local::channel::close",
                         "attempting to close an already closed channel");
                     return 0;
@@ -513,9 +515,10 @@ namespace pika { namespace lcos { namespace local {
                 std::exception_ptr e;
                 {
                     util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
-                    e = std::exception_ptr(PIKA_GET_EXCEPTION(
-                        pika::future_cancelled, "pika::lcos::local::close",
-                        "canceled waiting on this entry"));
+                    e = std::exception_ptr(
+                        PIKA_GET_EXCEPTION(pika::error::future_cancelled,
+                            "pika::lcos::local::close",
+                            "canceled waiting on this entry"));
                 }
 
                 return buffer_.cancel(PIKA_MOVE(e), l);

--- a/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
+++ b/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
@@ -233,7 +233,7 @@ namespace pika { namespace lcos { namespace local {
                     std::make_pair(step, std::make_shared<entry_data>()));
                 if (!res.second)
                 {
-                    PIKA_THROW_EXCEPTION(invalid_status,
+                    PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                         "base_receive_buffer::get_buffer_entry",
                         "couldn't insert a new entry into the receive buffer");
                 }
@@ -455,7 +455,7 @@ namespace pika { namespace lcos { namespace local {
                     std::make_pair(step, std::make_shared<entry_data>()));
                 if (!res.second)
                 {
-                    PIKA_THROW_EXCEPTION(invalid_status,
+                    PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                         "base_receive_buffer::get_buffer_entry",
                         "couldn't insert a new entry into the receive buffer");
                 }

--- a/libs/pika/lcos/include/pika/lcos/trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/trigger.hpp
@@ -66,7 +66,7 @@ namespace pika { namespace lcos { namespace local {
         bool trigger_conditions(error_code& ec = throws)
         {
             bool triggered = false;
-            error_code rc(lightweight);
+            error_code rc(throwmode::lightweight);
             for (conditional_trigger* c : conditions_)
             {
                 triggered |= c->set(rc);
@@ -166,7 +166,7 @@ namespace pika { namespace lcos { namespace local {
 
             if (generation_value < generation_)
             {
-                PIKA_THROWS_IF(ec, pika::invalid_status, function_name,
+                PIKA_THROWS_IF(ec, pika::error::invalid_status, function_name,
                     "sequencing error, generational counter too small");
                 return;
             }

--- a/libs/pika/lcos/tests/unit/channel.cpp
+++ b/libs/pika/lcos/tests/unit/channel.cpp
@@ -134,7 +134,7 @@ void dispatch_work()
     pika::apply([jobs, done, &received_jobs, &was_closed]() mutable {
         while (true)
         {
-            pika::error_code ec(pika::lightweight);
+            pika::error_code ec(pika::throwmode::lightweight);
             int next = jobs.get(pika::launch::sync, ec);
             (void) next;
             if (!ec)

--- a/libs/pika/lock_registration/src/register_locks.cpp
+++ b/libs/pika/lock_registration/src/register_locks.cpp
@@ -287,7 +287,8 @@ namespace pika { namespace util {
                     }
                     else
                     {
-                        PIKA_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                        PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                            "verify_no_locks",
                             "suspending thread while at least one lock is "
                             "being held (default handler)");
                     }
@@ -310,7 +311,7 @@ namespace pika { namespace util {
         //    // we throw an error if there are still registered locks for
         //    // this OS-thread
         //    if (!held_locks.empty()) {
-        //        PIKA_THROW_EXCEPTION(invalid_status, "force_error_on_lock",
+        //        PIKA_THROW_EXCEPTION(pika::error::invalid_status, "force_error_on_lock",
         //            "At least one lock is held while thread is being "
         //            terminated or interrupted.");
         //    }

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -99,7 +99,7 @@ namespace pika { namespace util {
 
             if (provided < minimal)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "pika::util::mpi_environment::init",
                     "MPI doesn't provide minimal requested thread level");
             }

--- a/libs/pika/prefix/src/find_prefix.cpp
+++ b/libs/pika/prefix/src/find_prefix.cpp
@@ -57,7 +57,7 @@ namespace pika { namespace util {
         char exe_path[MAX_PATH + 1] = {'\0'};
         if (!GetModuleFileNameA(nullptr, exe_path, sizeof(exe_path)))
         {
-            PIKA_THROW_EXCEPTION(pika::dynamic_link_failure,
+            PIKA_THROW_EXCEPTION(pika::error::dynamic_link_failure,
                 "get_executable_filename",
                 "unable to find executable filename");
         }
@@ -133,7 +133,7 @@ namespace pika { namespace util {
             }
         }
 
-        PIKA_THROW_EXCEPTION(pika::dynamic_link_failure,
+        PIKA_THROW_EXCEPTION(pika::error::dynamic_link_failure,
             "get_executable_filename", "unable to find executable filename");
 
 #elif defined(__APPLE__)
@@ -144,7 +144,7 @@ namespace pika { namespace util {
 
         if (0 != _NSGetExecutablePath(exe_path, &len))
         {
-            PIKA_THROW_EXCEPTION(pika::dynamic_link_failure,
+            PIKA_THROW_EXCEPTION(pika::error::dynamic_link_failure,
                 "get_executable_filename",
                 "unable to find executable filename");
         }

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -72,7 +72,7 @@ int pika_main(/*pika::program_options::variables_map& vm*/)
 
     if (num_threads == 1)
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "the oversubscribing_resource_partitioner example requires at "
             "least 2 worker threads (1 given)");
     }

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -35,13 +35,13 @@ namespace pika { namespace resource { namespace detail {
     [[noreturn]] void throw_runtime_error(
         std::string const& func, std::string const& message)
     {
-        PIKA_THROW_EXCEPTION(invalid_status, func, message);
+        PIKA_THROW_EXCEPTION(pika::error::invalid_status, func, message);
     }
 
     [[noreturn]] void throw_invalid_argument(
         std::string const& func, std::string const& message)
     {
-        PIKA_THROW_EXCEPTION(bad_parameter, func, message);
+        PIKA_THROW_EXCEPTION(pika::error::bad_parameter, func, message);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -918,7 +918,8 @@ namespace pika { namespace resource { namespace detail {
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            PIKA_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "partitioner::shrink_pool",
                 "dynamic pools have not been enabled for the partitioner");
         }
 
@@ -946,7 +947,8 @@ namespace pika { namespace resource { namespace detail {
 
         if (!has_non_exclusive_pus)
         {
-            PIKA_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "partitioner::shrink_pool",
                 "pool '{}' has no non-exclusive pus associated", pool_name);
         }
 
@@ -963,7 +965,8 @@ namespace pika { namespace resource { namespace detail {
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            PIKA_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "partitioner::expand_pool",
                 "dynamic pools have not been enabled for the partitioner");
         }
 
@@ -991,7 +994,8 @@ namespace pika { namespace resource { namespace detail {
 
         if (!has_non_exclusive_pus)
         {
-            PIKA_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+                "partitioner::expand_pool",
                 "pool '{}' has no non-exclusive pus associated", pool_name);
         }
 

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -109,7 +109,7 @@ namespace pika { namespace resource {
         {
             // if the resource partitioner is not accessed for the first time
             // if the command-line parsing has not yet been done
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::resource::get_partitioner",
                 "can be called only after the resource partitioner has "
                 "been initialized and before it has been deleted.");

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -397,7 +397,7 @@ namespace pika {
 
             // if this is not a pika thread we do not need to query neither for
             // the shepherd thread nor for the thread id
-            error_code ec(lightweight);
+            error_code ec(throwmode::lightweight);
             std::uint32_t node = get_locality_id(ec);
 
             std::size_t shepherd = std::size_t(-1);

--- a/libs/pika/runtime/src/get_locality_name.cpp
+++ b/libs/pika/runtime/src/get_locality_name.cpp
@@ -18,7 +18,7 @@ namespace pika { namespace detail {
         runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::detail::get_locality_name",
                 "the runtime system is not operational at this point");
             return "";

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -183,7 +183,7 @@ namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     PIKA_EXPORT void PIKA_CDECL new_handler()
     {
-        PIKA_THROW_EXCEPTION(out_of_memory, "new_handler",
+        PIKA_THROW_EXCEPTION(pika::error::out_of_memory, "new_handler",
             "new allocator failed to allocate memory");
     }
 
@@ -860,7 +860,8 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "pika::get_os_thread_count()",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika::get_os_thread_count()",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -872,7 +873,7 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::is_scheduler_numa_sensitive",
                 "the runtime system has not been initialized yet");
             return false;
@@ -1004,7 +1005,8 @@ namespace pika { namespace threads {
         pika::runtime* rt = pika::get_runtime_ptr();
         if (rt == nullptr)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "pika::threads::get_topology",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika::threads::get_topology",
                 "the pika runtime system has not been initialized yet");
         }
         return rt->get_topology();
@@ -1060,7 +1062,7 @@ namespace pika {
         {
             if (rt->get_state() > state_pre_startup)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "register_pre_startup_function",
                     "Too late to register a new pre-startup function.");
                 return;
@@ -1080,7 +1082,7 @@ namespace pika {
         {
             if (rt->get_state() > state_startup)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "register_startup_function",
                     "Too late to register a new startup function.");
                 return;
@@ -1100,7 +1102,7 @@ namespace pika {
         {
             if (rt->get_state() > state_pre_shutdown)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "register_pre_shutdown_function",
                     "Too late to register a new pre-shutdown function.");
                 return;
@@ -1120,7 +1122,7 @@ namespace pika {
         {
             if (rt->get_state() > state_shutdown)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "register_shutdown_function",
                     "Too late to register a new shutdown function.");
                 return;
@@ -1185,7 +1187,7 @@ namespace pika {
                     // Make sure the mask does not contradict the CPU bindings
                     // returned by the system (see #973: Would like option to
                     // report HWLOC bindings).
-                    error_code ec(lightweight);
+                    error_code ec(throwmode::lightweight);
                     std::thread& blob = tm.get_os_thread_handle(i);
                     threads::detail::mask_type boundcpu =
                         top.get_cpubind_mask(blob, ec);
@@ -1199,7 +1201,7 @@ namespace pika {
                             threads::detail::to_string(boundcpu);
                         std::string pu_mask_str =
                             threads::detail::to_string(pu_mask);
-                        PIKA_THROW_EXCEPTION(invalid_status,
+                        PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                             "handle_print_bind",
                             pika::util::format(
                                 "unexpected mismatch between locality {1}: "
@@ -1513,7 +1515,8 @@ namespace pika {
 
         if (state_.load() != state_running)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "runtime::suspend",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "runtime::suspend",
                 "Can only suspend runtime from running state");
             return -1;
         }
@@ -1536,7 +1539,7 @@ namespace pika {
 
         if (state_.load() != state_sleeping)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "runtime::resume",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status, "runtime::resume",
                 "Can only resume runtime from suspended state");
             return -1;
         }
@@ -1687,7 +1690,7 @@ namespace pika {
         std::size_t local_thread_num, std::size_t global_thread_num,
         char const* pool_name, char const* postfix, bool service_thread)
     {
-        error_code ec(lightweight);
+        error_code ec(throwmode::lightweight);
         return init_tss_ex(context, type, local_thread_num, global_thread_num,
             pool_name, postfix, service_thread, ec);
     }
@@ -1765,15 +1768,17 @@ namespace pika {
                         used_processing_units),
                     ec);
 
-                // comment this out for now as on CircleCI this is causing unending grief
-                //if (ec)
-                //{
-                //    PIKA_THROW_EXCEPTION(kernel_error, "runtime::init_tss_ex",
-                //        "failed to set thread affinity mask ({}) for service "
-                //        "thread: {}",
-                //        pika::threads::detail::to_string(used_processing_units),
-                //        detail::thread_name());
-                //}
+                // comment this out for now as on CircleCI this is causing
+                // unending grief
+                // if (ec)
+                // {
+                //     PIKA_THROW_EXCEPTION(pika::error::kernel_error,
+                //         "runtime::init_tss_ex",
+                //         "failed to set thread affinity mask ({}) for service "
+                //         "thread: {}",
+                //         pika::threads::detail::to_string(used_processing_units),
+                //         detail::thread_name());
+                // }
             }
 #endif
         }
@@ -1895,7 +1900,8 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "pika::get_num_worker_threads",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika::get_num_worker_threads",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -1910,7 +1916,8 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "pika::get_num_localities",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika::get_num_localities",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -1923,7 +1930,7 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::get_initial_num_localities",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
@@ -1937,7 +1944,8 @@ namespace pika {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "pika::get_num_localities",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "pika::get_num_localities",
                 "the runtime system has not been initialized yet");
             return make_ready_future(std::uint32_t(0));
         }

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -67,7 +67,7 @@ namespace pika { namespace detail {
             strm << " (" << msg << ")";
         }
 
-        pika::exception e(pika::assertion_failure, strm.str());
+        pika::exception e(pika::error::assertion_failure, strm.str());
         std::cerr << pika::diagnostic_information(pika::detail::get_exception(
                          e, loc.function_name, loc.file_name, loc.line_number))
                   << std::endl;
@@ -106,14 +106,16 @@ namespace pika { namespace detail {
         {
             if (back_trace.empty())
             {
-                PIKA_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                    "verify_no_locks",
                     "suspending thread while at least one lock is "
                     "being held (stack backtrace was disabled at "
                     "compile time)");
             }
             else
             {
-                PIKA_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                    "verify_no_locks",
                     "suspending thread while at least one lock is "
                     "being held, stack backtrace: {}",
                     back_trace);
@@ -132,7 +134,7 @@ namespace pika { namespace detail {
         pika::runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::detail::get_default_pool",
                 "The runtime system is not active");
         }

--- a/libs/pika/runtime/src/thread_mapper.cpp
+++ b/libs/pika/runtime/src/thread_mapper.cpp
@@ -93,7 +93,7 @@ namespace pika { namespace util {
         {
             if (tinfo.tid_ == tid)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_mapper::register_thread",
                     "thread already registered");
             }

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -640,7 +640,8 @@ namespace pika { namespace util {
             // file doesn't exist or is ill-formed
             if (&ec == &throws)
                 throw;
-            ec = make_error_code(e.get_error(), e.what(), pika::rethrow);
+            ec = make_error_code(
+                e.get_error(), e.what(), pika::throwmode::rethrow);
             return false;
         }
         return true;

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -897,7 +897,7 @@ namespace pika { namespace threads { namespace policies {
                 default:
                 case execution::thread_priority::unknown:
                 {
-                    PIKA_THROW_EXCEPTION(bad_parameter,
+                    PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                         "local_priority_queue_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(execution::thread_priority::unknown)");
@@ -953,7 +953,7 @@ namespace pika { namespace threads { namespace policies {
             default:
             case execution::thread_priority::unknown:
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "local_priority_queue_scheduler::get_thread_count",
                     "unknown thread priority value "
                     "(execution::thread_priority::unknown)");

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -586,7 +586,7 @@ namespace pika { namespace threads { namespace policies {
                 default:
                 case execution::thread_priority::unknown:
                 {
-                    PIKA_THROW_EXCEPTION(bad_parameter,
+                    PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                         "local_queue_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(execution::thread_priority::unknown)");
@@ -614,7 +614,7 @@ namespace pika { namespace threads { namespace policies {
             default:
             case execution::thread_priority::unknown:
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "local_queue_scheduler::get_thread_count",
                     "unknown thread priority value "
                     "(execution::thread_priority::unknown)");

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -636,7 +636,7 @@ namespace pika { namespace threads { namespace policies {
                         &tid));
 
                 lk.unlock();
-                PIKA_THROW_EXCEPTION(pika::out_of_memory,
+                PIKA_THROW_EXCEPTION(pika::error::out_of_memory,
                     "queue_holder_thread::add_to_thread_map",
                     "Couldn't add new thread to the thread map {}", map_size);
             }
@@ -847,7 +847,7 @@ namespace pika { namespace threads { namespace policies {
             default:
             case execution::thread_priority::unknown:
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "queue_holder_thread::get_thread_count_staged",
                     "unknown thread priority value "
                     "(execution::thread_priority::unknown)");
@@ -899,7 +899,7 @@ namespace pika { namespace threads { namespace policies {
             default:
             case execution::thread_priority::unknown:
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "queue_holder_thread::get_thread_count_pending",
                     "unknown thread priority value "
                     "(execution::thread_priority::unknown)");
@@ -1005,7 +1005,7 @@ namespace pika { namespace threads { namespace policies {
             }
             else if (state == threads::detail::thread_schedule_state::staged)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "queue_holder_thread::iterate_threads",
                     "can't iterate over thread ids of staged threads");
                 return false;

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -386,7 +386,7 @@ namespace pika { namespace threads { namespace policies {
                 break;
             }
             default:
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "shared_priority_queue_scheduler::create_thread",
                     "Invalid schedule hint mode: {}",
                     static_cast<std::size_t>(data.schedulehint.mode));
@@ -813,7 +813,7 @@ namespace pika { namespace threads { namespace policies {
             }
 
             default:
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "shared_priority_queue_scheduler::schedule_thread",
                     "Invalid schedule hint mode: {}",
                     static_cast<std::size_t>(schedulehint.mode));
@@ -1266,7 +1266,7 @@ namespace pika { namespace threads { namespace policies {
         {
             if (thread_num > num_workers_)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_stop_thread",
                     "Invalid thread number: {}", std::to_string(thread_num));
             }
@@ -1278,7 +1278,7 @@ namespace pika { namespace threads { namespace policies {
         {
             if (thread_num > num_workers_)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_error",
                     "Invalid thread number: {}", std::to_string(thread_num));
             }
@@ -1288,7 +1288,7 @@ namespace pika { namespace threads { namespace policies {
 #ifdef PIKA_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         std::uint64_t get_creation_time(bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_creation_time",
                 "the shared_priority_scheduler does not support the "
                 "get_creation_time performance counter");
@@ -1296,7 +1296,7 @@ namespace pika { namespace threads { namespace policies {
         }
         std::uint64_t get_cleanup_time(bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_cleanup_time",
                 "the shared_priority_scheduler does not support the "
                 "get_cleanup_time performance counter");
@@ -1308,7 +1308,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_pending_misses(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_num_pending_misses",
                 "the shared_priority_scheduler does not support the "
                 "get_num_pending_misses performance counter");
@@ -1318,7 +1318,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_pending_accesses(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_num_pending_accesses",
                 "the shared_priority_scheduler does not support the "
                 "get_num_pending_accesses performance counter");
@@ -1328,7 +1328,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_stolen_from_pending(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_from_pending",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_from_pending performance counter");
@@ -1338,7 +1338,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_stolen_to_pending(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_creation_time",
                 "the shared_priority_scheduler does not support the "
                 "get_creation_time performance counter");
@@ -1348,7 +1348,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_stolen_from_staged(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_from_staged",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_from_staged performance counter");
@@ -1358,7 +1358,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_num_stolen_to_staged(
             std::size_t /* num */, bool /* reset */) override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_to_staged",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_to_staged performance counter");
@@ -1370,7 +1370,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_average_thread_wait_time(
             std::size_t /* num_thread */ = std::size_t(-1)) const override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_average_thread_wait_time",
                 "the shared_priority_scheduler does not support the "
                 "get_average_thread_wait_time performance counter");
@@ -1379,7 +1379,7 @@ namespace pika { namespace threads { namespace policies {
         std::int64_t get_average_task_wait_time(
             std::size_t /* num_thread */ = std::size_t(-1)) const override
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "shared_priority_scheduler::get_average_task_wait_time",
                 "the shared_priority_scheduler does not support the "
                 "get_average_task_wait_time performance counter");

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -253,7 +253,7 @@ namespace pika { namespace threads { namespace policies {
                 {
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
-                    PIKA_THROW_EXCEPTION(pika::out_of_memory,
+                    PIKA_THROW_EXCEPTION(pika::error::out_of_memory,
                         "thread_queue::add_new",
                         "Couldn't add new thread to the thread map");
                     return 0;
@@ -693,7 +693,7 @@ namespace pika { namespace threads { namespace policies {
                     if (PIKA_UNLIKELY(!p.second))
                     {
                         lk.unlock();
-                        PIKA_THROWS_IF(ec, pika::out_of_memory,
+                        PIKA_THROWS_IF(ec, pika::error::out_of_memory,
                             "thread_queue::create_thread",
                             "Couldn't add new thread to the map of threads");
                         return;
@@ -737,7 +737,7 @@ namespace pika { namespace threads { namespace policies {
             if (data.initial_state !=
                 threads::detail::thread_schedule_state::pending)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_queue::create_thread",
                     "staged tasks must have 'pending' as their initial state");
             }
@@ -973,7 +973,7 @@ namespace pika { namespace threads { namespace policies {
             }
             else if (state == threads::detail::thread_schedule_state::staged)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_queue::iterate_threads",
                     "can't iterate over thread ids of staged threads");
                 return false;

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
@@ -176,7 +176,7 @@ namespace pika { namespace threads { namespace policies {
         // Return the number of existing threads with the given state.
         std::int64_t get_thread_count() const
         {
-            PIKA_THROW_EXCEPTION(bad_parameter, "get_thread_count",
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "get_thread_count",
                 "use get_queue_length_staged/get_queue_length_pending");
             return 0;
         }
@@ -234,7 +234,7 @@ namespace pika { namespace threads { namespace policies {
             if (data.initial_state !=
                 threads::detail::thread_schedule_state::pending)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_queue_mc::create_thread",
                     "staged tasks must have 'pending' as their initial state");
             }

--- a/libs/pika/synchronization/include/pika/synchronization/channel_mpmc.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/channel_mpmc.hpp
@@ -178,7 +178,7 @@ namespace pika { namespace lcos { namespace local {
             if (closed_)
             {
                 l.unlock();
-                PIKA_THROW_EXCEPTION(pika::invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "pika::lcos::local::bounded_channel::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/pika/synchronization/include/pika/synchronization/channel_mpsc.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/channel_mpsc.hpp
@@ -177,7 +177,7 @@ namespace pika { namespace lcos { namespace local {
             bool expected = false;
             if (!closed_.compare_exchange_weak(expected, true))
             {
-                PIKA_THROW_EXCEPTION(pika::invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "pika::lcos::local::base_channel_mpsc::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/pika/synchronization/include/pika/synchronization/channel_spsc.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/channel_spsc.hpp
@@ -167,7 +167,7 @@ namespace pika { namespace lcos { namespace local {
             bool expected = false;
             if (!closed_.compare_exchange_weak(expected, true))
             {
-                PIKA_THROW_EXCEPTION(pika::invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "pika::lcos::local::channel_spsc::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/pika/synchronization/include/pika/synchronization/lock_types.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/lock_types.hpp
@@ -121,12 +121,12 @@ namespace pika { namespace lcos { namespace local {
         {
             if (m == nullptr)
             {
-                PIKA_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (owns_lock())
             {
-                PIKA_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
                     "upgrade_lock already owns the mutex");
             }
             m->lock_upgrade();
@@ -136,12 +136,12 @@ namespace pika { namespace lcos { namespace local {
         {
             if (m == nullptr)
             {
-                PIKA_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (owns_lock())
             {
-                PIKA_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
                     "upgrade_lock already owns the mutex");
             }
             is_locked = m->try_lock_upgrade();
@@ -151,12 +151,12 @@ namespace pika { namespace lcos { namespace local {
         {
             if (m == nullptr)
             {
-                PIKA_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (!owns_lock())
             {
-                PIKA_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                PIKA_THROW_EXCEPTION(pika::error::lock_error, "mutex::unlock",
                     "upgrade_lock doesn't own the mutex");
             }
             m->unlock_upgrade();

--- a/libs/pika/synchronization/src/detail/condition_variable.cpp
+++ b/libs/pika/synchronization/src/detail/condition_variable.cpp
@@ -78,7 +78,7 @@ namespace pika { namespace lcos { namespace local { namespace detail {
             {
                 lock.unlock();
 
-                PIKA_THROWS_IF(ec, null_thread_id,
+                PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                     "condition_variable::notify_one",
                     "null thread id encountered");
                 return false;
@@ -126,7 +126,7 @@ namespace pika { namespace lcos { namespace local { namespace detail {
                     prepend_entries(lock, queue);
                     lock.unlock();
 
-                    PIKA_THROWS_IF(ec, null_thread_id,
+                    PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                         "condition_variable::notify_all",
                         "null thread id encountered");
                     return;

--- a/libs/pika/synchronization/src/mutex.cpp
+++ b/libs/pika/synchronization/src/mutex.cpp
@@ -48,7 +48,7 @@ namespace pika { namespace lcos { namespace local {
         {
             PIKA_ITT_SYNC_CANCEL(this);
             l.unlock();
-            PIKA_THROWS_IF(ec, deadlock, description,
+            PIKA_THROWS_IF(ec, pika::error::deadlock, description,
                 "The calling thread already owns the mutex");
             return;
         }
@@ -103,7 +103,7 @@ namespace pika { namespace lcos { namespace local {
         if (PIKA_UNLIKELY(owner_id_ != self_id))
         {
             l.unlock();
-            PIKA_THROWS_IF(ec, lock_error, "mutex::unlock",
+            PIKA_THROWS_IF(ec, pika::error::lock_error, "mutex::unlock",
                 "The calling thread does not own the mutex");
             return;
         }

--- a/libs/pika/synchronization/tests/unit/shared_mutex/thread_group.hpp
+++ b/libs/pika/synchronization/tests/unit/shared_mutex/thread_group.hpp
@@ -89,7 +89,7 @@ namespace test {
             {
                 if (is_thread_in(thrd))
                 {
-                    PIKA_THROW_EXCEPTION(pika::thread_resource_error,
+                    PIKA_THROW_EXCEPTION(pika::error::thread_resource_error,
                         "thread_group::add_thread",
                         "resource_deadlock_would_occur: trying to add a "
                         "duplicated thread");
@@ -115,7 +115,7 @@ namespace test {
         {
             if (is_this_thread_in())
             {
-                PIKA_THROW_EXCEPTION(pika::thread_resource_error,
+                PIKA_THROW_EXCEPTION(pika::error::thread_resource_error,
                     "thread_group::join_all",
                     "resource_deadlock_would_occur: trying joining itself");
                 return;

--- a/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -22,17 +22,18 @@ namespace pika { namespace threads {
     {
         if (!threads::detail::get_self_ptr())
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "resume_processing_unit",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "resume_processing_unit",
                 "cannot call resume_processing_unit from outside pika, use"
                 "resume_processing_unit_cb instead");
         }
         else if (!pool.get_scheduler()->has_scheduler_mode(
                      policies::enable_elasticity))
         {
-            return pika::make_exceptional_future<void>(
-                PIKA_GET_EXCEPTION(invalid_status, "resume_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units"));
+            return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
+                pika::error::invalid_status, "resume_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units"));
         }
 
         return pika::async([&pool, virt_core]() -> void {
@@ -47,7 +48,8 @@ namespace pika { namespace threads {
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::enable_elasticity))
         {
-            PIKA_THROWS_IF(ec, invalid_status, "resume_processing_unit_cb",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status,
+                "resume_processing_unit_cb",
                 "this thread pool does not support suspending "
                 "processing units");
             return;
@@ -74,26 +76,27 @@ namespace pika { namespace threads {
     {
         if (!threads::detail::get_self_ptr())
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "suspend_processing_unit",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                "suspend_processing_unit",
                 "cannot call suspend_processing_unit from outside pika, use"
                 "suspend_processing_unit_cb instead");
         }
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::enable_elasticity))
         {
-            return pika::make_exceptional_future<void>(
-                PIKA_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units"));
+            return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
+                pika::error::invalid_status, "suspend_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units"));
         }
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::enable_stealing) &&
             pika::this_thread::get_pool() == &pool)
         {
-            return pika::make_exceptional_future<void>(
-                PIKA_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units from itself (no thread stealing)"));
+            return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
+                pika::error::invalid_status, "suspend_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units from itself (no thread stealing)"));
         }
 
         return pika::async([&pool, virt_core]() -> void {
@@ -108,7 +111,8 @@ namespace pika { namespace threads {
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::enable_elasticity))
         {
-            PIKA_THROWS_IF(ec, invalid_status, "suspend_processing_unit_cb",
+            PIKA_THROWS_IF(ec, pika::error::invalid_status,
+                "suspend_processing_unit_cb",
                 "this thread pool does not support suspending processing "
                 "units");
             return;
@@ -126,7 +130,7 @@ namespace pika { namespace threads {
                     policies::enable_stealing) &&
                 pika::this_thread::get_pool() == &pool)
             {
-                PIKA_THROW_EXCEPTION(invalid_status,
+                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                     "suspend_processing_unit_"
                     "cb",
                     "this thread pool does not support suspending "
@@ -145,7 +149,7 @@ namespace pika { namespace threads {
     {
         if (!threads::detail::get_self_ptr())
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "resume_pool",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status, "resume_pool",
                 "cannot call resume_pool from outside pika, use resume_pool_cb "
                 "or the member function resume_direct instead");
             return pika::make_ready_future();
@@ -178,7 +182,7 @@ namespace pika { namespace threads {
     {
         if (!threads::detail::get_self_ptr())
         {
-            PIKA_THROW_EXCEPTION(invalid_status, "suspend_pool",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status, "suspend_pool",
                 "cannot call suspend_pool from outside pika, use "
                 "suspend_pool_cb or the member function suspend_direct "
                 "instead");
@@ -188,7 +192,7 @@ namespace pika { namespace threads {
             pika::this_thread::get_pool() == &pool)
         {
             return pika::make_exceptional_future<void>(
-                PIKA_GET_EXCEPTION(bad_parameter, "suspend_pool",
+                PIKA_GET_EXCEPTION(pika::error::bad_parameter, "suspend_pool",
                     "cannot suspend a pool from itself"));
         }
 
@@ -202,7 +206,7 @@ namespace pika { namespace threads {
         if (threads::detail::get_self_ptr() &&
             pika::this_thread::get_pool() == &pool)
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "suspend_pool_cb",
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter, "suspend_pool_cb",
                 "cannot suspend a pool from itself");
             return;
         }

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -285,7 +285,7 @@ namespace pika { namespace threads { namespace detail {
         if (0 == pool_threads)
         {
             PIKA_THROW_EXCEPTION(
-                bad_parameter, "run", "number of threads is zero");
+                pika::error::bad_parameter, "run", "number of threads is zero");
         }
 
         if (!threads_.empty() ||
@@ -416,7 +416,7 @@ namespace pika { namespace threads { namespace detail {
         if (threads::detail::get_self_ptr() &&
             pika::this_thread::get_pool() == this)
         {
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_direct",
                 "cannot suspend a pool from itself");
             return;
@@ -439,7 +439,7 @@ namespace pika { namespace threads { namespace detail {
         if (LPIKA_ENABLED(debug))
             topo.write_to_log();
 
-        error_code ec(lightweight);
+        error_code ec(throwmode::lightweight);
         if (any(mask))
         {
             topo.set_thread_affinity_mask(mask, ec);
@@ -579,8 +579,8 @@ namespace pika { namespace threads { namespace detail {
             catch (std::exception const& e)
             {
                 // Repackage exceptions to avoid slicing.
-                pika::throw_with_info(
-                    pika::exception(unhandled_exception, e.what()));
+                pika::throw_with_info(pika::exception(
+                    pika::error::unhandled_exception, e.what()));
             }
         }
         catch (...)
@@ -608,7 +608,7 @@ namespace pika { namespace threads { namespace detail {
         if (thread_count_ == 0 && !sched_->Scheduler::is_state(state_running))
         {
             // thread-manager is not currently running
-            PIKA_THROWS_IF(ec, invalid_status,
+            PIKA_THROWS_IF(ec, pika::error::invalid_status,
                 "thread_pool<Scheduler>::create_thread",
                 "invalid state: thread pool is not running");
             return;
@@ -628,7 +628,7 @@ namespace pika { namespace threads { namespace detail {
         if (thread_count_ == 0 && !sched_->Scheduler::is_state(state_running))
         {
             // thread-manager is not currently running
-            PIKA_THROWS_IF(ec, invalid_status,
+            PIKA_THROWS_IF(ec, pika::error::invalid_status,
                 "thread_pool<Scheduler>::create_work",
                 "invalid state: thread pool is not running");
             return invalid_thread_id;
@@ -1852,7 +1852,7 @@ namespace pika { namespace threads { namespace detail {
         if (threads_[virt_core].joinable())
         {
             l.unlock();
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::add_processing_unit",
                 "the given virtual core has already been added to this "
                 "thread pool");
@@ -1882,7 +1882,7 @@ namespace pika { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::remove_processing_unit",
                 "the given virtual core has already been stopped to run on "
                 "this thread pool");
@@ -1941,7 +1941,7 @@ namespace pika { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_processing_unit_"
                 "direct",
                 "the given virtual core has already been stopped to run on "
@@ -1980,7 +1980,7 @@ namespace pika { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::resume_processing_unit",
                 "the given virtual core has already been stopped to run on "
                 "this thread pool");

--- a/libs/pika/threading/src/thread.cpp
+++ b/libs/pika/threading/src/thread.cpp
@@ -60,7 +60,7 @@ namespace pika {
         {
             l2.unlock();
             l.unlock();
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "thread::operator=", "destroying running thread");
         }
         id_ = rhs.id_;
@@ -76,8 +76,8 @@ namespace pika {
             {
                 try
                 {
-                    PIKA_THROW_EXCEPTION(invalid_status, "thread::~thread",
-                        "destroying running thread");
+                    PIKA_THROW_EXCEPTION(pika::error::invalid_status,
+                        "thread::~thread", "destroying running thread");
                 }
                 catch (...)
                 {
@@ -106,8 +106,8 @@ namespace pika {
         threads::detail::thread_id_type id = threads::detail::get_self_id();
         if (id == threads::detail::invalid_thread_id)
         {
-            PIKA_THROW_EXCEPTION(null_thread_id, "run_thread_exit_callbacks",
-                "null thread id encountered");
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
+                "run_thread_exit_callbacks", "null thread id encountered");
         }
         threads::detail::run_thread_exit_callbacks(id);
         threads::detail::free_thread_exit_callbacks(id);
@@ -177,12 +177,12 @@ namespace pika {
 
         // create the new thread, note that id_ is guaranteed to be valid
         // before the thread function is executed
-        error_code ec(lightweight);
+        error_code ec(throwmode::lightweight);
         pool->create_thread(data, id_, ec);
         if (ec)
         {
-            PIKA_THROW_EXCEPTION(thread_resource_error, "thread::start_thread",
-                "Could not create thread");
+            PIKA_THROW_EXCEPTION(pika::error::thread_resource_error,
+                "thread::start_thread", "Could not create thread");
             return;
         }
     }
@@ -200,7 +200,7 @@ namespace pika {
         if (!joinable_locked())
         {
             l.unlock();
-            PIKA_THROW_EXCEPTION(invalid_status, "thread::join",
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status, "thread::join",
                 "trying to join a non joinable thread");
         }
 
@@ -208,8 +208,8 @@ namespace pika {
         if (this_id == id_)
         {
             l.unlock();
-            PIKA_THROW_EXCEPTION(thread_resource_error, "thread::join",
-                "pika::thread: trying joining itself");
+            PIKA_THROW_EXCEPTION(pika::error::thread_resource_error,
+                "thread::join", "pika::thread: trying joining itself");
             return;
         }
         this_thread::interruption_point();
@@ -297,7 +297,7 @@ namespace pika {
                 if (!this->is_ready())
                 {
                     threads::detail::interrupt_thread(id_.noref());
-                    this->set_error(thread_cancelled,
+                    this->set_error(pika::error::thread_cancelled,
                         "thread_task_base::cancel", "future has been canceled");
                     id_ = threads::detail::invalid_thread_id;
                 }
@@ -322,8 +322,8 @@ namespace pika {
     {
         if (id_ == threads::detail::invalid_thread_id)
         {
-            PIKA_THROWS_IF(ec, null_thread_id, "thread::get_future",
-                "null thread id encountered");
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
+                "thread::get_future", "null thread id encountered");
             return pika::future<void>();
         }
 
@@ -331,7 +331,8 @@ namespace pika {
         pika::intrusive_ptr<lcos::detail::future_data<void>> base(p);
         if (!p->valid())
         {
-            PIKA_THROWS_IF(ec, thread_resource_error, "thread::get_future",
+            PIKA_THROWS_IF(ec, pika::error::thread_resource_error,
+                "thread::get_future",
                 "Could not create future as thread has been terminated.");
             return pika::future<void>();
         }

--- a/libs/pika/threading/tests/unit/error_callback.cpp
+++ b/libs/pika/threading/tests/unit/error_callback.cpp
@@ -24,7 +24,7 @@ bool on_thread_error(std::size_t, std::exception_ptr const&)
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main()
 {
-    PIKA_THROW_EXCEPTION(pika::invalid_status, "test", "test");
+    PIKA_THROW_EXCEPTION(pika::error::invalid_status, "test", "test");
     return pika::finalize();
 }
 

--- a/libs/pika/threading/tests/unit/thread.cpp
+++ b/libs/pika/threading/tests/unit/thread.cpp
@@ -187,7 +187,7 @@ void do_test_thread_no_interrupt_if_interrupts_disabled_at_interruption_point()
     }
     catch (pika::exception& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::thread_not_interruptable);
+        PIKA_TEST_EQ(e.get_error(), pika::error::thread_not_interruptable);
         caught = true;
     }
 
@@ -347,7 +347,7 @@ void test_double_join()
     }
     catch (pika::exception& e)
     {
-        PIKA_TEST_EQ(e.get_error(), pika::invalid_status);
+        PIKA_TEST_EQ(e.get_error(), pika::error::invalid_status);
         caught = true;
     }
 

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -471,7 +471,7 @@ namespace pika::threads::detail {
             if (flag && !enabled_interrupt_)
             {
                 l.unlock();
-                PIKA_THROW_EXCEPTION(thread_not_interruptable,
+                PIKA_THROW_EXCEPTION(pika::error::thread_not_interruptable,
                     "thread_data::interrupt",
                     "interrupts are disabled for this thread");
                 return;

--- a/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
@@ -48,7 +48,7 @@ namespace pika::threads::detail {
         {
             if (initial_state == thread_schedule_state::staged)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_init_data::thread_init_data",
                     "threads shouldn't have 'staged' as their initial state");
             }
@@ -142,7 +142,7 @@ namespace pika::threads::detail {
 
             if (initial_state == thread_schedule_state::staged)
             {
-                PIKA_THROW_EXCEPTION(bad_parameter,
+                PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
                     "thread_init_data::thread_init_data",
                     "threads shouldn't have 'staged' as their initial state");
             }

--- a/libs/pika/threading_base/src/create_thread.cpp
+++ b/libs/pika/threading_base/src/create_thread.cpp
@@ -34,8 +34,9 @@ namespace pika::threads::detail {
 
         default:
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "threads::detail::create_thread",
-                "invalid initial state: {}", data.initial_state);
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "threads::detail::create_thread", "invalid initial state: {}",
+                data.initial_state);
             return;
         }
         }
@@ -43,8 +44,8 @@ namespace pika::threads::detail {
 #ifdef PIKA_HAVE_THREAD_DESCRIPTION
         if (!data.description)
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "threads::detail::create_thread",
-                "description is nullptr");
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "threads::detail::create_thread", "description is nullptr");
             return;
         }
 #endif

--- a/libs/pika/threading_base/src/create_work.cpp
+++ b/libs/pika/threading_base/src/create_work.cpp
@@ -28,8 +28,9 @@ namespace pika::threads::detail {
 
         default:
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "thread::detail::create_work",
-                "invalid initial state: {}", data.initial_state);
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "thread::detail::create_work", "invalid initial state: {}",
+                data.initial_state);
             return invalid_thread_id;
         }
         }
@@ -37,8 +38,8 @@ namespace pika::threads::detail {
 #ifdef PIKA_HAVE_THREAD_DESCRIPTION
         if (!data.description)
         {
-            PIKA_THROWS_IF(ec, bad_parameter, "thread::detail::create_work",
-                "description is nullptr");
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "thread::detail::create_work", "description is nullptr");
             return invalid_thread_id;
         }
 #endif

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -43,7 +43,8 @@ namespace pika::threads::detail {
         thread_id_type id = self_.get_thread_id();
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id, "execution_agent::description",
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
+                "execution_agent::description",
                 "null thread id encountered (is this executed on a "
                 "pika-thread?)");
         }
@@ -149,7 +150,8 @@ namespace pika::threads::detail {
         thread_id_ref_type id = self_.get_thread_id();    // keep alive
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id, "execution_agent::do_yield",
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
+                "execution_agent::do_yield",
                 "null thread id encountered (is this executed on a "
                 "pika-thread?)");
         }
@@ -198,7 +200,7 @@ namespace pika::threads::detail {
         // handle interrupt and abort
         if (statex == thread_restart_state::abort)
         {
-            PIKA_THROW_EXCEPTION(yield_aborted, desc,
+            PIKA_THROW_EXCEPTION(pika::error::yield_aborted, desc,
                 "thread({}) aborted (yield returned wait_abort)",
                 description());
         }

--- a/libs/pika/threading_base/src/get_default_pool.cpp
+++ b/libs/pika/threading_base/src/get_default_pool.cpp
@@ -50,7 +50,7 @@ namespace pika::threads::detail {
         }
         else
         {
-            PIKA_THROW_EXCEPTION(invalid_status,
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status,
                 "pika::threads::detail::get_self_or_default_pool",
                 "Attempting to register a thread outside the pika "
                 "runtime and no default pool handler is installed. "

--- a/libs/pika/threading_base/src/set_thread_state.cpp
+++ b/libs/pika/threading_base/src/set_thread_state.cpp
@@ -30,7 +30,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!thrd))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "threads::detail::set_active_state",
                 "null thread id encountered");
             return thread_result_type(
@@ -60,7 +60,7 @@ namespace pika::threads::detail {
             get_thread_id_data(thrd)->get_last_worker_thread_num())};
 
         // just retry, set_state will create new thread if target is still active
-        error_code ec(lightweight);    // do not throw
+        error_code ec(throwmode::lightweight);    // do not throw
         set_thread_state(thrd.noref(), newstate, newstate_ex, priority,
             schedulehint, true, ec);
 
@@ -77,7 +77,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!thrd))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
             return thread_state(
@@ -87,7 +87,7 @@ namespace pika::threads::detail {
         // set_state can't be used to force a thread into active state
         if (new_state == thread_schedule_state::active)
         {
-            PIKA_THROWS_IF(ec, bad_parameter,
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                 "threads::detail::set_thread_state", "invalid new state: {}",
                 new_state);
             return thread_state(
@@ -204,7 +204,7 @@ namespace pika::threads::detail {
                     // NOLINTNEXTLINE(bugprone-branch-clone)
                     LTM_(fatal) << str;
 
-                    PIKA_THROWS_IF(ec, bad_parameter,
+                    PIKA_THROWS_IF(ec, pika::error::bad_parameter,
                         "threads::detail::set_thread_state", str);
                     return thread_state(thread_schedule_state::unknown,
                         thread_restart_state::unknown);

--- a/libs/pika/threading_base/src/set_thread_state_timed.cpp
+++ b/libs/pika/threading_base/src/set_thread_state_timed.cpp
@@ -33,7 +33,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!thrd))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (id)");
             return thread_result_type(
@@ -42,7 +42,7 @@ namespace pika::threads::detail {
 
         if (PIKA_UNLIKELY(!timer_id))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (timer_id)");
             return thread_result_type(
@@ -54,7 +54,7 @@ namespace pika::threads::detail {
 
         if (!triggered->load())
         {
-            error_code ec(lightweight);    // do not throw
+            error_code ec(throwmode::lightweight);    // do not throw
             set_thread_state(timer_id, thread_schedule_state::pending,
                 my_statex, execution::thread_priority::boost,
                 execution::thread_schedule_hint(), retry_on_active, ec);
@@ -74,8 +74,8 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!thrd))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id, "threads::detail::at_timer",
-                "null thread id encountered");
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
+                "threads::detail::at_timer", "null thread id encountered");
             return thread_result_type(
                 thread_schedule_state::terminated, invalid_thread_id);
         }
@@ -98,7 +98,7 @@ namespace pika::threads::detail {
         thread_id_ref_type wake_id = invalid_thread_id;
         create_thread(scheduler, data, wake_id);
 
-        PIKA_THROW_EXCEPTION(invalid_status, "at_timer",
+        PIKA_THROW_EXCEPTION(pika::error::invalid_status, "at_timer",
             "Timed suspension is currently not supported");
         // // create timer firing in correspondence with given time
         // using deadline_timer =
@@ -169,7 +169,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!thrd))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
             return invalid_thread_id;

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -258,7 +258,7 @@ namespace pika::threads::detail {
         thread_self* p = get_self_ptr();
         if (PIKA_UNLIKELY(p == nullptr))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id, "get_self",
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id, "get_self",
                 "null thread id encountered (is this executed on a "
                 "pika-thread?)");
         }
@@ -289,7 +289,8 @@ namespace pika::threads::detail {
 
         if (PIKA_UNLIKELY(p == nullptr))
         {
-            PIKA_THROWS_IF(ec, null_thread_id, "get_self_ptr_checked",
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
+                "get_self_ptr_checked",
                 "null thread id encountered (is this executed on a "
                 "pika-thread?)");
             return nullptr;

--- a/libs/pika/threading_base/src/thread_description.cpp
+++ b/libs/pika/threading_base/src/thread_description.cpp
@@ -105,7 +105,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::set_thread_description",
                 "null thread id encountered");
             return util::detail::thread_description();
@@ -122,7 +122,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::get_thread_lco_description",
                 "null thread id encountered");
             return nullptr;
@@ -140,7 +140,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::set_thread_lco_description",
                 "null thread id encountered");
             return nullptr;

--- a/libs/pika/threading_base/src/thread_helpers.cpp
+++ b/libs/pika/threading_base/src/thread_helpers.cpp
@@ -101,7 +101,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::interrupt_thread",
                 "null thread id encountered");
             return;
@@ -123,7 +123,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::interruption_point",
                 "null thread id encountered");
             return;
@@ -141,7 +141,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::detail::get_thread_interruption_enabled",
                 "null thread id encountered");
             return false;
@@ -158,7 +158,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROW_EXCEPTION(null_thread_id,
+            PIKA_THROW_EXCEPTION(pika::error::null_thread_id,
                 "pika::threads::detail::get_thread_interruption_enabled",
                 "null thread id encountered");
             return false;
@@ -175,7 +175,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::get_thread_interruption_requested",
                 "null thread id encountered");
             return false;
@@ -192,7 +192,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::get_thread_data",
                 "null thread id encountered");
             return 0;
@@ -206,7 +206,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::set_thread_data",
                 "null thread id encountered");
             return 0;
@@ -238,7 +238,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::run_thread_exit_callbacks",
                 "null thread id encountered");
             return;
@@ -255,7 +255,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::add_thread_exit_callback",
                 "null thread id encountered");
             return false;
@@ -271,7 +271,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::add_thread_exit_callback",
                 "null thread id encountered");
             return;
@@ -293,7 +293,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::get_thread_backtrace",
                 "null thread id encountered");
             return nullptr;
@@ -316,7 +316,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::set_thread_backtrace",
                 "null thread id encountered");
             return nullptr;
@@ -333,7 +333,7 @@ namespace pika::threads::detail {
     {
         if (PIKA_UNLIKELY(!id))
         {
-            PIKA_THROWS_IF(ec, null_thread_id,
+            PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::get_pool",
                 "null thread id encountered");
             return nullptr;
@@ -415,7 +415,7 @@ namespace pika::this_thread {
         // handle interrupt and abort
         if (statex == threads::detail::thread_restart_state::abort)
         {
-            PIKA_THROWS_IF(ec, yield_aborted, "suspend",
+            PIKA_THROWS_IF(ec, pika::error::yield_aborted, "suspend",
                 "thread({}, {}) aborted (yield returned wait_abort)",
                 id.noref(),
                 threads::detail::get_thread_description(id.noref()));
@@ -497,7 +497,7 @@ namespace pika::this_thread {
                 PIKA_ASSERT(
                     statex == threads::detail::thread_restart_state::abort ||
                     statex == threads::detail::thread_restart_state::signaled);
-                error_code ec1(lightweight);    // do not throw
+                error_code ec1(throwmode::lightweight);    // do not throw
                 pika::util::yield_while(
                     [&timer_started]() { return !timer_started.load(); },
                     "set_thread_state_timed");
@@ -516,7 +516,7 @@ namespace pika::this_thread {
         // handle interrupt and abort
         if (statex == threads::detail::thread_restart_state::abort)
         {
-            PIKA_THROWS_IF(ec, yield_aborted, "suspend_at",
+            PIKA_THROWS_IF(ec, pika::error::yield_aborted, "suspend_at",
                 "thread({}, {}) aborted (yield returned wait_abort)",
                 id.noref(),
                 threads::detail::get_thread_description(id.noref()));
@@ -554,8 +554,8 @@ namespace pika::this_thread {
         std::ptrdiff_t remaining_stack = get_available_stack_space();
         if (remaining_stack < 0)
         {
-            PIKA_THROW_EXCEPTION(
-                out_of_memory, "has_sufficient_stack_space", "Stack overflow");
+            PIKA_THROW_EXCEPTION(pika::error::out_of_memory,
+                "has_sufficient_stack_space", "Stack overflow");
         }
         bool sufficient_stack_space =
             std::size_t(remaining_stack) >= space_needed;

--- a/libs/pika/threadmanager/src/threadmanager.cpp
+++ b/libs/pika/threadmanager/src/threadmanager.cpp
@@ -569,7 +569,8 @@ namespace pika { namespace threads {
         }
 
         //! FIXME Add names of available pools?
-        PIKA_THROW_EXCEPTION(bad_parameter, "threadmanager::get_pool",
+        PIKA_THROW_EXCEPTION(pika::error::bad_parameter,
+            "threadmanager::get_pool",
             "the resource partitioner does not own a thread pool named '{}'.\n",
             pool_name);
     }

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -172,7 +172,8 @@ namespace pika::threads::detail {
         tid = syscall(SYS_gettid);
         if (setpriority(PRIO_PROCESS, tid, 19))
         {
-            PIKA_THROWS_IF(ec, no_success, "topology::reduce_thread_priority",
+            PIKA_THROWS_IF(ec, pika::error::no_success,
+                "topology::reduce_thread_priority",
                 "setpriority returned an error");
             return false;
         }
@@ -180,7 +181,8 @@ namespace pika::threads::detail {
 
         if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_LOWEST))
         {
-            PIKA_THROWS_IF(ec, no_success, "topology::reduce_thread_priority",
+            PIKA_THROWS_IF(ec, pika::error::no_success,
+                "topology::reduce_thread_priority",
                 "SetThreadPriority returned an error");
             return false;
         }
@@ -206,7 +208,7 @@ namespace pika::threads::detail {
         int err = hwloc_topology_init(&topo);
         if (err != 0)
         {
-            PIKA_THROW_EXCEPTION(no_success, "topology::topology",
+            PIKA_THROW_EXCEPTION(pika::error::no_success, "topology::topology",
                 "Failed to init hwloc topology");
         }
 
@@ -219,7 +221,7 @@ namespace pika::threads::detail {
             topo, HWLOC_OBJ_CORE, HWLOC_TYPE_FILTER_KEEP_NONE);
         if (err != 0)
         {
-            PIKA_THROW_EXCEPTION(no_success, "topology::topology",
+            PIKA_THROW_EXCEPTION(pika::error::no_success, "topology::topology",
                 "Failed to set core filter for hwloc topology");
         }
 #endif
@@ -228,7 +230,7 @@ namespace pika::threads::detail {
         err = hwloc_topology_load(topo);
         if (err != 0)
         {
-            PIKA_THROW_EXCEPTION(no_success, "topology::topology",
+            PIKA_THROW_EXCEPTION(pika::error::no_success, "topology::topology",
                 "Failed to load hwloc topology");
         }
 
@@ -364,7 +366,7 @@ namespace pika::threads::detail {
             num_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
             if (num_cores <= 0)
             {
-                PIKA_THROWS_IF(ec, no_success,
+                PIKA_THROWS_IF(ec, pika::error::no_success,
                     "topology::hwloc_get_nobjs_by_type",
                     "Failed to get number of cores");
                 return std::size_t(-1);
@@ -411,7 +413,7 @@ namespace pika::threads::detail {
             return socket_affinity_masks_[num_pu];
         }
 
-        PIKA_THROWS_IF(ec, bad_parameter,
+        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
             "pika::threads::detail::topology::get_socket_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -430,7 +432,7 @@ namespace pika::threads::detail {
             return numa_node_affinity_masks_[num_pu];
         }
 
-        PIKA_THROWS_IF(ec, bad_parameter,
+        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
             "pika::threads::detail::topology::get_numa_node_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -449,7 +451,7 @@ namespace pika::threads::detail {
             return core_affinity_masks_[num_pu];
         }
 
-        PIKA_THROWS_IF(ec, bad_parameter,
+        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
             "pika::threads::detail::topology::get_core_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -468,7 +470,7 @@ namespace pika::threads::detail {
             return thread_affinity_masks_[num_pu];
         }
 
-        PIKA_THROWS_IF(ec, bad_parameter,
+        PIKA_THROWS_IF(ec, pika::error::bad_parameter,
             "pika::threads::detail::topology::get_thread_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -510,7 +512,7 @@ namespace pika::threads::detail {
                     hwloc_bitmap_snprintf(buffer.get(), 1024, cpuset);
                     hwloc_bitmap_free(cpuset);
 
-                    PIKA_THROWS_IF(ec, kernel_error,
+                    PIKA_THROWS_IF(ec, pika::error::kernel_error,
                         "pika::threads::detail::topology::set_thread_affinity_"
                         "mask",
                         "failed to set thread affinity mask ({}) for cpuset {}",
@@ -583,7 +585,7 @@ namespace pika::threads::detail {
                 std::string errstr = std::strerror(errno);
 
                 lk.unlock();
-                PIKA_THROW_EXCEPTION(no_success,
+                PIKA_THROW_EXCEPTION(pika::error::no_success,
                     "topology::get_thread_affinity_mask_from_lva",
                     "failed calling 'hwloc_get_area_membind_nodeset', "
                     "reported error: {}",
@@ -741,7 +743,7 @@ namespace pika::threads::detail {
         int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_SOCKET);
         if (0 > nobjs)
         {
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_number_of_sockets",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
@@ -754,7 +756,7 @@ namespace pika::threads::detail {
         int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_NUMANODE);
         if (0 > nobjs)
         {
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_number_of_numa_nodes",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
@@ -769,7 +771,7 @@ namespace pika::threads::detail {
         // If num_cores is smaller 0, we have an error
         if (0 > nobjs)
         {
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type(HWLOC_OBJ_CORE) failed");
             return std::size_t(nobjs);
@@ -781,7 +783,7 @@ namespace pika::threads::detail {
             nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
             if (0 > nobjs)
             {
-                PIKA_THROW_EXCEPTION(kernel_error,
+                PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                     "pika::threads::detail::topology::get_number_of_cores",
                     "hwloc_get_nbobjs_by_type(HWLOC_OBJ_PU) failed");
                 return std::size_t(nobjs);
@@ -792,7 +794,7 @@ namespace pika::threads::detail {
         // avoid division by zero, we should always have at least one core
         if (0 == nobjs)
         {
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type reports zero cores/pus");
             return std::size_t(nobjs);
@@ -971,7 +973,7 @@ namespace pika::threads::detail {
                 hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, unsigned(i));
             if (!obj)
             {
-                PIKA_THROW_EXCEPTION(kernel_error,
+                PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                     "pika::threads::detail::topology::print_affinity_mask",
                     "object not found");
                 return;
@@ -1020,7 +1022,7 @@ namespace pika::threads::detail {
             return machine_affinity_mask;
         }
 
-        PIKA_THROW_EXCEPTION(kernel_error,
+        PIKA_THROW_EXCEPTION(pika::error::kernel_error,
             "pika::threads::detail::topology::init_machine_affinity_mask",
             "failed to initialize machine affinity mask");
         return empty_mask;
@@ -1167,7 +1169,7 @@ namespace pika::threads::detail {
             // core
             if (num_cores <= 0)
             {
-                PIKA_THROW_EXCEPTION(kernel_error,
+                PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                     "pika::threads::detail::topology::init_thread_affinity_"
                     "mask",
                     "hwloc_get_nbobjs_by_type failed");
@@ -1244,7 +1246,7 @@ namespace pika::threads::detail {
             if (hwloc_get_cpubind(topo, cpuset, HWLOC_CPUBIND_THREAD))
             {
                 hwloc_bitmap_free(cpuset);
-                PIKA_THROWS_IF(ec, kernel_error,
+                PIKA_THROWS_IF(ec, pika::error::kernel_error,
                     "pika::threads::detail::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
@@ -1291,7 +1293,7 @@ namespace pika::threads::detail {
 #endif
             {
                 hwloc_bitmap_free(cpuset);
-                PIKA_THROWS_IF(ec, kernel_error,
+                PIKA_THROWS_IF(ec, pika::error::kernel_error,
                     "pika::threads::detail::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
@@ -1364,7 +1366,7 @@ namespace pika::threads::detail {
                 msg = "the action is not supported";
             if (errno == EXDEV)
                 msg = "the binding cannot be enforced";
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::set_area_membind_nodeset",
                 "hwloc_set_area_membind_nodeset failed : {}", msg);
             return false;
@@ -1410,7 +1412,7 @@ namespace pika::threads::detail {
 #endif
             == -1)
         {
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_area_membind_nodeset",
                 "hwloc_get_area_membind_nodeset failed");
             return bitmap_to_mask(ns, HWLOC_OBJ_MACHINE);
@@ -1441,7 +1443,7 @@ namespace pika::threads::detail {
             return 0;
 #else
             std::string msg(strerror(errno));
-            PIKA_THROW_EXCEPTION(kernel_error,
+            PIKA_THROW_EXCEPTION(pika::error::kernel_error,
                 "pika::threads::detail::topology::get_numa_domain",
                 "hwloc_get_area_memlocation failed {}", msg);
             return -1;

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -473,13 +473,13 @@ int pika_main(pika::program_options::variables_map& vm)
 
     if (vector_size < 1)
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "Invalid vector size, must be at least 1");
     }
 
     if (iterations < 1)
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "Invalid number of iterations given, must be at least 1");
     }
 
@@ -547,7 +547,7 @@ int pika_main(pika::program_options::variables_map& vm)
     }
     else
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "Invalid executor id given (0-4 allowed");
     }
     duration<double> dur_total = high_resolution_clock::now() - start_total;

--- a/tests/performance/local/stream_report.cpp
+++ b/tests/performance/local/stream_report.cpp
@@ -422,13 +422,13 @@ int pika_main(pika::program_options::variables_map& vm)
 
     if (vector_size < 1)
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "Invalid vector size, must be at least 1");
     }
 
     if (iterations < 1)
     {
-        PIKA_THROW_EXCEPTION(pika::commandline_option_error, "pika_main",
+        PIKA_THROW_EXCEPTION(pika::error::commandline_option_error, "pika_main",
             "Invalid number of iterations given, must be at least 1");
     }
 

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -197,7 +197,7 @@ pika::threads::detail::thread_result_type invoke_worker_timed_suspension(
 {
     worker_timed(delay * 1000);
 
-    pika::error_code ec(pika::lightweight);
+    pika::error_code ec(pika::throwmode::lightweight);
     pika::this_thread::suspend(
         pika::threads::detail::thread_schedule_state::suspended, "suspend", ec);
 

--- a/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
@@ -43,7 +43,8 @@ int start_func(pika::lcos::local::spinlock& mtx,
 
 void pika_thread_func()
 {
-    PIKA_THROW_EXCEPTION(pika::invalid_status, "pika_thread_func", "test");
+    PIKA_THROW_EXCEPTION(
+        pika::error::invalid_status, "pika_thread_func", "test");
 }
 
 int main(int argc, char** argv)

--- a/tests/regressions/unhandled_exception_582.cpp
+++ b/tests/regressions/unhandled_exception_582.cpp
@@ -12,7 +12,7 @@
 
 int pika_main()
 {
-    PIKA_THROW_EXCEPTION(pika::invalid_status, "pika_main", "testing");
+    PIKA_THROW_EXCEPTION(pika::error::invalid_status, "pika_main", "testing");
     return pika::finalize();
 }
 
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
     }
     catch (pika::exception const& e)
     {
-        PIKA_TEST(e.get_error() == pika::invalid_status);
+        PIKA_TEST(e.get_error() == pika::error::invalid_status);
         caught_exception = true;
     }
     catch (...)


### PR DESCRIPTION
Part of #16.

The main changes are making `pika::error` and `pika::throwmode` class enums. In addition to that some functions were moved to `detail`.