### PR TITLE
Remove restriction to call `pika::finalize` on a pika thread

### DIFF
--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -121,13 +121,6 @@ namespace pika {
 
     int finalize(error_code& ec)
     {
-        if (!threads::detail::get_self_ptr())
-        {
-            PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::finalize",
-                "this function can be called from an pika thread only");
-            return -1;
-        }
-
         if (!is_running())
         {
             PIKA_THROWS_IF(ec, pika::error::invalid_status, "pika::finalize",

--- a/libs/pika/init_runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/init_runtime/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    config_entry const_args_init scoped_finalize
+    config_entry const_args_init finalize_non_pika_thread scoped_finalize
     # shutdown_suspended_thread # Disabled due to unavailable timed suspension
 )
 

--- a/libs/pika/init_runtime/tests/unit/finalize_non_pika_thread.cpp
+++ b/libs/pika/init_runtime/tests/unit/finalize_non_pika_thread.cpp
@@ -1,0 +1,30 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This test checks that pika::finalize can be called on a non-pika thread.
+
+#include <pika/init.hpp>
+#include <pika/testing.hpp>
+
+bool ran_pika_main = false;
+
+int pika_main()
+{
+    ran_pika_main = true;
+
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    pika::start(pika_main, argc, argv);
+    pika::finalize();
+    PIKA_TEST_EQ_MSG(pika::stop(), 0, "pika main exited with non-zero status");
+
+    PIKA_TEST(ran_pika_main);
+
+    return pika::util::report_errors();
+}


### PR DESCRIPTION
Fixes #349.