### PR TITLE
Improve `report_errors` output

### DIFF
--- a/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
+++ b/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
@@ -169,6 +169,11 @@ int pika_main(pika::program_options::variables_map& vm)
         matrix_size.uiWC, matrix_size.uiHC);
 
     matrixMultiply<float>(matrix_size, device, iterations);
+
+    // There are no actual tests to run here. We only expect to reach this point
+    // without exceptions having been thrown.
+    PIKA_TEST(true);
+
     return pika::finalize();
 }
 

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -126,6 +126,9 @@ void test_saxpy(pika::cuda::experimental::cuda_scheduler& cuda_sched)
                 max_error = (std::max)(max_error, abs(h_B[jdx] - 4.0f));
             }
             std::cout << "Max Error: " << max_error << std::endl;
+
+            // We must reach this point. Otherwise something has gone wrong.
+            PIKA_TEST(true);
         });
 
     // the sync_wait() is important because without it, this function returns

--- a/libs/pika/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_bulk.cpp
@@ -262,6 +262,9 @@ int main()
     }
 
     test_adl_isolation(ex::bulk(ex::just(), 1, my_namespace::my_type{}));
+#else
+    // No tests with the P2300 reference implementation
+    PIKA_TEST(true);
 #endif
 
     return pika::util::report_errors();

--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -204,6 +204,9 @@ int main()
     {
         test_adl_isolation(ex::ensure_started(my_namespace::my_sender{}));
     }
+#else
+    // No tests with the P2300 reference implementation
+    PIKA_TEST(true);
 #endif
 
     return pika::util::report_errors();

--- a/libs/pika/functional/tests/regressions/CMakeLists.txt
+++ b/libs/pika/functional/tests/regressions/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 # Function tests
-set(function_tests bind_sfinae_5488 is_callable_1179 protect_with_nullary_pfo)
+set(function_tests is_callable_1179 protect_with_nullary_pfo)
 
 foreach(test ${function_tests})
   set(sources ${test}.cpp)
@@ -22,5 +22,20 @@ foreach(test ${function_tests})
   )
 
   pika_add_regression_test("modules.functional" ${test} ${${test}_PARAMETERS})
-
 endforeach()
+
+if(PIKA_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests bind_sfinae_5488)
+
+  foreach(compile_test ${compile_tests})
+    set(sources ${compile_test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    pika_add_regression_compile_test(
+      "modules.functional" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Regressions/Modules/Functional/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/pika/functional/tests/regressions/bind_sfinae_5488.cpp
+++ b/libs/pika/functional/tests/regressions/bind_sfinae_5488.cpp
@@ -7,7 +7,6 @@
 // #5488: pika::util::bind doesn't bounds-check placeholders
 
 #include <pika/modules/functional.hpp>
-#include <pika/testing.hpp>
 
 #include <type_traits>
 
@@ -28,5 +27,4 @@ void foo(int) {}
 int main()
 {
     test(pika::util::bind(foo, pika::util::placeholders::_1));
-    return pika::util::report_errors();
 }

--- a/libs/pika/functional/tests/unit/CMakeLists.txt
+++ b/libs/pika/functional/tests/unit/CMakeLists.txt
@@ -36,7 +36,6 @@ set(function_tests
     nothrow_swap
     protect_test
     stateless_test
-    sum_avg
 )
 
 foreach(test ${function_tests})
@@ -56,3 +55,19 @@ foreach(test ${function_tests})
   pika_add_unit_test("modules.functional" ${test})
 
 endforeach()
+
+if(PIKA_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests sum_avg)
+
+  foreach(compile_test ${compile_tests})
+    set(sources ${compile_test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    pika_add_unit_compile_test(
+      "modules.functional" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Unit/Modules/Functional/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/pika/functional/tests/unit/stateless_test.cpp
+++ b/libs/pika/functional/tests/unit/stateless_test.cpp
@@ -44,5 +44,9 @@ int main(int, char*[])
     pika::util::function<int(int, int)> f;
     f = stateless_integer_add();
 
+    // This test checks that function does not allocate. We should reach this
+    // point without an exception having been thrown.
+    PIKA_TEST(true);
+
     return pika::util::report_errors();
 }

--- a/libs/pika/functional/tests/unit/sum_avg.cpp
+++ b/libs/pika/functional/tests/unit/sum_avg.cpp
@@ -12,7 +12,6 @@
 // For more information, see http://www.boost.org/
 
 #include <pika/functional/function.hpp>
-#include <pika/testing.hpp>
 
 void do_sum_avg(int values[], int n, int& sum, double& avg)
 {
@@ -27,6 +26,4 @@ int main()
     pika::util::function<void(int values[], int n, int& sum, double& avg)>
         sum_avg;
     sum_avg = &do_sum_avg;
-
-    return pika::util::report_errors();
 }

--- a/libs/pika/futures/tests/regressions/CMakeLists.txt
+++ b/libs/pika/futures/tests/regressions/CMakeLists.txt
@@ -11,7 +11,6 @@ set(tests
     future_790
     future_unwrap_878
     future_unwrap_1182
-    set_pika_limit_798
     shared_future_continuation_order
     shared_future_then_2166
     wait_for_1751
@@ -37,7 +36,7 @@ endforeach()
 
 # compile only tests
 if(PIKA_WITH_COMPILE_ONLY_TESTS)
-  set(compile_tests future_range_ambiguity_2032)
+  set(compile_tests future_range_ambiguity_2032 set_pika_limit_798)
 
   if(PIKA_WITH_FAIL_COMPILE_TESTS)
     set(fail_compile_tests fail_future_2667)

--- a/libs/pika/futures/tests/regressions/set_pika_limit_798.cpp
+++ b/libs/pika/futures/tests/regressions/set_pika_limit_798.cpp
@@ -10,9 +10,7 @@
 #include <pika/config.hpp>
 #if !defined(PIKA_COMPUTE_DEVICE_CODE)
 #include <pika/future.hpp>
-#include <pika/init.hpp>
-#include <pika/pack_traversal/unwrap.hpp>
-#include <pika/testing.hpp>
+#include <pika/unwrap.hpp>
 
 // define large action
 double func(double x1, double, double, double, double, double, double)
@@ -20,17 +18,10 @@ double func(double x1, double, double, double, double, double, double)
     return x1;
 }
 
-int pika_main()
+int main(int argc, char* argv[])
 {
     pika::shared_future<double> f = pika::make_ready_future(1.0);
     f = pika::dataflow(
         pika::launch::sync, pika::unwrapping(&func), f, f, f, f, f, f, f);
-    return pika::finalize();
-}
-
-int main(int argc, char* argv[])
-{
-    pika::init(pika_main, argc, argv);
-    return pika::util::report_errors();
 }
 #endif

--- a/libs/pika/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/pika/iterator_support/tests/unit/CMakeLists.txt
@@ -5,7 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    boost_iterator_categories
     counting_iterator
     irange
     is_iterator
@@ -46,3 +45,19 @@ foreach(test ${tests})
 
   pika_add_unit_test("modules.iterator_support" ${test} ${${test}_PARAMETERS})
 endforeach()
+
+if(PIKA_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests boost_iterator_categories)
+
+  foreach(compile_test ${compile_tests})
+    set(sources ${compile_test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    pika_add_unit_compile_test(
+      "modules.iterator_support" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Unit/Modules/IteratorSupport/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/pika/iterator_support/tests/unit/boost_iterator_categories.cpp
+++ b/libs/pika/iterator_support/tests/unit/boost_iterator_categories.cpp
@@ -5,7 +5,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/modules/iterator_support.hpp>
-#include <pika/testing.hpp>
 
 #include <iterator>
 #include <type_traits>
@@ -33,6 +32,4 @@ int main()
                                    std::input_iterator_tag>,
                       pika::single_pass_traversal_tag>::value,
         "std::input_iterator_tag == pika::single_pass_traversal_tag");
-
-    return pika::util::report_errors();
 }

--- a/libs/pika/synchronization/tests/unit/stop_token_cb2.cpp
+++ b/libs/pika/synchronization/tests/unit/stop_token_cb2.cpp
@@ -152,6 +152,8 @@ int pika_main()
     try
     {
         test_stop_callback_inits();
+        // We expect to reach this point without an exception having been thrown
+        PIKA_TEST(true);
     }
     catch (...)
     {

--- a/testing/include/pika/testing.hpp
+++ b/testing/include/pika/testing.hpp
@@ -40,7 +40,9 @@ namespace pika { namespace util {
 
         private:
             std::ostream& stream_;
+            static std::atomic<std::size_t> sanity_tests_;
             static std::atomic<std::size_t> sanity_failures_;
+            static std::atomic<std::size_t> test_tests_;
             static std::atomic<std::size_t> test_failures_;
             mutex_type mutex_;
 
@@ -50,14 +52,18 @@ namespace pika { namespace util {
             {
             }
 
-            PIKA_EXPORT void increment(counter_type c);
+            PIKA_EXPORT void increment_tests(counter_type c);
+            PIKA_EXPORT void increment_failures(counter_type c);
 
-            PIKA_EXPORT std::size_t get(counter_type c) const;
+            PIKA_EXPORT std::size_t get_tests(counter_type c) const;
+            PIKA_EXPORT std::size_t get_failures(counter_type c) const;
 
             template <typename T>
             bool check_(char const* file, int line, char const* function,
                 counter_type c, T const& t, char const* msg)
             {
+                increment_tests(c);
+
                 if (!t)
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -65,7 +71,7 @@ namespace pika { namespace util {
                     stream_ << file << "(" << line << "): " << msg
                             << " failed in function '" << function << "'"
                             << std::endl;
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;
@@ -75,6 +81,8 @@ namespace pika { namespace util {
             bool check_equal(char const* file, int line, char const* function,
                 counter_type c, T const& t, U const& u, char const* msg)
             {
+                increment_tests(c);
+
                 if (!(t == u))
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -82,7 +90,7 @@ namespace pika { namespace util {
                     stream_ << file << "(" << line << "): " << msg
                             << " failed in function '" << function << "': "
                             << "'" << t << "' != '" << u << "'" << std::endl;
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;
@@ -93,6 +101,8 @@ namespace pika { namespace util {
                 char const* function, counter_type c, T const& t, U const& u,
                 char const* msg)
             {
+                increment_tests(c);
+
                 if (!(t != u))
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -100,7 +110,7 @@ namespace pika { namespace util {
                     stream_ << file << "(" << line << "): " << msg
                             << " failed in function '" << function << "': "
                             << "'" << t << "' != '" << u << "'" << std::endl;
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;
@@ -110,6 +120,8 @@ namespace pika { namespace util {
             bool check_less(char const* file, int line, char const* function,
                 counter_type c, T const& t, U const& u, char const* msg)
             {
+                increment_tests(c);
+
                 if (!(t < u))
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -117,7 +129,7 @@ namespace pika { namespace util {
                     stream_ << file << "(" << line << "): " << msg
                             << " failed in function '" << function << "': "
                             << "'" << t << "' >= '" << u << "'" << std::endl;
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;
@@ -128,6 +140,8 @@ namespace pika { namespace util {
                 char const* function, counter_type c, T const& t, U const& u,
                 char const* msg)
             {
+                increment_tests(c);
+
                 if (!(t <= u))
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -135,7 +149,7 @@ namespace pika { namespace util {
                     stream_ << file << "(" << line << "): " << msg
                             << " failed in function '" << function << "': "
                             << "'" << t << "' > '" << u << "'" << std::endl;
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;
@@ -146,6 +160,8 @@ namespace pika { namespace util {
                 counter_type c, T const& t, U const& u, V const& v,
                 char const* msg)
             {
+                increment_tests(c);
+
                 if (!(t >= u && t <= v))
                 {
                     std::lock_guard<mutex_type> l(mutex_);
@@ -162,7 +178,7 @@ namespace pika { namespace util {
                                 << " failed in function '" << function << "': "
                                 << "'" << t << "' > '" << v << "'" << std::endl;
                     }
-                    increment(c);
+                    increment_failures(c);
                     return false;
                 }
                 return true;

--- a/testing/src/testing.cpp
+++ b/testing/src/testing.cpp
@@ -108,7 +108,13 @@ namespace pika { namespace util {
             detail::global_fixture.get_failures(counter_sanity);
         auto test_failures = detail::global_fixture.get_failures(counter_test);
 
-        if (sanity_failures == 0 && test_failures == 0)
+        if (sanity_tests == 0 && test_tests == 0)
+        {
+            pika::util::ios_flags_saver ifs(stream);
+            stream << "No tests run. Did you forget to add tests?" << std::endl;
+            return 1;
+        }
+        else if (sanity_failures == 0 && test_failures == 0)
         {
             pika::util::ios_flags_saver ifs(stream);
             stream << "All tests passed. Ran " << sanity_tests

--- a/testing/src/testing.cpp
+++ b/testing/src/testing.cpp
@@ -23,10 +23,28 @@
 namespace pika { namespace util {
     namespace detail {
 
+        std::atomic<std::size_t> fixture::sanity_tests_(0);
         std::atomic<std::size_t> fixture::sanity_failures_(0);
+        std::atomic<std::size_t> fixture::test_tests_(0);
         std::atomic<std::size_t> fixture::test_failures_(0);
 
-        void fixture::increment(counter_type c)
+        void fixture::increment_tests(counter_type c)
+        {
+            switch (c)
+            {
+            case counter_sanity:
+                ++sanity_tests_;
+                return;
+            case counter_test:
+                ++test_tests_;
+                return;
+            default:
+                break;
+            }
+            PIKA_ASSERT(false);
+        }
+
+        void fixture::increment_failures(counter_type c)
         {
             switch (c)
             {
@@ -42,7 +60,22 @@ namespace pika { namespace util {
             PIKA_ASSERT(false);
         }
 
-        std::size_t fixture::get(counter_type c) const
+        std::size_t fixture::get_tests(counter_type c) const
+        {
+            switch (c)
+            {
+            case counter_sanity:
+                return sanity_tests_;
+            case counter_test:
+                return test_tests_;
+            default:
+                break;
+            }
+            PIKA_ASSERT(false);
+            return std::size_t(-1);
+        }
+
+        std::size_t fixture::get_failures(counter_type c) const
         {
             switch (c)
             {
@@ -69,17 +102,30 @@ namespace pika { namespace util {
 
     int report_errors(std::ostream& stream)
     {
-        std::size_t sanity = detail::global_fixture.get(counter_sanity),
-                    test = detail::global_fixture.get(counter_test);
-        if (sanity == 0 && test == 0)
-            return 0;
+        auto sanity_tests = detail::global_fixture.get_tests(counter_sanity);
+        auto test_tests = detail::global_fixture.get_tests(counter_test);
+        auto sanity_failures =
+            detail::global_fixture.get_failures(counter_sanity);
+        auto test_failures = detail::global_fixture.get_failures(counter_test);
 
+        if (sanity_failures == 0 && test_failures == 0)
+        {
+            pika::util::ios_flags_saver ifs(stream);
+            stream << "All tests passed. Ran " << sanity_tests
+                   << " sanity check"    //-V128
+                   << ((sanity_tests == 1) ? " and " : "s and ") << test_tests
+                   << " test" << ((test_tests == 1) ? "." : "s.") << std::endl;
+            return 0;
+        }
         else
         {
             pika::util::ios_flags_saver ifs(stream);
-            stream << sanity << " sanity check"    //-V128
-                   << ((sanity == 1) ? " and " : "s and ") << test << " test"
-                   << ((test == 1) ? " failed." : "s failed.") << std::endl;
+            stream << "Tests failed. " << sanity_failures << "/" << sanity_tests
+                   << " sanity check"    //-V128
+                   << ((sanity_tests == 1) ? " and " : "s and ")
+                   << test_failures << "/" << test_tests << " test"
+                   << ((test_tests == 1) ? " failed." : "s failed.")
+                   << std::endl;
             return 1;
         }
     }


### PR DESCRIPTION
- Always print a message, even if no tests failed. This makes it easier to see that the test actually ran successfully. It also prints how many tests were run.
- Print a message and fail if `report_errors` is called but no tests were actually run.

Example outputs below. Success:
```
All tests passed. Ran 0 sanity checks and 150121 tests.
```
Failure:
```
Tests failed. 0/0 sanity checks and 1/13 tests failed.
```
No tests run:
```
No tests run. Did you forget to add tests?
```
Ideas to improve these messages are warmly welcome.

Related: #367. Not removing them yet, but I think we can quite safely remove the sanity checks (since they're unused).

Made a few tests that were triggering the "No tests run" case into compile-only tests. Added a few `PIKA_TEST(true)`s to others.