### PR TITLE
Increase maximum ccache cache size on macOS workflow

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -35,6 +35,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ccache-macos
+        max-size: 1G
     - name: Configure
       shell: bash
       run: |


### PR DESCRIPTION
In an attempt to make better use of the cache. The default limit is 500 MB and the cache is typically around 400 MB from one run. We may need to go back to the non-ccache, split setup for macOS if this doesn't work so well.