### PR TITLE
Fix a few more reference type sender issues

### DIFF
--- a/libs/pika/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_bulk.cpp
@@ -253,7 +253,8 @@ int main()
 
     {
         std::atomic<bool> set_error_called{false};
-        auto s = ex::bulk(const_reference_error_sender{}, 0, [](int) {});
+        auto s = ex::bulk(
+            const_reference_error_sender{}, 10, [](int) { PIKA_TEST(false); });
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));

--- a/libs/pika/execution/tests/unit/algorithm_let_error.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_error.cpp
@@ -180,6 +180,23 @@ int main()
         PIKA_TEST(set_value_called);
         PIKA_TEST(!let_error_callback_called);
     }
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        int x = 42;
+        auto s1 = const_reference_sender<decltype(x)>{x};
+        auto s2 = ex::let_error(std::move(s1), [&](std::exception_ptr) {
+            PIKA_TEST(false);
+            return ex::just(43);
+        });
+        auto f = [](int x) { PIKA_TEST_EQ(x, 42); };
+        auto r = callback_receiver<void_callback_helper<decltype(f)>>{
+            void_callback_helper<decltype(f)>{f}, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+        PIKA_TEST(!let_error_callback_called);
+    }
 
     {
         std::atomic<bool> set_value_called{false};

--- a/libs/pika/execution/tests/unit/algorithm_let_error.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_error.cpp
@@ -47,7 +47,6 @@ int main()
         PIKA_TEST(let_error_callback_called);
     }
 
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     {
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> let_error_callback_called{false};
@@ -64,7 +63,6 @@ int main()
         PIKA_TEST(set_value_called);
         PIKA_TEST(let_error_callback_called);
     }
-#endif
 
     {
         std::atomic<bool> set_value_called{false};


### PR DESCRIPTION
Part of #284.

- Slightly changes the test for `bulk`
- Adds a `const_reference_sender` test for `let_error`
- Enables the `const_reference_error_sender` test for `let_error` with the P2300 reference implementation

Also note that I've listed what still needs to be checked/updated in #284.