### PR TITLE
Fix `config_defines.hpp` timestamp being updated on every CMake reconfiguration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -974,8 +974,7 @@ pika_option(
   (default: OFF)"
   OFF
   ADVANCED
-  CATEGORY "Modules"
-  MODULE TOPOLOGY
+  CATEGORY "Debugging"
 )
 
 if(PIKA_WITH_ADDITIONAL_HWLOC_TESTING)
@@ -1548,7 +1547,7 @@ set(PIKA_WITH_TARGET_ARCHITECTURE
 pika_option(
   PIKA_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY BOOL
   "Enable Boost.Iterator traversal tag compatibility. (default: OFF)" OFF
-  ADVANCED CATEGORY "Modules"
+  ADVANCED CATEGORY "Generic"
 )
 if(PIKA_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
   pika_add_config_define_namespace(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,13 @@ pika_option(
   ADVANCED
 )
 
+pika_option(
+  PIKA_WITH_SWAP_CONTEXT_EMULATION BOOL
+  "Emulate SwapContext API for coroutines (Windows only, default: OFF)" OFF
+  CATEGORY "Thread Manager"
+  ADVANCED
+)
+
 # We create a target to contain libraries like rt, dl etc. in order to remove
 # global variables
 add_library(pika_base_libraries INTERFACE)
@@ -954,6 +961,28 @@ pika_option(
   CATEGORY "Debugging"
   ADVANCED
 )
+
+# Special option to enable testing of FreeBSD specific limitations This is
+# purely an option allowing to test whether things work properly on systems that
+# may not report cores in the topology at all (e.g. FreeBSD). There is no need
+# for a user to every enable this.
+pika_option(
+  PIKA_WITH_ADDITIONAL_HWLOC_TESTING
+  BOOL
+  "Enable HWLOC filtering that makes it report no cores, this is purely an
+  option supporting better testing - do not enable under normal circumstances.
+  (default: OFF)"
+  OFF
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE TOPOLOGY
+)
+
+if(PIKA_WITH_ADDITIONAL_HWLOC_TESTING)
+  pika_add_config_define_namespace(
+    DEFINE PIKA_HAVE_ADDITIONAL_HWLOC_TESTING NAMESPACE TOPOLOGY
+  )
+endif()
 
 # If APEX is defined, the action timers need thread debug info.
 pika_option(
@@ -1515,15 +1544,15 @@ set(PIKA_WITH_TARGET_ARCHITECTURE
     CACHE INTERNAL "" FORCE
 )
 
-# Compatibility with using Boost.Iterator traversal tags, introduced in V1.7.0
+# Compatibility with using Boost.Iterator traversal tags
 pika_option(
-  PIKA_ITERATOR_SUPPORT_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY BOOL
+  PIKA_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY BOOL
   "Enable Boost.Iterator traversal tag compatibility. (default: OFF)" OFF
   ADVANCED CATEGORY "Modules"
 )
-if(PIKA_ITERATOR_SUPPORT_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
+if(PIKA_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
   pika_add_config_define_namespace(
-    DEFINE PIKA_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
+    DEFINE PIKA_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
     NAMESPACE ITERATOR_SUPPORT
   )
 endif()

--- a/cmake/pika_option.cmake
+++ b/cmake/pika_option.cmake
@@ -8,12 +8,11 @@
 include(CMakeParseArguments)
 
 set(PIKA_OPTION_CATEGORIES "Generic" "Build Targets" "Thread Manager"
-                           "Profiling" "Debugging" "Modules"
+                           "Profiling" "Debugging"
 )
 
 function(pika_option option type description default)
   set(options ADVANCED)
-  set(one_value_args CATEGORY MODULE)
   set(multi_value_args STRINGS)
   cmake_parse_arguments(
     PIKA_OPTION "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
@@ -62,13 +61,7 @@ function(pika_option option type description default)
     endif()
   endif()
 
-  if(PIKA_OPTION_MODULE)
-    string(TOUPPER ${PIKA_OPTION_MODULE} module_uc)
-    set(varname_uc PIKA_MODULE_CONFIG_${module_uc})
-    set_property(GLOBAL APPEND PROPERTY ${varname_uc} ${option})
-  else()
-    set_property(GLOBAL APPEND PROPERTY PIKA_MODULE_CONFIG_PIKA ${option})
-  endif()
+  set_property(GLOBAL APPEND PROPERTY PIKA_MODULE_CONFIG_PIKA ${option})
 
   set(_category "Generic")
   if(PIKA_OPTION_CATEGORY)

--- a/cmake/pika_print_summary.cmake
+++ b/cmake/pika_print_summary.cmake
@@ -84,13 +84,15 @@ function(pika_create_configuration_summary message module_name)
   set(_base_dir "pika/config")
   set(_template "config_defines_strings.hpp.in")
 
-  configure_file(
-    "${PIKA_SOURCE_DIR}/cmake/templates/${_template}"
-    "${PIKA_BINARY_DIR}/${_base_dir_local}/config_strings.hpp" @ONLY
-  )
-  configure_file(
-    "${PIKA_SOURCE_DIR}/cmake/templates/${_template}"
-    "${PIKA_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_base_dir}/config_strings.hpp"
-    @ONLY
-  )
+  if("${module_name_uc}" STREQUAL "PIKA")
+    configure_file(
+      "${PIKA_SOURCE_DIR}/cmake/templates/${_template}"
+      "${PIKA_BINARY_DIR}/${_base_dir_local}/config_strings.hpp" @ONLY
+    )
+    configure_file(
+      "${PIKA_SOURCE_DIR}/cmake/templates/${_template}"
+      "${PIKA_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_base_dir}/config_strings.hpp"
+      @ONLY
+    )
+  endif()
 endfunction()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -101,7 +101,7 @@ configure_file(
   @ONLY
 )
 
-if(MSVC AND PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION)
+if(MSVC AND PIKA_WITH_SWAP_CONTEXT_EMULATION)
   target_link_options(pika PRIVATE "/EXPORT:switch_to_fiber")
 endif()
 

--- a/libs/pika/coroutines/CMakeLists.txt
+++ b/libs/pika/coroutines/CMakeLists.txt
@@ -6,14 +6,6 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-pika_option(
-  PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION BOOL
-  "Emulate SwapContext API for coroutines (Windows only, default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
-  MODULE COROUTINES
-)
-
 set(coroutines_headers
     pika/coroutines/coroutine.hpp
     pika/coroutines/coroutine_fwd.hpp
@@ -50,7 +42,7 @@ set(coroutines_sources
 )
 
 if(MSVC)
-  if(PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION)
+  if(PIKA_WITH_SWAP_CONTEXT_EMULATION)
     # ##########################################################################
     # Emulation of SwapContext on Windows
     # ##########################################################################
@@ -60,12 +52,12 @@ if(MSVC)
         "SwitchToFiber emulation can not be enabled. The masm compiler \
          could not be found. Try setting the ASM_MASM environment variable to the \
          assembler executable (ml.exe/ml64.exe) or disable the emulation by setting \
-         PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION to Off"
+         PIKA_WITH_SWAP_CONTEXT_EMULATION to Off"
       )
     endif()
 
     pika_add_config_define_namespace(
-      DEFINE PIKA_COROUTINES_HAVE_SWAP_CONTEXT_EMULATION NAMESPACE COROUTINES
+      DEFINE PIKA_HAVE_SWAP_CONTEXT_EMULATION NAMESPACE COROUTINES
     )
 
     set(switch_to_fiber_source
@@ -82,9 +74,9 @@ if(MSVC)
       VERBATIM
     )
   endif()
-elseif(PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION)
+elseif(PIKA_WITH_SWAP_CONTEXT_EMULATION)
   pika_error(
-    "The option PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION is not supported on "
+    "The option PIKA_WITH_SWAP_CONTEXT_EMULATION is not supported on "
     "this platform, please disable the emulation by setting it to Off"
   )
 endif()
@@ -117,7 +109,7 @@ pika_add_module(
   CMAKE_SUBDIRS examples tests
 )
 
-if(MSVC AND PIKA_COROUTINES_WITH_SWAP_CONTEXT_EMULATION)
+if(MSVC AND PIKA_WITH_SWAP_CONTEXT_EMULATION)
   pika_info(
     "    SwitchToFiber emulation is enabled, using compiler: '${CMAKE_ASM_MASM_COMPILER}'"
   )

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
@@ -50,7 +50,7 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
-#if defined(PIKA_COROUTINES_HAVE_SWAP_CONTEXT_EMULATION)
+#if defined(PIKA_HAVE_SWAP_CONTEXT_EMULATION)
 extern "C" void switch_to_fiber(void* lpFiber) noexcept;
 #endif
 
@@ -149,7 +149,7 @@ namespace pika::threads::coroutines {
                     from.m_ctx = ConvertThreadToFiber(nullptr);
                     PIKA_ASSERT(from.m_ctx != nullptr);
 
-#if defined(PIKA_COROUTINES_HAVE_SWAP_CONTEXT_EMULATION)
+#if defined(PIKA_HAVE_SWAP_CONTEXT_EMULATION)
                     switch_to_fiber(to.m_ctx);
 #else
                     SwitchToFiber(to.m_ctx);
@@ -164,7 +164,7 @@ namespace pika::threads::coroutines {
                     bool call_from_main = from.m_ctx == nullptr;
                     if (call_from_main)
                         from.m_ctx = GetCurrentFiber();
-#if defined(PIKA_COROUTINES_HAVE_SWAP_CONTEXT_EMULATION)
+#if defined(PIKA_HAVE_SWAP_CONTEXT_EMULATION)
                     switch_to_fiber(to.m_ctx);
 #else
                     SwitchToFiber(to.m_ctx);

--- a/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
@@ -10,8 +10,7 @@
 
 #include <pika/config.hpp>
 
-#if !defined(                                                                  \
-    PIKA_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
+#if !defined(PIKA_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
 
 #include <pika/type_support/identity.hpp>
 #include <pika/type_support/lazy_conditional.hpp>
@@ -139,7 +138,7 @@ namespace pika { namespace iterators {
 
 #define PIKA_ITERATOR_TRAVERSAL_TAG_NS boost
 
-#endif    // PIKA_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
+#endif    // PIKA_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
 
 namespace pika {
 

--- a/libs/pika/topology/CMakeLists.txt
+++ b/libs/pika/topology/CMakeLists.txt
@@ -6,28 +6,6 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# Special option to enable testing of FreeBSD specific limitations This is
-# purely an option allowing to test whether things work properly on systems that
-# may not report cores in the topology at all (e.g. FreeBSD). There is no need
-# for a user to every enable this.
-pika_option(
-  PIKA_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING
-  BOOL
-  "Enable HWLOC filtering that makes it report no cores, this is purely an
-  option supporting better testing - do not enable under normal circumstances.
-  (default: OFF)"
-  OFF
-  ADVANCED
-  CATEGORY "Modules"
-  MODULE TOPOLOGY
-)
-
-if(PIKA_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING)
-  pika_add_config_define_namespace(
-    DEFINE PIKA_TOPOLOGY_HAVE_ADDITIONAL_HWLOC_TESTING NAMESPACE TOPOLOGY
-  )
-endif()
-
 # Default location is $PIKA_ROOT/libs/topology/include
 set(topology_headers pika/topology/cpu_mask.hpp pika/topology/topology.hpp)
 

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -211,7 +211,7 @@ namespace pika::threads::detail {
         }
 
 #if HWLOC_API_VERSION >= 0x00020000
-#if defined(PIKA_TOPOLOGY_HAVE_ADDITIONAL_HWLOC_TESTING)
+#if defined(PIKA_HAVE_ADDITIONAL_HWLOC_TESTING)
         // Enable HWLOC filtering that makes it report no cores. This is purely
         // an option allowing to test whether things work properly on systems
         // that may not report cores in the topology at all (e.g. FreeBSD).


### PR DESCRIPTION
The file was being potentially written for every module, and since some of the modules added options (that get written into the `config_defines.hpp` file) the file would be rewritten every CMake reconfiguration, but the contents would stay unchanged.