### PR TITLE
Keep libpika source files for coverage reports, not tests or examples

### DIFF
--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -63,7 +63,8 @@ jobs:
               --output-path lcov.info \
               --output-type lcov \
               --llvm \
-              --ignore-not-existing
+              --ignore-not-existing \
+              --keep-only "*libs/pika/*/{src,include}/*"
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
               --project-token ${{ secrets.CODACY_PIKA_PROJECT_TOKEN }} \
               --language CPP \


### PR DESCRIPTION
Part of #353. From local testing this seems to include only the "right" files, i.e. no tests or examples. Let's see what codacy says once the reports are uploaded (this will only run once on `main`).