### PR TITLE
Move `SPACK_USER_CACHE_PATH` to Jenkins' scratch directory

### DIFF
--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -8,7 +8,7 @@ module load daint-gpu spack-config
 
 export SPACK_ROOT="/apps/daint/SSL/pika/spack"
 export SPACK_USER_CONFIG_PATH="${SPACK_ROOT}/../spack-user-config"
-export SPACK_USER_CACHE_PATH="/scratch/snx3000/simbergm/spack-user-cache-jenkins"
+export SPACK_USER_CACHE_PATH="$SCRATCH/jenkins-pika-spack-user-cache"
 source "${SPACK_ROOT}/share/spack/setup-env.sh"
 
 spack load ccache@4.5.1 %gcc@10.3.0


### PR DESCRIPTION
Closes the `SPACK_USER_CACHE_PATH` of #299.