### PR TITLE
Clean up type support part 2

### DIFF
--- a/libs/pika/algorithms/include/pika/parallel/algorithms/fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/fill.hpp
@@ -237,7 +237,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::fill<FwdIter>().call(
                        PIKA_FORWARD(ExPolicy, policy), first, last, value);
         }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop.hpp
@@ -1092,14 +1092,14 @@ namespace pika {
                         return util::partitioner<ExPolicy>::call(
                             PIKA_FORWARD(ExPolicy, policy), first, size,
                             part_iterations<ExPolicy, F, S>{PIKA_FORWARD(F, f)},
-                            pika::util::detail::empty_function{});
+                            ::pika::detail::empty_function{});
                     }
 
                     return util::partitioner<ExPolicy>::call_with_index(
                         PIKA_FORWARD(ExPolicy, policy), first, size, stride,
                         part_iterations<ExPolicy, F, S>{
                             PIKA_FORWARD(F, f), stride},
-                        pika::util::detail::empty_function{});
+                        ::pika::detail::empty_function{});
                 }
                 else
                 {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/nth_element.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/nth_element.hpp
@@ -387,7 +387,7 @@ namespace pika {
             using result_type =
                 pika::parallel::util::detail::algorithm_result_t<ExPolicy>;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::nth_element<RandomIt>().call(
                        PIKA_FORWARD(ExPolicy, policy), first, nth, last,
                        PIKA_FORWARD(Pred, pred),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
@@ -533,7 +533,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::sort<RandomIt>().call(
                        PIKA_FORWARD(ExPolicy, policy), first, last,
                        PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/stable_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/stable_sort.hpp
@@ -397,7 +397,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::stable_sort<RandomIt>().call(
                        PIKA_FORWARD(ExPolicy, policy), first, last,
                        PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
@@ -407,7 +407,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::uninitialized_default_construct<
                        FwdIter>()
                        .call(PIKA_FORWARD(ExPolicy, policy), first, last);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_fill.hpp
@@ -413,7 +413,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::uninitialized_fill<FwdIter>().call(
                        PIKA_FORWARD(ExPolicy, policy), first, last, value);
         }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
@@ -408,7 +408,7 @@ namespace pika {
                 typename pika::parallel::util::detail::algorithm_result<
                     ExPolicy>::type;
 
-            return pika::util::detail::void_guard<result_type>(),
+            return pika::detail::void_guard<result_type>(),
                    pika::parallel::detail::uninitialized_value_construct<
                        FwdIter>()
                        .call(PIKA_FORWARD(ExPolicy, policy), first, last);

--- a/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
@@ -278,7 +278,7 @@ namespace pika::parallel::util {
 
             static R reduce(std::vector<pika::future<Result>>&& workitems,
                 std::list<std::exception_ptr>&& errors,
-                pika::util::detail::empty_function)
+                ::pika::detail::empty_function)
             {
                 // wait for all tasks to finish
                 pika::wait_all_nothrow(workitems);

--- a/libs/pika/async_combinators/include/pika/async_combinators/wait_all.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/wait_all.hpp
@@ -351,7 +351,7 @@ namespace pika {
                 }
                 else
                 {
-                    using future_type = pika::util::detail::decay_unwrap_t<
+                    using future_type = pika::detail::decay_unwrap_t<
                         typename std::tuple_element<I, Tuple>::type>;
 
                     if constexpr (is_future_or_shared_state_v<future_type>)

--- a/libs/pika/async_combinators/include/pika/async_combinators/when_each.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/when_each.hpp
@@ -193,7 +193,7 @@ namespace pika {
                 }
                 else
                 {
-                    using future_type = pika::util::detail::decay_unwrap_t<
+                    using future_type = pika::detail::decay_unwrap_t<
                         typename std::tuple_element<I, Tuple>::type>;
 
                     if constexpr (pika::traits::is_future_v<future_type> ||
@@ -287,7 +287,7 @@ namespace pika {
             template <std::size_t I>
             PIKA_FORCEINLINE void await_future()
             {
-                using future_type = pika::util::detail::decay_unwrap_t<
+                using future_type = pika::detail::decay_unwrap_t<
                     typename std::tuple_element<I, Tuple>::type>;
 
                 pika::intrusive_ptr<when_each_frame> this_(this);

--- a/libs/pika/execution/include/pika/execution/algorithms/detail/predicates.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/detail/predicates.hpp
@@ -275,7 +275,7 @@ namespace pika { namespace parallel { namespace detail {
     {
         template <typename T1, typename T2,
             typename Enable = std::enable_if_t<
-                pika::traits::detail::is_equality_comparable_with_v<T1, T2>>>
+                pika::detail::is_equality_comparable_with_v<T1, T2>>>
         PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
             T1&& t1, T2&& t2) const
         {
@@ -287,7 +287,7 @@ namespace pika { namespace parallel { namespace detail {
     {
         template <typename T1, typename T2,
             typename Enable = std::enable_if_t<
-                pika::traits::detail::is_equality_comparable_with_v<T1, T2>>>
+                pika::detail::is_equality_comparable_with_v<T1, T2>>>
         PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
             T1&& t1, T2&& t2) const
         {

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -231,7 +231,7 @@ namespace pika::execution::experimental {
                 shared_state(Sender_&& sender, allocator_type const& alloc)
                   : alloc(alloc)
                 {
-                    os.emplace(pika::util::detail::with_result_of([&]() {
+                    os.emplace(pika::detail::with_result_of([&]() {
                         return pika::execution::experimental::connect(
                             PIKA_FORWARD(Sender_, sender),
                             ensure_started_receiver{this});

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -180,7 +180,7 @@ namespace pika { namespace execution { namespace experimental {
                             // state is not required to be copyable nor movable).
                             op_state.successor_op_state
                                 .template emplace<operation_state_type>(
-                                    pika::util::detail::with_result_of([&]() {
+                                    pika::detail::with_result_of([&]() {
                                         return pika::execution::experimental::
                                             connect(PIKA_INVOKE(
                                                         PIKA_MOVE(f), error),

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -237,7 +237,7 @@ namespace pika { namespace execution { namespace experimental {
                             // copyable nor movable).
                             op_state.successor_op_state.template emplace<
                                 operation_state_type>(
-                                pika::util::detail::with_result_of([&]() {
+                                pika::detail::with_result_of([&]() {
                                     return pika::execution::experimental::
                                         connect(
                                             pika::util::detail::invoke_fused(

--- a/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
@@ -184,7 +184,7 @@ namespace pika { namespace execution { namespace experimental {
               : resettable_operation_state_future_data<T, Allocator>(
                     no_addref, alloc)
             {
-                op_state.emplace(pika::util::detail::with_result_of([&]() {
+                op_state.emplace(pika::detail::with_result_of([&]() {
                     return pika::execution::experimental::connect(
                         PIKA_FORWARD(Sender, sender),
                         detail::make_future_receiver<T, Allocator>{this});

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -237,7 +237,7 @@ namespace pika { namespace execution { namespace experimental {
                     // intermediate copy construction (the operation
                     // state is not required to be copyable nor movable).
                     scheduler_op_state.emplace(
-                        pika::util::detail::with_result_of([&]() {
+                        pika::detail::with_result_of([&]() {
                             return pika::execution::experimental::connect(
                                 pika::execution::experimental::schedule(
                                     PIKA_MOVE(scheduler)),

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -233,7 +233,7 @@ namespace pika { namespace execution { namespace experimental {
                 shared_state(Sender_&& sender, allocator_type const& alloc)
                   : alloc(alloc)
                 {
-                    os.emplace(pika::util::detail::with_result_of([&]() {
+                    os.emplace(pika::detail::with_result_of([&]() {
                         return pika::execution::experimental::connect(
                             PIKA_FORWARD(Sender_, sender),
                             split_receiver{*this});

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -262,7 +262,7 @@ namespace pika::execution::experimental {
                     for (auto&& sender : senders)
                     {
                         op_states[i].emplace(
-                            pika::util::detail::with_result_of([&]() {
+                            pika::detail::with_result_of([&]() {
                                 return pika::execution::experimental::connect(
                                     PIKA_MOVE(sender),
                                     when_all_vector_receiver{*this, i});

--- a/libs/pika/execution/include/pika/execution/executors/execution.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution.hpp
@@ -55,9 +55,9 @@ namespace pika { namespace parallel { namespace execution {
         ///////////////////////////////////////////////////////////////////////
         // default implementation of the sync_execute() customization point
         template <typename Executor, typename F, typename... Ts>
-        PIKA_FORCEINLINE auto sync_execute_dispatch(
-            pika::traits::detail::wrap_int, Executor&& /* exec */, F&& /* f */,
-            Ts&&... /* ts */) -> sync_execute_not_callable<Executor, F, Ts...>
+        PIKA_FORCEINLINE auto sync_execute_dispatch(pika::detail::wrap_int,
+            Executor&& /* exec */, F&& /* f */, Ts&&... /* ts */)
+            -> sync_execute_not_callable<Executor, F, Ts...>
         {
             return sync_execute_not_callable<Executor, F, Ts...>{};
         }
@@ -194,9 +194,8 @@ namespace pika { namespace parallel { namespace execution {
                 !pika::traits::is_never_blocking_one_way_executor_v<Executor>>>
         {
             template <typename OneWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static void call_impl(
-                pika::traits::detail::wrap_int, OneWayExecutor&& exec, F&& f,
-                Ts&&... ts)
+            PIKA_FORCEINLINE static void call_impl(pika::detail::wrap_int,
+                OneWayExecutor&& exec, F&& f, Ts&&... ts)
             {
                 // execute synchronously
                 sync_execute_dispatch(0, PIKA_FORWARD(OneWayExecutor, exec),
@@ -243,9 +242,9 @@ namespace pika { namespace parallel { namespace execution {
         ///////////////////////////////////////////////////////////////////////
         // default implementation of the async_execute() customization point
         template <typename Executor, typename F, typename... Ts>
-        PIKA_FORCEINLINE auto async_execute_dispatch(
-            pika::traits::detail::wrap_int, Executor&& /* exec */, F&& /* f */,
-            Ts&&... /* ts */) -> async_execute_not_callable<Executor, F, Ts...>
+        PIKA_FORCEINLINE auto async_execute_dispatch(pika::detail::wrap_int,
+            Executor&& /* exec */, F&& /* f */, Ts&&... /* ts */)
+            -> async_execute_not_callable<Executor, F, Ts...>
         {
             return async_execute_not_callable<Executor, F, Ts...>{};
         }
@@ -329,9 +328,9 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                pika::traits::detail::wrap_int, TwoWayExecutor&& exec, F&& f,
-                Ts&&... ts) -> pika::util::detail::invoke_result_t<F, Ts...>
+            PIKA_FORCEINLINE static auto call_impl(pika::detail::wrap_int,
+                TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+                -> pika::util::detail::invoke_result_t<F, Ts...>
             {
                 using is_void = typename std::is_void<pika::util::detail::
                         invoke_deferred_result_t<F, Ts...>>::type;
@@ -379,8 +378,8 @@ namespace pika { namespace parallel { namespace execution {
                 typename... Ts>
             static pika::future<
                 pika::util::detail::invoke_deferred_result_t<F, Future, Ts...>>
-            call_impl(pika::traits::detail::wrap_int, TwoWayExecutor&& exec,
-                F&& f, Future&& predecessor, Ts&&... ts)
+            call_impl(pika::detail::wrap_int, TwoWayExecutor&& exec, F&& f,
+                Future&& predecessor, Ts&&... ts)
             {
                 using result_type =
                     pika::util::detail::invoke_deferred_result_t<F, Future,
@@ -440,9 +439,8 @@ namespace pika { namespace parallel { namespace execution {
                 !pika::traits::is_never_blocking_one_way_executor_v<Executor>>>
         {
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static void call_impl(
-                pika::traits::detail::wrap_int, TwoWayExecutor&& exec, F&& f,
-                Ts&&... ts)
+            PIKA_FORCEINLINE static void call_impl(pika::detail::wrap_int,
+                TwoWayExecutor&& exec, F&& f, Ts&&... ts)
             {
                 // simply discard the returned future
                 exec.async_execute(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
@@ -487,7 +485,7 @@ namespace pika { namespace parallel { namespace execution {
         struct post_not_callable;
 
         template <typename Executor, typename F, typename... Ts>
-        PIKA_FORCEINLINE auto post_dispatch(pika::traits::detail::wrap_int,
+        PIKA_FORCEINLINE auto post_dispatch(pika::detail::wrap_int,
             Executor&& /* exec */, F&& /* f */, Ts&&... /* ts */)
             -> post_not_callable<Executor, F, Ts...>
         {
@@ -549,7 +547,7 @@ namespace pika { namespace parallel { namespace execution {
         struct bulk_async_execute_not_callable;
 
         template <typename Executor, typename F, typename Shape, typename... Ts>
-        auto bulk_async_execute_dispatch(pika::traits::detail::wrap_int,
+        auto bulk_async_execute_dispatch(pika::detail::wrap_int,
             Executor&& /* exec */, F&& /* f */, Shape const& /* shape */,
             Ts&&... /* ts */)
             -> bulk_async_execute_not_callable<Executor, F, Shape, Ts...>
@@ -589,8 +587,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            static auto call_impl(pika::traits::detail::wrap_int,
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            static auto call_impl(pika::detail::wrap_int, BulkExecutor&& exec,
+                F&& f, Shape const& shape, Ts&&... ts)
                 -> std::vector<pika::traits::executor_future_t<Executor,
                     bulk_function_result_t<F, Shape, Ts...>, Ts...>>
             {
@@ -676,7 +674,7 @@ namespace pika { namespace parallel { namespace execution {
         struct bulk_sync_execute_not_callable;
 
         template <typename Executor, typename F, typename Shape, typename... Ts>
-        auto bulk_sync_execute_dispatch(pika::traits::detail::wrap_int,
+        auto bulk_sync_execute_dispatch(pika::detail::wrap_int,
             Executor&& /* exec */, F&& /* f */, Shape const& /* shape */,
             Ts&&... /* ts */)
             -> bulk_sync_execute_not_callable<Executor, F, Shape, Ts...>
@@ -789,9 +787,8 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                pika::traits::detail::wrap_int, BulkExecutor&& exec, F&& f,
-                Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto call_impl(pika::detail::wrap_int,
+                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> bulk_execute_result_t<F, Shape, Ts...>
             {
                 using is_void = typename std::is_void<
@@ -920,9 +917,8 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                pika::traits::detail::wrap_int, BulkExecutor&& exec, F&& f,
-                Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto call_impl(pika::detail::wrap_int,
+                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> bulk_execute_result_t<F, Shape, Ts...>
             {
                 using is_void = typename std::is_void<
@@ -1051,9 +1047,9 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                pika::traits::detail::wrap_int, BulkExecutor&& exec, F&& f,
-                Shape const& shape, Future&& predecessor, Ts&&... ts)
+            PIKA_FORCEINLINE static auto call_impl(pika::detail::wrap_int,
+                BulkExecutor&& exec, F&& f, Shape const& shape,
+                Future&& predecessor, Ts&&... ts)
                 -> pika::future<
                     bulk_then_execute_result_t<F, Shape, Future, Ts...>>
             {
@@ -1109,9 +1105,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts>
-            static auto call_impl(
-                pika::traits::detail::wrap_int, BulkExecutor&& exec, F&& f,
-                Shape const& shape, Future&& predecessor,
+            static auto call_impl(pika::detail::wrap_int, BulkExecutor&& exec,
+                F&& f, Shape const& shape, Future&& predecessor,
                 Ts&&...
 #if !defined(PIKA_COMPUTE_DEVICE_CODE)
                 ts

--- a/libs/pika/execution/include/pika/execution/executors/execution_parameters.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_parameters.hpp
@@ -696,8 +696,7 @@ namespace pika { namespace parallel { namespace execution {
     static_assert(                                                             \
         parameters_type_counter<                                               \
             PIKA_PP_CAT(pika::parallel::execution::detail::has_, func) <       \
-            pika::util::detail::decay_unwrap_t<Params>>::value... > ::value <= \
-            1,                                                                 \
+            pika::detail::decay_unwrap_t<Params>>::value... > ::value <= 1,    \
         "Passing more than one executor parameters type "                      \
         "exposing " PIKA_PP_STRINGIZE(func) " is not possible") /**/
 

--- a/libs/pika/execution/include/pika/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_parameters_fwd.hpp
@@ -94,7 +94,7 @@ namespace pika { namespace parallel { namespace execution {
             std::size_t cores, std::size_t num_tasks)
         {
             return detail::get_chunk_size_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f), cores,
                 num_tasks);
@@ -130,7 +130,7 @@ namespace pika { namespace parallel { namespace execution {
             std::size_t cores, std::size_t num_tasks)
         {
             return detail::maximal_number_of_chunks_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec), cores, num_tasks);
         }
@@ -161,7 +161,7 @@ namespace pika { namespace parallel { namespace execution {
             reset_thread_distribution_t, Parameters&& params, Executor&& exec)
         {
             return detail::reset_thread_distribution_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec));
         }
@@ -192,7 +192,7 @@ namespace pika { namespace parallel { namespace execution {
             processing_units_count_t, Parameters&& params, Executor&& exec)
         {
             return detail::processing_units_count_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec));
         }
@@ -221,7 +221,7 @@ namespace pika { namespace parallel { namespace execution {
             mark_begin_execution_t, Parameters&& params, Executor&& exec)
         {
             return detail::mark_begin_execution_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec));
         }
@@ -250,7 +250,7 @@ namespace pika { namespace parallel { namespace execution {
             mark_end_of_scheduling_t, Parameters&& params, Executor&& exec)
         {
             return detail::mark_end_of_scheduling_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec));
         }
@@ -279,7 +279,7 @@ namespace pika { namespace parallel { namespace execution {
             mark_end_execution_t, Parameters&& params, Executor&& exec)
         {
             return detail::mark_end_execution_fn_helper<
-                pika::util::detail::decay_unwrap_t<Parameters>,
+                pika::detail::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Parameters, params),
                 PIKA_FORWARD(Executor, exec));
         }

--- a/libs/pika/execution/include/pika/execution/traits/executor_traits.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/executor_traits.hpp
@@ -105,7 +105,7 @@ namespace pika { namespace parallel { namespace execution {
         using execution_category = typename T::execution_category;
 
     public:
-        using type = pika::util::detail::detected_or_t<
+        using type = pika::detail::detected_or_t<
             pika::execution::unsequenced_execution_tag, execution_category,
             Executor>;
     };
@@ -119,8 +119,8 @@ namespace pika { namespace parallel { namespace execution {
         using shape_type = typename T::shape_type;
 
     public:
-        using type = pika::util::detail::detected_or_t<std::size_t, shape_type,
-            Executor>;
+        using type =
+            pika::detail::detected_or_t<std::size_t, shape_type, Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -133,8 +133,9 @@ namespace pika { namespace parallel { namespace execution {
         using index_type = typename T::index_type;
 
     public:
-        using type = pika::util::detail::detected_or_t<
-            typename executor_shape<Executor>::type, index_type, Executor>;
+        using type =
+            pika::detail::detected_or_t<typename executor_shape<Executor>::type,
+                index_type, Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -146,8 +147,9 @@ namespace pika { namespace parallel { namespace execution {
         using parameters_type = typename T::parameters_type;
 
     public:
-        using type = pika::util::detail::detected_or_t<
-            pika::execution::static_chunk_size, parameters_type, Executor>;
+        using type =
+            pika::detail::detected_or_t<pika::execution::static_chunk_size,
+                parameters_type, Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/pika/execution/include/pika/execution/traits/future_then_result_exec.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/future_then_result_exec.hpp
@@ -42,7 +42,7 @@ namespace pika { namespace traits {
                 traits::executor_future_t<Executor, func_result_type, Future>;
 
             // perform unwrapping of future<future<R>>
-            using result_type = util::detail::lazy_conditional_t<
+            using result_type = ::pika::detail::lazy_conditional_t<
                 pika::traits::detail::is_unique_future_v<cont_result>,
                 pika::traits::future_traits<cont_result>,
                 pika::detail::type_identity<cont_result>>;

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -193,7 +193,7 @@ namespace pika { namespace execution { namespace experimental {
                 std::is_destructible<std::decay_t<F>>::value &&
                 std::is_move_constructible<std::decay_t<F>>::value &&
                 std::is_copy_constructible<Executor>::value &&
-                pika::traits::detail::is_equality_comparable_v<Executor>>>
+                pika::detail::is_equality_comparable_v<Executor>>>
           : std::true_type
         {
         };
@@ -468,8 +468,7 @@ namespace pika { namespace execution { namespace experimental {
         std::enable_if_t<
             pika::detail::is_invocable<schedule_t, Scheduler>::value &&
             std::is_copy_constructible<Scheduler>::value &&
-            pika::traits::detail::is_equality_comparable_v<Scheduler>>>
-      : std::true_type
+            pika::detail::is_equality_comparable_v<Scheduler>>> : std::true_type
     {
     };
 

--- a/libs/pika/functional/include/pika/functional/bind.hpp
+++ b/libs/pika/functional/include/pika/functional/bind.hpp
@@ -204,12 +204,12 @@ namespace pika::util::detail {
     template <typename F, typename... Ts>
     constexpr bound<std::decay_t<F>,
         util::detail::make_index_pack_t<sizeof...(Ts)>,
-        util::detail::decay_unwrap_t<Ts>...>
+        ::pika::detail::decay_unwrap_t<Ts>...>
     bind(F&& f, Ts&&... vs)
     {
         using result_type = bound<std::decay_t<F>,
             util::detail::make_index_pack_t<sizeof...(Ts)>,
-            util::detail::decay_unwrap_t<Ts>...>;
+            ::pika::detail::decay_unwrap_t<Ts>...>;
 
         return result_type(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/functional/include/pika/functional/bind_back.hpp
+++ b/libs/pika/functional/include/pika/functional/bind_back.hpp
@@ -142,12 +142,12 @@ namespace pika::util::detail {
     template <typename F, typename... Ts>
     constexpr bound_back<std::decay_t<F>,
         util::detail::make_index_pack_t<sizeof...(Ts)>,
-        util::detail::decay_unwrap_t<Ts>...>
+        ::pika::detail::decay_unwrap_t<Ts>...>
     bind_back(F&& f, Ts&&... vs)
     {
         using result_type = bound_back<std::decay_t<F>,
             util::detail::make_index_pack_t<sizeof...(Ts)>,
-            util::detail::decay_unwrap_t<Ts>...>;
+            ::pika::detail::decay_unwrap_t<Ts>...>;
 
         return result_type(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/functional/include/pika/functional/deferred_call.hpp
+++ b/libs/pika/functional/include/pika/functional/deferred_call.hpp
@@ -23,8 +23,8 @@
 namespace pika::detail {
     template <typename F, typename... Ts>
     struct is_deferred_invocable
-      : pika::detail::is_invocable<util::detail::decay_unwrap_t<F>,
-            util::detail::decay_unwrap_t<Ts>...>
+      : pika::detail::is_invocable<detail::decay_unwrap_t<F>,
+            detail::decay_unwrap_t<Ts>...>
     {
     };
 
@@ -36,8 +36,8 @@ namespace pika::detail {
 namespace pika::util::detail {
     template <typename F, typename... Ts>
     struct invoke_deferred_result
-      : util::detail::invoke_result<util::detail::decay_unwrap_t<F>,
-            util::detail::decay_unwrap_t<Ts>...>
+      : util::detail::invoke_result<::pika::detail::decay_unwrap_t<F>,
+            ::pika::detail::decay_unwrap_t<Ts>...>
     {
     };
 
@@ -116,7 +116,7 @@ namespace pika::util::detail {
 
     template <typename F, typename... Ts>
     deferred<std::decay_t<F>, util::detail::make_index_pack_t<sizeof...(Ts)>,
-        util::detail::decay_unwrap_t<Ts>...>
+        ::pika::detail::decay_unwrap_t<Ts>...>
     deferred_call(F&& f, Ts&&... vs)
     {
         static_assert(pika::detail::is_deferred_invocable_v<F, Ts...>,
@@ -124,7 +124,7 @@ namespace pika::util::detail {
 
         using result_type = deferred<std::decay_t<F>,
             util::detail::make_index_pack_t<sizeof...(Ts)>,
-            util::detail::decay_unwrap_t<Ts>...>;
+            ::pika::detail::decay_unwrap_t<Ts>...>;
 
         return result_type(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/functional/include/pika/functional/invoke.hpp
+++ b/libs/pika/functional/include/pika/functional/invoke.hpp
@@ -15,7 +15,7 @@
 
 namespace pika::util::detail {
 #define PIKA_INVOKE_R(R, F, ...)                                               \
-    (::pika::util::detail::void_guard<R>(), PIKA_INVOKE(F, __VA_ARGS__))
+    (::pika::detail::void_guard<R>(), PIKA_INVOKE(F, __VA_ARGS__))
 
     /// Invokes the given callable object f with the content of
     /// the argument pack vs

--- a/libs/pika/functional/include/pika/functional/invoke_fused.hpp
+++ b/libs/pika/functional/include/pika/functional/invoke_fused.hpp
@@ -93,7 +93,7 @@ namespace pika::util::detail {
         F&& f, Tuple&& t)
     {
         using index_pack = typename detail::fused_index_pack<Tuple>::type;
-        return util::detail::void_guard<R>(),
+        return ::pika::detail::void_guard<R>(),
                detail::invoke_fused_impl(
                    index_pack{}, PIKA_FORWARD(F, f), PIKA_FORWARD(Tuple, t));
     }

--- a/libs/pika/futures/include/pika/futures/future.hpp
+++ b/libs/pika/futures/include/pika/futures/future.hpp
@@ -1311,20 +1311,19 @@ namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     // extension: create a pre-initialized future object, with allocator
     template <int DeductionGuard = 0, typename Allocator, typename T>
-    future<pika::util::detail::decay_unwrap_t<T>> make_ready_future_alloc(
+    future<pika::detail::decay_unwrap_t<T>> make_ready_future_alloc(
         Allocator const& a, T&& init)
     {
-        return pika::make_ready_future_alloc<
-            pika::util::detail::decay_unwrap_t<T>>(a, PIKA_FORWARD(T, init));
+        return pika::make_ready_future_alloc<pika::detail::decay_unwrap_t<T>>(
+            a, PIKA_FORWARD(T, init));
     }
 
     // extension: create a pre-initialized future object
     template <int DeductionGuard = 0, typename T>
-    PIKA_FORCEINLINE future<pika::util::detail::decay_unwrap_t<T>>
-    make_ready_future(T&& init)
+    PIKA_FORCEINLINE future<pika::detail::decay_unwrap_t<T>> make_ready_future(
+        T&& init)
     {
-        return pika::make_ready_future_alloc<
-            pika::util::detail::decay_unwrap_t<T>>(
+        return pika::make_ready_future_alloc<pika::detail::decay_unwrap_t<T>>(
             pika::detail::internal_allocator<>{}, PIKA_FORWARD(T, init));
     }
 
@@ -1362,10 +1361,10 @@ namespace pika {
     // extension: create a pre-initialized future object which gets ready at
     // a given point in time
     template <int DeductionGuard = 0, typename T>
-    future<pika::util::detail::decay_unwrap_t<T>> make_ready_future_at(
+    future<pika::detail::decay_unwrap_t<T>> make_ready_future_at(
         pika::chrono::steady_time_point const& abs_time, T&& init)
     {
-        using result_type = pika::util::detail::decay_unwrap_t<T>;
+        using result_type = pika::detail::decay_unwrap_t<T>;
         using shared_state = lcos::detail::timed_future_data<result_type>;
 
         pika::intrusive_ptr<shared_state> p(
@@ -1376,7 +1375,7 @@ namespace pika {
     }
 
     template <int DeductionGuard = 0, typename T>
-    future<pika::util::detail::decay_unwrap_t<T>> make_ready_future_after(
+    future<pika::detail::decay_unwrap_t<T>> make_ready_future_after(
         pika::chrono::steady_duration const& rel_time, T&& init)
     {
         return pika::make_ready_future_at(

--- a/libs/pika/futures/include/pika/futures/future.hpp
+++ b/libs/pika/futures/include/pika/futures/future.hpp
@@ -902,7 +902,7 @@ namespace pika {
         else
         {
             return f.then(pika::launch::sync, [](pika::future<U>&& f) -> R {
-                return util::detail::void_guard<R>(), f.get();
+                return detail::void_guard<R>(), f.get();
             });
         }
     }
@@ -1199,7 +1199,7 @@ namespace pika {
         {
             return f.then(
                 pika::launch::sync, [](pika::shared_future<U>&& f) -> R {
-                    return util::detail::void_guard<R>(), f.get();
+                    return detail::void_guard<R>(), f.get();
                 });
         }
         // This silences a bogus warning from nvcc about no return from a

--- a/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
@@ -53,7 +53,7 @@ namespace pika { namespace traits {
             using cont_result = pika::util::detail::invoke_result_t<F&, Future>;
 
             // perform unwrapping of future<future<R>>
-            using result_type = util::detail::lazy_conditional_t<
+            using result_type = ::pika::detail::lazy_conditional_t<
                 pika::traits::detail::is_unique_future<cont_result>::value,
                 pika::traits::future_traits<cont_result>,
                 pika::detail::type_identity<cont_result>>;

--- a/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
@@ -53,24 +53,24 @@ namespace pika { namespace iterators {
         // for new-style types.
         template <typename Cat>
         struct std_category_to_traversal
-          : pika::util::detail::lazy_conditional<
+          : pika::detail::lazy_conditional<
                 std::is_convertible<Cat,
                     std::random_access_iterator_tag>::value,
                 ::pika::detail::type_identity<random_access_traversal_tag>,
-                pika::util::detail::lazy_conditional<
+                pika::detail::lazy_conditional<
                     std::is_convertible<Cat,
                         std::bidirectional_iterator_tag>::value,
                     ::pika::detail::type_identity<bidirectional_traversal_tag>,
-                    pika::util::detail::lazy_conditional<
+                    pika::detail::lazy_conditional<
                         std::is_convertible<Cat,
                             std::forward_iterator_tag>::value,
                         ::pika::detail::type_identity<forward_traversal_tag>,
-                        pika::util::detail::lazy_conditional<
+                        pika::detail::lazy_conditional<
                             std::is_convertible<Cat,
                                 std::input_iterator_tag>::value,
                             ::pika::detail::type_identity<
                                 single_pass_traversal_tag>,
-                            pika::util::detail::lazy_conditional<
+                            pika::detail::lazy_conditional<
                                 std::is_convertible<Cat,
                                     std::output_iterator_tag>::value,
                                 ::pika::detail::type_identity<
@@ -84,7 +84,7 @@ namespace pika { namespace iterators {
     // Convert an iterator category into a traversal tag
     template <typename Cat>
     struct iterator_category_to_traversal
-      : pika::util::detail::lazy_conditional<
+      : pika::detail::lazy_conditional<
             std::is_convertible<Cat, incrementable_traversal_tag>::value,
             ::pika::detail::type_identity<Cat>,
             detail::std_category_to_traversal<Cat>>
@@ -102,23 +102,23 @@ namespace pika { namespace iterators {
     // Convert an iterator traversal to one of the traversal tags.
     template <typename Traversal>
     struct pure_traversal_tag
-      : pika::util::detail::lazy_conditional<
+      : pika::detail::lazy_conditional<
             std::is_convertible<Traversal, random_access_traversal_tag>::value,
             ::pika::detail::type_identity<random_access_traversal_tag>,
-            pika::util::detail::lazy_conditional<
+            pika::detail::lazy_conditional<
                 std::is_convertible<Traversal,
                     bidirectional_traversal_tag>::value,
                 ::pika::detail::type_identity<bidirectional_traversal_tag>,
-                pika::util::detail::lazy_conditional<
+                pika::detail::lazy_conditional<
                     std::is_convertible<Traversal,
                         forward_traversal_tag>::value,
                     ::pika::detail::type_identity<forward_traversal_tag>,
-                    pika::util::detail::lazy_conditional<
+                    pika::detail::lazy_conditional<
                         std::is_convertible<Traversal,
                             single_pass_traversal_tag>::value,
                         ::pika::detail::type_identity<
                             single_pass_traversal_tag>,
-                        pika::util::detail::lazy_conditional<
+                        pika::detail::lazy_conditional<
                             std::is_convertible<Traversal,
                                 incrementable_traversal_tag>::value,
                             ::pika::detail::type_identity<

--- a/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
@@ -41,12 +41,12 @@ namespace pika { namespace util {
                     typename std::iterator_traits<Iterator>::iterator_category;
             };
 
-            using base_traversal = util::detail::lazy_conditional<
+            using base_traversal = ::pika::detail::lazy_conditional<
                 std::is_integral<Incrementable>::value,
                 ::pika::detail::type_identity<std::random_access_iterator_tag>,
                 iterator_category<Incrementable>>;
 
-            using traversal = util::detail::lazy_conditional_t<
+            using traversal = ::pika::detail::lazy_conditional_t<
                 std::is_void<CategoryOrTraversal>::value, base_traversal,
                 ::pika::detail::type_identity<CategoryOrTraversal>>;
 
@@ -71,12 +71,12 @@ namespace pika { namespace util {
                     typename std::iterator_traits<Iterator>::difference_type;
             };
 
-            using base_difference = util::detail::lazy_conditional<
+            using base_difference = ::pika::detail::lazy_conditional<
                 std::is_integral<Incrementable>::value,
                 integer_difference_type<Incrementable>,
                 iterator_difference_type<Incrementable>>;
 
-            using difference = util::detail::lazy_conditional_t<
+            using difference = ::pika::detail::lazy_conditional_t<
                 std::is_void<Difference>::value, base_difference,
                 ::pika::detail::type_identity<Difference>>;
 

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
@@ -62,28 +62,26 @@ namespace pika { namespace util {
         {
             // the following type calculations use lazy_conditional to avoid
             // premature instantiations
-            using value_type =
-                typename std::conditional<std::is_void<Value>::value,
-                    typename util::detail::lazy_conditional<
-                        std::is_void<Reference>::value,
-                        value_type_iterator_traits_helper<Base>,
-                        std::remove_reference<Reference>>::type,
-                    Value>::type;
+            using value_type = std::conditional_t<std::is_void<Value>::value,
+                ::pika::detail::lazy_conditional_t<
+                    std::is_void<Reference>::value,
+                    value_type_iterator_traits_helper<Base>,
+                    std::remove_reference<Reference>>,
+                Value>;
 
-            using reference_type =
-                typename std::conditional<std::is_void<Reference>::value,
-                    typename util::detail::lazy_conditional<
-                        std::is_void<Value>::value,
-                        reference_iterator_traits_helper<Base>,
-                        std::add_lvalue_reference<Value>>::type,
-                    Reference>::type;
+            using reference_type = std::conditional_t<
+                std::is_void<Reference>::value,
+                ::pika::detail::lazy_conditional_t<std::is_void<Value>::value,
+                    reference_iterator_traits_helper<Base>,
+                    std::add_lvalue_reference<Value>>,
+                Reference>;
 
-            using iterator_category =
-                util::detail::lazy_conditional_t<std::is_void<Category>::value,
-                    category_iterator_traits_helper<Base>,
-                    ::pika::detail::type_identity<Category>>;
+            using iterator_category = ::pika::detail::lazy_conditional_t<
+                std::is_void<Category>::value,
+                category_iterator_traits_helper<Base>,
+                ::pika::detail::type_identity<Category>>;
 
-            using difference_type = util::detail::lazy_conditional_t<
+            using difference_type = ::pika::detail::lazy_conditional_t<
                 std::is_void<Difference>::value,
                 difference_type_iterator_traits_helper<Base>,
                 ::pika::detail::type_identity<Difference>>;

--- a/libs/pika/iterator_support/include/pika/iterator_support/traits/is_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/traits/is_iterator.hpp
@@ -175,16 +175,18 @@ namespace pika { namespace traits {
         template <typename Iter>
         struct bidirectional_concept<Iter,
             std::void_t<typename dereference_result<Iter>::type,
-                equality_result_t<Iter, Iter>, inequality_result_t<Iter, Iter>,
+                ::pika::detail::equality_result_t<Iter, Iter>,
+                ::pika::detail::inequality_result_t<Iter, Iter>,
                 typename predecrement_result<Iter>::type,
                 typename preincrement_result<Iter>::type,
                 typename postdecrement_result<Iter>::type,
                 typename postincrement_result<Iter>::type>>
           : std::integral_constant<bool,
                 std::is_convertible<bool,
-                    equality_result_t<Iter, Iter>>::value &&
+                    ::pika::detail::equality_result_t<Iter, Iter>>::value &&
                     std::is_convertible<bool,
-                        inequality_result_t<Iter, Iter>>::value &&
+                        ::pika::detail::inequality_result_t<Iter,
+                            Iter>>::value &&
                     std::is_same<typename std::add_lvalue_reference<Iter>::type,
                         typename predecrement_result<Iter>::type>::value &&
                     std::is_same<typename std::add_lvalue_reference<Iter>::type,

--- a/libs/pika/iterator_support/include/pika/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/traits/is_sentinel_for.hpp
@@ -25,8 +25,8 @@ namespace pika { namespace traits {
 
     template <typename Sent, typename Iter>
     struct is_sentinel_for<Sent, Iter,
-        typename std::enable_if_t<is_iterator_v<Iter> &&
-            detail::is_weakly_equality_comparable_with_v<Iter, Sent>>>
+        typename std::enable_if_t<is_iterator_v<Iter>&& ::pika::detail::
+                is_weakly_equality_comparable_with_v<Iter, Sent>>>
       : std::true_type
     {
     };

--- a/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
@@ -31,25 +31,25 @@ namespace pika { namespace util {
         {
             // the following type calculations use lazy_conditional to avoid
             // premature instantiations
-            using reference_type = typename util::detail::lazy_conditional<
+            using reference_type = ::pika::detail::lazy_conditional_t<
                 std::is_void<Reference>::value,
                 util::detail::invoke_result<Transformer, Iterator>,
-                ::pika::detail::type_identity<Reference>>::type;
+                ::pika::detail::type_identity<Reference>>;
 
-            using value_type = typename util::detail::lazy_conditional<
-                std::is_void<Value>::value,
-                std::remove_reference<reference_type>,
-                ::pika::detail::type_identity<Value>>::type;
+            using value_type =
+                ::pika::detail::lazy_conditional_t<std::is_void<Value>::value,
+                    std::remove_reference<reference_type>,
+                    ::pika::detail::type_identity<Value>>;
 
-            using iterator_category = typename util::detail::lazy_conditional<
+            using iterator_category = ::pika::detail::lazy_conditional_t<
                 std::is_void<Category>::value,
                 category_iterator_traits_helper<Iterator>,
-                ::pika::detail::type_identity<Category>>::type;
+                ::pika::detail::type_identity<Category>>;
 
-            using difference_type = typename util::detail::lazy_conditional<
+            using difference_type = ::pika::detail::lazy_conditional_t<
                 std::is_void<Difference>::value,
                 difference_type_iterator_traits_helper<Iterator>,
-                ::pika::detail::type_identity<Difference>>::type;
+                ::pika::detail::type_identity<Difference>>;
 
             using type = pika::util::iterator_adaptor<
                 transform_iterator<Iterator, Transformer, Reference, Value,

--- a/libs/pika/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/is_iterator.cpp
@@ -284,8 +284,8 @@ void dereference_result()
 
 void equality_result()
 {
-    using pika::traits::detail::equality_result;
-    using pika::traits::detail::equality_result_t;
+    using pika::detail::equality_result;
+    using pika::detail::equality_result_t;
 
     struct A
     {
@@ -310,8 +310,8 @@ void equality_result()
 
 void inequality_result()
 {
-    using pika::traits::detail::inequality_result;
-    using pika::traits::detail::inequality_result_t;
+    using pika::detail::inequality_result;
+    using pika::detail::inequality_result_t;
 
     struct A
     {

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -487,7 +487,7 @@ namespace pika {
             template <typename Current>
             void async_traverse_one(Current&& current)
             {
-                using ElementType = typename pika::util::detail::decay_unwrap<
+                using ElementType = typename pika::detail::decay_unwrap<
                     decltype(*current)>::type;
                 return async_traverse_one_impl(
                     container_category_of_t<ElementType>{},

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
@@ -847,7 +847,7 @@ namespace pika { namespace util { namespace detail {
         auto traverse(Strategy, T&& element)
             -> decltype(std::declval<mapping_helper>().match(
                 std::declval<container_category_of_t<
-                    typename pika::util::detail::decay_unwrap<T>::type>>(),
+                    typename pika::detail::decay_unwrap<T>::type>>(),
                 std::declval<T>()));
 
         /// \copybrief traverse
@@ -855,7 +855,7 @@ namespace pika { namespace util { namespace detail {
         auto try_traverse(Strategy, T&& element)
             -> decltype(std::declval<mapping_helper>().try_match(
                 std::declval<container_category_of_t<
-                    typename pika::util::detail::decay_unwrap<T>::type>>(),
+                    typename pika::detail::decay_unwrap<T>::type>>(),
                 std::declval<T>()))
         {
             // We use tag dispatching here, to categorize the type T whether
@@ -863,7 +863,7 @@ namespace pika { namespace util { namespace detail {
             // Then we can choose the underlying implementation accordingly.
             return try_match(
                 container_category_of_t<
-                    typename pika::util::detail::decay_unwrap<T>::type>{},
+                    typename pika::detail::decay_unwrap<T>::type>{},
                 PIKA_FORWARD(T, element));
         }
 

--- a/libs/pika/threading_base/include/pika/threading_base/annotated_function.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/annotated_function.hpp
@@ -37,7 +37,7 @@ namespace pika {
         template <typename F>
         struct annotated_function
         {
-            using fun_type = util::detail::decay_unwrap_t<F>;
+            using fun_type = detail::decay_unwrap_t<F>;
 
             annotated_function() noexcept
               : name_(nullptr)

--- a/libs/pika/type_support/include/pika/type_support/decay.hpp
+++ b/libs/pika/type_support/include/pika/type_support/decay.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::util::detail {
+namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename TD>
     struct decay_unwrap_impl
@@ -34,4 +34,4 @@ namespace pika::util::detail {
 
     template <typename T>
     using decay_unwrap_t = typename decay_unwrap<T>::type;
-}    // namespace pika::util::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/detail/with_result_of.hpp
+++ b/libs/pika/type_support/include/pika/type_support/detail/with_result_of.hpp
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-namespace pika::util::detail {
+namespace pika::detail {
     // Based on
     // https://quuxplusone.github.io/blog/2018/05/17/super-elider-round-2/ and
     // https://akrzemi1.wordpress.com/2018/05/16/rvalues-redefined/.
@@ -42,4 +42,4 @@ namespace pika::util::detail {
     {
         return with_result_of_t<F>(PIKA_FORWARD(F, f));
     }
-}    // namespace pika::util::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/detail/wrap_int.hpp
+++ b/libs/pika/type_support/include/pika/type_support/detail/wrap_int.hpp
@@ -8,10 +8,10 @@
 
 #include <pika/config.hpp>
 
-namespace pika::traits::detail {
+namespace pika::detail {
     // wraps int so that int argument is favored over wrap_int
     struct wrap_int
     {
         constexpr wrap_int(int) {}
     };
-}    // namespace pika::traits::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/detected.hpp
+++ b/libs/pika/type_support/include/pika/type_support/detected.hpp
@@ -11,9 +11,9 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::util::detail {
-    // pika::util::detail::nonesuch is a class type used by
-    // pika::util::detail::detected_t to indicate detection failure.
+namespace pika::detail {
+    // pika::detail::nonesuch is a class type used by
+    // pika::detail::detected_t to indicate detection failure.
     struct nonesuch
     {
         nonesuch() = delete;
@@ -46,7 +46,7 @@ namespace pika::util::detail {
 
     // The alias template detected_t is an alias for Op<Args...> if that
     // template-id is valid; otherwise it is an alias for the class
-    // pika::util::detail::nonesuch.
+    // pika::detail::nonesuch.
     template <template <typename...> class Op, typename... Args>
     using detected_t = typename detector<nonesuch, void, Op, Args...>::type;
 
@@ -77,4 +77,4 @@ namespace pika::util::detail {
     template <typename To, template <typename...> class Op, typename... Args>
     using is_detected_convertible =
         std::is_convertible<detected_t<Op, Args...>, To>;
-}    // namespace pika::util::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/empty_function.hpp
+++ b/libs/pika/type_support/include/pika/type_support/empty_function.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-namespace pika::util::detail {
+namespace pika::detail {
 
     struct empty_function
     {
@@ -15,4 +15,4 @@ namespace pika::util::detail {
         {
         }
     };
-}    // namespace pika::util::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/equality.hpp
+++ b/libs/pika/type_support/include/pika/type_support/equality.hpp
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::traits::detail {
+namespace pika::detail {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename U, typename Enable = void>
@@ -97,4 +97,4 @@ namespace pika::traits::detail {
     template <typename T>
     inline constexpr bool is_equality_comparable_v =
         is_equality_comparable<T>::value;
-}    // namespace pika::traits::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/lazy_conditional.hpp
+++ b/libs/pika/type_support/include/pika/type_support/lazy_conditional.hpp
@@ -8,7 +8,7 @@
 
 #include <type_traits>
 
-namespace pika::util::detail {
+namespace pika::detail {
     template <bool Enable, typename C1, typename C2>
     struct lazy_conditional : std::conditional<Enable, C1, C2>::type
     {
@@ -16,4 +16,4 @@ namespace pika::util::detail {
 
     template <bool Enable, typename C1, typename C2>
     using lazy_conditional_t = typename lazy_conditional<Enable, C1, C2>::type;
-}    // namespace pika::util::detail
+}    // namespace pika::detail

--- a/libs/pika/type_support/include/pika/type_support/void_guard.hpp
+++ b/libs/pika/type_support/include/pika/type_support/void_guard.hpp
@@ -8,7 +8,7 @@
 
 #include <pika/config.hpp>
 
-namespace pika::util::detail {
+namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     // This utility simplifies templates returning compatible types
     //
@@ -29,4 +29,4 @@ namespace pika::util::detail {
         {
         }
     };
-}    // namespace pika::util::detail
+}    // namespace pika::detail


### PR DESCRIPTION
I moved most of the symbols to `pika::detail` to match other PRs. Part of #16 