### PR TITLE
Use `std::function` for startup/shutdown functions and run shutdown functions at shutdown

### DIFF
--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -449,6 +449,7 @@ namespace pika {
         void wait_finalize();
 
         void call_startup_functions(bool pre_startup);
+        void call_shutdown_functions(bool pre_shutdown);
 
         std::list<startup_function_type> pre_startup_functions_;
         std::list<startup_function_type> startup_functions_;

--- a/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/shutdown_function.hpp
@@ -10,12 +10,13 @@
 #pragma once
 
 #include <pika/config.hpp>
-#include <pika/functional/unique_function.hpp>
+
+#include <functional>
 
 namespace pika {
     /// The type of a function which is registered to be executed as a
     /// shutdown or pre-shutdown function.
-    using shutdown_function_type = util::detail::unique_function<void()>;
+    using shutdown_function_type = std::function<void()>;
 
     /// \brief Add a function to be executed by a pika thread during
     /// \a pika::finalize() but guaranteed before any shutdown function is

--- a/libs/pika/runtime/include/pika/runtime/startup_function.hpp
+++ b/libs/pika/runtime/include/pika/runtime/startup_function.hpp
@@ -10,13 +10,14 @@
 #pragma once
 
 #include <pika/config.hpp>
-#include <pika/functional/unique_function.hpp>
+
+#include <functional>
 
 namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     /// The type of a function which is registered to be executed as a
     /// startup or pre-startup function.
-    using startup_function_type = util::detail::unique_function<void()>;
+    using startup_function_type = std::function<void()>;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add a function to be executed by a pika thread before pika_main

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -345,28 +345,24 @@ namespace pika {
             for (startup_function_type& f :
                 detail::global_pre_startup_functions)
             {
-                add_pre_startup_function(PIKA_MOVE(f));
+                add_pre_startup_function(f);
             }
-            detail::global_pre_startup_functions.clear();
 
             for (startup_function_type& f : detail::global_startup_functions)
             {
-                add_startup_function(PIKA_MOVE(f));
+                add_startup_function(f);
             }
-            detail::global_startup_functions.clear();
 
             for (shutdown_function_type& f :
                 detail::global_pre_shutdown_functions)
             {
-                add_pre_shutdown_function(PIKA_MOVE(f));
+                add_pre_shutdown_function(f);
             }
-            detail::global_pre_shutdown_functions.clear();
 
             for (shutdown_function_type& f : detail::global_shutdown_functions)
             {
-                add_shutdown_function(PIKA_MOVE(f));
+                add_shutdown_function(f);
             }
-            detail::global_shutdown_functions.clear();
         }
         catch (std::exception const& e)
         {
@@ -1828,38 +1824,26 @@ namespace pika {
 
     void runtime::add_pre_startup_function(startup_function_type f)
     {
-        if (!f.empty())
-        {
-            std::lock_guard<std::mutex> l(mtx_);
-            pre_startup_functions_.push_back(PIKA_MOVE(f));
-        }
+        std::lock_guard<std::mutex> l(mtx_);
+        pre_startup_functions_.push_back(PIKA_MOVE(f));
     }
 
     void runtime::add_startup_function(startup_function_type f)
     {
-        if (!f.empty())
-        {
-            std::lock_guard<std::mutex> l(mtx_);
-            startup_functions_.push_back(PIKA_MOVE(f));
-        }
+        std::lock_guard<std::mutex> l(mtx_);
+        startup_functions_.push_back(PIKA_MOVE(f));
     }
 
     void runtime::add_pre_shutdown_function(shutdown_function_type f)
     {
-        if (!f.empty())
-        {
-            std::lock_guard<std::mutex> l(mtx_);
-            pre_shutdown_functions_.push_back(PIKA_MOVE(f));
-        }
+        std::lock_guard<std::mutex> l(mtx_);
+        pre_shutdown_functions_.push_back(PIKA_MOVE(f));
     }
 
     void runtime::add_shutdown_function(shutdown_function_type f)
     {
-        if (!f.empty())
-        {
-            std::lock_guard<std::mutex> l(mtx_);
-            shutdown_functions_.push_back(PIKA_MOVE(f));
-        }
+        std::lock_guard<std::mutex> l(mtx_);
+        shutdown_functions_.push_back(PIKA_MOVE(f));
     }
 
     /// Register an external OS-thread with pika

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -1155,6 +1155,24 @@ namespace pika {
         }
     }
 
+    void runtime::call_shutdown_functions(bool pre_shutdown)
+    {
+        if (pre_shutdown)
+        {
+            for (shutdown_function_type& f : pre_shutdown_functions_)
+            {
+                f();
+            }
+        }
+        else
+        {
+            for (shutdown_function_type& f : shutdown_functions_)
+            {
+                f();
+            }
+        }
+    }
+
     namespace detail {
         void handle_print_bind(std::size_t num_threads)
         {
@@ -1448,6 +1466,8 @@ namespace pika {
     {
         LRT_(warning).format("runtime: about to stop services");
 
+        call_shutdown_functions(true);
+
         // execute all on_exit functions whenever the first thread calls this
         this->runtime::stopping();
 
@@ -1485,6 +1505,8 @@ namespace pika {
 
             LRT_(info).format("runtime: stopped all services");
         }
+
+        call_shutdown_functions(false);
     }
 
     // Second step in termination: shut down all services.


### PR DESCRIPTION
- Uses `std::function` instead of pika's `unique_function` for startup/shutdown functions
- Actually calls shutdown functions at shutdown
- Doesn't clear startup/shutdown functions registered before the runtime starts so that they are registered again if the runtime is restarted

This is preliminary work and will be followed up by better tests once I understand a bit better the requirements here. I'm experimenting with `pika::register_{startup,shutdown}_function` as a way to initialize/finalize a separate polling thread for CUDA polling (see #17 and #83).