### PR TITLE
Test all `async_cuda` tests on HIP CI

### DIFF
--- a/.jenkins/cscs-ault/ctest.cmake
+++ b/.jenkins/cscs-ault/ctest.cmake
@@ -83,7 +83,7 @@ ctest_build(TARGET tests.performance.modules.async_cuda FLAGS "-k0 ${CTEST_BUILD
 ctest_build(TARGET tests.regressions.modules.async_cuda FLAGS "-k0 ${CTEST_BUILD_EXTRA_OPTIONS}")
 ctest_build(TARGET tests.unit.modules.async_cuda FLAGS "-k0 ${CTEST_BUILD_EXTRA_OPTIONS}")
 ctest_submit(PARTS Build)
-ctest_test(INCLUDE tests.unit.modules.async_cuda PARALLEL_LEVEL "${CTEST_TEST_PARALLELISM}")
+ctest_test(INCLUDE "tests.*.modules.async_cuda" PARALLEL_LEVEL "${CTEST_TEST_PARALLELISM}")
 ctest_submit(PARTS Test BUILD_ID CTEST_BUILD_ID)
 file(WRITE "${CTEST_JOB_NAME}-cdash-build-id.txt"
      "${CTEST_BUILD_ID}"


### PR DESCRIPTION
Based on #67.
Try to enable globbing for `ctest_test` command, globbing can't be used for building targets.