### PR TITLE
Disable precompiled headers on coverage workflow

### DIFF
--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -37,7 +37,6 @@ jobs:
               -DCMAKE_CXX_FLAGS="--coverage" \
               -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
               -DPIKA_WITH_UNITY_BUILD=ON \
-              -DPIKA_WITH_PRECOMPILED_HEADERS=ON \
               -DPIKA_WITH_MALLOC=system \
               -DPIKA_WITH_EXAMPLES=ON \
               -DPIKA_WITH_TESTS=ON \


### PR DESCRIPTION
This seems to be inhibiting ccache to cache compilations. This workflow has in principle the same problem as in #409 (i.e. it builds all tests and examples and is prone to full rebuilds), but since the non-cached builds are already a lot faster than on macOS there's less to be gained by splitting the workflow into multiple steps.