### PR TITLE
Slightly reformulate `advance_to_sentinel` to be more obvious

### DIFF
--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/advance_to_sentinel.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/advance_to_sentinel.hpp
@@ -28,9 +28,9 @@ namespace pika::parallel::detail {
         }
         else
         {
-            for (/**/; first != last; ++first)
+            while (first != last)
             {
-                /**/;
+                ++first;
             }
             return first;
         }


### PR DESCRIPTION
Mostly a style question, but I find the while version clearer to read.