### PR TITLE
Fix out-of-bounds access in `(stable_)sort_range` tests

### DIFF
--- a/libs/pika/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
@@ -123,7 +123,7 @@ template <typename T>
 void test_sort1_sent(T)
 {
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);
@@ -148,7 +148,7 @@ void test_sort1_sent(ExPolicy&& policy, T)
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);
@@ -174,7 +174,7 @@ void test_sort1_comp_sent(ExPolicy&& policy, T, Compare comp = Compare())
         random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);

--- a/libs/pika/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
+++ b/libs/pika/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
@@ -124,7 +124,7 @@ template <typename T>
 void test_stable_sort1_sent(T)
 {
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);
@@ -149,7 +149,7 @@ void test_stable_sort1_sent(ExPolicy&& policy, T)
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);
@@ -175,7 +175,7 @@ void test_stable_sort1_comp_sent(ExPolicy&& policy, T, Compare comp = Compare())
         random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = std::rand() % 10007;
+    std::size_t N = (std::rand() % 10007) + 1;
 
     // Fill vector with random values
     std::vector<T> c(N);


### PR DESCRIPTION
When `N` is `0` writing into the vector at index `N - 1 == -1` is out of bounds.