### PR TITLE
Reduce job time on ault CI jobs

### DIFF
--- a/.jenkins/cscs-ault/entry.sh
+++ b/.jenkins/cscs-ault/entry.sh
@@ -38,7 +38,7 @@ sbatch \
     --nodes="1" \
     --partition="${configuration_slurm_partition}" \
     --account="djenkssl" \
-    --time="03:00:00" \
+    --time="00:30:00" \
     --output="${job_name}.out" \
     --error="${job_name}.err" \
     --exclusive \


### PR DESCRIPTION
3 hours is a bit unnecessarily wrong (the job should usually finish in less than 10 minutes), so I'm reducing it to 30 minutes. In addition, the job launches still seem to be occasionally failing. This will trigger another build, so let's see how it goes...