### PR TITLE
Add MPI streams

### DIFF
--- a/cmake/pika_add_test.cmake
+++ b/cmake/pika_add_test.cmake
@@ -64,7 +64,7 @@ function(pika_add_test category name)
     set(args ${args} "--pika:bind=none")
   endif()
 
-  set(args "${${name}_UNPARSED_ARGUMENTS}" ${args})
+  set(args "${${name}_ARGS}" "${${name}_UNPARSED_ARGUMENTS}" ${args})
 
   set(_script_location ${PROJECT_BINARY_DIR})
 

--- a/cmake/pika_add_test.cmake
+++ b/cmake/pika_add_test.cmake
@@ -71,8 +71,10 @@ function(pika_add_test category name)
   set(cmd ${_exe})
 
   if(${name}_RUNWRAPPER)
+    set(_preflags_list_ ${MPIEXEC_PREFLAGS})
+    separate_arguments(_preflags_list_)
     list(PREPEND cmd "${MPIEXEC_EXECUTABLE}" "${MPIEXEC_NUMPROC_FLAG}"
-         "${${name}_LOCALITIES}"
+         "${${name}_LOCALITIES}" ${_preflags_list_}
     )
   endif()
 

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Default location is $PIKA_ROOT/libs/mpi/include
 set(async_mpi_headers
     pika/async_mpi/mpi_exception.hpp pika/async_mpi/mpi_polling.hpp
-    pika/async_mpi/transform_mpi.hpp
+    pika/async_mpi/mpi_throttling.hpp pika/async_mpi/transform_mpi.hpp
 )
 
 # Default location is $PIKA_ROOT/libs/mpi/src

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Default location is $PIKA_ROOT/libs/mpi/include
 set(async_mpi_headers
     pika/async_mpi/mpi_exception.hpp pika/async_mpi/mpi_polling.hpp
-    pika/async_mpi/mpi_throttling.hpp pika/async_mpi/transform_mpi.hpp
+    pika/async_mpi/transform_mpi.hpp
 )
 
 # Default location is $PIKA_ROOT/libs/mpi/src

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -12,7 +12,6 @@
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
 #include <pika/async_mpi/mpi_polling.hpp>
-#include <pika/async_mpi/mpi_throttling.hpp>
 #include <pika/concepts/concepts.hpp>
 #include <pika/datastructures/variant.hpp>
 #include <pika/execution/algorithms/detail/partial_algorithm.hpp>

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -120,8 +120,8 @@ namespace pika::mpi::experimental {
             };
 
             template <typename... Ts>
-            requires is_mpi_request_invocable_v<F,
-                Ts...> using invoke_result_helper =
+            requires is_mpi_request_invocable_v<F, Ts...>
+            using invoke_result_helper =
                 pika::execution::experimental::completion_signatures<
                     typename result_type_signature_helper<
                         mpi_request_invoke_result_t<F, Ts...>>::type>;

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -26,14 +26,18 @@
 #include <vector>
 
 namespace pika::mpi::experimental {
+
+    constexpr std::uint32_t max_mpi_streams = 4;
+
     namespace detail {
         // -----------------------------------------------------------------
         /// Holds an MPI_Request and a callback. The callback is intended to be
         /// called when the operation tied to the request handle completes.
         struct request_callback
         {
-            MPI_Request request;
-            request_callback_function_type callback_function;
+            MPI_Request request_;
+            request_callback_function_type callback_function_;
+            stream_index index_{0};
         };
 
         // -----------------------------------------------------------------
@@ -53,7 +57,23 @@ namespace pika::mpi::experimental {
         /// Queries an environment variable to get/override a default value for
         /// the number of messages allowed 'in flight' before we throttle a
         /// thread trying to send more data
-        size_t get_throttling_default();
+        std::uint32_t get_throttling_default();
+
+        // -----------------------------------------------------------------
+        /// To enable independent throttling of sends/receives/other
+        /// we maintina several "queues" which have their own condition
+        /// variables for suspension
+        struct mpi_stream
+        {
+            mutex_type throttling_mtx_;
+            pika::lcos::local::condition_variable throttling_cond_;
+            std::atomic<std::uint32_t> in_flight_{0};
+            std::uint32_t limit_{get_throttling_default()};
+            std::uint32_t index;
+        };
+
+        using mpi_cbq_tuple =
+            std::tuple<request_callback_function_type, mpi_stream*>;
 
         // -----------------------------------------------------------------
         /// a convenience structure to hold state vars in one place
@@ -66,13 +86,13 @@ namespace pika::mpi::experimental {
             // requests vector holds the requests that are checked; this
             // represents the number of active requests in the vector, not the
             // size of the vector
-            std::atomic<size_t> active_request_vector_size_{0};
+            std::atomic<std::uint32_t> active_request_vector_size_{0};
             // requests queue holds the requests recently added
-            std::atomic<size_t> request_queue_size_{0};
+            std::atomic<std::uint32_t> request_queue_size_{0};
             // The sum of messages in queue + vector
-            std::atomic<size_t> in_flight_{0};
+            std::atomic<std::uint32_t> in_flight_{0};
             // for debugging of code creating/destroying polling handlers
-            std::atomic<size_t> register_polling_count_{0};
+            std::atomic<std::uint32_t> register_polling_count_{0};
 
             // Principal storage of requests for polling
             // we track requests and callbacks in two vectors
@@ -80,8 +100,10 @@ namespace pika::mpi::experimental {
             // with a vector of requests to save overheads compared
             // to testing one by one every item (using a list)
             request_callback_queue_type request_callback_queue_;
+            //
             std::vector<MPI_Request> request_vector_;
-            std::vector<request_callback_function_type> callback_vector_;
+            std::vector<mpi_cbq_tuple> callback_vector_;
+            //
             std::vector<MPI_Status> status_vector_;
             std::vector<int> indices_vector_;
 
@@ -91,10 +113,8 @@ namespace pika::mpi::experimental {
             // we use a spinlock for both cases
             mutex_type polling_vector_mtx_;
 
-            // variables used when throttling mpi traffic,
-            mutex_type throttling_mtx_;
-            pika::lcos::local::condition_variable throttling_cond_;
-            size_t throttling_limit_ = get_throttling_default();
+            // streams used when throttling mpi traffic,
+            std::array<mpi_stream, max_mpi_streams> default_queues_;
         };
 
         /// a single instance of all the mpi variables initialized once at startup
@@ -129,9 +149,9 @@ namespace pika::mpi::experimental {
         }
 
         // -----------------------------------------------------------------
-        void wait_for_throttling()
+        void wait_for_throttling_snd(mpi_stream& queue)
         {
-            if (mpi_data_.in_flight_ < mpi_data_.throttling_limit_)
+            if (queue.in_flight_ < queue.limit_)
             {
                 return;
             }
@@ -139,25 +159,40 @@ namespace pika::mpi::experimental {
             // (any thread can post more messages between when we are woken and
             // when we test the "in_flight" condition)
             // and if we have any spurious wakeup, we don't really care as it just
-            // means an extra message would be posted
-            std::unique_lock lk(mpi_data_.throttling_mtx_);
-            mpi_data_.throttling_cond_.wait(lk);
+            // means an extra message would be posted.
+            // note that since we don't use a predicate, we use notify_one
+            // and not notify_all to wake threads - if we used notify_all, then all
+            // threads would always be woken and throttling would be compromised
+            std::unique_lock lk(queue.throttling_mtx_);
+            queue.throttling_cond_.wait(lk);
         }
 
         // -----------------------------------------------------------------
-        size_t get_throttling_default()
+        void wait_for_throttling_snd(stream_index stream)
         {
-            size_t def = size_t(-1);    // unlimited
+            wait_for_throttling_snd(mpi_data_.default_queues_[stream]);
+        }
+
+        // -----------------------------------------------------------------
+        std::uint32_t get_throttling_default()
+        {
+            std::uint32_t def = std::uint32_t(-1);    // unlimited
             char* env = std::getenv("PIKA_MPI_MSG_THROTTLE");
             if (env)
             {
                 def = std::atoi(env);
                 // badly formed env var
                 if (def == 0)
-                    def = size_t(-1);    // unlimited
+                    def = std::uint32_t(-1);    // unlimited
                 mpi_debug.debug(
                     debug::detail::str<>("throttling"), "default", def);
             }
+
+            for (size_t i = 0; i < mpi_data_.default_queues_.size(); ++i)
+            {
+                mpi_data_.default_queues_[i].index = i;
+            }
+
             return def;
         }
 
@@ -167,15 +202,20 @@ namespace pika::mpi::experimental {
         /// have completed
         void add_to_request_callback_queue(request_callback&& req_callback)
         {
-            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
-            ++mpi_data_.request_queue_size_;
-            ++mpi_data_.in_flight_;
-
+            // access data before moving it
+            auto index = req_callback.index_;
             if constexpr (mpi_debug.is_enabled())
             {
                 mpi_debug.debug(debug::detail::str<>("CB queued"), mpi_data_,
-                    "request", debug::detail::hex<8>(req_callback.request));
+                    "request", debug::detail::hex<8>(req_callback.request_),
+                    "stream",
+                    debug::detail::dec<2>(std::uint32_t(req_callback.index_)));
             }
+
+            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
+            ++mpi_data_.request_queue_size_;
+            ++mpi_data_.default_queues_[index].in_flight_;
+            ++mpi_data_.in_flight_;
         }
 
         // -----------------------------------------------------------------
@@ -186,9 +226,10 @@ namespace pika::mpi::experimental {
         inline void add_to_request_callback_vector(
             request_callback&& req_callback)
         {
-            mpi_data_.request_vector_.push_back(req_callback.request);
+            mpi_data_.request_vector_.push_back(req_callback.request_);
             mpi_data_.callback_vector_.push_back(
-                PIKA_MOVE(req_callback.callback_function));
+                {PIKA_MOVE(req_callback.callback_function_),
+                    &mpi_data_.default_queues_[req_callback.index_]});
             ++(mpi_data_.active_request_vector_size_);
 
             if constexpr (mpi_debug.is_enabled())
@@ -196,23 +237,24 @@ namespace pika::mpi::experimental {
                 // clang-format off
                 mpi_debug.debug(debug::detail::str<>("CB queue => vector"),
                     mpi_data_,
-                    "request", debug::detail::hex<8>(req_callback.request),
-                    "callbacks", debug::detail::dec<3>(mpi_data_.callback_vector_.size()),
+                    "request", debug::detail::hex<8>(req_callback.request_),
+                    "stream", debug::detail::dec<2>(static_cast<std::uint32_t>(req_callback.index_)),
                     "requests", debug::detail::dec<3>(mpi_data_.request_vector_.size()),
+                    "callbacks", debug::detail::dec<3>(mpi_data_.callback_vector_.size()),
                     "null", debug::detail::dec<3>(get_num_null_requests_in_vector()));
                 // clang-format on
             }
         }
 
 #if defined(PIKA_DEBUG)
-        std::atomic<size_t>& get_register_polling_count()
+        std::atomic<std::uint32_t>& get_register_polling_count()
         {
             return mpi_data_.register_polling_count_;
         }
 #endif
 
-        void add_request_callback(
-            request_callback_function_type&& callback, MPI_Request request)
+        void add_request_callback(request_callback_function_type&& callback,
+            MPI_Request request, stream_index queue)
         {
             PIKA_ASSERT_MSG(get_register_polling_count() != 0,
                 "MPI event polling has not been enabled on any pool. Make sure "
@@ -221,17 +263,20 @@ namespace pika::mpi::experimental {
 
             // Eagerly check if request already completed. If it did, call the
             // callback immediately.
+#ifdef EAGER_CHECK
             int flag = 0;
             int result = MPI_Test(&request, &flag, MPI_STATUS_IGNORE);
             if (flag)
             {
                 mpi_debug.debug(debug::detail::str<>("eager poll"), "success");
                 PIKA_INVOKE(PIKA_MOVE(callback), result);
+                // note that since we didn't increment the 'in flight' counter
+                // we don't notify any condition either
                 return;
             }
-
+#endif
             add_to_request_callback_queue(
-                request_callback{request, PIKA_MOVE(callback)});
+                request_callback{request, PIKA_MOVE(callback), queue});
         }
 
         // an MPI error handling type that we can use to intercept
@@ -246,17 +291,34 @@ namespace pika::mpi::experimental {
                 "pika_MPI_Handler", error_message(*errorcode));
         }
 
-        size_t set_max_requests_in_flight(size_t N)
+        std::uint32_t set_max_requests_in_flight(
+            std::uint32_t N, stream_index s)
         {
-            return std::exchange(detail::mpi_data_.throttling_limit_, N);
+            if (s == stream_index(-1))
+            {
+                // start from 1
+                for (size_t i = 1; i < mpi_data_.default_queues_.size(); ++i)
+                {
+                    mpi_data_.default_queues_[i].limit_ = N;
+                }
+                // set and return stream 0
+                return std::exchange(mpi_data_.default_queues_[0].limit_, N);
+            }
+            PIKA_ASSERT(s <= mpi_data_.default_queues_.size());
+            return std::exchange(mpi_data_.default_queues_[s].limit_, N);
         }
 
-        size_t get_max_requests_in_flight()
+        std::uint32_t get_max_requests_in_flight(stream_index s)
         {
-            return detail::mpi_data_.throttling_limit_;
+            if (s == stream_index(-1))
+            {
+                return mpi_data_.default_queues_[0].limit_;
+            }
+            PIKA_ASSERT(s <= mpi_data_.default_queues_.size());
+            return mpi_data_.default_queues_[s].limit_;
         }
 
-        size_t get_num_requests_in_flight()
+        std::uint32_t get_num_requests_in_flight()
         {
             return detail::mpi_data_.in_flight_;
         }
@@ -394,25 +456,31 @@ namespace pika::mpi::experimental {
 
                 // decrement before invoking callback to avoid race
                 // if invoked code checks in_flight value
-                size_t inflight = --detail::mpi_data_.in_flight_;
+                detail::mpi_stream* stream =
+                    std::get<1>(detail::mpi_data_.callback_vector_[index]);
+                size_t inflight = --stream->in_flight_;
+                --detail::mpi_data_.in_flight_;
                 --detail::mpi_data_.active_request_vector_size_;
 
                 // Invoke the callback with the status of the completed
                 // operation (status of the request is forwarded to MPI_Testany)
-                detail::mpi_data_.callback_vector_[index](
+                std::get<0>(detail::mpi_data_.callback_vector_[index])(
                     detail::mpi_data_.status_vector_[i].MPI_ERROR);
 
                 // Remove the request from our vector to prevent retesting
-                detail::mpi_data_.callback_vector_[index].reset();
                 detail::mpi_data_.request_vector_[index] = MPI_REQUEST_NULL;
+                // reset (delete) the callback now that it has been used
+                std::get<0>(detail::mpi_data_.callback_vector_[index]).reset();
 
                 // wake any thread that is waiting for throttling
-                if (inflight < detail::mpi_data_.throttling_limit_)
+                if (inflight < stream->limit_)
                 {
                     mpi_debug.debug(debug::detail::str<>("throttling"),
+                        "stream", debug::detail::dec<2>(stream->index),
                         "notify_one", "in_flight",
                         debug::detail::dec<4>(inflight));
-                    detail::mpi_data_.throttling_cond_.notify_one();
+                    //stream->throttling_cond_.notify_all();
+                    stream->throttling_cond_.notify_one();
                 }
             }
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -517,7 +517,7 @@ namespace pika::mpi::experimental {
     std::uint32_t set_max_requests_in_flight(
         std::uint32_t N, std::optional<stream_type> s)
     {
-        if (s == std::nullopt)
+        if (!s)
         {
             // start from 1
             for (size_t i = 1; i < detail::mpi_data_.default_queues_.size();
@@ -540,7 +540,7 @@ namespace pika::mpi::experimental {
 
     std::uint32_t get_max_requests_in_flight(std::optional<stream_type> s)
     {
-        if (s == std::nullopt)
+        if (!s)
         {
             return detail::mpi_data_.default_queues_[0].limit_;
         }

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -8,30 +8,18 @@ set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver
           mpi_async_storage
 )
 
+# cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
-    ARGS
-    "--in-flight-limit=32"
-    THREADS
-    4
-    LOCALITIES
-    2
-    RUNWRAPPER
-    mpi
+    ARGS "--in-flight-limit=32"
+    THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 
 set(mpi_async_storage_PARAMETERS
     ARGS
-    "--in-flight-limit=256"
-    "--localMB=256"
-    "--transferKB=1024"
-    "--seconds=1"
-    THREADS
-    4
-    LOCALITIES
-    2
-    RUNWRAPPER
-    mpi
+        "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1"
+    THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
+# cmake-format: on
 
 set(algorithm_transform_mpi_PARAMETERS LOCALITIES 2 RUNWRAPPER mpi)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -8,10 +8,30 @@ set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver
           mpi_async_storage
 )
 
-set(mpi_ring_async_sender_receiver_PARAMETERS THREADS 4 LOCALITIES 2 RUNWRAPPER
-                                              mpi
+set(mpi_ring_async_sender_receiver_PARAMETERS
+    ARGS
+    "--in-flight-limit=32"
+    THREADS
+    4
+    LOCALITIES
+    2
+    RUNWRAPPER
+    mpi
 )
-set(mpi_async_storage_PARAMETERS THREADS 4 LOCALITIES 2 RUNWRAPPER mpi)
+
+set(mpi_async_storage_PARAMETERS
+    ARGS
+    "--in-flight-limit=256"
+    "--localMB=256"
+    "--transferKB=1024"
+    "--seconds=1"
+    THREADS
+    4
+    LOCALITIES
+    2
+    RUNWRAPPER
+    mpi
+)
 
 set(algorithm_transform_mpi_PARAMETERS LOCALITIES 2 RUNWRAPPER mpi)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -67,9 +67,9 @@ struct test_options
 {
     std::uint64_t local_storage_MB;
     std::uint64_t transfer_size_B;
-    std::uint64_t threads;
-    std::uint64_t num_seconds;
-    std::uint64_t in_flight_limit;
+    std::uint32_t threads;
+    std::uint32_t num_seconds;
+    std::uint32_t in_flight_limit;
 
     bool warmup;
     bool final;
@@ -235,7 +235,9 @@ void test_send_recv(std::uint32_t rank, std::uint32_t nranks, std::mt19937& gen,
             void* buffer_to_recv = &local_recv_storage[memory_offset_recv];
             auto rsnd = ex::just(buffer_to_recv, options.transfer_size_B,
                             MPI_UNSIGNED_CHAR, recv_rank, tag, MPI_COMM_WORLD) |
-                mpi::transform_mpi(MPI_Irecv) | ex::then([&](int result) {
+                mpi::transform_mpi(
+                    MPI_Irecv, /*mpi::mpi_stream::*/ mpi::receive_stream) |
+                ex::then([&](int result) {
                     --recvs_in_flight;
                     nws_deb<5>.debug(deb::str<>("recv complete"),
                         "recv in flight", recvs_in_flight, "send in flight",
@@ -258,7 +260,9 @@ void test_send_recv(std::uint32_t rank, std::uint32_t nranks, std::mt19937& gen,
             void* buffer_to_send = &local_send_storage[memory_offset_send];
             auto ssnd = ex::just(buffer_to_send, options.transfer_size_B,
                             MPI_UNSIGNED_CHAR, send_rank, tag, MPI_COMM_WORLD) |
-                mpi::transform_mpi(MPI_Isend) | ex::then([&](int result) {
+                mpi::transform_mpi(
+                    MPI_Isend, mpi::/*mpi_stream::*/ send_stream) |
+                ex::then([&](int result) {
                     --sends_in_flight;
                     nws_deb<5>.debug(deb::str<>("send complete"),
                         "recv in flight", recvs_in_flight, "send in flight",
@@ -386,21 +390,15 @@ int pika_main(pika::program_options::variables_map& vm)
     options.transfer_size_B =
         static_cast<std::uint64_t>(vm["transferKB"].as<double>() * 1024);
     options.local_storage_MB = vm["localMB"].as<std::uint64_t>();
-    options.num_seconds = vm["seconds"].as<std::uint64_t>();
-    options.in_flight_limit = vm["in-flight-limit"].as<std::uint64_t>();
+    options.num_seconds = vm["seconds"].as<std::uint32_t>();
+    options.in_flight_limit = vm["in-flight-limit"].as<std::uint32_t>();
     options.threads = pika::get_os_thread_count();
     options.warmup = false;
     options.final = false;
 
-    size_t throttling = mpi::detail::get_max_requests_in_flight();
-    if (throttling == size_t(-1))
-    {
-        mpi::detail::set_max_requests_in_flight(options.in_flight_limit);
-    }
-    else
-    {
-        options.in_flight_limit = throttling;
-    }
+    mpi::detail::set_max_requests_in_flight(options.in_flight_limit);
+    nws_deb<1>.debug("set_max_requests_in_flight", rank,
+        deb::dec<04>(options.in_flight_limit));
 
     nws_deb<1>.debug("Allocating local storage on rank", rank, "MB",
         deb::dec<03>(options.local_storage_MB));
@@ -529,14 +527,15 @@ int main(int argc, char* argv[])
     cmdline.add_options()("no-mpi-pool", pika::program_options::bool_switch(),
         "Disable the MPI pool.");
 
+    cmdline.add_options()("in-flight-limit",
+        pika::program_options::value<std::uint32_t>()->default_value(
+            mpi::detail::get_max_requests_in_flight(mpi::stream_index(-1))),
+        "Apply a limit to the number of messages in flight.");
+
     cmdline.add_options()("localMB",
         pika::program_options::value<std::uint64_t>()->default_value(256),
         "Sets the storage capacity (in MB) on each node.\n"
         "The total storage will be num_ranks * localMB");
-
-    cmdline.add_options()("in-flight-limit",
-        pika::program_options::value<std::uint64_t>()->default_value(256),
-        "Apply a limit to then number of messages in flight.");
 
     cmdline.add_options()("transferKB",
         pika::program_options::value<double>()->default_value(512),
@@ -544,7 +543,7 @@ int main(int argc, char* argv[])
         "Each put/get IOP will be this size");
 
     cmdline.add_options()("seconds",
-        pika::program_options::value<std::uint64_t>()->default_value(5),
+        pika::program_options::value<std::uint32_t>()->default_value(5),
         "The number of seconds to run each iteration for.\n");
 
     nws_deb<6>.debug(3, "Calling pika::init");

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -80,15 +80,18 @@ int pika_main(pika::program_options::variables_map& vm)
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    // if comm size < 2 this test should fail
+    // if not debugging standalone and comm size < 2 this test should fail
     // it needs to run on N>2 ranks to be useful
-    //PIKA_TEST_MSG(size > 1, "This test requires N>1 mpi ranks");
+    if (vm.count("standalone") == 0)
+    {
+        PIKA_TEST_MSG(size > 1, "This test requires N>1 mpi ranks");
+    }
 
     const std::uint64_t iterations = vm["iterations"].as<std::uint64_t>();
     //
     output = vm.count("output") != 0;
     auto throttling = vm["in-flight-limit"].as<std::uint32_t>();
-    mpi::detail::set_max_requests_in_flight(throttling);
+    mpi::set_max_requests_in_flight(throttling);
 
     if (rank == 0 && output)
     {
@@ -129,7 +132,8 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto snd = ex::just(&tokens[tag], 1, MPI_INT, rank_from,
                                    tag, MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Irecv, mpi::receive_stream) |
+                        mpi::transform_mpi(
+                            MPI_Irecv, mpi::stream_type::receive) |
                         ex::then([=, &tokens, &counter](int /*result*/) {
                             msg_recv(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -142,7 +146,8 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto recv_snd = ex::just(&tokens[tag], 1, MPI_INT,
                                         rank_from, tag, MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Irecv, mpi::receive_stream) |
+                        mpi::transform_mpi(
+                            MPI_Irecv, mpi::stream_type::receive) |
                         ex::then([=, &tokens](int /*result*/) {
                             msg_recv(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -154,7 +159,7 @@ int pika_main(pika::program_options::variables_map& vm)
                         ex::when_all(ex::just(&tokens[tag], 1, MPI_INT, rank_to,
                                          tag, MPI_COMM_WORLD),
                             std::move(recv_snd)) |
-                        mpi::transform_mpi(MPI_Isend, mpi::send_stream) |
+                        mpi::transform_mpi(MPI_Isend, mpi::stream_type::send) |
                         ex::then([=, &tokens, &counter](int /*result*/) {
                             msg_send(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -169,7 +174,7 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto snd0 = ex::just(&tokens[tag], 1, MPI_INT, rank_to, tag,
                                     MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Isend, mpi::send_stream) |
+                        mpi::transform_mpi(MPI_Isend, mpi::stream_type::send) |
                         ex::then([=, &tokens](int /*result*/) {
                             msg_send(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -184,13 +189,7 @@ int pika_main(pika::program_options::variables_map& vm)
             }
         }
 
-        //        auto tt = mpi::detail::get_num_requests_in_flight();
-        //        if (tt != 0)
-        //        {
-        //            std::cout << "Rank " << rank << " flight " << tt << " counter "
-        //                      << counter << std::endl;
-        //        }
-        PIKA_ASSERT(mpi::detail::get_num_requests_in_flight() == 0);
+        PIKA_ASSERT(mpi::get_num_requests_in_flight() == 0);
         std::cout << "Rank " << rank << " reached end of test " << counter
                   << std::endl;
 
@@ -229,10 +228,14 @@ int main(int argc, char* argv[])
 
     cmdline.add_options()("in-flight-limit",
         pika::program_options::value<std::uint32_t>()->default_value(
-            mpi::detail::get_max_requests_in_flight(mpi::stream_index(-1))),
+            mpi::get_max_requests_in_flight()),
         "Apply a limit to the number of messages in flight.");
 
-    cmdline.add_options()("output", "display messages during test");
+    cmdline.add_options()("output", "Display messages during test");
+
+    cmdline.add_options()("standalone",
+                          "Allow test to run with a single rank (debugging)");
+
     // clang-format on
 
     // Initialize and run pika.
@@ -240,6 +243,7 @@ int main(int argc, char* argv[])
     init_args.desc_cmdline = cmdline;
 
     auto result = pika::init(pika_main, argc, argv, init_args);
+    PIKA_TEST_EQ(result, 0);
 
     // Finalize MPI
     MPI_Finalize();

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -82,11 +82,13 @@ int pika_main(pika::program_options::variables_map& vm)
 
     // if comm size < 2 this test should fail
     // it needs to run on N>2 ranks to be useful
-    PIKA_TEST_MSG(size > 1, "This test requires N>1 mpi ranks");
+    //PIKA_TEST_MSG(size > 1, "This test requires N>1 mpi ranks");
 
     const std::uint64_t iterations = vm["iterations"].as<std::uint64_t>();
     //
     output = vm.count("output") != 0;
+    auto throttling = vm["in-flight-limit"].as<std::uint32_t>();
+    mpi::detail::set_max_requests_in_flight(throttling);
 
     if (rank == 0 && output)
     {
@@ -96,12 +98,6 @@ int pika_main(pika::program_options::variables_map& vm)
     }
 
     {
-        size_t throttling = mpi::detail::get_max_requests_in_flight();
-        if (throttling == size_t(-1))
-        {
-            mpi::detail::set_max_requests_in_flight(512);
-        }
-
         // this needs to scope all uses of transform_mpi
         mpi::enable_user_polling enable_polling;
 
@@ -133,7 +129,7 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto snd = ex::just(&tokens[tag], 1, MPI_INT, rank_from,
                                    tag, MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Irecv) |
+                        mpi::transform_mpi(MPI_Irecv, mpi::receive_stream) |
                         ex::then([=, &tokens, &counter](int /*result*/) {
                             msg_recv(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -146,7 +142,7 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto recv_snd = ex::just(&tokens[tag], 1, MPI_INT,
                                         rank_from, tag, MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Irecv) |
+                        mpi::transform_mpi(MPI_Irecv, mpi::receive_stream) |
                         ex::then([=, &tokens](int /*result*/) {
                             msg_recv(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -158,7 +154,7 @@ int pika_main(pika::program_options::variables_map& vm)
                         ex::when_all(ex::just(&tokens[tag], 1, MPI_INT, rank_to,
                                          tag, MPI_COMM_WORLD),
                             std::move(recv_snd)) |
-                        mpi::transform_mpi(MPI_Isend) |
+                        mpi::transform_mpi(MPI_Isend, mpi::send_stream) |
                         ex::then([=, &tokens, &counter](int /*result*/) {
                             msg_send(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -173,7 +169,7 @@ int pika_main(pika::program_options::variables_map& vm)
                 {
                     auto snd0 = ex::just(&tokens[tag], 1, MPI_INT, rank_to, tag,
                                     MPI_COMM_WORLD) |
-                        mpi::transform_mpi(MPI_Isend) |
+                        mpi::transform_mpi(MPI_Isend, mpi::send_stream) |
                         ex::then([=, &tokens](int /*result*/) {
                             msg_send(rank, size, rank_to, rank_from,
                                 tokens[tag], tag);
@@ -188,12 +184,12 @@ int pika_main(pika::program_options::variables_map& vm)
             }
         }
 
-        auto tt = mpi::detail::get_num_requests_in_flight();
-        if (tt != 0)
-        {
-            std::cout << "Rank " << rank << " flight " << tt << " counter "
-                      << counter << std::endl;
-        }
+        //        auto tt = mpi::detail::get_num_requests_in_flight();
+        //        if (tt != 0)
+        //        {
+        //            std::cout << "Rank " << rank << " flight " << tt << " counter "
+        //                      << counter << std::endl;
+        //        }
         PIKA_ASSERT(mpi::detail::get_num_requests_in_flight() == 0);
         std::cout << "Rank " << rank << " reached end of test " << counter
                   << std::endl;
@@ -229,9 +225,14 @@ int main(int argc, char* argv[])
     cmdline.add_options()
         ("iterations",
             value<std::uint64_t>()->default_value(5000),
-            "number of iterations to test")
+            "number of iterations to test");
 
-        ("output", "display messages during test");
+    cmdline.add_options()("in-flight-limit",
+        pika::program_options::value<std::uint32_t>()->default_value(
+            mpi::detail::get_max_requests_in_flight(mpi::stream_index(-1))),
+        "Apply a limit to the number of messages in flight.");
+
+    cmdline.add_options()("output", "display messages during test");
     // clang-format on
 
     // Initialize and run pika.


### PR DESCRIPTION
This work is not completely finished - I can still get deadlocks with the async storage test, but I would like to start the process of merging this, so I can test it more and use dlaf as a more advanced testing framework

```
Support throttling of mpi traffic using streams
    
Throttling using a single counter causes deadlocks as a
receive might be blocked by a send, or vice versa.
 ```
+ Some flyby cmake and cleanup fixes