### PR TITLE
Use `nv_diag_suppress` when available instead of `diag_suppress`

### DIFF
--- a/libs/pika/format/include/pika/util/from_string.hpp
+++ b/libs/pika/format/include/pika/util/from_string.hpp
@@ -43,14 +43,22 @@ namespace pika { namespace util {
 #pragma warning(push)
 #pragma warning(disable : 186)
 #elif defined(PIKA_CUDA_VERSION)
+#if PIKA_CUDA_VERSION >= 1105
+#pragma nv_diag_suppress 186
+#else
 #pragma diag_suppress 186
+#endif
 #endif
             if (value < min || value > max)
                 throw std::out_of_range("from_string: out of range");
 #if defined(PIKA_INTEL_VERSION)
 #pragma warning(pop)
 #elif defined(PIKA_CUDA_VERSION)
+#if PIKA_CUDA_VERSION >= 1105
+#pragma nv_diag_suppress 186
+#else
 #pragma diag_default 186
+#endif
 #endif
             return static_cast<T>(value);
         }


### PR DESCRIPTION
I skipped this earlier, but not doing the conditional use of `(nv_)diag*` ends up with annoying warnings about deprecated pragmas.