### PR TITLE
Don't run CUDA continuations eagerly if stream is ready

### DIFF
--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -149,15 +149,6 @@ namespace pika::cuda::experimental::detail {
         void add_to_event_callback_queue(
             event_callback_function_type&& f, cudaStream_t stream)
         {
-            // Eagerly check if the stream is empty. If it is the kernel has
-            // already completed and we can call the callback immediately.
-            auto status = cudaStreamQuery(stream);
-            if (status == cudaSuccess)
-            {
-                PIKA_INVOKE(PIKA_MOVE(f), status);
-                return;
-            }
-
             cudaEvent_t event;
             if (!cuda_event_pool::get_event_pool().pop(event))
             {


### PR DESCRIPTION
The probability of deep recursion (and in turn stack overflows) is too high compared to the almost zero performance benefit from it.

I'm still trying to understand why it's triggered so frequently in DLA-Future, but I think it's still fair to revert this for 0.8.0.