### PR TITLE
Ignore lock in tss test

### DIFF
--- a/libs/pika/threading/tests/unit/tss.cpp
+++ b/libs/pika/threading/tests/unit/tss.cpp
@@ -36,6 +36,7 @@ struct tss_value_t
     {
         std::unique_lock<pika::lcos::local::spinlock> lock(tss_mutex);
         --tss_instances;
+        pika::util::ignore_while_checking il(&lock);
         p.set_value();
     }
     pika::lcos::local::promise<void> p;


### PR DESCRIPTION
Fixes the occasional failures on the `tss` unit test. `promise::set_value` may occasionally suspend, and if it does the lock verification will throw unless the `tss_mutex` in the test is ignored from verification.