### PR TITLE
Clean up threading base

### DIFF
--- a/examples/quickstart/disable_thread_stealing_executor.cpp
+++ b/examples/quickstart/disable_thread_stealing_executor.cpp
@@ -52,13 +52,14 @@ namespace executor_example {
         static void mark_begin_execution(Parameters&&)
         {
             pika::threads::remove_scheduler_mode(
-                pika::threads::enable_stealing);
+                pika::threads::scheduler_mode::enable_stealing);
         }
 
         template <typename Parameters>
         static void mark_end_execution(Parameters&&)
         {
-            pika::threads::add_scheduler_mode(pika::threads::enable_stealing);
+            pika::threads::add_scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing);
         }
     };
 

--- a/libs/pika/algorithms/tests/performance/foreach_report.cpp
+++ b/libs/pika/algorithms/tests/performance/foreach_report.cpp
@@ -55,11 +55,13 @@ int pika_main(pika::program_options::variables_map& vm)
 
     if (disable_stealing)
     {
-        pika::threads::detail::remove_scheduler_mode(pika::threads::enable_stealing);
+        pika::threads::remove_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_stealing);
     }
     if (fast_idle_mode)
     {
-        pika::threads::detail::add_scheduler_mode(pika::threads::fast_idle_mode);
+        pika::threads::add_scheduler_mode(
+            ::pika::threads::scheduler_mode::fast_idle_mode);
     }
 
     {

--- a/libs/pika/algorithms/tests/performance/foreach_report.cpp
+++ b/libs/pika/algorithms/tests/performance/foreach_report.cpp
@@ -55,11 +55,11 @@ int pika_main(pika::program_options::variables_map& vm)
 
     if (disable_stealing)
     {
-        pika::threads::remove_scheduler_mode(pika::threads::enable_stealing);
+        pika::threads::detail::remove_scheduler_mode(pika::threads::enable_stealing);
     }
     if (fast_idle_mode)
     {
-        pika::threads::add_scheduler_mode(pika::threads::fast_idle_mode);
+        pika::threads::detail::add_scheduler_mode(pika::threads::fast_idle_mode);
     }
 
     {

--- a/libs/pika/algorithms/tests/performance/foreach_scaling.cpp
+++ b/libs/pika/algorithms/tests/performance/foreach_scaling.cpp
@@ -226,6 +226,7 @@ int pika_main(pika::program_options::variables_map& vm)
 {
     pika::scoped_finalize f;
 
+    using pika::threads::scheduler_mode;
     // pull values from cmd
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();
     bool csvoutput = vm.count("csv_output") != 0;
@@ -260,12 +261,11 @@ int pika_main(pika::program_options::variables_map& vm)
         if (disable_stealing)
         {
             pika::threads::remove_scheduler_mode(
-                pika::threads::enable_stealing);
+                scheduler_mode::enable_stealing);
         }
         if (fast_idle_mode)
         {
-            pika::threads::detail::add_scheduler_mode(
-                pika::threads::fast_idle_mode);
+            pika::threads::add_scheduler_mode(scheduler_mode::fast_idle_mode);
         }
 
         // results
@@ -388,12 +388,12 @@ int pika_main(pika::program_options::variables_map& vm)
 
         if (disable_stealing)
         {
-            pika::threads::detail::add_scheduler_mode(
-                pika::threads::enable_stealing);
+            pika::threads::add_scheduler_mode(scheduler_mode::enable_stealing);
         }
         if (fast_idle_mode)
         {
-            pika::threads::remove_scheduler_mode(pika::threads::fast_idle_mode);
+            pika::threads::remove_scheduler_mode(
+                scheduler_mode::fast_idle_mode);
         }
 
         if (csvoutput)

--- a/libs/pika/algorithms/tests/performance/foreach_scaling.cpp
+++ b/libs/pika/algorithms/tests/performance/foreach_scaling.cpp
@@ -264,7 +264,8 @@ int pika_main(pika::program_options::variables_map& vm)
         }
         if (fast_idle_mode)
         {
-            pika::threads::add_scheduler_mode(pika::threads::fast_idle_mode);
+            pika::threads::detail::add_scheduler_mode(
+                pika::threads::fast_idle_mode);
         }
 
         // results
@@ -387,7 +388,8 @@ int pika_main(pika::program_options::variables_map& vm)
 
         if (disable_stealing)
         {
-            pika::threads::add_scheduler_mode(pika::threads::enable_stealing);
+            pika::threads::detail::add_scheduler_mode(
+                pika::threads::enable_stealing);
         }
         if (fast_idle_mode)
         {

--- a/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -44,7 +44,7 @@ struct disable_stealing_parameter
     template <typename Executor>
     void mark_begin_execution(Executor&&)
     {
-        pika::threads::add_remove_scheduler_mode(
+        pika::threads::detail::add_remove_scheduler_mode(
             pika::threads::enable_stealing, pika::threads::enable_idle_backoff);
     }
 
@@ -57,7 +57,7 @@ struct disable_stealing_parameter
     template <typename Executor>
     void mark_end_execution(Executor&&)
     {
-        pika::threads::add_remove_scheduler_mode(
+        pika::threads::detail::add_remove_scheduler_mode(
             pika::threads::enable_idle_backoff, pika::threads::enable_stealing);
     }
 };

--- a/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -44,21 +44,24 @@ struct disable_stealing_parameter
     template <typename Executor>
     void mark_begin_execution(Executor&&)
     {
-        pika::threads::detail::add_remove_scheduler_mode(
-            pika::threads::enable_stealing, pika::threads::enable_idle_backoff);
+        pika::threads::add_remove_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_stealing,
+            ::pika::threads::scheduler_mode::enable_idle_backoff);
     }
 
     template <typename Executor>
     void mark_end_of_scheduling(Executor&&)
     {
-        pika::threads::remove_scheduler_mode(pika::threads::enable_stealing);
+        pika::threads::remove_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_stealing);
     }
 
     template <typename Executor>
     void mark_end_execution(Executor&&)
     {
-        pika::threads::detail::add_remove_scheduler_mode(
-            pika::threads::enable_idle_backoff, pika::threads::enable_stealing);
+        pika::threads::add_remove_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_idle_backoff,
+            ::pika::threads::scheduler_mode::enable_stealing);
     }
 };
 

--- a/libs/pika/algorithms/tests/regressions/for_each_annotated_function.cpp
+++ b/libs/pika/algorithms/tests/regressions/for_each_annotated_function.cpp
@@ -25,7 +25,7 @@ int pika_main()
     pika::ranges::for_each(pika::execution::par, c,
         pika::annotated_function(
             [](int) -> void {
-                pika::util::detail::thread_description desc(
+                pika::detail::thread_description desc(
                     pika::threads::detail::get_thread_description(
                         pika::threads::detail::get_self_id()));
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)

--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_event_callback.hpp
@@ -33,6 +33,8 @@ namespace pika::cuda::experimental::detail {
     PIKA_EXPORT void add_event_callback(
         event_callback_function_type&& f, cuda_stream const& stream);
 
-    PIKA_EXPORT void register_polling(pika::threads::thread_pool_base& pool);
-    PIKA_EXPORT void unregister_polling(pika::threads::thread_pool_base& pool);
+    PIKA_EXPORT void register_polling(
+        pika::threads::detail::thread_pool_base& pool);
+    PIKA_EXPORT void unregister_polling(
+        pika::threads::detail::thread_pool_base& pool);
 }    // namespace pika::cuda::experimental::detail

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -280,7 +280,7 @@ namespace pika::cuda::experimental::detail {
     }
 
     // -------------------------------------------------------------
-    void register_polling(pika::threads::thread_pool_base& pool)
+    void register_polling(pika::threads::detail::thread_pool_base& pool)
     {
 #if defined(PIKA_DEBUG)
         ++get_register_polling_count();
@@ -292,7 +292,7 @@ namespace pika::cuda::experimental::detail {
     }
 
     // -------------------------------------------------------------
-    void unregister_polling(pika::threads::thread_pool_base& pool)
+    void unregister_polling(pika::threads::detail::thread_pool_base& pool)
     {
 #if defined(PIKA_DEBUG)
         {

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -48,8 +48,10 @@ namespace pika::mpi::experimental {
 
         PIKA_EXPORT void add_request_callback(
             request_callback_function_type&&, MPI_Request, stream_type);
-        PIKA_EXPORT void register_polling(pika::threads::thread_pool_base&);
-        PIKA_EXPORT void unregister_polling(pika::threads::thread_pool_base&);
+        PIKA_EXPORT void register_polling(
+            pika::threads::detail::thread_pool_base&);
+        PIKA_EXPORT void unregister_polling(
+            pika::threads::detail::thread_pool_base&);
 
         // -----------------------------------------------------------------
         // an MPI error handling type that we can use to intercept

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -474,7 +474,7 @@ namespace pika::mpi::experimental {
         }
 
         // -------------------------------------------------------------
-        void register_polling(pika::threads::thread_pool_base& pool)
+        void register_polling(pika::threads::detail::thread_pool_base& pool)
         {
 #if defined(PIKA_DEBUG)
             ++get_register_polling_count();
@@ -486,7 +486,7 @@ namespace pika::mpi::experimental {
         }
 
         // -------------------------------------------------------------
-        void unregister_polling(pika::threads::thread_pool_base& pool)
+        void unregister_polling(pika::threads::detail::thread_pool_base& pool)
         {
 #if defined(PIKA_DEBUG)
             {

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -358,7 +358,8 @@ void test_send_recv(std::uint32_t rank, std::uint32_t nranks, std::mt19937& gen,
 int pika_main(pika::program_options::variables_map& vm)
 {
     // Disable idle backoff on the default pool
-    pika::threads::remove_scheduler_mode(pika::threads::enable_idle_backoff);
+    pika::threads::remove_scheduler_mode(
+        ::pika::threads::scheduler_mode::enable_idle_backoff);
 
     pika::util::mpi_environment mpi_env;
     pika::runtime* rt = pika::get_runtime_ptr();

--- a/libs/pika/execution/include/pika/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/async_launch_policy_dispatch.hpp
@@ -67,7 +67,7 @@ namespace pika { namespace detail {
         PIKA_FORCEINLINE static std::enable_if_t<
             pika::detail::is_deferred_invocable_v<F, Ts...>,
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
-        call(launch policy, pika::util::detail::thread_description const& desc,
+        call(launch policy, pika::detail::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             using result_type =
@@ -110,8 +110,8 @@ namespace pika { namespace detail {
         PIKA_FORCEINLINE static std::enable_if_t<
             pika::detail::is_deferred_invocable_v<F, Ts...>,
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
-        call(launch policy, pika::util::detail::thread_description const& desc,
-            F&& f, Ts&&... ts)
+        call(launch policy, pika::detail::thread_description const& desc, F&& f,
+            Ts&&... ts)
         {
             return call(policy, desc,
                 threads::detail::get_self_or_default_pool(), PIKA_FORWARD(F, f),
@@ -124,7 +124,7 @@ namespace pika { namespace detail {
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(launch policy, F&& f, Ts&&... ts)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
             return call(policy, desc,
                 threads::detail::get_self_or_default_pool(), PIKA_FORWARD(F, f),
                 PIKA_FORWARD(Ts, ts)...);
@@ -145,7 +145,7 @@ namespace pika { namespace detail {
             pika::detail::is_deferred_invocable_v<F, Ts...>,
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::async_policy policy,
-            pika::util::detail::thread_description const& desc,
+            pika::detail::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             PIKA_ASSERT(pool);
@@ -177,7 +177,7 @@ namespace pika { namespace detail {
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::async_policy policy, F&& f, Ts&&... ts)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
             return call(policy, desc,
                 threads::detail::get_self_or_default_pool(), PIKA_FORWARD(F, f),
                 PIKA_FORWARD(Ts, ts)...);
@@ -188,7 +188,7 @@ namespace pika { namespace detail {
             pika::detail::is_deferred_invocable_v<F, Ts...>,
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::fork_policy policy,
-            pika::util::detail::thread_description const& desc,
+            pika::detail::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             PIKA_ASSERT(pool);
@@ -230,7 +230,7 @@ namespace pika { namespace detail {
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::fork_policy policy, F&& f, Ts&&... ts)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
             return call(policy, desc,
                 threads::detail::get_self_or_default_pool(), PIKA_FORWARD(F, f),
                 PIKA_FORWARD(Ts, ts)...);

--- a/libs/pika/execution/include/pika/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/async_launch_policy_dispatch.hpp
@@ -68,7 +68,7 @@ namespace pika { namespace detail {
             pika::detail::is_deferred_invocable_v<F, Ts...>,
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(launch policy, pika::detail::thread_description const& desc,
-            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             using result_type =
                 util::detail::invoke_deferred_result_t<F, Ts...>;
@@ -146,7 +146,7 @@ namespace pika { namespace detail {
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::async_policy policy,
             pika::detail::thread_description const& desc,
-            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             PIKA_ASSERT(pool);
 
@@ -189,7 +189,7 @@ namespace pika { namespace detail {
             pika::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(pika::detail::fork_policy policy,
             pika::detail::thread_description const& desc,
-            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             PIKA_ASSERT(pool);
 

--- a/libs/pika/execution/include/pika/execution/detail/future_exec.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/future_exec.hpp
@@ -151,7 +151,7 @@ namespace pika { namespace lcos { namespace detail {
     struct post_policy_spawner
     {
         template <typename F>
-        void operator()(F&& f, pika::util::detail::thread_description desc)
+        void operator()(F&& f, pika::detail::thread_description desc)
         {
             parallel::execution::detail::post_policy_dispatch<
                 pika::launch::async_policy>::call(pika::launch::async, desc,
@@ -165,7 +165,7 @@ namespace pika { namespace lcos { namespace detail {
         Executor exec;
 
         template <typename F>
-        void operator()(F&& f, pika::util::detail::thread_description)
+        void operator()(F&& f, pika::detail::thread_description)
         {
             pika::parallel::execution::post(exec, PIKA_FORWARD(F, f));
         }

--- a/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
@@ -32,7 +32,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     {
         template <typename F, typename... Ts>
         static void call(launch::fork_policy const& policy,
-            pika::util::detail::thread_description const& desc,
+            pika::detail::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             threads::detail::thread_init_data data(
@@ -65,8 +65,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
 
         template <typename F, typename... Ts>
         static void call(launch::fork_policy const& policy,
-            pika::util::detail::thread_description const& desc, F&& f,
-            Ts&&... ts)
+            pika::detail::thread_description const& desc, F&& f, Ts&&... ts)
         {
             call(policy, desc, threads::detail::get_self_or_default_pool(),
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
@@ -78,7 +77,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     {
         template <typename F, typename... Ts>
         static void call(launch::sync_policy const&,
-            pika::util::detail::thread_description const& /* desc */,
+            pika::detail::thread_description const& /* desc */,
             threads::thread_pool_base* /* pool */, F&& f, Ts&&... ts)
         {
             pika::detail::call_sync(
@@ -87,7 +86,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
 
         template <typename F, typename... Ts>
         static void call(launch::sync_policy const& /* policy */,
-            pika::util::detail::thread_description const& /* desc */, F&& f,
+            pika::detail::thread_description const& /* desc */, F&& f,
             Ts&&... ts) noexcept
         {
             pika::detail::call_sync(
@@ -100,7 +99,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     {
         template <typename F, typename... Ts>
         static void call(Policy const& policy,
-            pika::util::detail::thread_description const& desc,
+            pika::detail::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             if (policy == launch::sync)
@@ -131,8 +130,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
 
         template <typename F, typename... Ts>
         static void call(Policy const& policy,
-            pika::util::detail::thread_description const& desc, F&& f,
-            Ts&&... ts)
+            pika::detail::thread_description const& desc, F&& f, Ts&&... ts)
         {
             if (policy == launch::sync)
             {

--- a/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
@@ -33,7 +33,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         template <typename F, typename... Ts>
         static void call(launch::fork_policy const& policy,
             pika::detail::thread_description const& desc,
-            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             threads::detail::thread_init_data data(
                 threads::detail::make_thread_function_nullary(
@@ -78,7 +78,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         template <typename F, typename... Ts>
         static void call(launch::sync_policy const&,
             pika::detail::thread_description const& /* desc */,
-            threads::thread_pool_base* /* pool */, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* /* pool */, F&& f, Ts&&... ts)
         {
             pika::detail::call_sync(
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
@@ -100,7 +100,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         template <typename F, typename... Ts>
         static void call(Policy const& policy,
             pika::detail::thread_description const& desc,
-            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+            threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             if (policy == launch::sync)
             {

--- a/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
+++ b/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
@@ -43,7 +43,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     hierarchical_bulk_async_execute_helper(
         pika::detail::thread_description const& desc,
-        threads::thread_pool_base* pool, std::size_t first_thread,
+        threads::detail::thread_pool_base* pool, std::size_t first_thread,
         std::size_t num_threads, std::size_t hierarchical_threshold,
         Launch policy, F&& f, S const& shape, Ts&&... ts)
     // NOLINTEND(bugprone-easily-swappable-parameters)
@@ -116,10 +116,10 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     template <typename Launch, typename F, typename S, typename... Ts>
     std::vector<
         pika::future<typename detail::bulk_function_result<F, S, Ts...>::type>>
-    hierarchical_bulk_async_execute_helper(threads::thread_pool_base* pool,
-        std::size_t first_thread, std::size_t num_threads,
-        std::size_t hierarchical_threshold, Launch policy, F&& f,
-        S const& shape, Ts&&... ts)
+    hierarchical_bulk_async_execute_helper(
+        threads::detail::thread_pool_base* pool, std::size_t first_thread,
+        std::size_t num_threads, std::size_t hierarchical_threshold,
+        Launch policy, F&& f, S const& shape, Ts&&... ts)
     {
         pika::detail::thread_description const desc(f,
             "pika::parallel::execution::detail::hierarchical_bulk_async_"

--- a/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
+++ b/libs/pika/executors/include/pika/executors/detail/hierarchical_spawning.hpp
@@ -42,7 +42,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         pika::future<typename detail::bulk_function_result<F, S, Ts...>::type>>
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     hierarchical_bulk_async_execute_helper(
-        pika::util::detail::thread_description const& desc,
+        pika::detail::thread_description const& desc,
         threads::thread_pool_base* pool, std::size_t first_thread,
         std::size_t num_threads, std::size_t hierarchical_threshold,
         Launch policy, F&& f, S const& shape, Ts&&... ts)
@@ -121,7 +121,7 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
         std::size_t hierarchical_threshold, Launch policy, F&& f,
         S const& shape, Ts&&... ts)
     {
-        pika::util::detail::thread_description const desc(f,
+        pika::detail::thread_description const desc(f,
             "pika::parallel::execution::detail::hierarchical_bulk_async_"
             "execute_"
             "helper");

--- a/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
@@ -275,8 +275,7 @@ namespace pika { namespace execution { namespace experimental {
                     queues_.resize(num_threads_);
                 }
 
-                pika::util::detail::thread_description desc(
-                    "fork_join_executor");
+                pika::detail::thread_description desc("fork_join_executor");
                 for (std::size_t t = 0; t < num_threads_; ++t)
                 {
                     if (t == main_thread_)

--- a/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
@@ -127,7 +127,7 @@ namespace pika { namespace execution { namespace experimental {
 
             // Members that are used for all parallel regions executed through
             // this executor.
-            threads::thread_pool_base* pool_ = nullptr;
+            threads::detail::thread_pool_base* pool_ = nullptr;
             execution::thread_priority priority_ =
                 execution::thread_priority::default_;
             execution::thread_stacksize stacksize_ =

--- a/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/guided_pool_executor.hpp
@@ -264,7 +264,7 @@ namespace pika { namespace parallel { namespace execution {
 
     public:
         guided_pool_executor(
-            threads::thread_pool_base* pool, bool hp_sync = false)
+            threads::detail::thread_pool_base* pool, bool hp_sync = false)
           : pool_(pool)
           , priority_(pika::execution::thread_priority::default_)
           , stacksize_(pika::execution::thread_stacksize::default_)
@@ -272,7 +272,7 @@ namespace pika { namespace parallel { namespace execution {
         {
         }
 
-        guided_pool_executor(threads::thread_pool_base* pool,
+        guided_pool_executor(threads::detail::thread_pool_base* pool,
             pika::execution::thread_stacksize stacksize, bool hp_sync = false)
           : pool_(pool)
           , priority_(pika::execution::thread_priority::default_)
@@ -281,7 +281,7 @@ namespace pika { namespace parallel { namespace execution {
         {
         }
 
-        guided_pool_executor(threads::thread_pool_base* pool,
+        guided_pool_executor(threads::detail::thread_pool_base* pool,
             pika::execution::thread_priority priority,
             pika::execution::thread_stacksize stacksize =
                 pika::execution::thread_stacksize::default_,
@@ -512,7 +512,7 @@ namespace pika { namespace parallel { namespace execution {
         }
 
     private:
-        threads::thread_pool_base* pool_;
+        threads::detail::thread_pool_base* pool_;
         pika::execution::thread_priority priority_;
         pika::execution::thread_stacksize stacksize_;
         pool_numa_hint<Tag> hint_;
@@ -527,21 +527,23 @@ namespace pika { namespace parallel { namespace execution {
     struct guided_pool_executor_shim
     {
     public:
-        guided_pool_executor_shim(
-            bool guided, threads::thread_pool_base* pool, bool hp_sync = false)
+        guided_pool_executor_shim(bool guided,
+            threads::detail::thread_pool_base* pool, bool hp_sync = false)
           : guided_(guided)
           , guided_exec_(pool, hp_sync)
         {
         }
 
-        guided_pool_executor_shim(bool guided, threads::thread_pool_base* pool,
+        guided_pool_executor_shim(bool guided,
+            threads::detail::thread_pool_base* pool,
             pika::execution::thread_stacksize stacksize, bool hp_sync = false)
           : guided_(guided)
           , guided_exec_(pool, hp_sync, stacksize)
         {
         }
 
-        guided_pool_executor_shim(bool guided, threads::thread_pool_base* pool,
+        guided_pool_executor_shim(bool guided,
+            threads::detail::thread_pool_base* pool,
             pika::execution::thread_priority priority,
             pika::execution::thread_stacksize stacksize =
                 pika::execution::thread_stacksize::default_,

--- a/libs/pika/executors/include/pika/executors/parallel_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/parallel_executor.hpp
@@ -255,7 +255,7 @@ namespace pika { namespace execution {
             typename pika::util::detail::invoke_deferred_result<F, Ts...>::type>
         async_execute(F&& f, Ts&&... ts) const
         {
-            pika::util::detail::thread_description desc(f, annotation_);
+            pika::detail::thread_description desc(f, annotation_);
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
 
@@ -293,7 +293,7 @@ namespace pika { namespace execution {
         template <typename F, typename... Ts>
         void post(F&& f, Ts&&... ts) const
         {
-            pika::util::detail::thread_description desc(f, annotation_);
+            pika::detail::thread_description desc(f, annotation_);
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
             parallel::execution::detail::post_policy_dispatch<Policy>::call(
@@ -307,7 +307,7 @@ namespace pika { namespace execution {
                 bulk_function_result<F, S, Ts...>::type>>
         bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
         {
-            pika::util::detail::thread_description desc(f, annotation_);
+            pika::detail::thread_description desc(f, annotation_);
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
             return parallel::execution::detail::

--- a/libs/pika/executors/include/pika/executors/parallel_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/parallel_executor.hpp
@@ -138,7 +138,7 @@ namespace pika { namespace execution {
         }
 
         constexpr explicit parallel_policy_executor(
-            threads::thread_pool_base* pool,
+            threads::detail::thread_pool_base* pool,
             execution::thread_priority priority =
                 execution::thread_priority::default_,
             execution::thread_stacksize stacksize =
@@ -335,7 +335,7 @@ namespace pika { namespace execution {
         /// \cond NOINTERNAL
         static constexpr std::size_t hierarchical_threshold_default_ = 6;
 
-        threads::thread_pool_base* pool_;
+        threads::detail::thread_pool_base* pool_;
         Policy policy_;
         std::size_t hierarchical_threshold_ = hierarchical_threshold_default_;
         char const* annotation_ = nullptr;

--- a/libs/pika/executors/include/pika/executors/restricted_thread_pool_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/restricted_thread_pool_executor.hpp
@@ -105,7 +105,7 @@ namespace pika { namespace parallel { namespace execution {
             typename pika::util::detail::invoke_deferred_result<F, Ts...>::type>
         async_execute(F&& f, Ts&&... ts)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
 
             auto policy = launch::async_policy(priority_, stacksize_,
                 pika::execution::thread_schedule_hint(get_next_thread_num()));
@@ -140,7 +140,7 @@ namespace pika { namespace parallel { namespace execution {
         template <typename F, typename... Ts>
         void post(F&& f, Ts&&... ts)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
 
             auto policy = launch::async_policy(priority_, stacksize_,
                 pika::execution::thread_schedule_hint(get_next_thread_num()));

--- a/libs/pika/executors/include/pika/executors/restricted_thread_pool_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/restricted_thread_pool_executor.hpp
@@ -175,7 +175,7 @@ namespace pika { namespace parallel { namespace execution {
         /// \endcond
 
     private:
-        threads::thread_pool_base* pool_ = nullptr;
+        threads::detail::thread_pool_base* pool_ = nullptr;
 
         pika::execution::thread_priority priority_ =
             pika::execution::thread_priority::default_;

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -29,7 +29,8 @@ namespace pika { namespace execution { namespace experimental {
     struct thread_pool_scheduler
     {
         constexpr thread_pool_scheduler() = default;
-        explicit thread_pool_scheduler(pika::threads::thread_pool_base* pool)
+        explicit thread_pool_scheduler(
+            pika::threads::detail::thread_pool_base* pool)
           : pool_(pool)
         {
         }
@@ -47,7 +48,7 @@ namespace pika { namespace execution { namespace experimental {
             return !(*this == rhs);
         }
 
-        pika::threads::thread_pool_base* get_thread_pool()
+        pika::threads::detail::thread_pool_base* get_thread_pool()
         {
             PIKA_ASSERT(pool_);
             return pool_;
@@ -331,7 +332,7 @@ namespace pika { namespace execution { namespace experimental {
             return "<unknown>";
         }
 
-        pika::threads::thread_pool_base* pool_ =
+        pika::threads::detail::thread_pool_base* pool_ =
             pika::threads::detail::get_self_or_default_pool();
         pika::execution::thread_priority priority_ =
             pika::execution::thread_priority::normal;

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -138,7 +138,7 @@ namespace pika { namespace execution { namespace experimental {
         template <typename F>
         void execute(F&& f, char const* fallback_annotation) const
         {
-            pika::util::detail::thread_description desc(f, fallback_annotation);
+            pika::detail::thread_description desc(f, fallback_annotation);
             threads::detail::thread_init_data data(
                 threads::detail::make_thread_function_nullary(
                     PIKA_FORWARD(F, f)),
@@ -315,11 +315,10 @@ namespace pika { namespace execution { namespace experimental {
                 pika::threads::detail::get_self_id();
             if (id)
             {
-                pika::util::detail::thread_description desc =
+                pika::detail::thread_description desc =
                     pika::threads::detail::get_thread_description(id);
                 if (desc.kind() ==
-                    pika::util::detail::thread_description::
-                        data_type_description)
+                    pika::detail::thread_description::data_type_description)
                 {
                     return desc.get_description();
                 }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -416,7 +416,7 @@ namespace pika::thread_pool_bulk_detail {
                     // bulk for thread_pool_scheduler we must currently be
                     // running on a pika thread.
                     PIKA_ASSERT(pika::threads::detail::get_self_id());
-                    pika::util::detail::thread_description desc =
+                    pika::detail::thread_description desc =
                         pika::threads::detail::get_thread_description(
                             pika::threads::detail::get_self_id());
 

--- a/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
@@ -172,7 +172,7 @@ int main()
         pika::detail::affinity_data ad{};
         ad.init(num_threads, max_cores, 0, 1, 0, "core", "balanced", true);
         pika::threads::callback_notifier notifier{};
-        pika::threads::thread_queue_init_parameters thread_queue_init{};
+        pika::threads::detail::thread_queue_init_parameters thread_queue_init{};
         sched_type::init_parameter_type scheduler_init(
             num_threads, ad, num_threads, thread_queue_init, "my_scheduler");
         pika::threads::detail::network_background_callback_type

--- a/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/pika/executors/tests/unit/standalone_thread_pool_executor.cpp
@@ -177,9 +177,9 @@ int main()
             num_threads, ad, num_threads, thread_queue_init, "my_scheduler");
         pika::threads::detail::network_background_callback_type
             network_callback{};
-        pika::threads::thread_pool_init_parameters thread_pool_init("my_pool",
-            0, pika::threads::scheduler_mode::default_mode, num_threads, 0,
-            notifier, ad, network_callback, 0,
+        pika::threads::detail::thread_pool_init_parameters thread_pool_init(
+            "my_pool", 0, pika::threads::scheduler_mode::default_mode,
+            num_threads, 0, notifier, ad, network_callback, 0,
             (std::numeric_limits<std::int64_t>::max)(),
             (std::numeric_limits<std::int64_t>::max)());
 

--- a/libs/pika/futures/include/pika/futures/detail/future_data.hpp
+++ b/libs/pika/futures/include/pika/futures/detail/future_data.hpp
@@ -876,8 +876,8 @@ namespace pika { namespace lcos { namespace detail {
 
         // run in a separate thread
         virtual threads::detail::thread_id_ref_type apply(
-            threads::thread_pool_base* /*pool*/, const char* /*annotation*/,
-            launch /*policy*/, error_code& /*ec*/)
+            threads::detail::thread_pool_base* /*pool*/,
+            const char* /*annotation*/, launch /*policy*/, error_code& /*ec*/)
         {
             PIKA_ASSERT(false);    // shouldn't ever be called
             return threads::detail::invalid_thread_id;

--- a/libs/pika/futures/include/pika/futures/futures_factory.hpp
+++ b/libs/pika/futures/include/pika/futures/futures_factory.hpp
@@ -105,7 +105,7 @@ namespace pika { namespace lcos { namespace local {
                         threads::detail::make_thread_function_nullary(
                             util::detail::deferred_call(
                                 &base_type::run_impl, PIKA_MOVE(this_))),
-                        util::detail::thread_description(f_, annotation),
+                        ::pika::detail::thread_description(f_, annotation),
                         policy.priority(),
                         execution::thread_schedule_hint(
                             static_cast<std::int16_t>(get_worker_thread_num())),
@@ -121,7 +121,7 @@ namespace pika { namespace lcos { namespace local {
                     threads::detail::make_thread_function_nullary(
                         util::detail::deferred_call(
                             &base_type::run_impl, PIKA_MOVE(this_))),
-                    util::detail::thread_description(f_, annotation),
+                    ::pika::detail::thread_description(f_, annotation),
                     policy.priority(), policy.hint(), policy.stacksize(),
                     threads::detail::thread_schedule_state::pending);
 

--- a/libs/pika/futures/include/pika/futures/futures_factory.hpp
+++ b/libs/pika/futures/include/pika/futures/futures_factory.hpp
@@ -93,7 +93,7 @@ namespace pika { namespace lcos { namespace local {
         protected:
             // run in a separate thread
             threads::detail::thread_id_ref_type apply(
-                threads::thread_pool_base* pool, const char* annotation,
+                threads::detail::thread_pool_base* pool, const char* annotation,
                 launch policy, error_code& ec) override
             {
                 this->check_started();
@@ -236,7 +236,7 @@ namespace pika { namespace lcos { namespace local {
         protected:
             // run in a separate thread
             threads::detail::thread_id_ref_type apply(
-                threads::thread_pool_base* pool, const char* annotation,
+                threads::detail::thread_pool_base* pool, const char* annotation,
                 launch policy, error_code& ec) override
             {
                 if (exec_)
@@ -736,7 +736,7 @@ namespace pika { namespace lcos { namespace local {
         }
 
         threads::detail::thread_id_ref_type apply(
-            threads::thread_pool_base* pool,
+            threads::detail::thread_pool_base* pool,
             const char* annotation = "futures_factory::apply",
             launch policy = launch::async, error_code& ec = throws) const
         {

--- a/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
@@ -288,7 +288,7 @@ namespace pika { namespace lcos { namespace detail {
             }
 
             pika::intrusive_ptr<continuation> this_(this);
-            pika::util::detail::thread_description desc(f_, "async");
+            pika::detail::thread_description desc(f_, "async");
             spawner(
                 [this_ = PIKA_MOVE(this_), f = PIKA_MOVE(f)]() mutable -> void {
                     this_->async_impl(PIKA_MOVE(f));
@@ -318,7 +318,7 @@ namespace pika { namespace lcos { namespace detail {
             }
 
             pika::intrusive_ptr<continuation> this_(this);
-            pika::util::detail::thread_description desc(f_, "async_nounwrap");
+            pika::detail::thread_description desc(f_, "async_nounwrap");
             spawner(
                 [this_ = PIKA_MOVE(this_), f = PIKA_MOVE(f)]() mutable -> void {
                     this_->async_impl_nounwrap(PIKA_MOVE(f));

--- a/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
+++ b/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
@@ -168,10 +168,11 @@ PIKA_EXPORT void itt_metadata_add(___itt_domain* domain, ___itt_id* id,
     ___itt_string_handle* key, void const* data) noexcept;
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::detail {
 
     struct thread_description;
-}}    // namespace pika::util
+
+}    // namespace pika::detail
 
 namespace pika { namespace util { namespace itt {
 
@@ -645,10 +646,11 @@ inline constexpr void itt_metadata_add(
 }
 
 //////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::detail {
 
     struct thread_description;
-}}    // namespace pika::util
+
+}    // namespace pika::detail
 
 namespace pika { namespace util { namespace itt {
 

--- a/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
@@ -228,7 +228,8 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
     // a user supplied scheduler attached
     rp.create_thread_pool(CUSTOM_POOL_NAME,
         [](pika::threads::detail::thread_pool_init_parameters init,
-            pika::threads::thread_queue_init_parameters thread_queue_init)
+            pika::threads::detail::thread_queue_init_parameters
+                thread_queue_init)
             -> std::unique_ptr<pika::threads::detail::thread_pool_base> {
             std::cout << "User defined scheduler creation callback "
                       << std::endl;

--- a/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
@@ -227,9 +227,9 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached
     rp.create_thread_pool(CUSTOM_POOL_NAME,
-        [](pika::threads::thread_pool_init_parameters init,
+        [](pika::threads::detail::thread_pool_init_parameters init,
             pika::threads::thread_queue_init_parameters thread_queue_init)
-            -> std::unique_ptr<pika::threads::thread_pool_base> {
+            -> std::unique_ptr<pika::threads::detail::thread_pool_base> {
             std::cout << "User defined scheduler creation callback "
                       << std::endl;
             high_priority_sched::init_parameter_type scheduler_init(
@@ -240,7 +240,7 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
 
             init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
 
-            std::unique_ptr<pika::threads::thread_pool_base> pool(
+            std::unique_ptr<pika::threads::detail::thread_pool_base> pool(
                 new pika::threads::detail::scheduled_thread_pool<
                     high_priority_sched>(std::move(scheduler), init));
             return pool;

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -235,10 +235,9 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
     {
         // we use unspecified as the scheduler type and it will be set according to
         // the --pika:queuing=xxx option or default.
-        std::uint32_t deft = pika::threads::scheduler_mode::default_mode;
+        auto deft = ::pika::threads::scheduler_mode::default_mode;
         rp.create_thread_pool(pool_name,
-            pika::resource::scheduling_policy::shared_priority,
-            pika::threads::scheduler_mode(deft));
+            pika::resource::scheduling_policy::shared_priority, deft);
         // add N pus to network pool
         int count = 0;
         for (pika::resource::numa_domain const& d : rp.numa_domains())
@@ -257,9 +256,8 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
             }
         }
 
-        rp.create_thread_pool("default",
-            pika::resource::scheduling_policy::unspecified,
-            pika::threads::scheduler_mode(deft));
+        rp.create_thread_pool(
+            "default", pika::resource::scheduling_policy::unspecified, deft);
     }
 }
 

--- a/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -35,7 +35,6 @@ static std::string const pool_name = "mpi";
 // this is our custom scheduler type
 using numa_scheduler = pika::threads::shared_priority_queue_scheduler<>;
 using namespace pika::threads;
-using pika::threads::scheduler_mode;
 
 // ------------------------------------------------------------------------
 // dummy function we will call using async
@@ -223,10 +222,9 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
     {
         // we use unspecified as the scheduler type and it will be set according to
         // the --pika:queuing=xxx option or default.
-        std::uint32_t deft = pika::threads::scheduler_mode::default_mode;
+        auto deft = ::pika::threads::scheduler_mode::default_mode;
         rp.create_thread_pool(pool_name,
-            pika::resource::scheduling_policy::shared_priority,
-            pika::threads::scheduler_mode(deft));
+            pika::resource::scheduling_policy::shared_priority, deft);
         // add N pus to network pool
         int count = 0;
         for (pika::resource::numa_domain const& d : rp.numa_domains())
@@ -245,9 +243,8 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
             }
         }
 
-        rp.create_thread_pool("default",
-            pika::resource::scheduling_policy::unspecified,
-            pika::threads::scheduler_mode(deft));
+        rp.create_thread_pool(
+            "default", pika::resource::scheduling_policy::unspecified, deft);
     }
 }
 

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -49,9 +49,9 @@ namespace pika { namespace resource {
         mode_allow_dynamic_pools = 2
     };
 
-    using scheduler_function =
-        util::detail::function<std::unique_ptr<pika::threads::thread_pool_base>(
-            pika::threads::thread_pool_init_parameters,
+    using scheduler_function = util::detail::function<
+        std::unique_ptr<pika::threads::detail::thread_pool_base>(
+            pika::threads::detail::thread_pool_init_parameters,
             pika::threads::thread_queue_init_parameters)>;
 
     // Choose same names as in command-line options except with _ instead of

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -52,7 +52,7 @@ namespace pika { namespace resource {
     using scheduler_function = util::detail::function<
         std::unique_ptr<pika::threads::detail::thread_pool_base>(
             pika::threads::detail::thread_pool_init_parameters,
-            pika::threads::thread_queue_init_parameters)>;
+            pika::threads::detail::thread_queue_init_parameters)>;
 
     // Choose same names as in command-line options except with _ instead of
     // -.

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -244,7 +244,8 @@ namespace pika { namespace resource { namespace detail {
                 threads::scheduler_mode(pika::util::from_string<std::size_t>(
                     default_scheduler_mode_str));
             PIKA_ASSERT_MSG((default_scheduler_mode_ &
-                                ~threads::scheduler_mode::all_flags) == 0,
+                                ~threads::scheduler_mode::all_flags) ==
+                    threads::scheduler_mode{},
                 "pika.default_scheduler_mode contains unknown scheduler "
                 "modes");
         }

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -65,21 +65,19 @@ int pika_main()
     if (std::string("core-shared_priority_queue_scheduler") ==
         sched->get_description())
     {
+        using ::pika::threads::scheduler_mode;
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::enable_stealing |
-                pika::threads::scheduler_mode::enable_stealing_numa |
-                pika::threads::scheduler_mode::assign_work_thread_parent |
-                pika::threads::scheduler_mode::steal_after_local),
+            scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_after_local,
             // remove these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::assign_work_round_robin |
-                pika::threads::scheduler_mode::steal_high_priority_first));
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_high_priority_first);
+        sched->update_scheduler_mode(scheduler_mode::enable_stealing, false);
         sched->update_scheduler_mode(
-            pika::threads::scheduler_mode::enable_stealing, false);
-        sched->update_scheduler_mode(
-            pika::threads::scheduler_mode::enable_stealing_numa, false);
+            scheduler_mode::enable_stealing_numa, false);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -69,12 +69,12 @@ int pika_main()
         sched->add_remove_scheduler_mode(
             // add these flags
             scheduler_mode::enable_stealing |
-            scheduler_mode::enable_stealing_numa |
-            scheduler_mode::assign_work_thread_parent |
-            scheduler_mode::steal_after_local,
+                scheduler_mode::enable_stealing_numa |
+                scheduler_mode::assign_work_thread_parent |
+                scheduler_mode::steal_after_local,
             // remove these flags
             scheduler_mode::assign_work_round_robin |
-            scheduler_mode::steal_high_priority_first);
+                scheduler_mode::steal_high_priority_first);
         sched->update_scheduler_mode(scheduler_mode::enable_stealing, false);
         sched->update_scheduler_mode(
             scheduler_mode::enable_stealing_numa, false);

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -67,17 +67,19 @@ int pika_main()
     {
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(pika::threads::enable_stealing |
-                pika::threads::enable_stealing_numa |
-                pika::threads::assign_work_thread_parent |
-                pika::threads::steal_after_local),
+            pika::threads::scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing |
+                pika::threads::scheduler_mode::enable_stealing_numa |
+                pika::threads::scheduler_mode::assign_work_thread_parent |
+                pika::threads::scheduler_mode::steal_after_local),
             // remove these flags
             pika::threads::scheduler_mode(
-                pika::threads::assign_work_round_robin |
-                pika::threads::steal_high_priority_first));
-        sched->update_scheduler_mode(pika::threads::enable_stealing, false);
+                pika::threads::scheduler_mode::assign_work_round_robin |
+                pika::threads::scheduler_mode::steal_high_priority_first));
         sched->update_scheduler_mode(
-            pika::threads::enable_stealing_numa, false);
+            pika::threads::scheduler_mode::enable_stealing, false);
+        sched->update_scheduler_mode(
+            pika::threads::scheduler_mode::enable_stealing_numa, false);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/resource_partitioner_info.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/resource_partitioner_info.cpp
@@ -29,7 +29,7 @@ int pika_main()
     PIKA_TEST_EQ(std::string("default"), pika::resource::get_pool_name(0));
 
     {
-        pika::threads::thread_pool_base& pool =
+        pika::threads::detail::thread_pool_base& pool =
             pika::resource::get_thread_pool(0);
         PIKA_TEST_EQ(std::size_t(0), pool.get_pool_index());
         PIKA_TEST_EQ(std::string("default"), pool.get_pool_name());
@@ -37,7 +37,7 @@ int pika_main()
     }
 
     {
-        pika::threads::thread_pool_base& pool =
+        pika::threads::detail::thread_pool_base& pool =
             pika::resource::get_thread_pool("default");
         PIKA_TEST_EQ(std::size_t(0), pool.get_pool_index());
         PIKA_TEST_EQ(std::string("default"), pool.get_pool_name());

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
         // setup the default pool with a numa/binding aware scheduler
         rp.create_thread_pool("default",
             pika::resource::scheduling_policy::shared_priority,
-            pika::threads::scheduler_mode(pika::threads::default_mode));
+            pika::threads::scheduler_mode::default_mode);
     };
 
     return pika::init(pika_main, argc, argv, init_args);

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -62,17 +62,16 @@ int pika_main(variables_map& vm)
         sched->add_remove_scheduler_mode(
             // add these flags
             scheduler_mode::enable_stealing |
-            scheduler_mode::enable_stealing_numa |
-            scheduler_mode::assign_work_round_robin |
-            scheduler_mode::steal_high_priority_first,
+                scheduler_mode::enable_stealing_numa |
+                scheduler_mode::assign_work_round_robin |
+                scheduler_mode::steal_high_priority_first,
             // remove these flags
             scheduler_mode::assign_work_thread_parent |
-            scheduler_mode::steal_after_local |
-            scheduler_mode::do_background_work |
-            scheduler_mode::reduce_thread_priority |
-            scheduler_mode::delay_exit |
-            scheduler_mode::fast_idle_mode |
-            scheduler_mode::enable_elasticity);
+                scheduler_mode::steal_after_local |
+                scheduler_mode::do_background_work |
+                scheduler_mode::reduce_thread_priority |
+                scheduler_mode::delay_exit | scheduler_mode::fast_idle_mode |
+                scheduler_mode::enable_elasticity);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -60,18 +60,20 @@ int pika_main(variables_map& vm)
         std::cout << "Setting shared-priority mode flags" << std::endl;
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(pika::threads::enable_stealing |
-                pika::threads::enable_stealing_numa |
-                pika::threads::assign_work_round_robin |
-                pika::threads::steal_high_priority_first),
+            pika::threads::scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing |
+                pika::threads::scheduler_mode::enable_stealing_numa |
+                pika::threads::scheduler_mode::assign_work_round_robin |
+                pika::threads::scheduler_mode::steal_high_priority_first),
             // remove these flags
             pika::threads::scheduler_mode(
-                pika::threads::assign_work_thread_parent |
-                pika::threads::steal_after_local |
-                pika::threads::do_background_work |
-                pika::threads::reduce_thread_priority |
-                pika::threads::delay_exit | pika::threads::fast_idle_mode |
-                pika::threads::enable_elasticity));
+                pika::threads::scheduler_mode::assign_work_thread_parent |
+                pika::threads::scheduler_mode::steal_after_local |
+                pika::threads::scheduler_mode::do_background_work |
+                pika::threads::scheduler_mode::reduce_thread_priority |
+                pika::threads::scheduler_mode::delay_exit |
+                pika::threads::scheduler_mode::fast_idle_mode |
+                pika::threads::scheduler_mode::enable_elasticity));
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -57,23 +57,22 @@ int pika_main(variables_map& vm)
     if (std::string("core-shared_priority_queue_scheduler") ==
         sched->get_description())
     {
+        using ::pika::threads::scheduler_mode;
         std::cout << "Setting shared-priority mode flags" << std::endl;
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::enable_stealing |
-                pika::threads::scheduler_mode::enable_stealing_numa |
-                pika::threads::scheduler_mode::assign_work_round_robin |
-                pika::threads::scheduler_mode::steal_high_priority_first),
+            scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_high_priority_first,
             // remove these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::assign_work_thread_parent |
-                pika::threads::scheduler_mode::steal_after_local |
-                pika::threads::scheduler_mode::do_background_work |
-                pika::threads::scheduler_mode::reduce_thread_priority |
-                pika::threads::scheduler_mode::delay_exit |
-                pika::threads::scheduler_mode::fast_idle_mode |
-                pika::threads::scheduler_mode::enable_elasticity));
+            scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_after_local |
+            scheduler_mode::do_background_work |
+            scheduler_mode::reduce_thread_priority |
+            scheduler_mode::delay_exit |
+            scheduler_mode::fast_idle_mode |
+            scheduler_mode::enable_elasticity);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -57,12 +57,12 @@ void test_scheduler(
 {
     pika::init_params init_args;
 
+    using ::pika::threads::scheduler_mode;
     init_args.cfg = {"pika.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler,
-            pika::threads::scheduler_mode(pika::threads::default_mode |
-                pika::threads::enable_elasticity));
+            scheduler_mode::default_mode | scheduler_mode::enable_elasticity);
     };
 
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -31,7 +31,7 @@ int pika_main()
 
     PIKA_TEST_EQ(std::size_t(max_threads), num_threads);
 
-    pika::threads::thread_pool_base& tp =
+    pika::threads::detail::thread_pool_base& tp =
         pika::resource::get_thread_pool("default");
 
     PIKA_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(max_threads));

--- a/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
@@ -48,6 +48,7 @@ int main(int argc, char* argv[])
 {
     pika::init_params init_args;
 
+    using ::pika::threads::scheduler_mode;
     init_args.cfg = {"pika.os_threads=" +
         std::to_string(((std::min)(std::size_t(4),
             std::size_t(pika::threads::detail::hardware_concurrency()))))};
@@ -56,8 +57,7 @@ int main(int argc, char* argv[])
         // Explicitly disable elasticity if it is in defaults
         rp.create_thread_pool("default",
             pika::resource::scheduling_policy::local_priority_fifo,
-            pika::threads::scheduler_mode(pika::threads::default_mode &
-                ~pika::threads::enable_elasticity));
+            scheduler_mode::default_mode & ~scheduler_mode::enable_elasticity);
     };
 
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_disabled.cpp
@@ -25,7 +25,7 @@ int pika_main()
 
     try
     {
-        pika::threads::thread_pool_base& tp =
+        pika::threads::detail::thread_pool_base& tp =
             pika::resource::get_thread_pool("default");
 
         // Use .get() to throw exception

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -48,7 +48,7 @@ int pika_main()
 
     PIKA_TEST(exception_thrown);
 
-    pika::threads::thread_pool_base& worker_pool =
+    pika::threads::detail::thread_pool_base& worker_pool =
         pika::resource::get_thread_pool("worker");
     pika::execution::parallel_executor worker_exec(
         &pika::resource::get_thread_pool("worker"));

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -40,7 +40,7 @@ void test_scheduler(
 
     pika::start(nullptr, argc, argv, init_args);
 
-    pika::threads::thread_pool_base& default_pool =
+    pika::threads::detail::thread_pool_base& default_pool =
         pika::resource::get_thread_pool("default");
     std::size_t const default_pool_threads =
         pika::resource::get_num_threads("default");

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -15,7 +15,6 @@
 #include <pika/testing.hpp>
 #include <pika/thread.hpp>
 #include <pika/thread_pool_util/thread_pool_suspension_helpers.hpp>
-#include <pika/threading_base/scheduler_mode.hpp>
 #include <pika/threading_base/thread_helpers.hpp>
 
 #include <atomic>

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -208,13 +208,13 @@ int pika_main()
 void test_scheduler(
     int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    using ::pika::threads::scheduler_mode;
     pika::init_params init_args;
     init_args.cfg = {"pika.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler,
-            pika::threads::scheduler_mode(pika::threads::default_mode |
-                pika::threads::enable_elasticity));
+            scheduler_mode::default_mode | scheduler_mode::enable_elasticity);
     };
 
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -33,7 +33,7 @@ int pika_main()
 
     PIKA_TEST_EQ(std::size_t(max_threads), num_threads);
 
-    pika::threads::thread_pool_base& tp =
+    pika::threads::detail::thread_pool_base& tp =
         pika::resource::get_thread_pool("default");
 
     PIKA_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(max_threads));

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -33,7 +33,7 @@ int pika_main()
 
     PIKA_TEST_EQ(std::size_t(max_threads - 1), num_threads);
 
-    pika::threads::thread_pool_base& tp =
+    pika::threads::detail::thread_pool_base& tp =
         pika::resource::get_thread_pool("worker");
 
     {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -163,12 +163,12 @@ void test_scheduler(
 {
     pika::init_params init_args;
 
+    using ::pika::threads::scheduler_mode;
     init_args.cfg = {"pika.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("worker", scheduler,
-            pika::threads::scheduler_mode(pika::threads::default_mode |
-                pika::threads::enable_elasticity));
+            scheduler_mode::default_mode | scheduler_mode::enable_elasticity);
 
         std::size_t const worker_pool_threads = max_threads - 1;
         std::size_t worker_pool_threads_added = 0;

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -31,7 +31,7 @@ std::size_t const max_threads = (std::min)(
 
 int pika_main(int argc, char* argv[])
 {
-    pika::threads::thread_pool_base& worker_pool =
+    pika::threads::detail::thread_pool_base& worker_pool =
         pika::resource::get_thread_pool("default");
     std::cout << "Starting test with scheduler "
               << worker_pool.get_scheduler()->get_description() << std::endl;
@@ -39,7 +39,7 @@ int pika_main(int argc, char* argv[])
 
     PIKA_TEST_EQ(max_threads, num_threads);
 
-    pika::threads::thread_pool_base& tp =
+    pika::threads::detail::thread_pool_base& tp =
         pika::resource::get_thread_pool("default");
 
     {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -115,14 +115,14 @@ void test_scheduler(
 {
     pika::init_params init_args;
 
+    using ::pika::threads::scheduler_mode;
     init_args.cfg = {"pika.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp) {
         std::cout << "\nCreating pool with scheduler " << scheduler
                   << std::endl;
 
         rp.create_thread_pool("default", scheduler,
-            pika::threads::scheduler_mode(pika::threads::default_mode |
-                pika::threads::enable_elasticity));
+            scheduler_mode::default_mode | scheduler_mode::enable_elasticity);
     };
 
     PIKA_TEST_EQ(pika::init(pika_main, argc, argv, init_args), 0);

--- a/libs/pika/resource_partitioner/tests/unit/used_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/used_pus.cpp
@@ -19,7 +19,7 @@
 int pika_main()
 {
     std::size_t num_threads = pika::resource::get_num_threads("default");
-    pika::threads::thread_pool_base& tp =
+    pika::threads::detail::thread_pool_base& tp =
         pika::resource::get_thread_pool("default");
 
     auto used_pu_mask = tp.get_used_processing_units();

--- a/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
@@ -82,7 +82,7 @@ namespace pika {
     ///
     /// This function returns whether the runtime system is currently being
     /// started or not, e.g. whether the current state of the runtime system is
-    /// \a pika::state_startup
+    /// \a pika::state::startup
     ///
     /// \note   This function needs to be executed on a pika-thread. It will
     ///         return false otherwise.
@@ -100,7 +100,7 @@ namespace pika {
     ///
     /// This function returns whether the runtime system is currently running
     /// or not, e.g.  whether the current state of the runtime system is
-    /// \a pika::state_running
+    /// \a pika::state::running
     ///
     /// \note   This function needs to be executed on a pika-thread. It will
     ///         return false otherwise.
@@ -111,7 +111,7 @@ namespace pika {
     ///
     /// This function returns whether the runtime system is currently stopped
     /// or not, e.g.  whether the current state of the runtime system is
-    /// \a pika::state_stopped
+    /// \a pika::state::stopped
     ///
     /// \note   This function needs to be executed on a pika-thread. It will
     ///         return false otherwise.
@@ -122,7 +122,7 @@ namespace pika {
     ///
     /// This function returns whether the runtime system is currently being
     /// shut down or not, e.g.  whether the current state of the runtime system
-    /// is \a pika::state_stopped or \a pika::state_shutdown
+    /// is \a pika::state::stopped or \a pika::state::shutdown
     ///
     /// \note   This function needs to be executed on a pika-thread. It will
     ///         return false otherwise.

--- a/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
@@ -27,7 +27,7 @@ namespace pika { namespace detail {
     PIKA_EXPORT void registered_locks_error_handler();
     PIKA_EXPORT bool register_locks_predicate();
 #endif
-    PIKA_EXPORT threads::thread_pool_base* get_default_pool();
+    PIKA_EXPORT threads::detail::thread_pool_base* get_default_pool();
     PIKA_EXPORT threads::detail::mask_cref_type get_pu_mask(
         threads::detail::topology& topo, std::size_t thread_num);
 }}    // namespace pika::detail

--- a/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
@@ -41,11 +41,11 @@ namespace pika { namespace resource {
     PIKA_EXPORT std::string const& get_pool_name(std::size_t pool_index);
 
     /// Return the name of the pool given its name
-    PIKA_EXPORT threads::thread_pool_base& get_thread_pool(
+    PIKA_EXPORT threads::detail::thread_pool_base& get_thread_pool(
         std::string const& pool_name);
 
     /// Return the thread pool given its internal index
-    PIKA_EXPORT threads::thread_pool_base& get_thread_pool(
+    PIKA_EXPORT threads::detail::thread_pool_base& get_thread_pool(
         std::size_t pool_index);
 
     /// Return true if the pool with the given name exists

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -389,7 +389,8 @@ namespace pika {
                 state rts_state = rt->get_state();
                 state_name = pika::detail::get_runtime_state_name(rts_state);
 
-                if (rts_state >= state_initialized && rts_state < state_stopped)
+                if (rts_state >= state::initialized &&
+                    rts_state < state::stopped)
                 {
                     hostname = get_runtime().here();
                 }
@@ -408,7 +409,7 @@ namespace pika {
                 threads::detail::get_self_ptr();
             if (nullptr != self)
             {
-                if (threads::thread_manager_is(state_running))
+                if (threads::thread_manager_is(state::running))
                     shepherd = pika::get_worker_thread_num();
 
                 thread_id = threads::detail::get_self_id();

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -403,7 +403,7 @@ namespace pika {
 
             std::size_t shepherd = std::size_t(-1);
             threads::detail::thread_id_type thread_id;
-            util::detail::thread_description thread_name;
+            detail::thread_description thread_name;
 
             threads::detail::thread_self* self =
                 threads::detail::get_self_ptr();
@@ -428,8 +428,7 @@ namespace pika {
                 pika::detail::throw_shepherd(shepherd),
                 pika::detail::throw_thread_id(
                     reinterpret_cast<std::size_t>(thread_id.get())),
-                pika::detail::throw_thread_name(
-                    util::detail::as_string(thread_name)),
+                pika::detail::throw_thread_name(detail::as_string(thread_name)),
                 pika::detail::throw_function(func),
                 pika::detail::throw_file(file), pika::detail::throw_line(line),
                 pika::detail::throw_env(env),

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -129,7 +129,7 @@ namespace pika { namespace detail {
     }
 #endif
 
-    threads::thread_pool_base* get_default_pool()
+    threads::detail::thread_pool_base* get_default_pool()
     {
         pika::runtime* rt = get_runtime_ptr();
         if (rt == nullptr)

--- a/libs/pika/runtime/src/state.cpp
+++ b/libs/pika/runtime/src/state.cpp
@@ -20,7 +20,7 @@ namespace pika { namespace threads {
         if (nullptr == rt)
         {
             // we're probably either starting or stopping
-            return st <= state_starting || st >= state_stopping;
+            return st <= state::starting || st >= state::stopping;
         }
         return (rt->get_thread_manager().status() == st);
     }

--- a/libs/pika/runtime/src/thread_pool_helpers.cpp
+++ b/libs/pika/runtime/src/thread_pool_helpers.cpp
@@ -51,12 +51,13 @@ namespace pika { namespace resource {
         return get_partitioner().get_pool_name(pool_index);
     }
 
-    threads::thread_pool_base& get_thread_pool(std::string const& pool_name)
+    threads::detail::thread_pool_base& get_thread_pool(
+        std::string const& pool_name)
     {
         return get_runtime().get_thread_manager().get_pool(pool_name);
     }
 
-    threads::thread_pool_base& get_thread_pool(std::size_t pool_index)
+    threads::detail::thread_pool_base& get_thread_pool(std::size_t pool_index)
     {
         return get_thread_pool(get_pool_name(pool_index));
     }

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -80,7 +80,7 @@ namespace pika::threads {
             init_parameter(std::size_t num_queues,
                 pika::detail::affinity_data const& affinity_data,
                 std::size_t num_high_priority_queues = std::size_t(-1),
-                thread_queue_init_parameters thread_queue_init = {},
+                detail::thread_queue_init_parameters thread_queue_init = {},
                 char const* description = "local_priority_queue_scheduler")
               : num_queues_(num_queues)
               , num_high_priority_queues_(
@@ -106,7 +106,7 @@ namespace pika::threads {
 
             std::size_t num_queues_;
             std::size_t num_high_priority_queues_;
-            thread_queue_init_parameters thread_queue_init_;
+            detail::thread_queue_init_parameters thread_queue_init_;
             pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -1350,7 +1350,7 @@ namespace pika::threads {
             });
 
             // check for the rest and if we are NUMA aware
-            if (has_scheduler_mode(enable_stealing_numa) &&
+            if (has_scheduler_mode(scheduler_mode::enable_stealing_numa) &&
                 ::pika::threads::detail::any(first_mask & pu_mask))
             {
                 iterate([&](std::size_t other_num_thread) {

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -62,7 +62,8 @@ namespace pika::threads {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_local_priority_queue_scheduler_terminated_queue>
-    class PIKA_EXPORT local_priority_queue_scheduler : public scheduler_base
+    class PIKA_EXPORT local_priority_queue_scheduler
+      : public detail::scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -113,7 +114,7 @@ namespace pika::threads {
 
         local_priority_queue_scheduler(init_parameter_type const& init,
             bool deferred_initialization = true)
-          : scheduler_base(
+          : detail::scheduler_base(
                 init.num_queues_, init.description_, init.thread_queue_init_)
           , curr_queue_(0)
           , affinity_data_(init.affinity_data_)

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -327,7 +327,7 @@ namespace pika::threads {
         /// available
         virtual bool get_next_thread(std::size_t num_thread, bool running,
             threads::detail::thread_id_ref_type& thrd,
-            bool /*enable_stealing*/) override
+            bool /*scheduler_mode::enable_stealing*/) override
         {
             std::size_t queues_size = queues_.size();
 
@@ -355,7 +355,8 @@ namespace pika::threads {
                 return false;
             }
 
-            bool numa_stealing = has_scheduler_mode(enable_stealing_numa);
+            bool numa_stealing =
+                has_scheduler_mode(scheduler_mode::enable_stealing_numa);
             if (!numa_stealing)
             {
                 // steal work items: first try to steal from other cores in
@@ -703,7 +704,8 @@ namespace pika::threads {
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
         virtual bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count, bool /* enable_stealing */,
+            std::int64_t& idle_loop_count,
+            bool /* scheduler_mode::enable_stealing */,
             std::size_t& added) override
         {
             std::size_t queues_size = queues_.size();
@@ -724,7 +726,8 @@ namespace pika::threads {
                 return true;
             }
 
-            bool numa_stealing_ = has_scheduler_mode(enable_stealing_numa);
+            bool numa_stealing_ =
+                has_scheduler_mode(scheduler_mode::enable_stealing_numa);
             // limited or no stealing across domains
             if (!numa_stealing_)
             {
@@ -904,7 +907,8 @@ namespace pika::threads {
             else
                 first_mask = core_mask;
 
-            bool numa_stealing = has_scheduler_mode(enable_stealing_numa);
+            bool numa_stealing =
+                has_scheduler_mode(scheduler_mode::enable_stealing_numa);
             if (numa_stealing &&
                 ::pika::threads::detail::any(first_mask & core_mask))
             {

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -54,7 +54,7 @@ namespace pika::threads {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_local_queue_scheduler_terminated_queue>
-    class PIKA_EXPORT local_queue_scheduler : public scheduler_base
+    class PIKA_EXPORT local_queue_scheduler : public detail::scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -94,7 +94,7 @@ namespace pika::threads {
 
         local_queue_scheduler(init_parameter_type const& init,
             bool deferred_initialization = true)
-          : scheduler_base(
+          : detail::scheduler_base(
                 init.num_queues_, init.description_, init.thread_queue_init_)
           , queues_(init.num_queues_)
           , curr_queue_(0)

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -66,7 +66,7 @@ namespace pika::threads {
         {
             init_parameter(std::size_t num_queues,
                 pika::detail::affinity_data const& affinity_data,
-                thread_queue_init_parameters thread_queue_init = {},
+                detail::thread_queue_init_parameters thread_queue_init = {},
                 char const* description = "local_queue_scheduler")
               : num_queues_(num_queues)
               , thread_queue_init_(thread_queue_init)
@@ -86,7 +86,7 @@ namespace pika::threads {
             }
 
             std::size_t num_queues_;
-            thread_queue_init_parameters thread_queue_init_;
+            detail::thread_queue_init_parameters thread_queue_init_;
             pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -153,7 +153,7 @@ namespace pika::threads {
             std::atomic<std::int32_t>>
             terminated_items_count_;
 
-        thread_queue_init_parameters parameters_;
+        detail::thread_queue_init_parameters parameters_;
         std::thread::id owner_id_;
 
         // ------------------------------------------------------------
@@ -209,7 +209,8 @@ namespace pika::threads {
         queue_holder_thread(QueueType* bp_queue, QueueType* hp_queue,
             QueueType* np_queue, QueueType* lp_queue, std::size_t domain,
             std::size_t queue, std::size_t thread_num, std::size_t owner,
-            const thread_queue_init_parameters& init, std::thread::id owner_id)
+            const detail::thread_queue_init_parameters& init,
+            std::thread::id owner_id)
           // NOLINTEND(bugprone-easily-swappable-parameters)
           : bp_queue_(bp_queue)
           , hp_queue_(hp_queue)

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -107,7 +107,7 @@ namespace pika::threads {
             init_parameter(std::size_t num_worker_threads,
                 const core_ratios& cores_per_queue,
                 pika::detail::affinity_data const& affinity_data,
-                const thread_queue_init_parameters& thread_queue_init,
+                const detail::thread_queue_init_parameters& thread_queue_init,
                 char const* description = "shared_priority_queue_scheduler")
               : num_worker_threads_(num_worker_threads)
               , cores_per_queue_(cores_per_queue)
@@ -131,7 +131,7 @@ namespace pika::threads {
 
             std::size_t num_worker_threads_;
             core_ratios cores_per_queue_;
-            thread_queue_init_parameters thread_queue_init_;
+            detail::thread_queue_init_parameters thread_queue_init_;
             pika::detail::affinity_data const& affinity_data_;
             char const* description_;
         };
@@ -1443,7 +1443,7 @@ namespace pika::threads {
 
         pika::detail::affinity_data const& affinity_data_;
 
-        const thread_queue_init_parameters queue_parameters_;
+        const detail::thread_queue_init_parameters queue_parameters_;
 
         // used to make sure the scheduler is only initialized once on a thread
         std::mutex init_mutex;

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -93,7 +93,7 @@ namespace pika::threads {
     ///
     /// Warning: PendingQueuing lifo causes lockup on termination
     template <typename Mutex = std::mutex>
-    class shared_priority_queue_scheduler : public scheduler_base
+    class shared_priority_queue_scheduler : public detail::scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -138,7 +138,7 @@ namespace pika::threads {
         using init_parameter_type = init_parameter;
 
         explicit shared_priority_queue_scheduler(init_parameter const& init)
-          : scheduler_base(init.num_worker_threads_, init.description_,
+          : detail::scheduler_base(init.num_worker_threads_, init.description_,
                 init.thread_queue_init_)
           , d_lookup_(pika::threads::detail::hardware_concurrency())
           , q_lookup_(pika::threads::detail::hardware_concurrency())
@@ -170,7 +170,7 @@ namespace pika::threads {
         /// and then sets some flags we need later for scheduling
         void set_scheduler_mode(scheduler_mode mode) override
         {
-            scheduler_base::set_scheduler_mode(mode);
+            detail::scheduler_base::set_scheduler_mode(mode);
             round_robin_ = mode & assign_work_round_robin;
             steal_hp_first_ = mode & steal_high_priority_first;
             core_stealing_ = mode & enable_stealing;

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -171,10 +171,14 @@ namespace pika::threads {
         void set_scheduler_mode(scheduler_mode mode) override
         {
             detail::scheduler_base::set_scheduler_mode(mode);
-            round_robin_ = mode & assign_work_round_robin;
-            steal_hp_first_ = mode & steal_high_priority_first;
-            core_stealing_ = mode & enable_stealing;
-            numa_stealing_ = mode & enable_stealing_numa;
+            round_robin_ =
+                has_scheduler_mode(scheduler_mode::assign_work_round_robin);
+            steal_hp_first_ =
+                has_scheduler_mode(scheduler_mode::steal_high_priority_first);
+            core_stealing_ =
+                has_scheduler_mode(scheduler_mode::enable_stealing);
+            numa_stealing_ =
+                has_scheduler_mode(scheduler_mode::enable_stealing_numa);
             // clang-format off
             DEBUG(spq_deb<5>,debug(debug::detail::str<>("scheduler_mode")
                 , round_robin_ ? "round_robin" : "thread parent"
@@ -322,8 +326,9 @@ namespace pika::threads {
                     }
                     DEBUG(spq_deb<7>,
                         debug(debug::detail::str<>("create_thread"),
-                            "assign_work_thread_parent", "thread_num",
-                            thread_num, "pool", parent_pool_->get_pool_name()));
+                            "scheduler_mode::assign_work_thread_parent",
+                            "thread_num", thread_num, "pool",
+                            parent_pool_->get_pool_name()));
                 }
                 else /*(round_robin)*/
                 {
@@ -331,8 +336,9 @@ namespace pika::threads {
                     q_index = q_lookup_[thread_num];
                     DEBUG(spq_deb<7>,
                         debug(debug::detail::str<>("create_thread"),
-                            "assign_work_round_robin", "thread_num", thread_num,
-                            "pool", parent_pool_->get_pool_name(),
+                            "scheduler_mode::assign_work_round_robin",
+                            "thread_num", thread_num, "pool",
+                            parent_pool_->get_pool_name(),
                             typename thread_holder_type::queue_data_print(
                                 numa_holder_[domain_num].thread_queue(
                                     static_cast<std::size_t>(q_index)))));
@@ -470,7 +476,8 @@ namespace pika::threads {
                     {
                         DEBUG(spq_deb<5>,
                             debug(debug::detail::str<>(prefix),
-                                "steal_high_priority_first BP/HP",
+                                "scheduler_mode::steal_high_priority_first "
+                                "BP/HP",
                                 (d == 0 ? "taken" : "stolen"), "D",
                                 debug::detail::dec<2>(domain), "Q",
                                 debug::detail::dec<3>(q_index)));
@@ -490,7 +497,8 @@ namespace pika::threads {
                     {
                         DEBUG(spq_deb<5>,
                             debug(debug::detail::str<>(prefix),
-                                "steal_high_priority_first NP/LP",
+                                "scheduler_mode::steal_high_priority_first "
+                                "NP/LP",
                                 (d == 0 ? "taken" : "stolen"), "D",
                                 debug::detail::dec<2>(domain), "Q",
                                 debug::detail::dec<3>(q_index)));
@@ -501,7 +509,7 @@ namespace pika::threads {
                         break;
                 }
             }
-            else /*steal_after_local*/
+            else /*scheduler_mode::steal_after_local*/
             {
                 // do this local core/queue
                 result =
@@ -512,8 +520,8 @@ namespace pika::threads {
                 {
                     DEBUG(spq_deb<5>,
                         debug(debug::detail::str<>(prefix),
-                            "steal_after_local local taken", "D",
-                            debug::detail::dec<2>(domain), "Q",
+                            "scheduler_mode::steal_after_local local taken",
+                            "D", debug::detail::dec<2>(domain), "Q",
                             debug::detail::dec<3>(q_index)));
                     return result;
                 }
@@ -533,8 +541,10 @@ namespace pika::threads {
                         {
                             DEBUG(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
-                                    "steal_after_local this numa", "stolen",
-                                    "D", debug::detail::dec<2>(domain), "Q",
+                                    "scheduler_mode::steal_after_local this "
+                                    "numa",
+                                    "stolen", "D",
+                                    debug::detail::dec<2>(domain), "Q",
                                     debug::detail::dec<3>(q_index)));
                             return result;
                         }
@@ -554,7 +564,8 @@ namespace pika::threads {
                         {
                             DEBUG(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
-                                    "steal_after_local other numa BP/HP",
+                                    "scheduler_mode::steal_after_local other "
+                                    "numa BP/HP",
                                     (d == 0 ? "taken" : "stolen"), "D",
                                     debug::detail::dec<2>(domain), "Q",
                                     debug::detail::dec<3>(q_index)));
@@ -572,7 +583,8 @@ namespace pika::threads {
                         {
                             DEBUG(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
-                                    "steal_after_local other numa NP/LP",
+                                    "scheduler_mode::steal_after_local other "
+                                    "numa NP/LP",
                                     (d == 0 ? "taken" : "stolen"), "D",
                                     debug::detail::dec<2>(domain), "Q",
                                     debug::detail::dec<3>(q_index)));
@@ -753,8 +765,8 @@ namespace pika::threads {
                     q_index = q_lookup_[thread_num];
                     DEBUG(spq_deb<5>,
                         debug(debug::detail::str<>("schedule_thread"),
-                            "assign_work_thread_parent", "thread_num",
-                            thread_num,
+                            "scheduler_mode::assign_work_thread_parent",
+                            "thread_num", thread_num,
                             debug::detail::threadinfo<
                                 threads::detail::thread_id_ref_type*>(&thrd)));
                 }
@@ -767,7 +779,8 @@ namespace pika::threads {
                                      ->worker_next(num_workers_);
                     DEBUG(spq_deb<5>,
                         debug(debug::detail::str<>("schedule_thread"),
-                            "assign_work_round_robin", "thread_num", thread_num,
+                            "scheduler_mode::assign_work_round_robin",
+                            "thread_num", thread_num,
                             debug::detail::threadinfo<
                                 threads::detail::thread_id_ref_type*>(&thrd)));
                 }

--- a/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
@@ -62,7 +62,8 @@ namespace pika::threads {
         {
             // disable thread stealing to begin with
             this->remove_scheduler_mode(
-                scheduler_mode(enable_stealing | enable_stealing_numa));
+                scheduler_mode(scheduler_mode::enable_stealing |
+                    scheduler_mode::enable_stealing_numa));
         }
 
         void set_scheduler_mode(scheduler_mode mode) override

--- a/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
@@ -70,7 +70,7 @@ namespace pika::threads {
             // this scheduler does not support stealing or numa stealing
             mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing);
             mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing_numa);
-            scheduler_base::set_scheduler_mode(mode);
+            detail::scheduler_base::set_scheduler_mode(mode);
         }
 
         static std::string get_scheduler_name()

--- a/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
@@ -72,7 +72,7 @@ namespace pika::threads {
             // this scheduler does not support stealing or numa stealing
             mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing);
             mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing_numa);
-            scheduler_base::set_scheduler_mode(mode);
+            detail::scheduler_base::set_scheduler_mode(mode);
         }
 
         /// Return the next thread to be executed, return false if none is

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -457,7 +457,7 @@ namespace pika::threads {
         }
 
         thread_queue(std::size_t queue_num = std::size_t(-1),
-            thread_queue_init_parameters parameters = {})
+            detail::thread_queue_init_parameters parameters = {})
           : parameters_(parameters)
           , thread_map_count_(0)
           , work_items_(128, queue_num)
@@ -1196,7 +1196,7 @@ namespace pika::threads {
         }
 
     private:
-        thread_queue_init_parameters parameters_;
+        detail::thread_queue_init_parameters parameters_;
 
         mutable mutex_type mtx_;    // mutex protecting the members
 

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
@@ -125,7 +125,8 @@ namespace pika::threads {
         }
 
     public:
-        explicit thread_queue_mc(const thread_queue_init_parameters& parameters,
+        explicit thread_queue_mc(
+            const detail::thread_queue_init_parameters& parameters,
             std::size_t queue_num = std::size_t(-1))
           : parameters_(parameters)
           , queue_index_(static_cast<int>(queue_num))
@@ -347,7 +348,7 @@ namespace pika::threads {
 #endif
 
     public:
-        /*const*/ thread_queue_init_parameters parameters_;
+        detail::thread_queue_init_parameters parameters_;
 
         int const queue_index_;
 

--- a/libs/pika/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/pika/schedulers/tests/unit/schedule_last.cpp
@@ -48,7 +48,8 @@ void test_scheduler(int argc, char* argv[])
         rp.create_thread_pool("default",
             [](pika::threads::detail::thread_pool_init_parameters
                     thread_pool_init,
-                pika::threads::thread_queue_init_parameters thread_queue_init)
+                pika::threads::detail::thread_queue_init_parameters
+                    thread_queue_init)
                 -> std::unique_ptr<pika::threads::detail::thread_pool_base> {
                 typename Scheduler::init_parameter_type init(
                     thread_pool_init.num_threads_,

--- a/libs/pika/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/pika/schedulers/tests/unit/schedule_last.cpp
@@ -56,9 +56,9 @@ void test_scheduler(int argc, char* argv[])
                 std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
                 thread_pool_init.mode_ = pika::threads::scheduler_mode(
-                    pika::threads::do_background_work |
-                    pika::threads::reduce_thread_priority |
-                    pika::threads::delay_exit);
+                    pika::threads::scheduler_mode::do_background_work |
+                    pika::threads::scheduler_mode::reduce_thread_priority |
+                    pika::threads::scheduler_mode::delay_exit);
 
                 std::unique_ptr<pika::threads::thread_pool_base> pool(
                     new pika::threads::detail::scheduled_thread_pool<Scheduler>(

--- a/libs/pika/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/pika/schedulers/tests/unit/schedule_last.cpp
@@ -46,9 +46,10 @@ void test_scheduler(int argc, char* argv[])
     init_args.rp_callback = [](auto& rp,
                                 pika::program_options::variables_map const&) {
         rp.create_thread_pool("default",
-            [](pika::threads::thread_pool_init_parameters thread_pool_init,
+            [](pika::threads::detail::thread_pool_init_parameters
+                    thread_pool_init,
                 pika::threads::thread_queue_init_parameters thread_queue_init)
-                -> std::unique_ptr<pika::threads::thread_pool_base> {
+                -> std::unique_ptr<pika::threads::detail::thread_pool_base> {
                 typename Scheduler::init_parameter_type init(
                     thread_pool_init.num_threads_,
                     thread_pool_init.affinity_data_, std::size_t(-1),
@@ -60,7 +61,7 @@ void test_scheduler(int argc, char* argv[])
                     pika::threads::scheduler_mode::reduce_thread_priority |
                     pika::threads::scheduler_mode::delay_exit);
 
-                std::unique_ptr<pika::threads::thread_pool_base> pool(
+                std::unique_ptr<pika::threads::detail::thread_pool_base> pool(
                     new pika::threads::detail::scheduled_thread_pool<Scheduler>(
                         std::move(scheduler), thread_pool_init));
 

--- a/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
+++ b/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
@@ -148,7 +148,7 @@ namespace pika::threads::detail {
         //! least advanced thread pool
         state status() const
         {
-            pika::state result(last_valid_runtime_state);
+            pika::state result(state::last_valid_runtime);
 
             for (auto& pool_iter : pools_)
             {

--- a/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
+++ b/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
@@ -53,7 +53,7 @@ namespace pika::threads::detail {
     public:
         using notification_policy_type = threads::callback_notifier;
         using pool_type = std::unique_ptr<thread_pool_base>;
-        using scheduler_type = threads::scheduler_base;
+        using scheduler_type = threads::detail::scheduler_base;
         using pool_vector = std::vector<pool_type>;
 
         thread_manager(pika::util::runtime_configuration& rtcfg_,

--- a/libs/pika/thread_manager/src/thread_manager.cpp
+++ b/libs/pika/thread_manager/src/thread_manager.cpp
@@ -1011,7 +1011,7 @@ namespace pika::threads::detail {
                 rp.get_num_threads(pool_iter->get_pool_name());
 
             if (pool_iter->get_os_thread_count() != 0 ||
-                pool_iter->has_reached_state(state_running))
+                pool_iter->has_reached_state(state::running))
             {
                 return true;    // do nothing if already running
             }
@@ -1024,7 +1024,7 @@ namespace pika::threads::detail {
             // set all states of all schedulers to "running"
             scheduler_base* sched = pool_iter->get_scheduler();
             if (sched)
-                sched->set_all_states(state_running);
+                sched->set_all_states(state::running);
         }
 
         LTM_(info).format("run: running");

--- a/libs/pika/thread_manager/src/thread_manager.cpp
+++ b/libs/pika/thread_manager/src/thread_manager.cpp
@@ -216,7 +216,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -254,7 +254,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -294,7 +294,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -328,7 +328,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -365,7 +365,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -405,7 +405,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -451,7 +451,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(
@@ -484,7 +484,7 @@ namespace pika::threads::detail {
                 sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
-                    enable_stealing_numa, !numa_sensitive);
+                    scheduler_mode::enable_stealing_numa, !numa_sensitive);
 
                 // instantiate the pool
                 std::unique_ptr<thread_pool_base> pool(

--- a/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
+++ b/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
@@ -28,7 +28,7 @@ namespace pika { namespace threads {
     /// \returns A `future<void>` which is ready when the given processing unit
     ///          has been resumed.
     PIKA_EXPORT pika::future<void> resume_processing_unit(
-        thread_pool_base& pool, std::size_t virt_core);
+        detail::thread_pool_base& pool, std::size_t virt_core);
 
     /// Resumes the given processing unit. Takes a callback as a parameter which
     /// will be called when the processing unit has been resumed.
@@ -42,7 +42,7 @@ namespace pika { namespace threads {
     /// \param ec        [in,out] this represents the error status on exit, if this
     ///                  is pre-initialized to \a pika#throws the function will throw
     ///                  on error instead.
-    PIKA_EXPORT void resume_processing_unit_cb(thread_pool_base& pool,
+    PIKA_EXPORT void resume_processing_unit_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, std::size_t virt_core,
         error_code& ec = throws);
 
@@ -63,7 +63,7 @@ namespace pika { namespace threads {
     ///
     /// \throws pika::exception if called from outside the pika runtime.
     PIKA_EXPORT pika::future<void> suspend_processing_unit(
-        thread_pool_base& pool, std::size_t virt_core);
+        detail::thread_pool_base& pool, std::size_t virt_core);
 
     /// Suspends the given processing unit. Takes a callback as a parameter
     /// which will be called when the processing unit has been suspended.
@@ -78,8 +78,9 @@ namespace pika { namespace threads {
     ///                  is pre-initialized to \a pika#throws the function will throw
     ///                  on error instead.
     PIKA_EXPORT void suspend_processing_unit_cb(
-        util::detail::function<void(void)> callback, thread_pool_base& pool,
-        std::size_t virt_core, error_code& ec = throws);
+        util::detail::function<void(void)> callback,
+        detail::thread_pool_base& pool, std::size_t virt_core,
+        error_code& ec = throws);
 
     /// Resumes the thread pool. When the all OS threads on the thread pool have
     /// been resumed the returned future will be ready.
@@ -91,7 +92,7 @@ namespace pika { namespace threads {
     ///          resumed.
     ///
     /// \throws pika::exception if called from outside the pika runtime.
-    PIKA_EXPORT pika::future<void> resume_pool(thread_pool_base& pool);
+    PIKA_EXPORT pika::future<void> resume_pool(detail::thread_pool_base& pool);
 
     /// Resumes the thread pool. Takes a callback as a parameter which will be
     /// called when all OS threads on the thread pool have been resumed.
@@ -100,7 +101,7 @@ namespace pika { namespace threads {
     /// \param ec       [in,out] this represents the error status on exit, if this
     ///                 is pre-initialized to \a pika#throws the function will throw
     ///                 on error instead.
-    PIKA_EXPORT void resume_pool_cb(thread_pool_base& pool,
+    PIKA_EXPORT void resume_pool_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, error_code& ec = throws);
 
     /// Suspends the thread pool. When the all OS threads on the thread pool
@@ -114,7 +115,7 @@ namespace pika { namespace threads {
     ///          been suspended.
     ///
     /// \throws pika::exception if called from outside the pika runtime.
-    PIKA_EXPORT pika::future<void> suspend_pool(thread_pool_base& pool);
+    PIKA_EXPORT pika::future<void> suspend_pool(detail::thread_pool_base& pool);
 
     /// Suspends the thread pool. Takes a callback as a parameter which will be
     /// called when all OS threads on the thread pool have been suspended.
@@ -129,6 +130,6 @@ namespace pika { namespace threads {
     ///
     /// \throws pika::exception if called from an pika thread which is running
     ///         on the pool itself.
-    PIKA_EXPORT void suspend_pool_cb(thread_pool_base& pool,
+    PIKA_EXPORT void suspend_pool_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, error_code& ec = throws);
 }}    // namespace pika::threads

--- a/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
+++ b/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
@@ -20,7 +20,7 @@ namespace pika { namespace threads {
     /// \note Can only be called from an pika thread. Use
     ///       resume_processing_unit_cb or to resume the processing unit from
     ///       outside pika. Requires that the pool has
-    ///       threads::enable_elasticity set.
+    ///       threads::scheduler_mode::enable_elasticity set.
     ///
     /// \param virt_core [in] The processing unit on the the pool to be resumed.
     ///                  The processing units are indexed starting from 0.
@@ -33,7 +33,7 @@ namespace pika { namespace threads {
     /// Resumes the given processing unit. Takes a callback as a parameter which
     /// will be called when the processing unit has been resumed.
     ///
-    /// \note Requires that the pool has threads::enable_elasticity
+    /// \note Requires that the pool has threads::scheduler_mode::enable_elasticity
     ///       set.
     ///
     /// \param callback  [in] Callback which is called when the processing
@@ -52,7 +52,7 @@ namespace pika { namespace threads {
     /// \note Can only be called from an pika thread. Use
     ///       suspend_processing_unit_cb or to suspend the processing unit from
     ///       outside pika. Requires that the pool has
-    ///       threads::enable_elasticity set.
+    ///       threads::scheduler_mode::enable_elasticity set.
     ///
     /// \param virt_core [in] The processing unit on the the pool to be
     ///                  suspended. The processing units are indexed starting
@@ -69,7 +69,7 @@ namespace pika { namespace threads {
     /// which will be called when the processing unit has been suspended.
     ///
     /// \note Requires that the pool has
-    ///       threads::enable_elasticity set.
+    ///       threads::scheduler_mode::enable_elasticity set.
     ///
     /// \param callback  [in] Callback which is called when the processing
     ///                  unit has been suspended.

--- a/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -27,7 +27,8 @@ namespace pika { namespace threads {
                 "cannot call resume_processing_unit from outside pika, use"
                 "resume_processing_unit_cb instead");
         }
-        else if (!pool.get_scheduler()->has_scheduler_mode(enable_elasticity))
+        else if (!pool.get_scheduler()->has_scheduler_mode(
+                     scheduler_mode::enable_elasticity))
         {
             return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
                 pika::error::invalid_status, "resume_processing_unit",
@@ -44,7 +45,8 @@ namespace pika { namespace threads {
         util::detail::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!pool.get_scheduler()->has_scheduler_mode(enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                scheduler_mode::enable_elasticity))
         {
             PIKA_THROWS_IF(ec, pika::error::invalid_status,
                 "resume_processing_unit_cb",
@@ -79,14 +81,16 @@ namespace pika { namespace threads {
                 "cannot call suspend_processing_unit from outside pika, use"
                 "suspend_processing_unit_cb instead");
         }
-        if (!pool.get_scheduler()->has_scheduler_mode(enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                scheduler_mode::enable_elasticity))
         {
             return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
                 pika::error::invalid_status, "suspend_processing_unit",
                 "this thread pool does not support suspending "
                 "processing units"));
         }
-        if (!pool.get_scheduler()->has_scheduler_mode(enable_stealing) &&
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                scheduler_mode::enable_stealing) &&
             pika::this_thread::get_pool() == &pool)
         {
             return pika::make_exceptional_future<void>(PIKA_GET_EXCEPTION(
@@ -104,7 +108,8 @@ namespace pika { namespace threads {
         util::detail::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!pool.get_scheduler()->has_scheduler_mode(enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                scheduler_mode::enable_elasticity))
         {
             PIKA_THROWS_IF(ec, pika::error::invalid_status,
                 "suspend_processing_unit_cb",
@@ -121,7 +126,8 @@ namespace pika { namespace threads {
 
         if (threads::detail::get_self_ptr())
         {
-            if (!pool.get_scheduler()->has_scheduler_mode(enable_stealing) &&
+            if (!pool.get_scheduler()->has_scheduler_mode(
+                    scheduler_mode::enable_stealing) &&
                 pika::this_thread::get_pool() == &pool)
             {
                 PIKA_THROW_EXCEPTION(pika::error::invalid_status,

--- a/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/pika/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -18,7 +18,7 @@
 
 namespace pika { namespace threads {
     pika::future<void> resume_processing_unit(
-        thread_pool_base& pool, std::size_t virt_core)
+        detail::thread_pool_base& pool, std::size_t virt_core)
     {
         if (!threads::detail::get_self_ptr())
         {
@@ -41,7 +41,7 @@ namespace pika { namespace threads {
         });
     }
 
-    void resume_processing_unit_cb(thread_pool_base& pool,
+    void resume_processing_unit_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
@@ -72,7 +72,7 @@ namespace pika { namespace threads {
     }
 
     pika::future<void> suspend_processing_unit(
-        thread_pool_base& pool, std::size_t virt_core)
+        detail::thread_pool_base& pool, std::size_t virt_core)
     {
         if (!threads::detail::get_self_ptr())
         {
@@ -104,7 +104,7 @@ namespace pika { namespace threads {
         });
     }
 
-    void suspend_processing_unit_cb(thread_pool_base& pool,
+    void suspend_processing_unit_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
@@ -145,7 +145,7 @@ namespace pika { namespace threads {
         }
     }
 
-    future<void> resume_pool(thread_pool_base& pool)
+    future<void> resume_pool(detail::thread_pool_base& pool)
     {
         if (!threads::detail::get_self_ptr())
         {
@@ -159,7 +159,7 @@ namespace pika { namespace threads {
             [&pool]() -> void { return pool.resume_direct(throws); });
     }
 
-    void resume_pool_cb(thread_pool_base& pool,
+    void resume_pool_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, error_code& /* ec */)
     {
         auto resume_direct_wrapper =
@@ -178,7 +178,7 @@ namespace pika { namespace threads {
         }
     }
 
-    future<void> suspend_pool(thread_pool_base& pool)
+    future<void> suspend_pool(detail::thread_pool_base& pool)
     {
         if (!threads::detail::get_self_ptr())
         {
@@ -200,7 +200,7 @@ namespace pika { namespace threads {
             [&pool]() -> void { return pool.suspend_direct(throws); });
     }
 
-    void suspend_pool_cb(thread_pool_base& pool,
+    void suspend_pool_cb(detail::thread_pool_base& pool,
         util::detail::function<void(void)> callback, error_code& ec)
     {
         if (threads::detail::get_self_ptr() &&

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -169,7 +169,7 @@ namespace pika::threads::detail {
                  ++thread_num)
             {
                 if (sched_->Scheduler::get_state(thread_num).load() ==
-                    state_running)
+                    state::running)
                 {
                     ++active_os_thread_count;
                 }

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -51,7 +51,7 @@ namespace pika::threads::detail {
 
         void print_pool(std::ostream& os) override;
 
-        threads::scheduler_base* get_scheduler() const override
+        threads::detail::scheduler_base* get_scheduler() const override
         {
             return sched_.get();
         }

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -41,7 +41,7 @@ namespace pika::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
-    class scheduled_thread_pool : public pika::threads::thread_pool_base
+    class scheduled_thread_pool : public pika::threads::detail::thread_pool_base
     {
     public:
         ///////////////////////////////////////////////////////////////////

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -461,7 +461,8 @@ namespace pika { namespace threads { namespace detail {
         // needs to
         // be done in order to give the parcel pool threads higher
         // priority
-        if (get_scheduler()->has_scheduler_mode(reduce_thread_priority))
+        if (get_scheduler()->has_scheduler_mode(
+                scheduler_mode::reduce_thread_priority))
         {
             topo.reduce_thread_priority(ec);
             if (ec)
@@ -528,7 +529,8 @@ namespace pika { namespace threads { namespace detail {
                     nullptr, nullptr, max_background_threads_,
                     max_idle_loop_count_, max_busy_loop_count_);
 
-                if (get_scheduler()->has_scheduler_mode(do_background_work) &&
+                if (get_scheduler()->has_scheduler_mode(
+                        scheduler_mode::do_background_work) &&
                     network_background_callback_)
                 {
 #if defined(PIKA_HAVE_BACKGROUND_THREAD_COUNTERS) &&                           \

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -116,7 +116,7 @@ namespace pika { namespace threads { namespace detail {
     {
         if (!threads_.empty())
         {
-            if (!sched_->Scheduler::has_reached_state(state_suspended))
+            if (!sched_->Scheduler::has_reached_state(state::suspended))
             {
                 // still running
                 std::mutex mtx;
@@ -148,7 +148,7 @@ namespace pika { namespace threads { namespace detail {
     void scheduled_thread_pool<Scheduler>::report_error(
         std::size_t global_thread_num, std::exception_ptr const& e)
     {
-        sched_->Scheduler::set_all_states_at_least(state_terminating);
+        sched_->Scheduler::set_all_states_at_least(state::terminating);
         this->thread_pool_base::report_error(global_thread_num, e);
         sched_->Scheduler::on_error(global_thread_num, e);
     }
@@ -232,7 +232,7 @@ namespace pika { namespace threads { namespace detail {
             resume_internal(blocking, throws);
 
             // set state to stopping
-            sched_->Scheduler::set_all_states_at_least(state_stopping);
+            sched_->Scheduler::set_all_states_at_least(state::stopping);
 
             // make sure we're not waiting
             sched_->Scheduler::do_some_work(std::size_t(-1));
@@ -289,7 +289,7 @@ namespace pika { namespace threads { namespace detail {
         }
 
         if (!threads_.empty() ||
-            sched_->Scheduler::has_reached_state(state_running))
+            sched_->Scheduler::has_reached_state(state::running))
         {
             return true;    // do nothing if already running
         }
@@ -399,9 +399,9 @@ namespace pika { namespace threads { namespace detail {
 
         for (std::size_t i = 0; i != threads_.size(); ++i)
         {
-            pika::state expected = state_running;
+            pika::state expected = state::running;
             sched_->Scheduler::get_state(i).compare_exchange_strong(
-                expected, state_pre_sleep);
+                expected, state::pre_sleep);
         }
 
         for (std::size_t i = 0; i != threads_.size(); ++i)
@@ -482,8 +482,8 @@ namespace pika { namespace threads { namespace detail {
         // set state to running
         std::atomic<pika::state>& state =
             sched_->Scheduler::get_state(thread_num);
-        pika::state oldstate = state.exchange(state_running);
-        PIKA_ASSERT(oldstate <= state_running);
+        pika::state oldstate = state.exchange(state::running);
+        PIKA_ASSERT(oldstate <= state::running);
         PIKA_UNUSED(oldstate);
 
         // wait for all threads to start up before before starting pika work
@@ -558,7 +558,7 @@ namespace pika { namespace threads { namespace detail {
                          execution::thread_priority::default_,
                          thread_num) == 0 &&
                         sched_->Scheduler::get_queue_length(thread_num) == 0) ||
-                    sched_->Scheduler::get_state(thread_num) > state_stopping);
+                    sched_->Scheduler::get_state(thread_num) > state::stopping);
             }
             catch (pika::exception const& e)
             {
@@ -608,7 +608,7 @@ namespace pika { namespace threads { namespace detail {
         thread_init_data& data, thread_id_ref_type& id, error_code& ec)
     {
         // verify state
-        if (thread_count_ == 0 && !sched_->Scheduler::is_state(state_running))
+        if (thread_count_ == 0 && !sched_->Scheduler::is_state(state::running))
         {
             // thread-manager is not currently running
             PIKA_THROWS_IF(ec, pika::error::invalid_status,
@@ -628,7 +628,7 @@ namespace pika { namespace threads { namespace detail {
         thread_init_data& data, error_code& ec)
     {
         // verify state
-        if (thread_count_ == 0 && !sched_->Scheduler::is_state(state_running))
+        if (thread_count_ == 0 && !sched_->Scheduler::is_state(state::running))
         {
             // thread-manager is not currently running
             PIKA_THROWS_IF(ec, pika::error::invalid_status,
@@ -1864,8 +1864,9 @@ namespace pika { namespace threads { namespace detail {
 
         std::atomic<pika::state>& state =
             sched_->Scheduler::get_state(virt_core);
-        pika::state oldstate = state.exchange(state_initialized);
-        PIKA_ASSERT(oldstate == state_stopped || oldstate == state_initialized);
+        pika::state oldstate = state.exchange(state::initialized);
+        PIKA_ASSERT(
+            oldstate == state::stopped || oldstate == state::initialized);
         PIKA_UNUSED(oldstate);
 
         threads_[virt_core] = std::thread(&scheduled_thread_pool::thread_func,
@@ -1896,18 +1897,18 @@ namespace pika { namespace threads { namespace detail {
             sched_->Scheduler::get_state(virt_core);
 
         // inform the scheduler to stop the virtual core
-        pika::state oldstate = state.exchange(state_stopping);
+        pika::state oldstate = state.exchange(state::stopping);
 
-        if (oldstate > state_stopping)
+        if (oldstate > state::stopping)
         {
             // If thread was terminating or already stopped we don't want to
             // change the value back to stopping, so we restore the old state.
             state.store(oldstate);
         }
 
-        PIKA_ASSERT(oldstate == state_starting || oldstate == state_running ||
-            oldstate == state_stopping || oldstate == state_stopped ||
-            oldstate == state_terminating);
+        PIKA_ASSERT(oldstate == state::starting || oldstate == state::running ||
+            oldstate == state::stopping || oldstate == state::stopped ||
+            oldstate == state::terminating);
 
         std::thread t;
         std::swap(threads_[virt_core], t);
@@ -1956,16 +1957,16 @@ namespace pika { namespace threads { namespace detail {
             sched_->Scheduler::get_state(virt_core);
 
         // Inform the scheduler to suspend the virtual core only if running
-        pika::state expected = state_running;
-        state.compare_exchange_strong(expected, state_pre_sleep);
+        pika::state expected = state::running;
+        state.compare_exchange_strong(expected, state::pre_sleep);
 
         l.unlock();
 
-        PIKA_ASSERT(expected == state_running || expected == state_pre_sleep ||
-            expected == state_sleeping);
+        PIKA_ASSERT(expected == state::running ||
+            expected == state::pre_sleep || expected == state::sleeping);
 
         util::yield_while(
-            [&state]() { return state.load() == state_pre_sleep; },
+            [&state]() { return state.load() == state::pre_sleep; },
             "scheduled_thread_pool::suspend_processing_unit_direct");
     }
 
@@ -1998,7 +1999,7 @@ namespace pika { namespace threads { namespace detail {
         util::yield_while(
             [this, &state, virt_core]() {
                 this->sched_->Scheduler::resume(virt_core);
-                return state.load() == state_sleeping;
+                return state.load() == state::sleeping;
             },
             "scheduled_thread_pool::resume_processing_unit_direct");
     }

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -616,7 +616,7 @@ namespace pika { namespace threads { namespace detail {
         thread_id_ref_type background_thread;
 
         if (scheduler.SchedulingPolicy::has_scheduler_mode(
-                do_background_work) &&
+                scheduler_mode::do_background_work) &&
             num_thread < params.max_background_threads_ &&
             !params.background_.empty())
         {
@@ -644,14 +644,15 @@ namespace pika { namespace threads { namespace detail {
             // extract the stealing mode once per loop iteration
             bool enable_stealing =
                 scheduler.SchedulingPolicy::has_scheduler_mode(
-                    ::pika::threads::enable_stealing);
+                    ::pika::threads::scheduler_mode::enable_stealing);
 
             // stealing staged threads is enabled if:
             // - fast idle mode is on: same as normal stealing
             // - fast idle mode off: only after normal stealing has failed for
             //                       a while
             bool enable_stealing_staged = enable_stealing;
-            if (!scheduler.SchedulingPolicy::has_scheduler_mode(fast_idle_mode))
+            if (!scheduler.SchedulingPolicy::has_scheduler_mode(
+                    scheduler_mode::fast_idle_mode))
             {
                 enable_stealing_staged = enable_stealing_staged &&
                     idle_loop_count > params.max_idle_loop_count_ / 2;
@@ -944,7 +945,7 @@ namespace pika { namespace threads { namespace detail {
                         if (can_exit)
                         {
                             if (!scheduler.SchedulingPolicy::has_scheduler_mode(
-                                    delay_exit))
+                                    scheduler_mode::delay_exit))
                             {
                                 // If this is an inner scheduler, try to exit immediately
                                 if (background_thread != nullptr)
@@ -987,7 +988,7 @@ namespace pika { namespace threads { namespace detail {
                 }
                 else if (!may_exit && added == 0 &&
                     (scheduler.SchedulingPolicy::has_scheduler_mode(
-                        fast_idle_mode)))
+                        scheduler_mode::fast_idle_mode)))
                 {
                     // speed up idle suspend if no work was stolen
                     idle_loop_count += params.max_idle_loop_count_ / 1024;

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -639,7 +639,7 @@ namespace pika { namespace threads { namespace detail {
 
             // Get the next pika thread from the queue
             bool running =
-                this_state.load(std::memory_order_relaxed) < state_pre_sleep;
+                this_state.load(std::memory_order_relaxed) < state::pre_sleep;
 
             // extract the stealing mode once per loop iteration
             bool enable_stealing =
@@ -927,7 +927,7 @@ namespace pika { namespace threads { namespace detail {
                         scheduler.SchedulingPolicy::get_queue_length(
                             num_thread) == 0;
 
-                    if (this_state.load() == state_pre_sleep)
+                    if (this_state.load() == state::pre_sleep)
                     {
                         if (can_exit)
                         {
@@ -972,7 +972,7 @@ namespace pika { namespace threads { namespace detail {
                                 }
                                 else
                                 {
-                                    this_state.store(state_stopped);
+                                    this_state.store(state::stopped);
                                     break;
                                 }
                             }
@@ -1039,7 +1039,7 @@ namespace pika { namespace threads { namespace detail {
             }
 
             // something went badly wrong, give up
-            if (PIKA_UNLIKELY(this_state.load() == state_terminating))
+            if (PIKA_UNLIKELY(this_state.load() == state::terminating))
                 break;
 
             if (busy_loop_count > params.max_busy_loop_count_)
@@ -1092,7 +1092,7 @@ namespace pika { namespace threads { namespace detail {
                 // break if we were idling after 'may_exit'
                 if (may_exit)
                 {
-                    PIKA_ASSERT(this_state.load() != state_pre_sleep);
+                    PIKA_ASSERT(this_state.load() != state::pre_sleep);
 
                     if (background_thread)
                     {
@@ -1127,7 +1127,7 @@ namespace pika { namespace threads { namespace detail {
 
                         if (can_exit)
                         {
-                            this_state.store(state_stopped);
+                            this_state.store(state::stopped);
                             break;
                         }
                     }

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -463,7 +463,7 @@ namespace pika { namespace threads { namespace detail {
                 return thread_result_type(
                     thread_schedule_state::terminated, invalid_thread_id);
             },
-            pika::util::detail::thread_description("background_work"),
+            pika::detail::thread_description("background_work"),
             execution::thread_priority::high_recursive, schedulehint,
             execution::thread_stacksize::large,
             // Create in suspended to prevent the thread from being scheduled
@@ -747,10 +747,9 @@ namespace pika { namespace threads { namespace detail {
                                 task_annotation
                                     << "pika/task:" << thrd << "/"
                                     << (desc.kind() ==
-                                                   pika::util::detail::
-                                                       thread_description::
-                                                           data_type::
-                                                               data_type_description ?
+                                                   pika::detail::thread_description::
+                                                       data_type::
+                                                           data_type_description ?
                                                desc.get_description() :
                                                "<unknown>");
                                 auto task_annotation_str =

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -70,13 +70,13 @@ namespace pika {
         }
 
         template <typename F>
-        thread(threads::thread_pool_base* pool, F&& f)
+        thread(threads::detail::thread_pool_base* pool, F&& f)
         {
             start_thread(pool, util::detail::deferred_call(PIKA_FORWARD(F, f)));
         }
 
         template <typename F, typename... Ts>
-        thread(threads::thread_pool_base* pool, F&& f, Ts&&... vs)
+        thread(threads::detail::thread_pool_base* pool, F&& f, Ts&&... vs)
         {
             start_thread(pool,
                 util::detail::deferred_call(
@@ -133,7 +133,7 @@ namespace pika {
         {
             id_ = threads::detail::invalid_thread_id;
         }
-        void start_thread(threads::thread_pool_base* pool,
+        void start_thread(threads::detail::thread_pool_base* pool,
             util::detail::unique_function<void()>&& func);
         static threads::detail::thread_result_type thread_function_nullary(
             util::detail::unique_function<void()> const& func);

--- a/libs/pika/threading/src/thread.cpp
+++ b/libs/pika/threading/src/thread.cpp
@@ -161,7 +161,7 @@ namespace pika {
         return pika::threads::detail::hardware_concurrency();
     }
 
-    void thread::start_thread(threads::thread_pool_base* pool,
+    void thread::start_thread(threads::detail::thread_pool_base* pool,
         util::detail::unique_function<void()>&& func)
     {
         PIKA_ASSERT(pool);

--- a/libs/pika/threading/tests/unit/tss.cpp
+++ b/libs/pika/threading/tests/unit/tss.cpp
@@ -43,7 +43,7 @@ struct tss_value_t
     int value;
 };
 
-pika::threads::thread_specific_ptr<tss_value_t> tss_value;
+pika::threads::detail::thread_specific_ptr<tss_value_t> tss_value;
 
 void test_tss_thread(pika::lcos::local::promise<void> p)
 {
@@ -96,7 +96,8 @@ void tss_custom_cleanup(Dummy* d)
     tss_cleanup_called = true;
 }
 
-pika::threads::thread_specific_ptr<Dummy> tss_with_cleanup(&tss_custom_cleanup);
+pika::threads::detail::thread_specific_ptr<Dummy> tss_with_cleanup(
+    &tss_custom_cleanup);
 
 void tss_thread_with_custom_cleanup()
 {
@@ -154,7 +155,7 @@ struct dummy_class_tracks_deletions
 
 unsigned dummy_class_tracks_deletions::deletions = 0;
 
-pika::threads::thread_specific_ptr<dummy_class_tracks_deletions>
+pika::threads::detail::thread_specific_ptr<dummy_class_tracks_deletions>
     tss_with_null_cleanup(nullptr);
 
 void tss_thread_with_null_cleanup(dummy_class_tracks_deletions* delete_tracker)
@@ -182,7 +183,8 @@ void thread_with_local_tss_ptr()
     tss_cleanup_called = false;
 
     {
-        pika::threads::thread_specific_ptr<Dummy> local_tss(tss_custom_cleanup);
+        pika::threads::detail::thread_specific_ptr<Dummy> local_tss(
+            tss_custom_cleanup);
         local_tss.reset(new Dummy);
     }
 
@@ -201,7 +203,8 @@ void test_tss_does_not_call_cleanup_after_ptr_destroyed()
 ///////////////////////////////////////////////////////////////////////////////
 void test_tss_cleanup_not_called_for_null_pointer()
 {
-    pika::threads::thread_specific_ptr<Dummy> local_tss(tss_custom_cleanup);
+    pika::threads::detail::thread_specific_ptr<Dummy> local_tss(
+        tss_custom_cleanup);
     local_tss.reset(new Dummy);
 
     tss_cleanup_called = false;

--- a/libs/pika/threading_base/CMakeLists.txt
+++ b/libs/pika/threading_base/CMakeLists.txt
@@ -51,6 +51,7 @@ set(threading_base_sources
     reset_backtrace.cpp
     reset_lco_description.cpp
     scheduler_base.cpp
+    scheduler_mode.cpp
     set_thread_state.cpp
     set_thread_state_timed.cpp
     thread_data.cpp

--- a/libs/pika/threading_base/docs/index.rst
+++ b/libs/pika/threading_base/docs/index.rst
@@ -18,7 +18,7 @@ for stackful and stackless threads:
 :cpp:class:`pika::threads::thread_data_stackless`. In addition, the module
 defines the base classes for schedulers and thread pools:
 :cpp:class:`pika::threads::detail::scheduler_base` and
-:cpp:class:`pika::threads::thread_pool_base`.
+:cpp:class:`pika::threads::detail::thread_pool_base`.
 
 See the :ref:`API reference <modules_thread_data_api>` of this module for more
 details.

--- a/libs/pika/threading_base/docs/index.rst
+++ b/libs/pika/threading_base/docs/index.rst
@@ -17,7 +17,7 @@ for stackful and stackless threads:
 :cpp:class:`pika::threads::thread_data_stackful` and
 :cpp:class:`pika::threads::thread_data_stackless`. In addition, the module
 defines the base classes for schedulers and thread pools:
-:cpp:class:`pika::threads::scheduler_base` and
+:cpp:class:`pika::threads::detail::scheduler_base` and
 :cpp:class:`pika::threads::thread_pool_base`.
 
 See the :ref:`API reference <modules_thread_data_api>` of this module for more

--- a/libs/pika/threading_base/include/pika/threading_base/detail/external_timer/apex.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/external_timer/apex.hpp
@@ -30,13 +30,13 @@ namespace pika::detail::external_timer {
     using apex::yield;
 
     PIKA_EXPORT std::shared_ptr<task_wrapper> new_task(
-        pika::util::detail::thread_description const& description,
+        pika::detail::thread_description const& description,
         std::uint32_t parent_locality_id,
         threads::detail::thread_id_type parent_task);
 
     PIKA_EXPORT std::shared_ptr<task_wrapper> update_task(
         std::shared_ptr<task_wrapper> wrapper,
-        pika::util::detail::thread_description const& description);
+        pika::detail::thread_description const& description);
 
     // This is a scoped object around task scheduling to measure the time spent
     // executing pika threads

--- a/libs/pika/threading_base/include/pika/threading_base/detail/external_timer/default.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/external_timer/default.hpp
@@ -16,15 +16,14 @@
 
 namespace pika::detail::external_timer {
     inline std::shared_ptr<task_wrapper> new_task(
-        pika::util::detail::thread_description const&, std::uint32_t,
+        pika::detail::thread_description const&, std::uint32_t,
         threads::detail::thread_id_type)
     {
         return nullptr;
     }
 
     inline std::shared_ptr<task_wrapper> update_task(
-        std::shared_ptr<task_wrapper>,
-        pika::util::detail::thread_description const&)
+        std::shared_ptr<task_wrapper>, pika::detail::thread_description const&)
     {
         return nullptr;
     }

--- a/libs/pika/threading_base/include/pika/threading_base/detail/reset_lco_description.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/reset_lco_description.hpp
@@ -18,12 +18,12 @@ namespace pika::threads::detail {
     struct reset_lco_description
     {
         PIKA_EXPORT reset_lco_description(thread_id_type const& id,
-            util::detail::thread_description const& description,
+            ::pika::detail::thread_description const& description,
             error_code& ec = throws);
         PIKA_EXPORT ~reset_lco_description();
 
         thread_id_type id_;
-        util::detail::thread_description old_desc_;
+        ::pika::detail::thread_description old_desc_;
         error_code& ec_;
     };
 }    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/network_background_callback.hpp
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace pika { namespace threads { namespace detail {
+namespace pika::threads::detail {
 #if defined(PIKA_HAVE_BACKGROUND_THREAD_COUNTERS) &&                           \
     defined(PIKA_HAVE_THREAD_IDLE_RATES)
     using network_background_callback_type =
@@ -21,4 +21,4 @@ namespace pika { namespace threads { namespace detail {
     using network_background_callback_type =
         util::detail::function<bool(std::size_t)>;
 #endif
-}}}    // namespace pika::threads::detail
+}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -37,17 +37,15 @@
 #include <pika/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika::threads {
-    namespace detail {
-        enum class polling_status
-        {
-            /// Signals that a polling function currently has no more work to do
-            idle = 0,
-            /// Signals that a polling function still has outstanding work to
-            /// poll for
-            busy = 1
-        };
-    }
+namespace pika::threads::detail {
+    enum class polling_status
+    {
+        /// Signals that a polling function currently has no more work to do
+        idle = 0,
+        /// Signals that a polling function still has outstanding work to
+        /// poll for
+        busy = 1
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     /// The scheduler_base defines the interface to be implemented by all
@@ -298,12 +296,12 @@ namespace pika::threads {
             return thread_queue_init_.small_stacksize_;
         }
 
-        using polling_function_ptr = detail::polling_status (*)();
+        using polling_function_ptr = polling_status (*)();
         using polling_work_count_function_ptr = std::size_t (*)();
 
-        static detail::polling_status null_polling_function()
+        static polling_status null_polling_function()
         {
-            return detail::polling_status::idle;
+            return polling_status::idle;
         }
 
         static std::size_t null_polling_work_count_function()
@@ -343,21 +341,21 @@ namespace pika::threads {
                 &null_polling_work_count_function, std::memory_order_relaxed);
         }
 
-        detail::polling_status custom_polling_function() const
+        polling_status custom_polling_function() const
         {
-            detail::polling_status status = detail::polling_status::idle;
+            polling_status status = polling_status::idle;
 #if defined(PIKA_HAVE_MODULE_ASYNC_MPI)
             if ((*polling_function_mpi_.load(std::memory_order_relaxed))() ==
-                detail::polling_status::busy)
+                polling_status::busy)
             {
-                status = detail::polling_status::busy;
+                status = polling_status::busy;
             }
 #endif
 #if defined(PIKA_HAVE_MODULE_ASYNC_CUDA)
             if ((*polling_function_cuda_.load(std::memory_order_relaxed))() ==
-                detail::polling_status::busy)
+                polling_status::busy)
             {
-                status = detail::polling_status::busy;
+                status = polling_status::busy;
             }
 #endif
             return status;
@@ -441,6 +439,6 @@ namespace pika::threads {
 
     PIKA_EXPORT std::ostream& operator<<(
         std::ostream& os, scheduler_base const& scheduler);
-}    // namespace pika::threads
+}    // namespace pika::threads::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -60,7 +60,7 @@ namespace pika::threads::detail {
 
         scheduler_base(std::size_t num_threads, char const* description = "",
             thread_queue_init_parameters thread_queue_init = {},
-            scheduler_mode mode = nothing_special);
+            scheduler_mode mode = scheduler_mode::nothing_special);
 
         virtual ~scheduler_base() = default;
 
@@ -125,7 +125,8 @@ namespace pika::threads::detail {
         // get/set scheduler mode
         bool has_scheduler_mode(scheduler_mode mode) const
         {
-            return (mode_.data_.load(std::memory_order_relaxed) & mode) != 0;
+            return (mode_.data_.load(std::memory_order_relaxed) & mode) !=
+                scheduler_mode{};
         }
 
         // set mode flags that control scheduler behaviour

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -64,13 +64,13 @@ namespace pika::threads::detail {
 
         virtual ~scheduler_base() = default;
 
-        threads::thread_pool_base* get_parent_pool() const
+        threads::detail::thread_pool_base* get_parent_pool() const
         {
             PIKA_ASSERT(parent_pool_ != nullptr);
             return parent_pool_;
         }
 
-        void set_parent_pool(threads::thread_pool_base* p)
+        void set_parent_pool(threads::detail::thread_pool_base* p)
         {
             PIKA_ASSERT(parent_pool_ == nullptr);
             parent_pool_ = p;
@@ -407,7 +407,7 @@ namespace pika::threads::detail {
         thread_queue_init_parameters thread_queue_init_;
 
         // the pool that owns this scheduler
-        threads::thread_pool_base* parent_pool_;
+        threads::detail::thread_pool_base* parent_pool_;
 
         std::atomic<std::int64_t> background_thread_count_;
 

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <pika/config.hpp>
+
 #include <cstdint>
 
 namespace pika::threads {
     /// This enumeration describes the possible modes of a scheduler.
-    enum scheduler_mode : std::uint32_t
+    enum class scheduler_mode : std::uint32_t
     {
         /// As the name suggests, this option can be used to disable all other
         /// options.
@@ -86,4 +88,13 @@ namespace pika::threads {
             enable_idle_backoff
         // clang-format on
     };
+
+    PIKA_EXPORT scheduler_mode operator&(
+        scheduler_mode sched1, scheduler_mode sched2);
+
+    PIKA_EXPORT scheduler_mode operator|(
+        scheduler_mode sched1, scheduler_mode sched2);
+
+    PIKA_EXPORT scheduler_mode operator~(scheduler_mode sched);
+
 }    // namespace pika::threads

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_state.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_state.hpp
@@ -10,25 +10,27 @@
 
 #include <pika/config.hpp>
 
+#include <cstdint>
+
 namespace pika {
-    enum state
+    enum class state : std::int8_t
     {
-        state_invalid = -1,
-        state_initialized = 0,
-        first_valid_runtime_state = state_initialized,
-        state_pre_startup = 1,
-        state_startup = 2,
-        state_pre_main = 3,
-        state_starting = 4,
-        state_running = 5,
-        state_suspended = 6,
-        state_pre_sleep = 7,
-        state_sleeping = 8,
-        state_pre_shutdown = 9,
-        state_shutdown = 10,
-        state_stopping = 11,
-        state_terminating = 12,
-        state_stopped = 13,
-        last_valid_runtime_state = state_stopped
+        invalid = -1,
+        initialized = 0,
+        first_valid_runtime = initialized,
+        pre_startup = 1,
+        startup = 2,
+        pre_main = 3,
+        starting = 4,
+        running = 5,
+        suspended = 6,
+        pre_sleep = 7,
+        sleeping = 8,
+        pre_shutdown = 9,
+        shutdown = 10,
+        stopping = 11,
+        terminating = 12,
+        stopped = 13,
+        last_valid_runtime = stopped
     };
 }

--- a/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
@@ -160,7 +160,7 @@ namespace pika {
                 std::enable_if_t<!std::is_same_v<std::decay_t<F>, std::string>>>
         explicit scoped_annotation(F&& f)
         {
-            pika::util::detail::thread_description desc(f);
+            pika::detail::thread_description desc(f);
 
             auto* self = pika::threads::detail::get_self_ptr();
             if (self != nullptr)
@@ -194,7 +194,7 @@ namespace pika {
 #endif
         }
 
-        pika::util::detail::thread_description desc_;
+        pika::detail::thread_description desc_;
     };
 #endif
 

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -252,34 +252,35 @@ namespace pika::threads::detail {
         }
 
 #if !defined(PIKA_HAVE_THREAD_DESCRIPTION)
-        util::detail::thread_description get_description() const
+        ::pika::detail::thread_description get_description() const
         {
-            return util::detail::thread_description("<unknown>");
-        }
-        util::detail::thread_description set_description(
-            util::detail::thread_description /*value*/)
-        {
-            return util::detail::thread_description("<unknown>");
+            return ::pika::detail::thread_description("<unknown>");
         }
 
-        util::detail::thread_description get_lco_description() const
+        ::pika::detail::thread_description set_description(
+            ::pika::detail::thread_description /*value*/)
         {
-            return util::detail::thread_description("<unknown>");
+            return ::pika::detail::thread_description("<unknown>");
         }
-        util::detail::thread_description set_lco_description(
-            util::detail::thread_description /*value*/)
+
+        ::pika::detail::thread_description get_lco_description() const
         {
-            return util::detail::thread_description("<unknown>");
+            return ::pika::detail::thread_description("<unknown>");
+        }
+        ::pika::detail::thread_description set_lco_description(
+            ::pika::detail::thread_description /*value*/)
+        {
+            return ::pika::detail::thread_description("<unknown>");
         }
 #else
-        util::detail::thread_description get_description() const
+        ::pika::detail::thread_description get_description() const
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
             return description_;
         }
-        util::detail::thread_description set_description(
-            util::detail::thread_description value)
+        ::pika::detail::thread_description set_description(
+            ::pika::detail::thread_description value)
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
@@ -287,14 +288,14 @@ namespace pika::threads::detail {
             return value;
         }
 
-        util::detail::thread_description get_lco_description() const
+        ::pika::detail::thread_description get_lco_description() const
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
             return lco_description_;
         }
-        util::detail::thread_description set_lco_description(
-            util::detail::thread_description value)
+        ::pika::detail::thread_description set_lco_description(
+            ::pika::detail::thread_description value)
         {
             std::lock_guard<pika::util::detail::spinlock> l(
                 spinlock_pool::spinlock_for(this));
@@ -584,8 +585,8 @@ namespace pika::threads::detail {
         ///////////////////////////////////////////////////////////////////////
         // Debugging/logging information
 #ifdef PIKA_HAVE_THREAD_DESCRIPTION
-        util::detail::thread_description description_;
-        util::detail::thread_description lco_description_;
+        ::pika::detail::thread_description description_;
+        ::pika::detail::thread_description lco_description_;
 #endif
 
 #ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE

--- a/libs/pika/threading_base/include/pika/threading_base/thread_description.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_description.hpp
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::util::detail {
+namespace pika::detail {
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
     struct thread_description
@@ -257,7 +257,7 @@ namespace pika::util::detail {
     PIKA_EXPORT std::ostream& operator<<(
         std::ostream&, thread_description const&);
     PIKA_EXPORT std::string as_string(thread_description const& desc);
-}    // namespace pika::util::detail
+}    // namespace pika::detail
 
 namespace pika::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
@@ -280,19 +280,19 @@ namespace pika::threads::detail {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of pika#exception.
-    PIKA_EXPORT util::detail::thread_description get_thread_description(
+    PIKA_EXPORT ::pika::detail::thread_description get_thread_description(
         thread_id_type const& id, error_code& ec = throws);
-    PIKA_EXPORT util::detail::thread_description set_thread_description(
+    PIKA_EXPORT ::pika::detail::thread_description set_thread_description(
         thread_id_type const& id,
-        util::detail::thread_description const& desc =
-            util::detail::thread_description(),
+        ::pika::detail::thread_description const& desc =
+            ::pika::detail::thread_description(),
         error_code& ec = throws);
 
-    PIKA_EXPORT util::detail::thread_description get_thread_lco_description(
+    PIKA_EXPORT ::pika::detail::thread_description get_thread_lco_description(
         thread_id_type const& id, error_code& ec = throws);
-    PIKA_EXPORT util::detail::thread_description set_thread_lco_description(
+    PIKA_EXPORT ::pika::detail::thread_description set_thread_lco_description(
         thread_id_type const& id,
-        util::detail::thread_description const& desc =
-            util::detail::thread_description(),
+        ::pika::detail::thread_description const& desc =
+            ::pika::detail::thread_description(),
         error_code& ec = throws);
 }    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
@@ -437,8 +437,8 @@ namespace pika::this_thread {
     PIKA_EXPORT threads::detail::thread_restart_state suspend(
         threads::detail::thread_schedule_state state,
         threads::detail::thread_id_type id,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
@@ -460,8 +460,8 @@ namespace pika::this_thread {
     inline threads::detail::thread_restart_state suspend(
         threads::detail::thread_schedule_state state =
             threads::detail::thread_schedule_state::pending,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(
@@ -488,8 +488,8 @@ namespace pika::this_thread {
     PIKA_EXPORT threads::detail::thread_restart_state suspend(
         pika::chrono::steady_time_point const& abs_time,
         threads::detail::thread_id_type id,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
@@ -511,8 +511,8 @@ namespace pika::this_thread {
     ///
     inline threads::detail::thread_restart_state suspend(
         pika::chrono::steady_time_point const& abs_time,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(
@@ -538,8 +538,8 @@ namespace pika::this_thread {
     ///
     inline threads::detail::thread_restart_state suspend(
         pika::chrono::steady_duration const& rel_time,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(rel_time.from_now(), threads::detail::invalid_thread_id,
@@ -566,8 +566,8 @@ namespace pika::this_thread {
     inline threads::detail::thread_restart_state suspend(
         pika::chrono::steady_duration const& rel_time,
         threads::detail::thread_id_type const& id,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(rel_time.from_now(), id, description, ec);
@@ -591,8 +591,8 @@ namespace pika::this_thread {
     ///         \a pika#invalid_status.
     ///
     inline threads::detail::thread_restart_state suspend(std::uint64_t ms,
-        util::detail::thread_description const& description =
-            util::detail::thread_description("this_thread::suspend"),
+        detail::thread_description const& description =
+            detail::thread_description("this_thread::suspend"),
         error_code& ec = throws)
     {
         return suspend(std::chrono::milliseconds(ms),

--- a/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_helpers.hpp
@@ -412,7 +412,7 @@ namespace pika::threads::detail {
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a pika#exception with an error code of
     ///         \a pika#invalid_status.
-    PIKA_EXPORT threads::thread_pool_base* get_pool(
+    PIKA_EXPORT threads::detail::thread_pool_base* get_pool(
         thread_id_type const& id, error_code& ec = throws);
 }    // namespace pika::threads::detail
 
@@ -610,7 +610,8 @@ namespace pika::this_thread {
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a pika#exception with an error code of
     ///         \a pika#invalid_status.
-    PIKA_EXPORT threads::thread_pool_base* get_pool(error_code& ec = throws);
+    PIKA_EXPORT threads::detail::thread_pool_base* get_pool(
+        error_code& ec = throws);
 
     /// \cond NOINTERNAL
     // returns the remaining available stack space

--- a/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
@@ -115,7 +115,7 @@ namespace pika::threads::detail {
             thread_schedule_state initial_state_ =
                 thread_schedule_state::pending,
             bool run_now_ = false,
-            ::pika::threads::scheduler_base* scheduler_base_ = nullptr)
+            ::pika::threads::detail::scheduler_base* scheduler_base_ = nullptr)
           : func(PIKA_FORWARD(F, f))
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
           , description(desc)
@@ -170,6 +170,6 @@ namespace pika::threads::detail {
         thread_schedule_state initial_state;
         bool run_now;
 
-        ::pika::threads::scheduler_base* scheduler_base;
+        ::pika::threads::detail::scheduler_base* scheduler_base;
     };
 }    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_init_data.hpp
@@ -105,7 +105,7 @@ namespace pika::threads::detail {
         }
 
         template <typename F>
-        thread_init_data(F&& f, util::detail::thread_description const& desc,
+        thread_init_data(F&& f, ::pika::detail::thread_description const& desc,
             execution::thread_priority priority_ =
                 execution::thread_priority::normal,
             execution::thread_schedule_hint os_thread =
@@ -151,7 +151,7 @@ namespace pika::threads::detail {
         thread_function_type func;
 
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
-        util::detail::thread_description description;
+        ::pika::detail::thread_description description;
 #endif
 #if defined(PIKA_HAVE_THREAD_PARENT_REFERENCE)
         std::uint32_t parent_locality_id;

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -261,7 +261,7 @@ namespace pika { namespace threads {
             return thread_offset_;
         }
 
-        virtual scheduler_base* get_scheduler() const
+        virtual detail::scheduler_base* get_scheduler() const
         {
             return nullptr;
         }

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -34,7 +34,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
     /// \brief Data structure which stores statistics collected by an
     ///        executor instance.
     struct executor_statistics
@@ -51,42 +51,40 @@ namespace pika { namespace threads {
         std::uint64_t queue_length_;
     };
 
-    namespace detail {
-        ///////////////////////////////////////////////////////////////////////
-        enum executor_parameter
-        {
-            min_concurrency = 1,
-            max_concurrency = 2,
-            current_concurrency = 3
-        };
+    ///////////////////////////////////////////////////////////////////////
+    enum executor_parameter
+    {
+        min_concurrency = 1,
+        max_concurrency = 2,
+        current_concurrency = 3
+    };
 
-        ///////////////////////////////////////////////////////////////////////
-        // The interface below is used by the resource manager to
-        // interact with the executor.
-        struct PIKA_EXPORT manage_executor
-        {
-            virtual ~manage_executor() {}
+    ///////////////////////////////////////////////////////////////////////
+    // The interface below is used by the resource manager to
+    // interact with the executor.
+    struct PIKA_EXPORT manage_executor
+    {
+        virtual ~manage_executor() {}
 
-            // Return the requested policy element
-            virtual std::size_t get_policy_element(
-                executor_parameter p, error_code& ec) const = 0;
+        // Return the requested policy element
+        virtual std::size_t get_policy_element(
+            executor_parameter p, error_code& ec) const = 0;
 
-            // Return statistics collected by this scheduler
-            virtual void get_statistics(
-                executor_statistics& stats, error_code& ec) const = 0;
+        // Return statistics collected by this scheduler
+        virtual void get_statistics(
+            executor_statistics& stats, error_code& ec) const = 0;
 
-            // Provide the given processing unit to the scheduler.
-            virtual void add_processing_unit(std::size_t virt_core,
-                std::size_t thread_num, error_code& ec) = 0;
+        // Provide the given processing unit to the scheduler.
+        virtual void add_processing_unit(
+            std::size_t virt_core, std::size_t thread_num, error_code& ec) = 0;
 
-            // Remove the given processing unit from the scheduler.
-            virtual void remove_processing_unit(
-                std::size_t thread_num, error_code& ec) = 0;
+        // Remove the given processing unit from the scheduler.
+        virtual void remove_processing_unit(
+            std::size_t thread_num, error_code& ec) = 0;
 
-            // return the description string of the underlying scheduler
-            virtual char const* get_description() const = 0;
-        };
-    }    // namespace detail
+        // return the description string of the underlying scheduler
+        virtual char const* get_description() const = 0;
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
@@ -238,14 +236,13 @@ namespace pika { namespace threads {
 
         virtual std::size_t get_active_os_thread_count() const;
 
-        virtual void create_thread(detail::thread_init_data& data,
-            detail::thread_id_ref_type& id, error_code& ec) = 0;
-        virtual detail::thread_id_ref_type create_work(
-            detail::thread_init_data& data, error_code& ec) = 0;
+        virtual void create_thread(
+            thread_init_data& data, thread_id_ref_type& id, error_code& ec) = 0;
+        virtual thread_id_ref_type create_work(
+            thread_init_data& data, error_code& ec) = 0;
 
-        virtual detail::thread_state set_state(detail::thread_id_type const& id,
-            detail::thread_schedule_state new_state,
-            detail::thread_restart_state new_state_ex,
+        virtual thread_state set_state(thread_id_type const& id,
+            thread_schedule_state new_state, thread_restart_state new_state_ex,
             execution::thread_priority priority, error_code& ec) = 0;
 
         std::size_t get_pool_index() const
@@ -261,13 +258,13 @@ namespace pika { namespace threads {
             return thread_offset_;
         }
 
-        virtual detail::scheduler_base* get_scheduler() const
+        virtual scheduler_base* get_scheduler() const
         {
             return nullptr;
         }
 
-        detail::mask_type get_used_processing_units() const;
-        detail::hwloc_bitmap_ptr get_numa_domain_bitmap() const;
+        mask_type get_used_processing_units() const;
+        hwloc_bitmap_ptr get_numa_domain_bitmap() const;
 
         // performance counters
 #if defined(PIKA_HAVE_THREAD_CUMULATIVE_COUNTS)
@@ -433,8 +430,7 @@ namespace pika { namespace threads {
         }
 #endif
 
-        virtual std::int64_t get_thread_count(
-            detail::thread_schedule_state /*state*/,
+        virtual std::int64_t get_thread_count(thread_schedule_state /*state*/,
             execution::thread_priority /*priority*/, std::size_t /*num_thread*/,
             bool /*reset*/)
         {
@@ -446,7 +442,7 @@ namespace pika { namespace threads {
             return 0;
         }
 
-        virtual void get_idle_core_mask(detail::mask_type&) const {}
+        virtual void get_idle_core_mask(mask_type&) const {}
 
         virtual std::int64_t get_background_thread_count()
         {
@@ -456,35 +452,35 @@ namespace pika { namespace threads {
         std::int64_t get_thread_count_unknown(
             std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::unknown,
+            return get_thread_count(thread_schedule_state::unknown,
                 execution::thread_priority::default_, num_thread, reset);
         }
         std::int64_t get_thread_count_active(std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::active,
+            return get_thread_count(thread_schedule_state::active,
                 execution::thread_priority::default_, num_thread, reset);
         }
         std::int64_t get_thread_count_pending(
             std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::pending,
+            return get_thread_count(thread_schedule_state::pending,
                 execution::thread_priority::default_, num_thread, reset);
         }
         std::int64_t get_thread_count_suspended(
             std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::suspended,
+            return get_thread_count(thread_schedule_state::suspended,
                 execution::thread_priority::default_, num_thread, reset);
         }
         std::int64_t get_thread_count_terminated(
             std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::terminated,
+            return get_thread_count(thread_schedule_state::terminated,
                 execution::thread_priority::default_, num_thread, reset);
         }
         std::int64_t get_thread_count_staged(std::size_t num_thread, bool reset)
         {
-            return get_thread_count(detail::thread_schedule_state::staged,
+            return get_thread_count(thread_schedule_state::staged,
                 execution::thread_priority::default_, num_thread, reset);
         }
 
@@ -497,9 +493,9 @@ namespace pika { namespace threads {
 
         ///////////////////////////////////////////////////////////////////////
         virtual bool enumerate_threads(
-            util::detail::function<bool(detail::thread_id_type)> const& /*f*/,
-            detail::thread_schedule_state /*state*/ =
-                detail::thread_schedule_state::unknown) const
+            util::detail::function<bool(thread_id_type)> const& /*f*/,
+            thread_schedule_state /*state*/ =
+                thread_schedule_state::unknown) const
         {
             return false;
         }
@@ -559,6 +555,6 @@ namespace pika { namespace threads {
 
     PIKA_EXPORT std::ostream& operator<<(
         std::ostream& os, thread_pool_base const& thread_pool);
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/threading_base/include/pika/threading_base/thread_queue_init_parameters.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_queue_init_parameters.hpp
@@ -13,7 +13,7 @@
 #include <limits>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika::threads {
+namespace pika::threads::detail {
     struct thread_queue_init_parameters
     {
         // NOLINTBEGIN(bugprone-easily-swappable-parameters)
@@ -76,4 +76,4 @@ namespace pika::threads {
         std::ptrdiff_t const huge_stacksize_;
         std::ptrdiff_t const nostack_stacksize_;
     };
-}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/include/pika/threading_base/thread_specific_ptr.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_specific_ptr.hpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     class thread_specific_ptr
@@ -72,7 +72,7 @@ namespace pika { namespace threads {
         ~thread_specific_ptr()
         {
             // clean up data if this type is used locally for one thread
-            if (detail::get_self_ptr())
+            if (get_self_ptr())
                 coroutines::detail::erase_tss_node(this, true);
         }
 
@@ -108,5 +108,5 @@ namespace pika { namespace threads {
             }
         }
     };
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail
 #endif

--- a/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
@@ -36,8 +36,11 @@ namespace pika::detail::external_timer {
 #endif
 }    // namespace pika::detail::external_timer
 
-namespace pika::threads {
+namespace pika::threads::detail {
     struct scheduler_base;
+}    // namespace pika::threads::detail
+
+namespace pika::threads {
 
     class PIKA_EXPORT thread_pool_base;
 

--- a/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/threading_base_fwd.hpp
@@ -36,44 +36,39 @@ namespace pika::detail::external_timer {
 #endif
 }    // namespace pika::detail::external_timer
 
-namespace pika::threads::detail {
-    struct scheduler_base;
-}    // namespace pika::threads::detail
-
 namespace pika::threads {
-
     class PIKA_EXPORT thread_pool_base;
+}    // namespace pika::threads
+
+namespace pika::threads::detail {
 
     /// \cond NOINTERNAL
-    namespace detail {
-        class thread_data;
-        class thread_data_stackful;
-        class thread_data_stackless;
+    struct scheduler_base;
+    class thread_data;
+    class thread_data_stackful;
+    class thread_data_stackless;
 
-        using thread_id_ref_type = thread_id_ref;
-        using thread_id_type = thread_id;
+    using thread_id_ref_type = thread_id_ref;
+    using thread_id_type = thread_id;
 
-        using coroutine_type = coroutines::detail::coroutine;
-        using stackless_coroutine_type =
-            coroutines::detail::stackless_coroutine;
+    using coroutine_type = coroutines::detail::coroutine;
+    using stackless_coroutine_type = coroutines::detail::stackless_coroutine;
 
-        using thread_result_type =
-            std::pair<thread_schedule_state, thread_id_type>;
-        using thread_arg_type = thread_restart_state;
+    using thread_result_type = std::pair<thread_schedule_state, thread_id_type>;
+    using thread_arg_type = thread_restart_state;
 
-        using thread_function_sig = thread_result_type(thread_arg_type);
-        using thread_function_type =
-            util::detail::unique_function<thread_function_sig>;
+    using thread_function_sig = thread_result_type(thread_arg_type);
+    using thread_function_type =
+        util::detail::unique_function<thread_function_sig>;
 
-        using thread_self = coroutines::detail::coroutine_self;
-        using thread_self_impl_type = coroutines::detail::coroutine_impl;
+    using thread_self = coroutines::detail::coroutine_self;
+    using thread_self_impl_type = coroutines::detail::coroutine_impl;
 
 #if defined(PIKA_HAVE_APEX)
-        PIKA_EXPORT std::shared_ptr<pika::detail::external_timer::task_wrapper>
-        get_self_timer_data(void);
-        PIKA_EXPORT void set_self_timer_data(
-            std::shared_ptr<pika::detail::external_timer::task_wrapper> data);
+    PIKA_EXPORT std::shared_ptr<pika::detail::external_timer::task_wrapper>
+    get_self_timer_data(void);
+    PIKA_EXPORT void set_self_timer_data(
+        std::shared_ptr<pika::detail::external_timer::task_wrapper> data);
 #endif
-    }    // namespace detail
     /// \endcond
-}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -178,7 +178,7 @@ namespace pika::threads::detail {
         {
 #ifdef PIKA_HAVE_THREAD_DESCRIPTION
             reset_lco_description desc(
-                id.noref(), util::detail::thread_description(desc));
+                id.noref(), ::pika::detail::thread_description(desc));
 #endif
 #ifdef PIKA_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
             reset_backtrace bt(id);

--- a/libs/pika/threading_base/src/external_timer_apex.cpp
+++ b/libs/pika/threading_base/src/external_timer_apex.cpp
@@ -18,7 +18,7 @@
 
 namespace pika::detail::external_timer {
     std::shared_ptr<task_wrapper> new_task(
-        pika::util::detail::thread_description const& description,
+        pika::detail::thread_description const& description,
         std::uint32_t /* parent_locality_id */,
         threads::detail::thread_id_type parent_task)
     {
@@ -29,7 +29,7 @@ namespace pika::detail::external_timer {
         }
 
         if (description.kind() ==
-            pika::util::detail::thread_description::data_type_description)
+            pika::detail::thread_description::data_type_description)
         {
             return external_timer::new_task(
                 description.get_description(), UINTMAX_MAX, parent_wrapper);
@@ -37,7 +37,7 @@ namespace pika::detail::external_timer {
         else
         {
             PIKA_ASSERT(description.kind() ==
-                pika::util::detail::thread_description::data_type_address);
+                pika::detail::thread_description::data_type_address);
             return external_timer::new_task(
                 description.get_address(), UINTMAX_MAX, parent_wrapper);
         }
@@ -45,7 +45,7 @@ namespace pika::detail::external_timer {
 
     std::shared_ptr<task_wrapper> update_task(
         std::shared_ptr<task_wrapper> wrapper,
-        pika::util::detail::thread_description const& description)
+        pika::detail::thread_description const& description)
     {
         if (wrapper == nullptr)
         {
@@ -54,7 +54,7 @@ namespace pika::detail::external_timer {
             return external_timer::new_task(description, 0, parent_task);
         }
         else if (description.kind() ==
-            pika::util::detail::thread_description::data_type_description)
+            pika::detail::thread_description::data_type_description)
         {
             // Disambiguate the call by making a temporary string object
             return external_timer::update_task(
@@ -63,7 +63,7 @@ namespace pika::detail::external_timer {
         else
         {
             PIKA_ASSERT(description.kind() ==
-                pika::util::detail::thread_description::data_type_address);
+                pika::detail::thread_description::data_type_address);
             return external_timer::update_task(
                 wrapper, description.get_address());
         }

--- a/libs/pika/threading_base/src/reset_lco_description.cpp
+++ b/libs/pika/threading_base/src/reset_lco_description.cpp
@@ -17,17 +17,16 @@
 
 namespace pika::threads::detail {
     reset_lco_description::reset_lco_description(thread_id_type const& id,
-        util::detail::thread_description const& description, error_code& ec)
+        ::pika::detail::thread_description const& description, error_code& ec)
       : id_(id)
       , ec_(ec)
     {
-        old_desc_ =
-            threads::detail::set_thread_lco_description(id_, description, ec_);
+        old_desc_ = set_thread_lco_description(id_, description, ec_);
     }
 
     reset_lco_description::~reset_lco_description()
     {
-        threads::detail::set_thread_lco_description(id_, old_desc_, ec_);
+        set_thread_lco_description(id_, old_desc_, ec_);
     }
 }    // namespace pika::threads::detail
 

--- a/libs/pika/threading_base/src/scheduler_base.cpp
+++ b/libs/pika/threading_base/src/scheduler_base.cpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika::threads {
+namespace pika::threads::detail {
     scheduler_base::scheduler_base(std::size_t num_threads,
         char const* description, thread_queue_init_parameters thread_queue_init,
         scheduler_mode mode)
@@ -429,4 +429,4 @@ namespace pika::threads {
 
         return os;
     }
-}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/src/scheduler_base.cpp
+++ b/libs/pika/threading_base/src/scheduler_base.cpp
@@ -65,7 +65,7 @@ namespace pika::threads::detail {
 #endif
 
         for (std::size_t i = 0; i != num_threads; ++i)
-            states_[i].store(state_initialized);
+            states_[i].store(state::initialized);
     }
 
     void scheduler_base::idle_callback(std::size_t num_thread)
@@ -116,18 +116,18 @@ namespace pika::threads::detail {
     {
         PIKA_ASSERT(num_thread < suspend_conds_.size());
 
-        states_[num_thread].store(state_sleeping);
+        states_[num_thread].store(state::sleeping);
         std::unique_lock<pu_mutex_type> l(suspend_mtxs_[num_thread]);
         suspend_conds_[num_thread].wait(l);
 
-        // Only set running if still in state_sleeping. Can be set with
+        // Only set running if still in state::sleeping. Can be set with
         // non-blocking/locking functions to stopping or terminating, in
         // which case the state is left untouched.
-        pika::state expected = state_sleeping;
-        states_[num_thread].compare_exchange_strong(expected, state_running);
+        pika::state expected = state::sleeping;
+        states_[num_thread].compare_exchange_strong(expected, state::running);
 
-        PIKA_ASSERT(expected == state_sleeping || expected == state_stopping ||
-            expected == state_terminating);
+        PIKA_ASSERT(expected == state::sleeping ||
+            expected == state::stopping || expected == state::terminating);
     }
 
     void scheduler_base::resume(std::size_t num_thread)
@@ -159,7 +159,7 @@ namespace pika::threads::detail {
                 // Try indefinitely as long as at least one thread is
                 // available for scheduling. Increase allowed state if no
                 // threads are available for scheduling.
-                auto max_allowed_state = state_suspended;
+                auto max_allowed_state = state::suspended;
 
                 pika::util::yield_while([this, states_size, &l, &num_thread,
                                             &max_allowed_state]() {
@@ -192,13 +192,13 @@ namespace pika::threads::detail {
 
                     if (0 == num_allowed_threads)
                     {
-                        if (max_allowed_state <= state_suspended)
+                        if (max_allowed_state <= state::suspended)
                         {
-                            max_allowed_state = state_sleeping;
+                            max_allowed_state = state::sleeping;
                         }
-                        else if (max_allowed_state <= state_sleeping)
+                        else if (max_allowed_state <= state::sleeping)
                         {
-                            max_allowed_state = state_stopping;
+                            max_allowed_state = state::stopping;
                         }
                         else
                         {
@@ -227,7 +227,7 @@ namespace pika::threads::detail {
                     pu_mtxs_[num_thread_local], std::try_to_lock);
 
                 if (l.owns_lock() &&
-                    states_[num_thread_local] <= state_suspended)
+                    states_[num_thread_local] <= state::suspended)
                 {
                     return num_thread_local;
                 }
@@ -297,7 +297,7 @@ namespace pika::threads::detail {
     std::pair<pika::state, pika::state> scheduler_base::get_minmax_state() const
     {
         std::pair<pika::state, pika::state> result(
-            last_valid_runtime_state, first_valid_runtime_state);
+            state::last_valid_runtime, state::first_valid_runtime);
 
         using state_type = std::atomic<pika::state>;
         for (state_type const& state_iter : states_)

--- a/libs/pika/threading_base/src/scheduler_base.cpp
+++ b/libs/pika/threading_base/src/scheduler_base.cpp
@@ -71,7 +71,7 @@ namespace pika::threads::detail {
     void scheduler_base::idle_callback(std::size_t num_thread)
     {
 #if defined(PIKA_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
-        if (mode_.data_.load(std::memory_order_relaxed) & enable_idle_backoff)
+        if (has_scheduler_mode(scheduler_mode::enable_idle_backoff))
         {
             // Put this thread to sleep for some time, additionally it gets
             // woken up on new work.
@@ -105,7 +105,7 @@ namespace pika::threads::detail {
     void scheduler_base::do_some_work(std::size_t)
     {
 #if defined(PIKA_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
-        if (mode_.data_.load(std::memory_order_relaxed) & enable_idle_backoff)
+        if (has_scheduler_mode(scheduler_mode::enable_idle_backoff))
         {
             cond_.notify_all();
         }
@@ -150,8 +150,7 @@ namespace pika::threads::detail {
         std::unique_lock<pu_mutex_type>& l, std::size_t num_thread,
         bool allow_fallback)
     {
-        if (mode_.data_.load(std::memory_order_relaxed) &
-            threads::enable_elasticity)
+        if (has_scheduler_mode(threads::scheduler_mode::enable_elasticity))
         {
             std::size_t states_size = states_.size();
 

--- a/libs/pika/threading_base/src/scheduler_mode.cpp
+++ b/libs/pika/threading_base/src/scheduler_mode.cpp
@@ -5,8 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/config.hpp>
-
 #include <pika/threading_base/thread_pool_base.hpp>
+
+#include <cstdint>
 
 namespace pika::threads {
 

--- a/libs/pika/threading_base/src/scheduler_mode.cpp
+++ b/libs/pika/threading_base/src/scheduler_mode.cpp
@@ -1,0 +1,30 @@
+//  Copyright (c) 2022  ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/config.hpp>
+
+#include <pika/threading_base/thread_pool_base.hpp>
+
+namespace pika::threads {
+
+    scheduler_mode operator&(scheduler_mode sched1, scheduler_mode sched2)
+    {
+        return static_cast<scheduler_mode>(static_cast<std::uint32_t>(sched1) &
+            static_cast<std::uint32_t>(sched2));
+    }
+
+    scheduler_mode operator|(scheduler_mode sched1, scheduler_mode sched2)
+    {
+        return static_cast<scheduler_mode>(static_cast<std::uint32_t>(sched1) |
+            static_cast<std::uint32_t>(sched2));
+    }
+
+    scheduler_mode operator~(scheduler_mode sched)
+    {
+        return static_cast<scheduler_mode>(~static_cast<std::uint32_t>(sched));
+    }
+
+}    // namespace pika::threads

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -200,7 +200,7 @@ namespace pika::threads::detail {
 
 #ifdef PIKA_HAVE_THREAD_DESCRIPTION
         description_ = init_data.description;
-        lco_description_ = util::detail::thread_description();
+        lco_description_ = ::pika::detail::thread_description();
 #endif
 #ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
         parent_locality_id_ = init_data.parent_locality_id;

--- a/libs/pika/threading_base/src/thread_description.cpp
+++ b/libs/pika/threading_base/src/thread_description.cpp
@@ -15,7 +15,7 @@
 #include <ostream>
 #include <string>
 
-namespace pika::util::detail {
+namespace pika::detail {
     std::ostream& operator<<(std::ostream& os, thread_description const& d)
     {
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
@@ -38,8 +38,7 @@ namespace pika::util::detail {
     std::string as_string(thread_description const& desc)
     {
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
-        if (desc.kind() ==
-            util::detail::thread_description::data_type_description)
+        if (desc.kind() == detail::thread_description::data_type_description)
             return desc ? desc.get_description() : "<unknown>";
 
         return pika::util::format("address: {:#x}", desc.get_address());
@@ -89,26 +88,26 @@ namespace pika::util::detail {
         PIKA_UNUSED(altname);
 #endif
     }
-}    // namespace pika::util::detail
+}    // namespace pika::detail
 
 namespace pika::threads::detail {
-    util::detail::thread_description get_thread_description(
+    ::pika::detail::thread_description get_thread_description(
         thread_id_type const& id, error_code& /* ec */)
     {
         return id ? get_thread_id_data(id)->get_description() :
-                    util::detail::thread_description("<unknown>");
+                    ::pika::detail::thread_description("<unknown>");
     }
 
-    util::detail::thread_description set_thread_description(
-        thread_id_type const& id, util::detail::thread_description const& desc,
-        error_code& ec)
+    ::pika::detail::thread_description set_thread_description(
+        thread_id_type const& id,
+        ::pika::detail::thread_description const& desc, error_code& ec)
     {
         if (PIKA_UNLIKELY(!id))
         {
             PIKA_THROWS_IF(ec, pika::error::null_thread_id,
                 "pika::threads::detail::set_thread_description",
                 "null thread id encountered");
-            return util::detail::thread_description();
+            return ::pika::detail::thread_description();
         }
         if (&ec != &throws)
             ec = make_success_code();
@@ -117,7 +116,7 @@ namespace pika::threads::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    util::detail::thread_description get_thread_lco_description(
+    ::pika::detail::thread_description get_thread_lco_description(
         thread_id_type const& id, error_code& ec)
     {
         if (PIKA_UNLIKELY(!id))
@@ -134,9 +133,9 @@ namespace pika::threads::detail {
         return get_thread_id_data(id)->get_lco_description();
     }
 
-    util::detail::thread_description set_thread_lco_description(
-        thread_id_type const& id, util::detail::thread_description const& desc,
-        error_code& ec)
+    ::pika::detail::thread_description set_thread_lco_description(
+        thread_id_type const& id,
+        ::pika::detail::thread_description const& desc, error_code& ec)
     {
         if (PIKA_UNLIKELY(!id))
         {

--- a/libs/pika/threading_base/src/thread_helpers.cpp
+++ b/libs/pika/threading_base/src/thread_helpers.cpp
@@ -357,7 +357,7 @@ namespace pika::this_thread {
     threads::detail::thread_restart_state suspend(
         threads::detail::thread_schedule_state state,
         threads::detail::thread_id_type nextid,
-        util::detail::thread_description const& description, error_code& ec)
+        detail::thread_description const& description, error_code& ec)
     {
         // let the thread manager do other things while waiting
         threads::detail::thread_self& self = threads::detail::get_self();
@@ -430,7 +430,7 @@ namespace pika::this_thread {
     threads::detail::thread_restart_state suspend(
         pika::chrono::steady_time_point const& abs_time,
         threads::detail::thread_id_type nextid,
-        util::detail::thread_description const& description, error_code& ec)
+        detail::thread_description const& description, error_code& ec)
     {
         // schedule a thread waking us up at_time
         threads::detail::thread_self& self = threads::detail::get_self();

--- a/libs/pika/threading_base/src/thread_helpers.cpp
+++ b/libs/pika/threading_base/src/thread_helpers.cpp
@@ -328,7 +328,7 @@ namespace pika::threads::detail {
         return get_thread_id_data(id)->set_backtrace(bt);
     }
 
-    threads::thread_pool_base* get_pool(
+    threads::detail::thread_pool_base* get_pool(
         thread_id_type const& id, error_code& ec)
     {
         if (PIKA_UNLIKELY(!id))
@@ -529,7 +529,7 @@ namespace pika::this_thread {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    threads::thread_pool_base* get_pool(error_code& ec)
+    threads::detail::thread_pool_base* get_pool(error_code& ec)
     {
         return threads::detail::get_pool(threads::detail::get_self_id(), ec);
     }

--- a/libs/pika/threading_base/src/thread_pool_base.cpp
+++ b/libs/pika/threading_base/src/thread_pool_base.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <thread>
 
-namespace pika { namespace threads {
+namespace pika::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
     thread_pool_base::thread_pool_base(thread_pool_init_parameters const& init)
       : id_(init.index_, init.name_)
@@ -36,14 +36,13 @@ namespace pika { namespace threads {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    detail::mask_type thread_pool_base::get_used_processing_units() const
+    mask_type thread_pool_base::get_used_processing_units() const
     {
-        auto const& topo = detail::create_topology();
+        auto const& topo = create_topology();
         auto const sched = get_scheduler();
 
-        detail::mask_type used_processing_units = detail::mask_type();
-        threads::detail::resize(
-            used_processing_units, detail::hardware_concurrency());
+        mask_type used_processing_units = mask_type();
+        resize(used_processing_units, hardware_concurrency());
 
         for (std::size_t thread_num = 0; thread_num < get_os_thread_count();
              ++thread_num)
@@ -58,10 +57,10 @@ namespace pika { namespace threads {
         return used_processing_units;
     }
 
-    detail::hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
+    hwloc_bitmap_ptr thread_pool_base::get_numa_domain_bitmap() const
     {
-        auto const& topo = detail::create_topology();
-        detail::mask_type used_processing_units = get_used_processing_units();
+        auto const& topo = create_topology();
+        mask_type used_processing_units = get_used_processing_units();
         return topo.cpuset_to_nodeset(used_processing_units);
     }
 
@@ -127,4 +126,4 @@ namespace pika { namespace threads {
 
         return os;
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads::detail

--- a/libs/pika/threading_base/src/thread_pool_base.cpp
+++ b/libs/pika/threading_base/src/thread_pool_base.cpp
@@ -48,7 +48,7 @@ namespace pika { namespace threads {
         for (std::size_t thread_num = 0; thread_num < get_os_thread_count();
              ++thread_num)
         {
-            if (sched->get_state(thread_num).load() <= state_suspended)
+            if (sched->get_state(thread_num).load() <= state::suspended)
             {
                 used_processing_units |= affinity_data_.get_pu_mask(
                     topo, thread_num + get_thread_offset());
@@ -73,7 +73,7 @@ namespace pika { namespace threads {
              ++thread_num)
         {
             if (get_scheduler()->get_state(thread_num).load() <=
-                state_suspended)
+                state::suspended)
             {
                 ++active_os_thread_count;
             }

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -166,12 +166,12 @@ void function_futures_limiting_executor(
         sched->add_remove_scheduler_mode(
             // add these flags
             scheduler_mode::enable_stealing |
-            scheduler_mode::enable_stealing_numa |
-            scheduler_mode::assign_work_round_robin |
-            scheduler_mode::steal_after_local,
+                scheduler_mode::enable_stealing_numa |
+                scheduler_mode::assign_work_round_robin |
+                scheduler_mode::steal_after_local,
             // remove these flags
             scheduler_mode::assign_work_thread_parent |
-            scheduler_mode::steal_high_priority_first);
+                scheduler_mode::steal_high_priority_first);
     }
 
     // test a parallel algorithm on custom pool with high priority
@@ -333,10 +333,10 @@ void function_futures_create_thread_hierarchical_placement(
     {
         using ::pika::threads::scheduler_mode;
         sched->add_remove_scheduler_mode(
-                // add
-                scheduler_mode::assign_work_thread_parent,
-                // remove
-                scheduler_mode::enable_stealing |
+            // add
+            scheduler_mode::assign_work_thread_parent,
+            // remove
+            scheduler_mode::enable_stealing |
                 scheduler_mode::enable_stealing_numa |
                 scheduler_mode::assign_work_round_robin |
                 scheduler_mode::steal_after_local |

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -164,14 +164,15 @@ void function_futures_limiting_executor(
     {
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(pika::threads::enable_stealing |
-                pika::threads::enable_stealing_numa |
-                pika::threads::assign_work_round_robin |
-                pika::threads::steal_after_local),
+            pika::threads::scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing |
+                pika::threads::scheduler_mode::enable_stealing_numa |
+                pika::threads::scheduler_mode::assign_work_round_robin |
+                pika::threads::scheduler_mode::steal_after_local),
             // remove these flags
             pika::threads::scheduler_mode(
-                pika::threads::assign_work_thread_parent |
-                pika::threads::steal_high_priority_first));
+                pika::threads::scheduler_mode::assign_work_thread_parent |
+                pika::threads::scheduler_mode::steal_high_priority_first));
     }
 
     // test a parallel algorithm on custom pool with high priority
@@ -333,12 +334,13 @@ void function_futures_create_thread_hierarchical_placement(
     {
         sched->add_remove_scheduler_mode(
             pika::threads::scheduler_mode(
-                pika::threads::assign_work_thread_parent),
-            pika::threads::scheduler_mode(pika::threads::enable_stealing |
-                pika::threads::enable_stealing_numa |
-                pika::threads::assign_work_round_robin |
-                pika::threads::steal_after_local |
-                pika::threads::steal_high_priority_first));
+                pika::threads::scheduler_mode::assign_work_thread_parent),
+            pika::threads::scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing |
+                pika::threads::scheduler_mode::enable_stealing_numa |
+                pika::threads::scheduler_mode::assign_work_round_robin |
+                pika::threads::scheduler_mode::steal_after_local |
+                pika::threads::scheduler_mode::steal_high_priority_first));
     }
     auto const func = [&l]() {
         null_function();

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -162,17 +162,16 @@ void function_futures_limiting_executor(
     if (std::string("core-shared_priority_queue_scheduler") ==
         sched->get_description())
     {
+        using ::pika::threads::scheduler_mode;
         sched->add_remove_scheduler_mode(
             // add these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::enable_stealing |
-                pika::threads::scheduler_mode::enable_stealing_numa |
-                pika::threads::scheduler_mode::assign_work_round_robin |
-                pika::threads::scheduler_mode::steal_after_local),
+            scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_after_local,
             // remove these flags
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::assign_work_thread_parent |
-                pika::threads::scheduler_mode::steal_high_priority_first));
+            scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_high_priority_first);
     }
 
     // test a parallel algorithm on custom pool with high priority
@@ -332,15 +331,16 @@ void function_futures_create_thread_hierarchical_placement(
     if (std::string("core-shared_priority_queue_scheduler") ==
         sched->get_description())
     {
+        using ::pika::threads::scheduler_mode;
         sched->add_remove_scheduler_mode(
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::assign_work_thread_parent),
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::enable_stealing |
-                pika::threads::scheduler_mode::enable_stealing_numa |
-                pika::threads::scheduler_mode::assign_work_round_robin |
-                pika::threads::scheduler_mode::steal_after_local |
-                pika::threads::scheduler_mode::steal_high_priority_first));
+                // add
+                scheduler_mode::assign_work_thread_parent,
+                // remove
+                scheduler_mode::enable_stealing |
+                scheduler_mode::enable_stealing_numa |
+                scheduler_mode::assign_work_round_robin |
+                scheduler_mode::steal_after_local |
+                scheduler_mode::steal_high_priority_first);
     }
     auto const func = [&l]() {
         null_function();

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -297,7 +297,7 @@ void function_futures_create_thread(std::uint64_t count, bool csv)
     };
     auto const thread_func =
         pika::threads::detail::thread_function_nullary<decltype(func)>{func};
-    auto const desc = pika::util::detail::thread_description();
+    auto const desc = pika::detail::thread_description();
     auto const prio = pika::execution::thread_priority::normal;
     auto const hint = pika::execution::thread_schedule_hint();
     auto const stack_size = pika::execution::thread_stacksize::small_;
@@ -348,7 +348,7 @@ void function_futures_create_thread_hierarchical_placement(
     };
     auto const thread_func =
         pika::threads::detail::thread_function_nullary<decltype(func)>{func};
-    auto const desc = pika::util::detail::thread_description();
+    auto const desc = pika::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;
     auto const stack_size = pika::execution::thread_stacksize::small_;
     auto const num_threads = pika::get_num_worker_threads();

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -82,10 +82,10 @@ void measure_function_futures_create_thread_hierarchical_placement(
             scheduler_mode::assign_work_thread_parent,
             // remove
             scheduler_mode::enable_stealing |
-            scheduler_mode::enable_stealing_numa |
-            scheduler_mode::assign_work_round_robin |
-            scheduler_mode::steal_after_local |
-            scheduler_mode::steal_high_priority_first);
+                scheduler_mode::enable_stealing_numa |
+                scheduler_mode::assign_work_round_robin |
+                scheduler_mode::steal_after_local |
+                scheduler_mode::steal_high_priority_first);
     }
     auto const desc = pika::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -76,15 +76,16 @@ void measure_function_futures_create_thread_hierarchical_placement(
     if (std::string("core-shared_priority_queue_scheduler") ==
         sched->get_description())
     {
+        using ::pika::threads::scheduler_mode;
         sched->add_remove_scheduler_mode(
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::assign_work_thread_parent),
-            pika::threads::scheduler_mode(
-                pika::threads::scheduler_mode::enable_stealing |
-                pika::threads::scheduler_mode::enable_stealing_numa |
-                pika::threads::scheduler_mode::assign_work_round_robin |
-                pika::threads::scheduler_mode::steal_after_local |
-                pika::threads::scheduler_mode::steal_high_priority_first));
+            // add
+            scheduler_mode::assign_work_thread_parent,
+            // remove
+            scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_after_local |
+            scheduler_mode::steal_high_priority_first);
     }
     auto const desc = pika::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -78,12 +78,13 @@ void measure_function_futures_create_thread_hierarchical_placement(
     {
         sched->add_remove_scheduler_mode(
             pika::threads::scheduler_mode(
-                pika::threads::assign_work_thread_parent),
-            pika::threads::scheduler_mode(pika::threads::enable_stealing |
-                pika::threads::enable_stealing_numa |
-                pika::threads::assign_work_round_robin |
-                pika::threads::steal_after_local |
-                pika::threads::steal_high_priority_first));
+                pika::threads::scheduler_mode::assign_work_thread_parent),
+            pika::threads::scheduler_mode(
+                pika::threads::scheduler_mode::enable_stealing |
+                pika::threads::scheduler_mode::enable_stealing_numa |
+                pika::threads::scheduler_mode::assign_work_round_robin |
+                pika::threads::scheduler_mode::steal_after_local |
+                pika::threads::scheduler_mode::steal_high_priority_first));
     }
     auto const desc = pika::util::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -86,7 +86,7 @@ void measure_function_futures_create_thread_hierarchical_placement(
                 pika::threads::scheduler_mode::steal_after_local |
                 pika::threads::scheduler_mode::steal_high_priority_first));
     }
-    auto const desc = pika::util::detail::thread_description();
+    auto const desc = pika::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;
     auto const stack_size = pika::execution::thread_stacksize::small_;
     auto const num_threads = pika::get_num_worker_threads();

--- a/tools/VS/thread_description.natvis
+++ b/tools/VS/thread_description.natvis
@@ -7,7 +7,7 @@
 <!-- or copy at http://www.boost.org/LICENSE_1_0.txt)                       -->
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-    <Type Name="pika::util::thread_description">
+    <Type Name="pika::detail::thread_description">
         <DisplayString Condition="type_ == 0">[desc] {data_.desc_,s}</DisplayString>
         <DisplayString Condition="type_ == 1">[addr] {(void*)data_.addr_,na}</DisplayString>
     </Type>


### PR DESCRIPTION
Part of #16 
- Move functionalities that are not used by DLA-Future in detail namespace.
- Change `enum`s to `enum class`es.