### PR TITLE
Reduce namespace nesting in sender adaptors

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -20,129 +20,129 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace drop_value_detail {
-        template <typename Receiver>
-        struct drop_value_receiver_impl
+namespace pika::drop_value_detail {
+    template <typename Receiver>
+    struct drop_value_receiver_impl
+    {
+        struct drop_value_receiver_type;
+    };
+
+    template <typename Receiver>
+    using drop_value_receiver =
+        typename drop_value_receiver_impl<Receiver>::drop_value_receiver_type;
+
+    template <typename Receiver>
+    struct drop_value_receiver_impl<Receiver>::drop_value_receiver_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+        template <typename Error>
+        friend void tag_invoke(pika::execution::experimental::set_error_t,
+            drop_value_receiver_type&& r, Error&& error) noexcept
         {
-            struct drop_value_receiver_type;
-        };
+            pika::execution::experimental::set_error(
+                PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
+        }
 
-        template <typename Receiver>
-        using drop_value_receiver = typename drop_value_receiver_impl<
-            Receiver>::drop_value_receiver_type;
-
-        template <typename Receiver>
-        struct drop_value_receiver_impl<Receiver>::drop_value_receiver_type
+        friend void tag_invoke(pika::execution::experimental::set_stopped_t,
+            drop_value_receiver_type&& r) noexcept
         {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            pika::execution::experimental::set_stopped(PIKA_MOVE(r.receiver));
+        }
 
-            template <typename Error>
-            friend void tag_invoke(set_error_t, drop_value_receiver_type&& r,
-                Error&& error) noexcept
-            {
-                pika::execution::experimental::set_error(
-                    PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, drop_value_receiver_type&& r) noexcept
-            {
-                pika::execution::experimental::set_stopped(
-                    PIKA_MOVE(r.receiver));
-            }
-
-            template <typename... Ts>
-            friend void tag_invoke(
-                set_value_t, drop_value_receiver_type&& r, Ts&&...) noexcept
-            {
-                pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
-            }
-
-            friend constexpr pika::execution::experimental::detail::empty_env
-            tag_invoke(pika::execution::experimental::get_env_t,
-                drop_value_receiver_type const&) noexcept
-            {
-                return {};
-            }
-        };
-
-        template <typename Sender>
-        struct drop_value_sender_impl
+        template <typename... Ts>
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            drop_value_receiver_type&& r, Ts&&...) noexcept
         {
-            struct drop_value_sender_type;
-        };
+            pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
+        }
 
-        template <typename Sender>
-        using drop_value_sender =
-            typename drop_value_sender_impl<Sender>::drop_value_sender_type;
-
-        template <typename Sender>
-        struct drop_value_sender_impl<Sender>::drop_value_sender_type
+        friend constexpr pika::execution::experimental::detail::empty_env
+        tag_invoke(pika::execution::experimental::get_env_t,
+            drop_value_receiver_type const&) noexcept
         {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+            return {};
+        }
+    };
+
+    template <typename Sender>
+    struct drop_value_sender_impl
+    {
+        struct drop_value_sender_type;
+    };
+
+    template <typename Sender>
+    using drop_value_sender =
+        typename drop_value_sender_impl<Sender>::drop_value_sender_type;
+
+    template <typename Sender>
+    struct drop_value_sender_impl<Sender>::drop_value_sender_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
 
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
-            template <class...>
-            using empty_set_value = completion_signatures<set_value_t()>;
+        template <class...>
+        using empty_set_value =
+            pika::execution::experimental::completion_signatures<
+                pika::execution::experimental::set_value_t()>;
 
-            using completion_signatures =
-                pika::execution::experimental::make_completion_signatures<
-                    Sender, pika::execution::experimental::detail::empty_env,
-                    pika::execution::experimental::completion_signatures<>,
-                    empty_set_value>;
+        using completion_signatures =
+            pika::execution::experimental::make_completion_signatures<Sender,
+                pika::execution::experimental::detail::empty_env,
+                pika::execution::experimental::completion_signatures<>,
+                empty_set_value>;
 #else
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = Variant<Tuple<>>;
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = Variant<Tuple<>>;
 
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template error_types<Variant>,
-                    std::exception_ptr>>;
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
 
-            static constexpr bool sends_done = false;
+        static constexpr bool sends_done = false;
 #endif
 
-            template <typename CPO,
-                // clang-format off
+        template <typename CPO,
+            // clang-format off
                 PIKA_CONCEPT_REQUIRES_(
                     pika::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     pika::execution::experimental::detail::has_completion_scheduler_v<
                         CPO, std::decay_t<Sender>>)
-                // clang-format on
-                >
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::get_completion_scheduler_t<CPO>,
-                drop_value_sender_type const& sender)
-            {
-                return pika::execution::experimental::get_completion_scheduler<
-                    CPO>(sender.sender);
-            }
+            // clang-format on
+            >
+        friend constexpr auto tag_invoke(
+            pika::execution::experimental::get_completion_scheduler_t<CPO>,
+            drop_value_sender_type const& sender)
+        {
+            return pika::execution::experimental::get_completion_scheduler<CPO>(
+                sender.sender);
+        }
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, drop_value_sender_type&& s, Receiver&& receiver)
-            {
-                return pika::execution::experimental::connect(
-                    PIKA_MOVE(s.sender),
-                    drop_value_receiver<Receiver>{
-                        PIKA_FORWARD(Receiver, receiver)});
-            }
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            drop_value_sender_type&& s, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(PIKA_MOVE(s.sender),
+                drop_value_receiver<Receiver>{
+                    PIKA_FORWARD(Receiver, receiver)});
+        }
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, drop_value_sender_type& r, Receiver&& receiver)
-            {
-                return pika::execution::experimental::connect(r.sender,
-                    drop_value_receiver<Receiver>{
-                        PIKA_FORWARD(Receiver, receiver)});
-            }
-        };
-    }    // namespace drop_value_detail
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            drop_value_sender_type& r, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(r.sender,
+                drop_value_receiver<Receiver>{
+                    PIKA_FORWARD(Receiver, receiver)});
+        }
+    };
+}    // namespace pika::drop_value_detail
 
+namespace pika::execution::experimental {
     inline constexpr struct drop_value_t final
       : pika::functional::detail::tag_fallback<drop_value_t>
     {
@@ -158,4 +158,4 @@ namespace pika { namespace execution { namespace experimental {
             return detail::partial_algorithm<drop_value_t>{};
         }
     } drop_value{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -22,109 +22,106 @@
 #include <stdexcept>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace just_detail {
-        template <typename Is, typename... Ts>
-        struct just_sender_impl;
+namespace pika::just_detail {
+    template <typename Is, typename... Ts>
+    struct just_sender_impl;
 
-        template <typename std::size_t... Is, typename... Ts>
-        struct just_sender_impl<pika::util::detail::index_pack<Is...>, Ts...>
+    template <typename std::size_t... Is, typename... Ts>
+    struct just_sender_impl<pika::util::detail::index_pack<Is...>, Ts...>
+    {
+        struct just_sender_type
         {
-            struct just_sender_type
+            pika::util::detail::member_pack_for<std::decay_t<Ts>...> ts;
+
+            constexpr just_sender_type() = default;
+
+            template <typename T,
+                typename = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<T>, just_sender_type>>>
+            explicit constexpr just_sender_type(T&& t)
+              : ts(std::piecewise_construct, PIKA_FORWARD(T, t))
             {
+            }
+
+            template <typename T0, typename T1, typename... Ts_>
+            explicit constexpr just_sender_type(T0&& t0, T1&& t1, Ts_&&... ts)
+              : ts(std::piecewise_construct, PIKA_FORWARD(T0, t0),
+                    PIKA_FORWARD(T1, t1), PIKA_FORWARD(Ts_, ts)...)
+            {
+            }
+
+            just_sender_type(just_sender_type&&) = default;
+            just_sender_type(just_sender_type const&) = default;
+            just_sender_type& operator=(just_sender_type&&) = default;
+            just_sender_type& operator=(just_sender_type const&) = default;
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<std::decay_t<Ts>...>>;
+
+            template <template <typename...> class Variant>
+            using error_types = Variant<std::exception_ptr>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename Receiver>
+            struct operation_state
+            {
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
                 pika::util::detail::member_pack_for<std::decay_t<Ts>...> ts;
 
-                constexpr just_sender_type() = default;
-
-                template <typename T,
-                    typename = std::enable_if_t<
-                        !std::is_same_v<std::decay_t<T>, just_sender_type>>>
-                explicit constexpr just_sender_type(T&& t)
-                  : ts(std::piecewise_construct, PIKA_FORWARD(T, t))
+                template <typename Receiver_>
+                operation_state(Receiver_&& receiver,
+                    pika::util::detail::member_pack_for<std::decay_t<Ts>...> ts)
+                  : receiver(PIKA_FORWARD(Receiver_, receiver))
+                  , ts(PIKA_MOVE(ts))
                 {
                 }
 
-                template <typename T0, typename T1, typename... Ts_>
-                explicit constexpr just_sender_type(
-                    T0&& t0, T1&& t1, Ts_&&... ts)
-                  : ts(std::piecewise_construct, PIKA_FORWARD(T0, t0),
-                        PIKA_FORWARD(T1, t1), PIKA_FORWARD(Ts_, ts)...)
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                friend void tag_invoke(pika::execution::experimental::start_t,
+                    operation_state& os) noexcept
                 {
-                }
-
-                just_sender_type(just_sender_type&&) = default;
-                just_sender_type(just_sender_type const&) = default;
-                just_sender_type& operator=(just_sender_type&&) = default;
-                just_sender_type& operator=(just_sender_type const&) = default;
-
-                template <template <typename...> class Tuple,
-                    template <typename...> class Variant>
-                using value_types = Variant<Tuple<std::decay_t<Ts>...>>;
-
-                template <template <typename...> class Variant>
-                using error_types = Variant<std::exception_ptr>;
-
-                static constexpr bool sends_done = false;
-
-                template <typename Receiver>
-                struct operation_state
-                {
-                    PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                    pika::util::detail::member_pack_for<std::decay_t<Ts>...> ts;
-
-                    template <typename Receiver_>
-                    operation_state(Receiver_&& receiver,
-                        pika::util::detail::member_pack_for<std::decay_t<Ts>...>
-                            ts)
-                      : receiver(PIKA_FORWARD(Receiver_, receiver))
-                      , ts(PIKA_MOVE(ts))
-                    {
-                    }
-
-                    operation_state(operation_state&&) = delete;
-                    operation_state& operator=(operation_state&&) = delete;
-                    operation_state(operation_state const&) = delete;
-                    operation_state& operator=(operation_state const&) = delete;
-
-                    friend void tag_invoke(
-                        start_t, operation_state& os) noexcept
-                    {
-                        pika::detail::try_catch_exception_ptr(
-                            [&]() {
-                                pika::execution::experimental::set_value(
-                                    PIKA_MOVE(os.receiver),
-                                    PIKA_MOVE(os.ts).template get<Is>()...);
-                            },
-                            [&](std::exception_ptr ep) {
-                                pika::execution::experimental::set_error(
-                                    PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
-                            });
-                    }
-                };
-
-                template <typename Receiver>
-                friend auto tag_invoke(
-                    connect_t, just_sender_type&& s, Receiver&& receiver)
-                {
-                    return operation_state<Receiver>{
-                        PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.ts)};
-                }
-
-                template <typename Receiver>
-                friend auto tag_invoke(
-                    connect_t, just_sender_type& s, Receiver&& receiver)
-                {
-                    return operation_state<Receiver>{
-                        PIKA_FORWARD(Receiver, receiver), s.ts};
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() {
+                            pika::execution::experimental::set_value(
+                                PIKA_MOVE(os.receiver),
+                                PIKA_MOVE(os.ts).template get<Is>()...);
+                        },
+                        [&](std::exception_ptr ep) {
+                            pika::execution::experimental::set_error(
+                                PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
+                        });
                 }
             };
+
+            template <typename Receiver>
+            friend auto tag_invoke(pika::execution::experimental::connect_t,
+                just_sender_type&& s, Receiver&& receiver)
+            {
+                return operation_state<Receiver>{
+                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.ts)};
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(pika::execution::experimental::connect_t,
+                just_sender_type& s, Receiver&& receiver)
+            {
+                return operation_state<Receiver>{
+                    PIKA_FORWARD(Receiver, receiver), s.ts};
+            }
         };
+    };
 
-        template <typename Is, typename... Ts>
-        using just_sender =
-            typename just_sender_impl<Is, Ts...>::just_sender_type;
-    }    // namespace just_detail
+    template <typename Is, typename... Ts>
+    using just_sender = typename just_sender_impl<Is, Ts...>::just_sender_type;
+}    // namespace pika::just_detail
 
+namespace pika::execution::experimental {
     inline constexpr struct just_t final
     {
         template <typename... Ts>
@@ -136,5 +133,5 @@ namespace pika { namespace execution { namespace experimental {
                 Ts...>{PIKA_FORWARD(Ts, ts)...};
         }
     } just{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
@@ -22,132 +22,137 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace detail {
-        template <typename Receiver, typename Future>
-        struct operation_state
+namespace pika::keep_future_detail {
+    template <typename Receiver, typename Future>
+    struct operation_state
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        std::decay_t<Future> future;
+
+        friend void tag_invoke(pika::execution::experimental::start_t,
+            operation_state& os) noexcept
         {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-            std::decay_t<Future> future;
+            pika::detail::try_catch_exception_ptr(
+                [&]() {
+                    auto state =
+                        pika::traits::detail::get_shared_state(os.future);
 
-            friend void tag_invoke(start_t, operation_state& os) noexcept
-            {
-                pika::detail::try_catch_exception_ptr(
-                    [&]() {
-                        auto state =
-                            pika::traits::detail::get_shared_state(os.future);
+                    if (!state)
+                    {
+                        PIKA_THROW_EXCEPTION(pika::error::no_state,
+                            "operation_state::start",
+                            "the future has no valid shared state");
+                    }
 
-                        if (!state)
-                        {
-                            PIKA_THROW_EXCEPTION(pika::error::no_state,
-                                "operation_state::start",
-                                "the future has no valid shared state");
-                        }
-
-                        // The operation state has to be kept alive until set_value
-                        // is called, which means that we don't need to move
-                        // receiver and future into the on_completed callback.
-                        state->set_on_completed([&os]() mutable {
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(os.receiver), PIKA_MOVE(os.future));
-                        });
-                    },
-                    [&](std::exception_ptr ep) {
-                        pika::execution::experimental::set_error(
-                            PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
+                    // The operation state has to be kept alive until set_value
+                    // is called, which means that we don't need to move
+                    // receiver and future into the on_completed callback.
+                    state->set_on_completed([&os]() mutable {
+                        pika::execution::experimental::set_value(
+                            PIKA_MOVE(os.receiver), PIKA_MOVE(os.future));
                     });
-            }
-        };
+                },
+                [&](std::exception_ptr ep) {
+                    pika::execution::experimental::set_error(
+                        PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
+                });
+        }
+    };
 
-        template <typename Future>
-        struct keep_future_sender_base
+    template <typename Future>
+    struct keep_future_sender_base
+    {
+        std::decay_t<Future> future;
+
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = Variant<Tuple<std::decay_t<Future>>>;
+
+        template <template <typename...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        using completion_signatures =
+            pika::execution::experimental::completion_signatures<
+                pika::execution::experimental::set_value_t(
+                    std::decay_t<Future>),
+                pika::execution::experimental::set_error_t(std::exception_ptr)>;
+    };
+
+    template <typename Future>
+    struct keep_future_sender;
+
+    template <typename T>
+    struct keep_future_sender<pika::future<T>>
+      : public keep_future_sender_base<pika::future<T>>
+    {
+        using future_type = pika::future<T>;
+        using base_type = keep_future_sender_base<pika::future<T>>;
+        using base_type::future;
+
+        template <typename Future,
+            typename = std::enable_if_t<
+                !std::is_same<std::decay_t<Future>, keep_future_sender>::value>>
+        explicit keep_future_sender(Future&& future)
+          : base_type{PIKA_FORWARD(Future, future)}
         {
-            std::decay_t<Future> future;
+        }
 
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = Variant<Tuple<std::decay_t<Future>>>;
+        keep_future_sender(keep_future_sender&&) = default;
+        keep_future_sender& operator=(keep_future_sender&&) = default;
+        keep_future_sender(keep_future_sender const&) = delete;
+        keep_future_sender& operator=(keep_future_sender const&) = delete;
 
-            template <template <typename...> class Variant>
-            using error_types = Variant<std::exception_ptr>;
-
-            static constexpr bool sends_done = false;
-
-            using completion_signatures =
-                pika::execution::experimental::completion_signatures<
-                    set_value_t(std::decay_t<Future>),
-                    set_error_t(std::exception_ptr)>;
-        };
-
-        template <typename Future>
-        struct keep_future_sender;
-
-        template <typename T>
-        struct keep_future_sender<pika::future<T>>
-          : public keep_future_sender_base<pika::future<T>>
+        template <typename Receiver>
+        friend operation_state<Receiver, future_type> tag_invoke(
+            pika::execution::experimental::connect_t, keep_future_sender&& s,
+            Receiver&& receiver)
         {
-            using future_type = pika::future<T>;
-            using base_type = keep_future_sender_base<pika::future<T>>;
-            using base_type::future;
+            return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
+        }
+    };
 
-            template <typename Future,
-                typename = std::enable_if_t<!std::is_same<std::decay_t<Future>,
-                    keep_future_sender>::value>>
-            explicit keep_future_sender(Future&& future)
-              : base_type{PIKA_FORWARD(Future, future)}
-            {
-            }
+    template <typename T>
+    struct keep_future_sender<pika::shared_future<T>>
+      : keep_future_sender_base<pika::shared_future<T>>
+    {
+        using future_type = pika::shared_future<T>;
+        using base_type = keep_future_sender_base<pika::shared_future<T>>;
+        using base_type::future;
 
-            keep_future_sender(keep_future_sender&&) = default;
-            keep_future_sender& operator=(keep_future_sender&&) = default;
-            keep_future_sender(keep_future_sender const&) = delete;
-            keep_future_sender& operator=(keep_future_sender const&) = delete;
-
-            template <typename Receiver>
-            friend operation_state<Receiver, future_type> tag_invoke(
-                connect_t, keep_future_sender&& s, Receiver&& receiver)
-            {
-                return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
-            }
-        };
-
-        template <typename T>
-        struct keep_future_sender<pika::shared_future<T>>
-          : keep_future_sender_base<pika::shared_future<T>>
+        template <typename Future,
+            typename = std::enable_if_t<
+                !std::is_same<std::decay_t<Future>, keep_future_sender>::value>>
+        explicit keep_future_sender(Future&& future)
+          : base_type{PIKA_FORWARD(Future, future)}
         {
-            using future_type = pika::shared_future<T>;
-            using base_type = keep_future_sender_base<pika::shared_future<T>>;
-            using base_type::future;
+        }
 
-            template <typename Future,
-                typename = std::enable_if_t<!std::is_same<std::decay_t<Future>,
-                    keep_future_sender>::value>>
-            explicit keep_future_sender(Future&& future)
-              : base_type{PIKA_FORWARD(Future, future)}
-            {
-            }
+        keep_future_sender(keep_future_sender&&) = default;
+        keep_future_sender& operator=(keep_future_sender&&) = default;
+        keep_future_sender(keep_future_sender const&) = default;
+        keep_future_sender& operator=(keep_future_sender const&) = default;
 
-            keep_future_sender(keep_future_sender&&) = default;
-            keep_future_sender& operator=(keep_future_sender&&) = default;
-            keep_future_sender(keep_future_sender const&) = default;
-            keep_future_sender& operator=(keep_future_sender const&) = default;
+        template <typename Receiver>
+        friend operation_state<Receiver, future_type> tag_invoke(
+            pika::execution::experimental::connect_t, keep_future_sender&& s,
+            Receiver&& receiver)
+        {
+            return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
+        }
 
-            template <typename Receiver>
-            friend operation_state<Receiver, future_type> tag_invoke(
-                connect_t, keep_future_sender&& s, Receiver&& receiver)
-            {
-                return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
-            }
+        template <typename Receiver>
+        friend operation_state<Receiver, future_type> tag_invoke(
+            pika::execution::experimental::connect_t, keep_future_sender& s,
+            Receiver&& receiver)
+        {
+            return {PIKA_FORWARD(Receiver, receiver), s.future};
+        }
+    };
+}    // namespace pika::keep_future_detail
 
-            template <typename Receiver>
-            friend operation_state<Receiver, future_type> tag_invoke(
-                connect_t, keep_future_sender& s, Receiver&& receiver)
-            {
-                return {PIKA_FORWARD(Receiver, receiver), s.future};
-            }
-        };
-    }    // namespace detail
-
+namespace pika::execution::experimental {
     inline constexpr struct keep_future_t final
     {
         // clang-format off
@@ -158,7 +163,7 @@ namespace pika { namespace execution { namespace experimental {
         // clang-format on
         constexpr PIKA_FORCEINLINE auto operator()(Future&& future) const
         {
-            return detail::keep_future_sender<std::decay_t<Future>>(
+            return keep_future_detail::keep_future_sender<std::decay_t<Future>>(
                 PIKA_FORWARD(Future, future));
         }
 
@@ -167,4 +172,4 @@ namespace pika { namespace execution { namespace experimental {
             return detail::partial_algorithm<keep_future_t>{};
         }
     } keep_future{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -28,296 +28,292 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace let_error_detail {
-        template <typename PredecessorSender, typename F>
-        struct let_error_sender_impl
+namespace pika::let_error_detail {
+    template <typename PredecessorSender, typename F>
+    struct let_error_sender_impl
+    {
+        struct let_error_sender_type;
+    };
+
+    template <typename PredecessorSender, typename F>
+    using let_error_sender = typename let_error_sender_impl<PredecessorSender,
+        F>::let_error_sender_type;
+
+    template <typename PredecessorSender, typename F>
+    struct let_error_sender_impl<PredecessorSender, F>::let_error_sender_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS typename std::decay_t<PredecessorSender>
+            predecessor_sender;
+        PIKA_NO_UNIQUE_ADDRESS typename std::decay_t<F> f;
+
+        // Type of the potential values returned from the predecessor sender
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using predecessor_value_types =
+            typename pika::execution::experimental::sender_traits<std::decay_t<
+                PredecessorSender>>::template value_types<Tuple, Variant>;
+
+        // Type of the potential errors returned from the predecessor sender
+        template <template <typename...> class Variant>
+        using predecessor_error_types = pika::util::detail::transform_t<
+            typename pika::execution::experimental::sender_traits<
+                PredecessorSender>::template error_types<Variant>,
+            std::decay>;
+        static_assert(
+            !std::is_same<predecessor_error_types<pika::util::detail::pack>,
+                pika::util::detail::pack<>>::value,
+            "let_error used with a predecessor that has an empty "
+            "error_types. Is let_error misplaced?");
+
+        template <typename Error>
+        struct successor_sender_types_helper
         {
-            struct let_error_sender_type;
+            using type = pika::util::detail::invoke_result_t<F,
+                std::add_lvalue_reference_t<Error>>;
+            static_assert(pika::execution::experimental::is_sender<
+                              std::decay_t<type>>::value,
+                "let_error expects the invocable sender factory to return "
+                "a sender");
         };
 
-        template <typename PredecessorSender, typename F>
-        using let_error_sender =
-            typename let_error_sender_impl<PredecessorSender,
-                F>::let_error_sender_type;
+        // Type of the potential senders returned from the sender factory F
+        template <template <typename...> class Variant>
+        using successor_sender_types = pika::util::detail::unique_t<
+            pika::util::detail::transform_t<predecessor_error_types<Variant>,
+                successor_sender_types_helper>>;
 
-        template <typename PredecessorSender, typename F>
-        struct let_error_sender_impl<PredecessorSender,
-            F>::let_error_sender_type
-        {
-            PIKA_NO_UNIQUE_ADDRESS typename std::decay_t<PredecessorSender>
-                predecessor_sender;
-            PIKA_NO_UNIQUE_ADDRESS typename std::decay_t<F> f;
-
-            // Type of the potential values returned from the predecessor sender
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using predecessor_value_types =
-                typename pika::execution::experimental::sender_traits<
-                    std::decay_t<PredecessorSender>>::
-                    template value_types<Tuple, Variant>;
-
-            // Type of the potential errors returned from the predecessor sender
-            template <template <typename...> class Variant>
-            using predecessor_error_types = pika::util::detail::transform_t<
-                typename pika::execution::experimental::sender_traits<
-                    PredecessorSender>::template error_types<Variant>,
-                std::decay>;
-            static_assert(
-                !std::is_same<predecessor_error_types<pika::util::detail::pack>,
-                    pika::util::detail::pack<>>::value,
-                "let_error used with a predecessor that has an empty "
-                "error_types. Is let_error misplaced?");
-
-            template <typename Error>
-            struct successor_sender_types_helper
-            {
-                using type = pika::util::detail::invoke_result_t<F,
-                    std::add_lvalue_reference_t<Error>>;
-                static_assert(pika::execution::experimental::is_sender<
-                                  std::decay_t<type>>::value,
-                    "let_error expects the invocable sender factory to return "
-                    "a sender");
-            };
-
-            // Type of the potential senders returned from the sender factory F
-            template <template <typename...> class Variant>
-            using successor_sender_types =
-                pika::util::detail::unique_t<pika::util::detail::transform_t<
-                    predecessor_error_types<Variant>,
-                    successor_sender_types_helper>>;
-
-            // The workaround for clang is due to a parsing bug in clang < 11
-            // in CUDA mode (where >>> also has a different meaning in kernel
-            // launches).
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = pika::util::detail::unique_concat_t<
-                predecessor_value_types<Tuple, Variant>,
-                pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
-                        transform_t<successor_sender_types<Variant>,
-                            detail::value_types<Tuple, Variant>::template apply
+        // The workaround for clang is due to a parsing bug in clang < 11
+        // in CUDA mode (where >>> also has a different meaning in kernel
+        // launches).
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = pika::util::detail::unique_concat_t<
+            predecessor_value_types<Tuple, Variant>,
+            pika::util::detail::concat_pack_of_packs_t<
+                pika::util::detail::transform_t<successor_sender_types<Variant>,
+                    pika::execution::experimental::detail::value_types<Tuple,
+                        Variant>::template apply
 #if defined(PIKA_CLANG_VERSION) && PIKA_CLANG_VERSION < 110000
-                            >
-                    //
-                    >>;
+                    >
+                //
+                >>;
 #else
-                            >>>;
+                    >>>;
 #endif
 
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    pika::util::detail::concat_pack_of_packs_t<pika::util::
-                            detail::transform_t<successor_sender_types<Variant>,
-                                detail::error_types<Variant>::template apply>>,
-                    std::exception_ptr>>;
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
+                        transform_t<successor_sender_types<Variant>,
+                            pika::execution::experimental::detail::error_types<
+                                Variant>::template apply>>,
+                std::exception_ptr>>;
 
-            static constexpr bool sends_done = false;
+        static constexpr bool sends_done = false;
 
-            template <typename Receiver>
-            struct operation_state
+        template <typename Receiver>
+        struct operation_state
+        {
+            struct let_error_predecessor_receiver
             {
-                struct let_error_predecessor_receiver
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+                operation_state& op_state;
+
+                template <typename Receiver_, typename F_>
+                let_error_predecessor_receiver(
+                    Receiver_&& receiver, F_&& f, operation_state& op_state)
+                  : receiver(PIKA_FORWARD(Receiver_, receiver))
+                  , f(PIKA_FORWARD(F_, f))
+                  , op_state(op_state)
+                {
+                }
+
+                struct start_visitor
+                {
+                    [[noreturn]] void operator()(pika::detail::monostate) const
+                    {
+                        PIKA_UNREACHABLE;
+                    }
+
+                    template <typename OperationState_,
+                        typename = std::enable_if_t<
+                            !std::is_same_v<std::decay_t<OperationState_>,
+                                pika::detail::monostate>>>
+                    void operator()(OperationState_& op_state) const
+                    {
+                        pika::execution::experimental::start(op_state);
+                    }
+                };
+
+                struct set_error_visitor
                 {
                     PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
                     PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
                     operation_state& op_state;
 
-                    template <typename Receiver_, typename F_>
-                    let_error_predecessor_receiver(
-                        Receiver_&& receiver, F_&& f, operation_state& op_state)
-                      : receiver(PIKA_FORWARD(Receiver_, receiver))
-                      , f(PIKA_FORWARD(F_, f))
-                      , op_state(op_state)
+                    [[noreturn]] void operator()(pika::detail::monostate) const
                     {
+                        PIKA_UNREACHABLE;
                     }
 
-                    struct start_visitor
+                    template <typename Error,
+                        typename = std::enable_if_t<!std::is_same_v<
+                            std::decay_t<Error>, pika::detail::monostate>>>
+                    void operator()(Error& error)
                     {
-                        [[noreturn]] void operator()(
-                            pika::detail::monostate) const
-                        {
-                            PIKA_UNREACHABLE;
-                        }
-
-                        template <typename OperationState_,
-                            typename = std::enable_if_t<
-                                !std::is_same_v<std::decay_t<OperationState_>,
-                                    pika::detail::monostate>>>
-                        void operator()(OperationState_& op_state) const
-                        {
-                            pika::execution::experimental::start(op_state);
-                        }
-                    };
-
-                    struct set_error_visitor
-                    {
-                        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-                        operation_state& op_state;
-
-                        [[noreturn]] void operator()(
-                            pika::detail::monostate) const
-                        {
-                            PIKA_UNREACHABLE;
-                        }
-
-                        template <typename Error,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<Error>, pika::detail::monostate>>>
-                        void operator()(Error& error)
-                        {
-                            using operation_state_type =
-                                decltype(pika::execution::experimental::connect(
-                                    PIKA_INVOKE(PIKA_MOVE(f), error),
-                                    std::declval<Receiver>()));
+                        using operation_state_type =
+                            decltype(pika::execution::experimental::connect(
+                                PIKA_INVOKE(PIKA_MOVE(f), error),
+                                std::declval<Receiver>()));
 
 #if defined(PIKA_HAVE_CXX17_COPY_ELISION)
-                            // with_result_of is used to emplace the operation
-                            // state returned from connect without any
-                            // intermediate copy construction (the operation
-                            // state is not required to be copyable nor movable).
-                            op_state.successor_op_state
-                                .template emplace<operation_state_type>(
-                                    pika::detail::with_result_of([&]() {
-                                        return pika::execution::experimental::
-                                            connect(PIKA_INVOKE(
-                                                        PIKA_MOVE(f), error),
-                                                PIKA_MOVE(receiver));
-                                    }));
-#else
-                            // MSVC doesn't get copy elision quite right, the operation
-                            // state must be constructed explicitly directly in place
-                            op_state.successor_op_state
-                                .template emplace_f<operation_state_type>(
-                                    pika::execution::experimental::connect,
+                        // with_result_of is used to emplace the operation
+                        // state returned from connect without any
+                        // intermediate copy construction (the operation
+                        // state is not required to be copyable nor movable).
+                        op_state.successor_op_state.template emplace<
+                            operation_state_type>(
+                            pika::detail::with_result_of([&]() {
+                                return pika::execution::experimental::connect(
                                     PIKA_INVOKE(PIKA_MOVE(f), error),
                                     PIKA_MOVE(receiver));
+                            }));
+#else
+                        // MSVC doesn't get copy elision quite right, the operation
+                        // state must be constructed explicitly directly in place
+                        op_state.successor_op_state
+                            .template emplace_f<operation_state_type>(
+                                pika::execution::experimental::connect,
+                                PIKA_INVOKE(PIKA_MOVE(f), error),
+                                PIKA_MOVE(receiver));
 #endif
+                        pika::detail::visit(
+                            start_visitor{}, op_state.successor_op_state);
+                    }
+                };
+
+                template <typename Error>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    let_error_predecessor_receiver&& r, Error&& error) noexcept
+                {
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() {
+                            // TODO: receiver is moved before the visit, but
+                            // the invoke inside the visit may throw.
+                            r.op_state.predecessor_error
+                                .template emplace<std::decay_t<Error>>(
+                                    PIKA_FORWARD(Error, error));
                             pika::detail::visit(
-                                start_visitor{}, op_state.successor_op_state);
-                        }
-                    };
-
-                    template <typename Error>
-                    friend void tag_invoke(set_error_t,
-                        let_error_predecessor_receiver&& r,
-                        Error&& error) noexcept
-                    {
-                        pika::detail::try_catch_exception_ptr(
-                            [&]() {
-                                // TODO: receiver is moved before the visit, but
-                                // the invoke inside the visit may throw.
-                                r.op_state.predecessor_error
-                                    .template emplace<std::decay_t<Error>>(
-                                        PIKA_FORWARD(Error, error));
-                                pika::detail::visit(
-                                    set_error_visitor{PIKA_MOVE(r.receiver),
-                                        PIKA_MOVE(r.f), r.op_state},
-                                    r.op_state.predecessor_error);
-                            },
-                            [&](std::exception_ptr ep) {
-                                pika::execution::experimental::set_error(
-                                    PIKA_MOVE(r.receiver), PIKA_MOVE(ep));
-                            });
-                    }
-
-                    friend void tag_invoke(set_stopped_t,
-                        let_error_predecessor_receiver&& r) noexcept
-                    {
-                        pika::execution::experimental::set_stopped(
-                            PIKA_MOVE(r.receiver));
-                    };
-
-                    template <typename... Ts,
-                        typename =
-                            std::enable_if_t<pika::detail::is_invocable_v<
-                                pika::execution::experimental::set_value_t,
-                                Receiver&&, Ts...>>>
-                    friend void tag_invoke(set_value_t,
-                        let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
-                    {
-                        pika::execution::experimental::set_value(
-                            PIKA_MOVE(r.receiver), PIKA_FORWARD(Ts, ts)...);
-                    }
-                };
-
-                // Type of the operation state returned when connecting the
-                // predecessor sender to the let_error_predecessor_receiver
-                using predecessor_operation_state_type =
-                    std::decay_t<connect_result_t<PredecessorSender&&,
-                        let_error_predecessor_receiver>>;
-
-                // Type of the potential operation states returned when
-                // connecting a sender in successor_sender_types to the receiver
-                // connected to the let_error_sender
-                template <typename Sender>
-                struct successor_operation_state_types_helper
-                {
-                    using type = connect_result_t<Sender, Receiver>;
-                };
-                template <template <typename...> class Variant>
-                using successor_operation_state_types =
-                    pika::util::detail::transform_t<
-                        successor_sender_types<Variant>,
-                        successor_operation_state_types_helper>;
-
-                // Operation state from connecting predecessor sender to
-                // let_error_predecessor_receiver
-                predecessor_operation_state_type predecessor_operation_state;
-
-                // Potential errors returned from the predecessor sender
-                pika::util::detail::prepend_t<
-                    predecessor_error_types<pika::detail::variant>,
-                    pika::detail::monostate>
-                    predecessor_error;
-
-                // Potential operation states returned when connecting a sender
-                // in successor_sender_types to the receiver connected to the
-                // let_error_sender
-                pika::util::detail::prepend_t<
-                    successor_operation_state_types<pika::detail::variant>,
-                    pika::detail::monostate>
-                    successor_op_state;
-
-                template <typename PredecessorSender_, typename Receiver_,
-                    typename F_>
-                operation_state(PredecessorSender_&& predecessor_sender,
-                    Receiver_&& receiver, F_&& f)
-                  : predecessor_operation_state{
-                        pika::execution::experimental::connect(
-                            std::forward<PredecessorSender_>(
-                                predecessor_sender),
-                            let_error_predecessor_receiver(
-                                PIKA_FORWARD(Receiver_, receiver),
-                                PIKA_FORWARD(F_, f), *this))}
-                {
+                                set_error_visitor{PIKA_MOVE(r.receiver),
+                                    PIKA_MOVE(r.f), r.op_state},
+                                r.op_state.predecessor_error);
+                        },
+                        [&](std::exception_ptr ep) {
+                            pika::execution::experimental::set_error(
+                                PIKA_MOVE(r.receiver), PIKA_MOVE(ep));
+                        });
                 }
 
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    let_error_predecessor_receiver&& r) noexcept
                 {
-                    pika::execution::experimental::start(
-                        os.predecessor_operation_state);
+                    pika::execution::experimental::set_stopped(
+                        PIKA_MOVE(r.receiver));
+                };
+
+                template <typename... Ts,
+                    typename = std::enable_if_t<pika::detail::is_invocable_v<
+                        pika::execution::experimental::set_value_t, Receiver&&,
+                        Ts...>>>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
+                {
+                    pika::execution::experimental::set_value(
+                        PIKA_MOVE(r.receiver), PIKA_FORWARD(Ts, ts)...);
                 }
             };
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, let_error_sender_type&& s, Receiver&& receiver)
+            // Type of the operation state returned when connecting the
+            // predecessor sender to the let_error_predecessor_receiver
+            using predecessor_operation_state_type =
+                std::decay_t<pika::execution::experimental::connect_result_t<
+                    PredecessorSender&&, let_error_predecessor_receiver>>;
+
+            // Type of the potential operation states returned when
+            // connecting a sender in successor_sender_types to the receiver
+            // connected to the let_error_sender
+            template <typename Sender>
+            struct successor_operation_state_types_helper
             {
-                return operation_state<Receiver>(
-                    PIKA_MOVE(s.predecessor_sender),
-                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
+                using type =
+                    pika::execution::experimental::connect_result_t<Sender,
+                        Receiver>;
+            };
+            template <template <typename...> class Variant>
+            using successor_operation_state_types =
+                pika::util::detail::transform_t<successor_sender_types<Variant>,
+                    successor_operation_state_types_helper>;
+
+            // Operation state from connecting predecessor sender to
+            // let_error_predecessor_receiver
+            predecessor_operation_state_type predecessor_operation_state;
+
+            // Potential errors returned from the predecessor sender
+            pika::util::detail::prepend_t<
+                predecessor_error_types<pika::detail::variant>,
+                pika::detail::monostate>
+                predecessor_error;
+
+            // Potential operation states returned when connecting a sender
+            // in successor_sender_types to the receiver connected to the
+            // let_error_sender
+            pika::util::detail::prepend_t<
+                successor_operation_state_types<pika::detail::variant>,
+                pika::detail::monostate>
+                successor_op_state;
+
+            template <typename PredecessorSender_, typename Receiver_,
+                typename F_>
+            operation_state(PredecessorSender_&& predecessor_sender,
+                Receiver_&& receiver, F_&& f)
+              : predecessor_operation_state{
+                    pika::execution::experimental::connect(
+                        std::forward<PredecessorSender_>(predecessor_sender),
+                        let_error_predecessor_receiver(
+                            PIKA_FORWARD(Receiver_, receiver),
+                            PIKA_FORWARD(F_, f), *this))}
+            {
+            }
+
+            operation_state(operation_state&&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
+
+            friend void tag_invoke(pika::execution::experimental::start_t,
+                operation_state& os) noexcept
+            {
+                pika::execution::experimental::start(
+                    os.predecessor_operation_state);
             }
         };
-    }    // namespace let_error_detail
 
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            let_error_sender_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(PIKA_MOVE(s.predecessor_sender),
+                PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
+        }
+    };
+}    // namespace pika::let_error_detail
+
+namespace pika::execution::experimental {
     inline constexpr struct let_error_t final
       : pika::functional::detail::tag_fallback<let_error_t>
     {
@@ -344,5 +340,5 @@ namespace pika { namespace execution { namespace experimental {
                 PIKA_FORWARD(F, f)};
         }
     } let_error{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -29,314 +29,311 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace let_value_detail {
-        template <typename PredecessorSender, typename F>
-        struct let_value_sender_impl
+namespace pika::let_value_detail {
+    template <typename PredecessorSender, typename F>
+    struct let_value_sender_impl
+    {
+        struct let_value_sender_type;
+    };
+
+    template <typename PredecessorSender, typename F>
+    using let_value_sender = typename let_value_sender_impl<PredecessorSender,
+        F>::let_value_sender_type;
+
+    template <typename PredecessorSender, typename F>
+    struct let_value_sender_impl<PredecessorSender, F>::let_value_sender_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<PredecessorSender>
+            predecessor_sender;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+        // Type of the potential values returned from the predecessor sender
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using predecessor_value_types =
+            typename pika::execution::experimental::sender_traits<std::decay_t<
+                PredecessorSender>>::template value_types<Tuple, Variant>;
+
+        template <typename Tuple>
+        struct successor_sender_types_helper;
+
+        template <template <typename...> class Tuple, typename... Ts>
+        struct successor_sender_types_helper<Tuple<Ts...>>
         {
-            struct let_value_sender_type;
+            using type = pika::util::detail::invoke_result_t<F,
+                std::add_lvalue_reference_t<Ts>...>;
+            static_assert(pika::execution::experimental::is_sender<
+                              std::decay_t<type>>::value,
+                "let_value expects the invocable sender factory to return "
+                "a sender");
         };
 
-        template <typename PredecessorSender, typename F>
-        using let_value_sender =
-            typename let_value_sender_impl<PredecessorSender,
-                F>::let_value_sender_type;
+        // Type of the potential senders returned from the sender factory F
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using successor_sender_types =
+            pika::util::detail::unique_t<pika::util::detail::transform_t<
+                predecessor_value_types<Tuple, Variant>,
+                successor_sender_types_helper>>;
 
-        template <typename PredecessorSender, typename F>
-        struct let_value_sender_impl<PredecessorSender,
-            F>::let_value_sender_type
-        {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<PredecessorSender>
-                predecessor_sender;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-
-            // Type of the potential values returned from the predecessor sender
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using predecessor_value_types =
-                typename pika::execution::experimental::sender_traits<
-                    std::decay_t<PredecessorSender>>::
-                    template value_types<Tuple, Variant>;
-
-            template <typename Tuple>
-            struct successor_sender_types_helper;
-
-            template <template <typename...> class Tuple, typename... Ts>
-            struct successor_sender_types_helper<Tuple<Ts...>>
-            {
-                using type = pika::util::detail::invoke_result_t<F,
-                    std::add_lvalue_reference_t<Ts>...>;
-                static_assert(pika::execution::experimental::is_sender<
-                                  std::decay_t<type>>::value,
-                    "let_value expects the invocable sender factory to return "
-                    "a sender");
-            };
-
-            // Type of the potential senders returned from the sender factory F
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using successor_sender_types =
-                pika::util::detail::unique_t<pika::util::detail::transform_t<
-                    predecessor_value_types<Tuple, Variant>,
-                    successor_sender_types_helper>>;
-
-            // The workaround for clang is due to a parsing bug in clang < 11
-            // in CUDA mode (where >>> also has a different meaning in kernel
-            // launches).
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = pika::util::detail::unique_t<
-                pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
-                        transform_t<successor_sender_types<Tuple, Variant>,
-                            detail::value_types<Tuple, Variant>::template apply
+        // The workaround for clang is due to a parsing bug in clang < 11
+        // in CUDA mode (where >>> also has a different meaning in kernel
+        // launches).
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = pika::util::detail::unique_t<
+            pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
+                    transform_t<successor_sender_types<Tuple, Variant>,
+                        pika::execution::experimental::detail::value_types<
+                            Tuple, Variant>::template apply
 #if defined(PIKA_CLANG_VERSION) && PIKA_CLANG_VERSION < 110000
-                            >
-                    //
-                    >>;
+                        >
+                //
+                >>;
 #else
-                            >>>;
+                        >>>;
 #endif
 
-            // pika::util::detail::pack acts as a concrete type in place of Tuple. It is
-            // required for computing successor_sender_types, but disappears
-            // from the final error_types.
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    pika::util::detail::concat_pack_of_packs_t<
-                        pika::util::detail::transform_t<
-                            successor_sender_types<pika::util::detail::pack,
-                                Variant>,
-                            detail::error_types<Variant>::template apply>>,
-                    std::exception_ptr>>;
+        // pika::util::detail::pack acts as a concrete type in place of Tuple. It is
+        // required for computing successor_sender_types, but disappears
+        // from the final error_types.
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                pika::util::detail::concat_pack_of_packs_t<pika::util::detail::
+                        transform_t<successor_sender_types<
+                                        pika::util::detail::pack, Variant>,
+                            pika::execution::experimental::detail::error_types<
+                                Variant>::template apply>>,
+                std::exception_ptr>>;
 
-            static constexpr bool sends_done = false;
+        static constexpr bool sends_done = false;
 
-            template <typename Receiver>
-            struct operation_state
+        template <typename Receiver>
+        struct operation_state
+        {
+            struct let_value_predecessor_receiver;
+
+            // Type of the operation state returned when connecting the
+            // predecessor sender to the let_value_predecessor_receiver
+            using predecessor_operation_state_type =
+                std::decay_t<pika::execution::experimental::connect_result_t<
+                    PredecessorSender&&, let_value_predecessor_receiver>>;
+
+            // Type of the potential operation states returned when
+            // connecting a sender in successor_sender_types to the receiver
+            // connected to the let_value_sender
+            template <typename Sender>
+            struct successor_operation_state_types_helper
             {
-                struct let_value_predecessor_receiver;
+                using type =
+                    pika::execution::experimental::connect_result_t<Sender,
+                        Receiver>;
+            };
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using successor_operation_state_types =
+                pika::util::detail::transform_t<
+                    successor_sender_types<Tuple, Variant>,
+                    successor_operation_state_types_helper>;
 
-                // Type of the operation state returned when connecting the
-                // predecessor sender to the let_value_predecessor_receiver
-                using predecessor_operation_state_type =
-                    std::decay_t<connect_result_t<PredecessorSender&&,
-                        let_value_predecessor_receiver>>;
+            // Operation state from connecting predecessor sender to
+            // let_value_predecessor_receiver
+            predecessor_operation_state_type predecessor_op_state;
 
-                // Type of the potential operation states returned when
-                // connecting a sender in successor_sender_types to the receiver
-                // connected to the let_value_sender
-                template <typename Sender>
-                struct successor_operation_state_types_helper
+            using predecessor_ts_type = pika::util::detail::prepend_t<
+                predecessor_value_types<std::tuple, pika::detail::variant>,
+                pika::detail::monostate>;
+
+            // Potential values returned from the predecessor sender
+            predecessor_ts_type predecessor_ts;
+
+            // Potential operation states returned when connecting a sender
+            // in successor_sender_types to the receiver connected to the
+            // let_value_sender
+            pika::util::detail::prepend_t<
+                successor_operation_state_types<std::tuple,
+                    pika::detail::variant>,
+                pika::detail::monostate>
+                successor_op_state;
+
+            struct let_value_predecessor_receiver
+            {
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+                operation_state& op_state;
+
+                template <typename Receiver_, typename F_>
+                let_value_predecessor_receiver(
+                    Receiver_&& receiver, F_&& f, operation_state& op_state)
+                  : receiver(PIKA_FORWARD(Receiver_, receiver))
+                  , f(PIKA_FORWARD(F_, f))
+                  , op_state(op_state)
                 {
-                    using type = connect_result_t<Sender, Receiver>;
+                }
+
+                template <typename Error>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    let_value_predecessor_receiver&& r, Error&& error) noexcept
+                {
+                    pika::execution::experimental::set_error(
+                        PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
+                }
+
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    let_value_predecessor_receiver&& r) noexcept
+                {
+                    pika::execution::experimental::set_stopped(
+                        PIKA_MOVE(r.receiver));
                 };
-                template <template <typename...> class Tuple,
-                    template <typename...> class Variant>
-                using successor_operation_state_types =
-                    pika::util::detail::transform_t<
-                        successor_sender_types<Tuple, Variant>,
-                        successor_operation_state_types_helper>;
 
-                // Operation state from connecting predecessor sender to
-                // let_value_predecessor_receiver
-                predecessor_operation_state_type predecessor_op_state;
+                struct start_visitor
+                {
+                    [[noreturn]] void operator()(pika::detail::monostate) const
+                    {
+                        PIKA_UNREACHABLE;
+                    }
 
-                using predecessor_ts_type = pika::util::detail::prepend_t<
-                    predecessor_value_types<std::tuple, pika::detail::variant>,
-                    pika::detail::monostate>;
+                    template <typename OperationState_,
+                        typename = std::enable_if_t<
+                            !std::is_same_v<std::decay_t<OperationState_>,
+                                pika::detail::monostate>>>
+                    void operator()(OperationState_& op_state) const
+                    {
+                        pika::execution::experimental::start(op_state);
+                    }
+                };
 
-                // Potential values returned from the predecessor sender
-                predecessor_ts_type predecessor_ts;
-
-                // Potential operation states returned when connecting a sender
-                // in successor_sender_types to the receiver connected to the
-                // let_value_sender
-                pika::util::detail::prepend_t<
-                    successor_operation_state_types<std::tuple,
-                        pika::detail::variant>,
-                    pika::detail::monostate>
-                    successor_op_state;
-
-                struct let_value_predecessor_receiver
+                struct set_value_visitor
                 {
                     PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
                     PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
                     operation_state& op_state;
 
-                    template <typename Receiver_, typename F_>
-                    let_value_predecessor_receiver(
-                        Receiver_&& receiver, F_&& f, operation_state& op_state)
-                      : receiver(PIKA_FORWARD(Receiver_, receiver))
-                      , f(PIKA_FORWARD(F_, f))
-                      , op_state(op_state)
+                    [[noreturn]] void operator()(pika::detail::monostate) const
                     {
+                        PIKA_UNREACHABLE;
                     }
 
-                    template <typename Error>
-                    friend void tag_invoke(set_error_t,
-                        let_value_predecessor_receiver&& r,
-                        Error&& error) noexcept
+                    template <typename T,
+                        typename = std::enable_if_t<!std::is_same_v<
+                            std::decay_t<T>, pika::detail::monostate>>>
+                    void operator()(T& t)
                     {
-                        pika::execution::experimental::set_error(
-                            PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
-                    }
-
-                    friend void tag_invoke(set_stopped_t,
-                        let_value_predecessor_receiver&& r) noexcept
-                    {
-                        pika::execution::experimental::set_stopped(
-                            PIKA_MOVE(r.receiver));
-                    };
-
-                    struct start_visitor
-                    {
-                        [[noreturn]] void operator()(
-                            pika::detail::monostate) const
-                        {
-                            PIKA_UNREACHABLE;
-                        }
-
-                        template <typename OperationState_,
-                            typename = std::enable_if_t<
-                                !std::is_same_v<std::decay_t<OperationState_>,
-                                    pika::detail::monostate>>>
-                        void operator()(OperationState_& op_state) const
-                        {
-                            pika::execution::experimental::start(op_state);
-                        }
-                    };
-
-                    struct set_value_visitor
-                    {
-                        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-                        operation_state& op_state;
-
-                        [[noreturn]] void operator()(
-                            pika::detail::monostate) const
-                        {
-                            PIKA_UNREACHABLE;
-                        }
-
-                        template <typename T,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<T>, pika::detail::monostate>>>
-                        void operator()(T& t)
-                        {
-                            using operation_state_type =
-                                decltype(pika::execution::experimental::connect(
-                                    pika::util::detail::invoke_fused(
-                                        PIKA_MOVE(f), t),
-                                    std::declval<Receiver>()));
+                        using operation_state_type =
+                            decltype(pika::execution::experimental::connect(
+                                pika::util::detail::invoke_fused(
+                                    PIKA_MOVE(f), t),
+                                std::declval<Receiver>()));
 
 #if defined(PIKA_HAVE_CXX17_COPY_ELISION)
-                            // with_result_of is used to emplace the operation state
-                            // returned from connect without any intermediate copy
-                            // construction (the operation state is not required to be
-                            // copyable nor movable).
-                            op_state.successor_op_state.template emplace<
-                                operation_state_type>(
-                                pika::detail::with_result_of([&]() {
-                                    return pika::execution::experimental::
-                                        connect(
-                                            pika::util::detail::invoke_fused(
-                                                PIKA_MOVE(f), t),
-                                            PIKA_MOVE(receiver));
-                                }));
-#else
-                            // MSVC doesn't get copy elision quite right, the operation
-                            // state must be constructed explicitly directly in place
-                            op_state.successor_op_state
-                                .template emplace_f<operation_state_type>(
-                                    pika::execution::experimental::connect,
+                        // with_result_of is used to emplace the operation state
+                        // returned from connect without any intermediate copy
+                        // construction (the operation state is not required to be
+                        // copyable nor movable).
+                        op_state.successor_op_state.template emplace<
+                            operation_state_type>(
+                            pika::detail::with_result_of([&]() {
+                                return pika::execution::experimental::connect(
                                     pika::util::detail::invoke_fused(
                                         PIKA_MOVE(f), t),
                                     PIKA_MOVE(receiver));
+                            }));
+#else
+                        // MSVC doesn't get copy elision quite right, the operation
+                        // state must be constructed explicitly directly in place
+                        op_state.successor_op_state
+                            .template emplace_f<operation_state_type>(
+                                pika::execution::experimental::connect,
+                                pika::util::detail::invoke_fused(
+                                    PIKA_MOVE(f), t),
+                                PIKA_MOVE(receiver));
 #endif
-                            pika::detail::visit(
-                                start_visitor{}, op_state.successor_op_state);
-                        }
-                    };
-
-                    // This typedef is duplicated from the parent struct. The
-                    // parent typedef is not instantiated early enough for use
-                    // here.
-                    using predecessor_ts_type = pika::util::detail::prepend_t<
-                        predecessor_value_types<std::tuple,
-                            pika::detail::variant>,
-                        pika::detail::monostate>;
-
-                    template <typename... Ts>
-                    void set_value(Ts&&... ts)
-                    {
-                        pika::detail::try_catch_exception_ptr(
-                            [&]() {
-                                op_state.predecessor_ts
-                                    .template emplace<std::tuple<Ts...>>(
-                                        PIKA_FORWARD(Ts, ts)...);
-                                pika::detail::visit(
-                                    set_value_visitor{PIKA_MOVE(receiver),
-                                        PIKA_MOVE(f), op_state},
-                                    op_state.predecessor_ts);
-                            },
-                            [&](std::exception_ptr ep) {
-                                pika::execution::experimental::set_error(
-                                    PIKA_MOVE(receiver), PIKA_MOVE(ep));
-                            });
-                    }
-
-                    template <typename... Ts>
-                    friend auto tag_invoke(set_value_t,
-                        let_value_predecessor_receiver&& r, Ts&&... ts) noexcept
-                        -> decltype(std::declval<predecessor_ts_type>()
-                                        .template emplace<std::tuple<Ts...>>(
-                                            PIKA_FORWARD(Ts, ts)...),
-                            void())
-                    {
-                        // set_value is in a member function only because of a
-                        // compiler bug in GCC 7. When the body of set_value is
-                        // inlined here compilation fails with an internal
-                        // compiler error.
-                        r.set_value(PIKA_FORWARD(Ts, ts)...);
+                        pika::detail::visit(
+                            start_visitor{}, op_state.successor_op_state);
                     }
                 };
 
-                template <typename PredecessorSender_, typename Receiver_,
-                    typename F_>
-                operation_state(PredecessorSender_&& predecessor_sender,
-                    Receiver_&& receiver, F_&& f)
-                  : predecessor_op_state{pika::execution::experimental::connect(
-                        PIKA_FORWARD(PredecessorSender_, predecessor_sender),
-                        let_value_predecessor_receiver(
-                            PIKA_FORWARD(Receiver_, receiver),
-                            PIKA_FORWARD(F_, f), *this))}
+                // This typedef is duplicated from the parent struct. The
+                // parent typedef is not instantiated early enough for use
+                // here.
+                using predecessor_ts_type = pika::util::detail::prepend_t<
+                    predecessor_value_types<std::tuple, pika::detail::variant>,
+                    pika::detail::monostate>;
+
+                template <typename... Ts>
+                void set_value(Ts&&... ts)
                 {
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() {
+                            op_state.predecessor_ts
+                                .template emplace<std::tuple<Ts...>>(
+                                    PIKA_FORWARD(Ts, ts)...);
+                            pika::detail::visit(
+                                set_value_visitor{PIKA_MOVE(receiver),
+                                    PIKA_MOVE(f), op_state},
+                                op_state.predecessor_ts);
+                        },
+                        [&](std::exception_ptr ep) {
+                            pika::execution::experimental::set_error(
+                                PIKA_MOVE(receiver), PIKA_MOVE(ep));
+                        });
                 }
 
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
+                template <typename... Ts>
+                friend auto tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    let_value_predecessor_receiver&& r, Ts&&... ts) noexcept
+                    -> decltype(std::declval<predecessor_ts_type>()
+                                    .template emplace<std::tuple<Ts...>>(
+                                        PIKA_FORWARD(Ts, ts)...),
+                        void())
                 {
-                    pika::execution::experimental::start(
-                        os.predecessor_op_state);
+                    // set_value is in a member function only because of a
+                    // compiler bug in GCC 7. When the body of set_value is
+                    // inlined here compilation fails with an internal
+                    // compiler error.
+                    r.set_value(PIKA_FORWARD(Ts, ts)...);
                 }
             };
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, let_value_sender_type&& s, Receiver&& receiver)
+            template <typename PredecessorSender_, typename Receiver_,
+                typename F_>
+            operation_state(PredecessorSender_&& predecessor_sender,
+                Receiver_&& receiver, F_&& f)
+              : predecessor_op_state{pika::execution::experimental::connect(
+                    PIKA_FORWARD(PredecessorSender_, predecessor_sender),
+                    let_value_predecessor_receiver(
+                        PIKA_FORWARD(Receiver_, receiver), PIKA_FORWARD(F_, f),
+                        *this))}
             {
-                return operation_state<Receiver>(
-                    PIKA_MOVE(s.predecessor_sender),
-                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
+            }
+
+            operation_state(operation_state&&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
+
+            friend void tag_invoke(pika::execution::experimental::start_t,
+                operation_state& os) noexcept
+            {
+                pika::execution::experimental::start(os.predecessor_op_state);
             }
         };
-    }    // namespace let_value_detail
 
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            let_value_sender_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(PIKA_MOVE(s.predecessor_sender),
+                PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
+        }
+    };
+}    // namespace pika::let_value_detail
+
+namespace pika::execution::experimental {
     inline constexpr struct let_value_t final
       : pika::functional::detail::tag_fallback<let_value_t>
     {
@@ -363,5 +360,5 @@ namespace pika { namespace execution { namespace experimental {
                 PIKA_FORWARD(F, f)};
         }
     } let_value{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
@@ -33,216 +33,213 @@
 #include <optional>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace detail {
-        template <typename T, typename Allocator>
-        struct resettable_operation_state_future_data
-          : pika::lcos::detail::future_data_allocator<T, Allocator>
+namespace pika::make_future_detail {
+    template <typename T, typename Allocator>
+    struct resettable_operation_state_future_data
+      : pika::lcos::detail::future_data_allocator<T, Allocator>
+    {
+        PIKA_NON_COPYABLE(resettable_operation_state_future_data);
+
+        virtual void reset_operation_state() = 0;
+
+        using init_no_addref =
+            typename pika::lcos::detail::future_data_allocator<T,
+                Allocator>::init_no_addref;
+
+        template <typename Allocator_>
+        resettable_operation_state_future_data(
+            init_no_addref no_addref, Allocator_ const& alloc)
+          : pika::lcos::detail::future_data_allocator<T, Allocator>(
+                no_addref, alloc)
         {
-            PIKA_NON_COPYABLE(resettable_operation_state_future_data);
+        }
+    };
 
-            virtual void reset_operation_state() = 0;
+    template <typename T, typename Allocator>
+    struct make_future_receiver
+    {
+        pika::intrusive_ptr<
+            resettable_operation_state_future_data<T, Allocator>>
+            data;
 
-            using init_no_addref =
-                typename pika::lcos::detail::future_data_allocator<T,
-                    Allocator>::init_no_addref;
-
-            template <typename Allocator_>
-            resettable_operation_state_future_data(
-                init_no_addref no_addref, Allocator_ const& alloc)
-              : pika::lcos::detail::future_data_allocator<T, Allocator>(
-                    no_addref, alloc)
-            {
-            }
-        };
-
-        template <typename T, typename Allocator>
-        struct make_future_receiver
+        friend void tag_invoke(pika::execution::experimental::set_error_t,
+            make_future_receiver&& r, std::exception_ptr ep) noexcept
         {
-            pika::intrusive_ptr<
-                resettable_operation_state_future_data<T, Allocator>>
-                data;
+            // We move the receiver into a local variable from the operation
+            // state which the receiver refers to. This allows us to safely
+            // reset the operation state without destroying the receiver.
+            make_future_receiver r_local = PIKA_MOVE(r);
 
-            friend void tag_invoke(set_error_t, make_future_receiver&& r,
-                std::exception_ptr ep) noexcept
-            {
-                // We move the receiver into a local variable from the operation
-                // state which the receiver refers to. This allows us to safely
-                // reset the operation state without destroying the receiver.
-                make_future_receiver r_local = PIKA_MOVE(r);
+            r_local.data->set_exception(PIKA_MOVE(ep));
+            r_local.data->reset_operation_state();
+            r_local.data.reset();
+        }
 
-                r_local.data->set_exception(PIKA_MOVE(ep));
-                r_local.data->reset_operation_state();
-                r_local.data.reset();
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, make_future_receiver&&) noexcept
-            {
-                std::terminate();
-            }
-
-            template <typename U>
-            friend void tag_invoke(
-                set_value_t, make_future_receiver&& r, U&& u) noexcept
-            {
-                // We move the receiver into a local variable from the operation
-                // state which the receiver refers to. This allows us to safely
-                // reset the operation state without destroying the receiver.
-                make_future_receiver r_local = PIKA_MOVE(r);
-
-                pika::detail::try_catch_exception_ptr(
-                    [&]() { r_local.data->set_value(PIKA_FORWARD(U, u)); },
-                    [&](std::exception_ptr ep) {
-                        r_local.data->set_exception(PIKA_MOVE(ep));
-                    });
-                r_local.data->reset_operation_state();
-                r_local.data.reset();
-            }
-
-            friend constexpr pika::execution::experimental::detail::empty_env
-            tag_invoke(pika::execution::experimental::get_env_t,
-                make_future_receiver const&) noexcept
-            {
-                return {};
-            }
-        };
-
-        template <typename Allocator>
-        struct make_future_receiver<void, Allocator>
+        friend void tag_invoke(pika::execution::experimental::set_stopped_t,
+            make_future_receiver&&) noexcept
         {
-            pika::intrusive_ptr<
-                resettable_operation_state_future_data<void, Allocator>>
-                data;
+            std::terminate();
+        }
 
-            friend void tag_invoke(set_error_t, make_future_receiver&& r,
-                std::exception_ptr ep) noexcept
-            {
-                // We move the receiver into a local variable from the operation
-                // state which the receiver refers to. This allows us to safely
-                // reset the operation state without destroying the receiver.
-                make_future_receiver r_local = PIKA_MOVE(r);
-
-                r_local.data->set_exception(PIKA_MOVE(ep));
-                r_local.data->reset_operation_state();
-                r_local.data.reset();
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, make_future_receiver&&) noexcept
-            {
-                std::terminate();
-            }
-
-            friend void tag_invoke(
-                set_value_t, make_future_receiver&& r) noexcept
-            {
-                // We move the receiver into a local variable from the operation
-                // state which the receiver refers to. This allows us to safely
-                // reset the operation state without destroying the receiver.
-                make_future_receiver r_local = PIKA_MOVE(r);
-
-                pika::detail::try_catch_exception_ptr(
-                    [&]() {
-                        r_local.data->set_value(pika::util::detail::unused);
-                    },
-                    [&](std::exception_ptr ep) {
-                        r_local.data->set_exception(PIKA_MOVE(ep));
-                    });
-                r_local.data->reset_operation_state();
-                r_local.data.reset();
-            }
-
-            friend constexpr pika::execution::experimental::detail::empty_env
-            tag_invoke(pika::execution::experimental::get_env_t,
-                make_future_receiver const&) noexcept
-            {
-                return {};
-            }
-        };
-
-        template <typename T, typename Allocator, typename OperationState>
-        struct future_data
-          : resettable_operation_state_future_data<T, Allocator>
+        template <typename U>
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            make_future_receiver&& r, U&& u) noexcept
         {
-            PIKA_NON_COPYABLE(future_data);
+            // We move the receiver into a local variable from the operation
+            // state which the receiver refers to. This allows us to safely
+            // reset the operation state without destroying the receiver.
+            make_future_receiver r_local = PIKA_MOVE(r);
 
-            using operation_state_type = std::decay_t<OperationState>;
-            using other_allocator = typename std::allocator_traits<
-                Allocator>::template rebind_alloc<future_data>;
-            using init_no_addref =
-                typename pika::lcos::detail::future_data_allocator<T,
-                    Allocator>::init_no_addref;
+            pika::detail::try_catch_exception_ptr(
+                [&]() { r_local.data->set_value(PIKA_FORWARD(U, u)); },
+                [&](std::exception_ptr ep) {
+                    r_local.data->set_exception(PIKA_MOVE(ep));
+                });
+            r_local.data->reset_operation_state();
+            r_local.data.reset();
+        }
 
-            // The operation state is stored in an optional so that it can be
-            // reset explicitly as soon as set_* is called.
-            std::optional<operation_state_type> op_state;
-
-            template <typename Sender>
-            future_data(init_no_addref no_addref, other_allocator const& alloc,
-                Sender&& sender)
-              : resettable_operation_state_future_data<T, Allocator>(
-                    no_addref, alloc)
-            {
-                op_state.emplace(pika::detail::with_result_of([&]() {
-                    return pika::execution::experimental::connect(
-                        PIKA_FORWARD(Sender, sender),
-                        detail::make_future_receiver<T, Allocator>{this});
-                }));
-                pika::execution::experimental::start(op_state.value());
-            }
-
-            void reset_operation_state() override
-            {
-                op_state.reset();
-            }
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sender, typename Allocator>
-        auto make_future(Sender&& sender, Allocator const& allocator)
+        friend constexpr pika::execution::experimental::detail::empty_env
+        tag_invoke(pika::execution::experimental::get_env_t,
+            make_future_receiver const&) noexcept
         {
-            using allocator_type = Allocator;
+            return {};
+        }
+    };
+
+    template <typename Allocator>
+    struct make_future_receiver<void, Allocator>
+    {
+        pika::intrusive_ptr<
+            resettable_operation_state_future_data<void, Allocator>>
+            data;
+
+        friend void tag_invoke(pika::execution::experimental::set_error_t,
+            make_future_receiver&& r, std::exception_ptr ep) noexcept
+        {
+            // We move the receiver into a local variable from the operation
+            // state which the receiver refers to. This allows us to safely
+            // reset the operation state without destroying the receiver.
+            make_future_receiver r_local = PIKA_MOVE(r);
+
+            r_local.data->set_exception(PIKA_MOVE(ep));
+            r_local.data->reset_operation_state();
+            r_local.data.reset();
+        }
+
+        friend void tag_invoke(pika::execution::experimental::set_stopped_t,
+            make_future_receiver&&) noexcept
+        {
+            std::terminate();
+        }
+
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            make_future_receiver&& r) noexcept
+        {
+            // We move the receiver into a local variable from the operation
+            // state which the receiver refers to. This allows us to safely
+            // reset the operation state without destroying the receiver.
+            make_future_receiver r_local = PIKA_MOVE(r);
+
+            pika::detail::try_catch_exception_ptr(
+                [&]() { r_local.data->set_value(pika::util::detail::unused); },
+                [&](std::exception_ptr ep) {
+                    r_local.data->set_exception(PIKA_MOVE(ep));
+                });
+            r_local.data->reset_operation_state();
+            r_local.data.reset();
+        }
+
+        friend constexpr pika::execution::experimental::detail::empty_env
+        tag_invoke(pika::execution::experimental::get_env_t,
+            make_future_receiver const&) noexcept
+        {
+            return {};
+        }
+    };
+
+    template <typename T, typename Allocator, typename OperationState>
+    struct future_data : resettable_operation_state_future_data<T, Allocator>
+    {
+        PIKA_NON_COPYABLE(future_data);
+
+        using operation_state_type = std::decay_t<OperationState>;
+        using other_allocator = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<future_data>;
+        using init_no_addref =
+            typename pika::lcos::detail::future_data_allocator<T,
+                Allocator>::init_no_addref;
+
+        // The operation state is stored in an optional so that it can be
+        // reset explicitly as soon as set_* is called.
+        std::optional<operation_state_type> op_state;
+
+        template <typename Sender>
+        future_data(init_no_addref no_addref, other_allocator const& alloc,
+            Sender&& sender)
+          : resettable_operation_state_future_data<T, Allocator>(
+                no_addref, alloc)
+        {
+            op_state.emplace(pika::detail::with_result_of([&]() {
+                return pika::execution::experimental::connect(
+                    PIKA_FORWARD(Sender, sender),
+                    make_future_receiver<T, Allocator>{this});
+            }));
+            pika::execution::experimental::start(op_state.value());
+        }
+
+        void reset_operation_state() override
+        {
+            op_state.reset();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sender, typename Allocator>
+    auto make_future(Sender&& sender, Allocator const& allocator)
+    {
+        using allocator_type = Allocator;
 
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
-            using value_types =
-                typename pika::execution::experimental::value_types_of_t<
-                    std::decay_t<Sender>,
-                    pika::execution::experimental::detail::empty_env,
-                    pika::util::detail::pack, pika::util::detail::pack>;
+        using value_types =
+            typename pika::execution::experimental::value_types_of_t<
+                std::decay_t<Sender>,
+                pika::execution::experimental::detail::empty_env,
+                pika::util::detail::pack, pika::util::detail::pack>;
 #else
-            using value_types = typename pika::execution::experimental::
-                sender_traits<std::decay_t<Sender>>::template value_types<
-                    pika::util::detail::pack, pika::util::detail::pack>;
+        using value_types = typename pika::execution::experimental::
+            sender_traits<std::decay_t<Sender>>::template value_types<
+                pika::util::detail::pack, pika::util::detail::pack>;
 #endif
-            using result_type =
-                std::decay_t<detail::single_result_t<value_types>>;
-            using operation_state_type = pika::util::detail::invoke_result_t<
-                pika::execution::experimental::connect_t, Sender,
-                detail::make_future_receiver<result_type, allocator_type>>;
+        using result_type =
+            std::decay_t<pika::execution::experimental::detail::single_result_t<
+                value_types>>;
+        using operation_state_type = pika::util::detail::invoke_result_t<
+            pika::execution::experimental::connect_t, Sender,
+            make_future_receiver<result_type, allocator_type>>;
 
-            using shared_state = detail::future_data<result_type,
-                allocator_type, operation_state_type>;
-            using init_no_addref = typename shared_state::init_no_addref;
-            using other_allocator = typename std::allocator_traits<
-                allocator_type>::template rebind_alloc<shared_state>;
-            using allocator_traits = std::allocator_traits<other_allocator>;
-            using unique_ptr = std::unique_ptr<shared_state,
-                pika::detail::allocator_deleter<other_allocator>>;
+        using shared_state =
+            future_data<result_type, allocator_type, operation_state_type>;
+        using init_no_addref = typename shared_state::init_no_addref;
+        using other_allocator = typename std::allocator_traits<
+            allocator_type>::template rebind_alloc<shared_state>;
+        using allocator_traits = std::allocator_traits<other_allocator>;
+        using unique_ptr = std::unique_ptr<shared_state,
+            pika::detail::allocator_deleter<other_allocator>>;
 
-            other_allocator alloc(allocator);
-            unique_ptr p(allocator_traits::allocate(alloc, 1),
-                pika::detail::allocator_deleter<other_allocator>{alloc});
+        other_allocator alloc(allocator);
+        unique_ptr p(allocator_traits::allocate(alloc, 1),
+            pika::detail::allocator_deleter<other_allocator>{alloc});
 
-            allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
-                PIKA_FORWARD(Sender, sender));
+        allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
+            PIKA_FORWARD(Sender, sender));
 
-            return pika::traits::future_access<future<result_type>>::create(
-                p.release(), false);
-        }
-    }    // namespace detail
+        return pika::traits::future_access<future<result_type>>::create(
+            p.release(), false);
+    }
+}    // namespace pika::make_future_detail
 
-    ///////////////////////////////////////////////////////////////////////////
+namespace pika::execution::experimental {
     inline constexpr struct make_future_t final
       : pika::functional::detail::tag_fallback<make_future_t>
     {
@@ -259,7 +256,8 @@ namespace pika { namespace execution { namespace experimental {
             make_future_t, Sender&& sender,
             Allocator const& allocator = Allocator{})
         {
-            return detail::make_future(PIKA_FORWARD(Sender, sender), allocator);
+            return make_future_detail::make_future(
+                PIKA_FORWARD(Sender, sender), allocator);
         }
 
         // clang-format off
@@ -275,4 +273,4 @@ namespace pika { namespace execution { namespace experimental {
                 allocator};
         }
     } make_future{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -30,53 +30,52 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace schedule_from_detail {
-        template <typename Sender, typename Scheduler>
-        struct schedule_from_sender_impl
-        {
-            struct schedule_from_sender_type;
-        };
+namespace pika::schedule_from_detail {
+    template <typename Sender, typename Scheduler>
+    struct schedule_from_sender_impl
+    {
+        struct schedule_from_sender_type;
+    };
 
-        template <typename Sender, typename Scheduler>
-        using schedule_from_sender = typename schedule_from_sender_impl<Sender,
-            Scheduler>::schedule_from_sender_type;
+    template <typename Sender, typename Scheduler>
+    using schedule_from_sender = typename schedule_from_sender_impl<Sender,
+        Scheduler>::schedule_from_sender_type;
 
-        template <typename Sender, typename Scheduler>
-        struct schedule_from_sender_impl<Sender,
-            Scheduler>::schedule_from_sender_type
-        {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> predecessor_sender;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+    template <typename Sender, typename Scheduler>
+    struct schedule_from_sender_impl<Sender,
+        Scheduler>::schedule_from_sender_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> predecessor_sender;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
 
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types =
-                typename pika::execution::experimental::sender_traits<
-                    Sender>::template value_types<Tuple, Variant>;
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types =
+            typename pika::execution::experimental::sender_traits<
+                Sender>::template value_types<Tuple, Variant>;
 
-            template <template <typename...> class Variant>
-            using predecessor_sender_error_types =
-                typename pika::execution::experimental::sender_traits<
-                    Sender>::template error_types<Variant>;
+        template <template <typename...> class Variant>
+        using predecessor_sender_error_types =
+            typename pika::execution::experimental::sender_traits<
+                Sender>::template error_types<Variant>;
 
-            using scheduler_sender_type =
-                typename pika::util::detail::invoke_result<
-                    pika::execution::experimental::schedule_t, Scheduler>::type;
-            template <template <typename...> class Variant>
-            using scheduler_sender_error_types =
-                typename pika::execution::experimental::sender_traits<
-                    scheduler_sender_type>::template error_types<Variant>;
+        using scheduler_sender_type =
+            typename pika::util::detail::invoke_result<
+                pika::execution::experimental::schedule_t, Scheduler>::type;
+        template <template <typename...> class Variant>
+        using scheduler_sender_error_types =
+            typename pika::execution::experimental::sender_traits<
+                scheduler_sender_type>::template error_types<Variant>;
 
-            template <template <typename...> class Variant>
-            using error_types = pika::util::detail::unique_concat_t<
-                predecessor_sender_error_types<Variant>,
-                scheduler_sender_error_types<Variant>>;
+        template <template <typename...> class Variant>
+        using error_types = pika::util::detail::unique_concat_t<
+            predecessor_sender_error_types<Variant>,
+            scheduler_sender_error_types<Variant>>;
 
-            static constexpr bool sends_done = false;
+        static constexpr bool sends_done = false;
 
-            template <typename CPO,
-                // clang-format off
+        template <typename CPO,
+            // clang-format off
                 PIKA_CONCEPT_REQUIRES_(
                     pika::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     (std::is_same_v<CPO, pika::execution::experimental::set_value_t> ||
@@ -86,39 +85,105 @@ namespace pika { namespace execution { namespace experimental {
                         pika::execution::experimental::detail::has_completion_scheduler_v<
                                 pika::execution::experimental::set_stopped_t,
                                 std::decay_t<Sender>>))
-                // clang-format on
-                >
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::get_completion_scheduler_t<CPO>,
-                schedule_from_sender_type const& sender)
+            // clang-format on
+            >
+        friend constexpr auto tag_invoke(
+            pika::execution::experimental::get_completion_scheduler_t<CPO>,
+            schedule_from_sender_type const& sender)
+        {
+            if constexpr (std::is_same_v<std::decay_t<CPO>,
+                              pika::execution::experimental::set_value_t>)
             {
-                if constexpr (std::is_same_v<std::decay_t<CPO>,
-                                  pika::execution::experimental::set_value_t>)
-                {
-                    return sender.scheduler;
-                }
-                else
-                {
-                    return pika::execution::experimental::
-                        get_completion_scheduler<CPO>(
-                            sender.predecessor_sender);
-                }
-                // This silences a bogus warning from nvcc about no return from
-                // a non-void function.
+                return sender.scheduler;
+            }
+            else
+            {
+                return pika::execution::experimental::get_completion_scheduler<
+                    CPO>(sender.predecessor_sender);
+            }
+            // This silences a bogus warning from nvcc about no return from
+            // a non-void function.
 #if defined(__NVCC__)
-                __builtin_unreachable();
+            __builtin_unreachable();
 #endif
+        }
+
+        template <typename Receiver>
+        struct operation_state
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+            struct predecessor_sender_receiver;
+            struct scheduler_sender_receiver;
+
+            template <typename Tuple>
+            struct value_types_helper
+            {
+                using type = pika::util::detail::transform_t<Tuple, std::decay>;
+            };
+
+            using value_type = pika::util::detail::prepend_t<
+                pika::util::detail::transform_t<
+                    typename pika::execution::experimental::sender_traits<
+                        Sender>::template value_types<std::tuple,
+                        pika::detail::variant>,
+                    value_types_helper>,
+                pika::detail::monostate>;
+            value_type ts;
+
+            using sender_operation_state_type =
+                pika::execution::experimental::connect_result_t<Sender,
+                    predecessor_sender_receiver>;
+            sender_operation_state_type sender_os;
+
+            using scheduler_operation_state_type =
+                pika::execution::experimental::connect_result_t<
+                    typename pika::util::detail::invoke_result<
+                        pika::execution::experimental::schedule_t,
+                        Scheduler>::type,
+                    scheduler_sender_receiver>;
+            std::optional<scheduler_operation_state_type> scheduler_op_state;
+
+            template <typename Sender_, typename Scheduler_, typename Receiver_>
+            operation_state(Sender_&& predecessor_sender,
+                Scheduler_&& scheduler, Receiver_&& receiver)
+              : scheduler(PIKA_FORWARD(Scheduler_, scheduler))
+              , receiver(PIKA_FORWARD(Receiver_, receiver))
+              , sender_os(pika::execution::experimental::connect(
+                    PIKA_FORWARD(Sender_, predecessor_sender),
+                    predecessor_sender_receiver{*this}))
+            {
             }
 
-            template <typename Receiver>
-            struct operation_state
+            operation_state(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
+
+            struct predecessor_sender_receiver
             {
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+                operation_state& op_state;
 
-                struct predecessor_sender_receiver;
-                struct scheduler_sender_receiver;
+                template <typename Error>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    predecessor_sender_receiver&& r, Error&& error) noexcept
+                {
+                    r.op_state.set_error_predecessor_sender(
+                        PIKA_FORWARD(Error, error));
+                }
 
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    predecessor_sender_receiver&& r) noexcept
+                {
+                    r.op_state.set_stopped_predecessor_sender();
+                }
+
+                // These typedefs are duplicated from the parent struct. The
+                // parent typedefs are not instantiated early enough for use
+                // here.
                 template <typename Tuple>
                 struct value_types_helper
                 {
@@ -133,223 +198,163 @@ namespace pika { namespace execution { namespace experimental {
                             pika::detail::variant>,
                         value_types_helper>,
                     pika::detail::monostate>;
-                value_type ts;
 
-                using sender_operation_state_type =
-                    connect_result_t<Sender, predecessor_sender_receiver>;
-                sender_operation_state_type sender_os;
-
-                using scheduler_operation_state_type =
-                    connect_result_t<typename pika::util::detail::invoke_result<
-                                         schedule_t, Scheduler>::type,
-                        scheduler_sender_receiver>;
-                std::optional<scheduler_operation_state_type>
-                    scheduler_op_state;
-
-                template <typename Sender_, typename Scheduler_,
-                    typename Receiver_>
-                operation_state(Sender_&& predecessor_sender,
-                    Scheduler_&& scheduler, Receiver_&& receiver)
-                  : scheduler(PIKA_FORWARD(Scheduler_, scheduler))
-                  , receiver(PIKA_FORWARD(Receiver_, receiver))
-                  , sender_os(pika::execution::experimental::connect(
-                        PIKA_FORWARD(Sender_, predecessor_sender),
-                        predecessor_sender_receiver{*this}))
+                template <typename... Ts>
+                friend auto tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    predecessor_sender_receiver&& r, Ts&&... ts) noexcept
+                    -> decltype(std::declval<value_type>()
+                                    .template emplace<
+                                        std::tuple<std::decay_t<Ts>...>>(
+                                        PIKA_FORWARD(Ts, ts)...),
+                        void())
                 {
-                }
-
-                operation_state(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                struct predecessor_sender_receiver
-                {
-                    operation_state& op_state;
-
-                    template <typename Error>
-                    friend void tag_invoke(set_error_t,
-                        predecessor_sender_receiver&& r, Error&& error) noexcept
-                    {
-                        r.op_state.set_error_predecessor_sender(
-                            PIKA_FORWARD(Error, error));
-                    }
-
-                    friend void tag_invoke(
-                        set_stopped_t, predecessor_sender_receiver&& r) noexcept
-                    {
-                        r.op_state.set_stopped_predecessor_sender();
-                    }
-
-                    // These typedefs are duplicated from the parent struct. The
-                    // parent typedefs are not instantiated early enough for use
-                    // here.
-                    template <typename Tuple>
-                    struct value_types_helper
-                    {
-                        using type =
-                            pika::util::detail::transform_t<Tuple, std::decay>;
-                    };
-
-                    using value_type = pika::util::detail::prepend_t<
-                        pika::util::detail::transform_t<
-                            typename pika::execution::experimental::
-                                sender_traits<Sender>::template value_types<
-                                    std::tuple, pika::detail::variant>,
-                            value_types_helper>,
-                        pika::detail::monostate>;
-
-                    template <typename... Ts>
-                    friend auto tag_invoke(set_value_t,
-                        predecessor_sender_receiver&& r, Ts&&... ts) noexcept
-                        -> decltype(std::declval<value_type>()
-                                        .template emplace<
-                                            std::tuple<std::decay_t<Ts>...>>(
-                                            PIKA_FORWARD(Ts, ts)...),
-                            void())
-                    {
-                        r.op_state.set_value_predecessor_sender(
-                            PIKA_FORWARD(Ts, ts)...);
-                    }
-                };
-
-                template <typename Error>
-                void set_error_predecessor_sender(Error&& error) noexcept
-                {
-                    pika::execution::experimental::set_error(
-                        PIKA_MOVE(receiver), PIKA_FORWARD(Error, error));
-                }
-
-                void set_stopped_predecessor_sender() noexcept
-                {
-                    pika::execution::experimental::set_stopped(
-                        PIKA_MOVE(receiver));
-                }
-
-                template <typename... Us>
-                void set_value_predecessor_sender(Us&&... us) noexcept
-                {
-                    ts.template emplace<std::tuple<std::decay_t<Us>...>>(
-                        PIKA_FORWARD(Us, us)...);
-#if defined(PIKA_HAVE_CXX17_COPY_ELISION)
-                    // with_result_of is used to emplace the operation
-                    // state returned from connect without any
-                    // intermediate copy construction (the operation
-                    // state is not required to be copyable nor movable).
-                    scheduler_op_state.emplace(
-                        pika::detail::with_result_of([&]() {
-                            return pika::execution::experimental::connect(
-                                pika::execution::experimental::schedule(
-                                    PIKA_MOVE(scheduler)),
-                                scheduler_sender_receiver{*this});
-                        }));
-#else
-                    // MSVC doesn't get copy elision quite right, the operation
-                    // state must be constructed explicitly directly in place
-                    scheduler_op_state.emplace_f(
-                        pika::execution::experimental::connect,
-                        pika::execution::experimental::schedule(
-                            PIKA_MOVE(scheduler)),
-                        scheduler_sender_receiver{*this});
-#endif
-                    pika::execution::experimental::start(
-                        scheduler_op_state.value());
-                }
-
-                struct scheduler_sender_receiver
-                {
-                    operation_state& op_state;
-
-                    template <typename Error>
-                    friend void tag_invoke(set_error_t,
-                        scheduler_sender_receiver&& r, Error&& error) noexcept
-                    {
-                        r.op_state.set_error_scheduler_sender(
-                            PIKA_FORWARD(Error, error));
-                    }
-
-                    friend void tag_invoke(
-                        set_stopped_t, scheduler_sender_receiver&& r) noexcept
-                    {
-                        r.op_state.set_stopped_scheduler_sender();
-                    }
-
-                    friend void tag_invoke(
-                        set_value_t, scheduler_sender_receiver&& r) noexcept
-                    {
-                        r.op_state.set_value_scheduler_sender();
-                    }
-                };
-
-                struct scheduler_sender_value_visitor
-                {
-                    PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-
-                    [[noreturn]] void operator()(pika::detail::monostate) const
-                    {
-                        PIKA_UNREACHABLE;
-                    }
-
-                    template <typename Ts,
-                        typename = std::enable_if_t<!std::is_same_v<
-                            std::decay_t<Ts>, pika::detail::monostate>>>
-                    void operator()(Ts&& ts)
-                    {
-                        pika::util::detail::invoke_fused(
-                            pika::util::detail::bind_front(
-                                pika::execution::experimental::set_value,
-                                PIKA_MOVE(receiver)),
-                            PIKA_FORWARD(Ts, ts));
-                    }
-                };
-
-                template <typename Error>
-                void set_error_scheduler_sender(Error&& error) noexcept
-                {
-                    scheduler_op_state.reset();
-                    pika::execution::experimental::set_error(
-                        PIKA_MOVE(receiver), PIKA_FORWARD(Error, error));
-                }
-
-                void set_stopped_scheduler_sender() noexcept
-                {
-                    scheduler_op_state.reset();
-                    pika::execution::experimental::set_stopped(
-                        PIKA_MOVE(receiver));
-                }
-
-                void set_value_scheduler_sender() noexcept
-                {
-                    scheduler_op_state.reset();
-                    pika::detail::visit(
-                        scheduler_sender_value_visitor{PIKA_MOVE(receiver)},
-                        PIKA_MOVE(ts));
-                }
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
-                {
-                    pika::execution::experimental::start(os.sender_os);
+                    r.op_state.set_value_predecessor_sender(
+                        PIKA_FORWARD(Ts, ts)...);
                 }
             };
 
-            template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                connect_t, schedule_from_sender_type&& s, Receiver&& receiver)
+            template <typename Error>
+            void set_error_predecessor_sender(Error&& error) noexcept
             {
-                return {PIKA_MOVE(s.predecessor_sender), PIKA_MOVE(s.scheduler),
-                    PIKA_FORWARD(Receiver, receiver)};
+                pika::execution::experimental::set_error(
+                    PIKA_MOVE(receiver), PIKA_FORWARD(Error, error));
             }
 
-            template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                connect_t, schedule_from_sender_type& s, Receiver&& receiver)
+            void set_stopped_predecessor_sender() noexcept
             {
-                return {s.predecessor_sender, s.scheduler,
-                    PIKA_FORWARD(Receiver, receiver)};
+                pika::execution::experimental::set_stopped(PIKA_MOVE(receiver));
+            }
+
+            template <typename... Us>
+            void set_value_predecessor_sender(Us&&... us) noexcept
+            {
+                ts.template emplace<std::tuple<std::decay_t<Us>...>>(
+                    PIKA_FORWARD(Us, us)...);
+#if defined(PIKA_HAVE_CXX17_COPY_ELISION)
+                // with_result_of is used to emplace the operation
+                // state returned from connect without any
+                // intermediate copy construction (the operation
+                // state is not required to be copyable nor movable).
+                scheduler_op_state.emplace(pika::detail::with_result_of([&]() {
+                    return pika::execution::experimental::connect(
+                        pika::execution::experimental::schedule(
+                            PIKA_MOVE(scheduler)),
+                        scheduler_sender_receiver{*this});
+                }));
+#else
+                // MSVC doesn't get copy elision quite right, the operation
+                // state must be constructed explicitly directly in place
+                scheduler_op_state.emplace_f(
+                    pika::execution::experimental::connect,
+                    pika::execution::experimental::schedule(
+                        PIKA_MOVE(scheduler)),
+                    scheduler_sender_receiver{*this});
+#endif
+                pika::execution::experimental::start(
+                    scheduler_op_state.value());
+            }
+
+            struct scheduler_sender_receiver
+            {
+                operation_state& op_state;
+
+                template <typename Error>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    scheduler_sender_receiver&& r, Error&& error) noexcept
+                {
+                    r.op_state.set_error_scheduler_sender(
+                        PIKA_FORWARD(Error, error));
+                }
+
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    scheduler_sender_receiver&& r) noexcept
+                {
+                    r.op_state.set_stopped_scheduler_sender();
+                }
+
+                friend void tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    scheduler_sender_receiver&& r) noexcept
+                {
+                    r.op_state.set_value_scheduler_sender();
+                }
+            };
+
+            struct scheduler_sender_value_visitor
+            {
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+                [[noreturn]] void operator()(pika::detail::monostate) const
+                {
+                    PIKA_UNREACHABLE;
+                }
+
+                template <typename Ts,
+                    typename = std::enable_if_t<!std::is_same_v<
+                        std::decay_t<Ts>, pika::detail::monostate>>>
+                void operator()(Ts&& ts)
+                {
+                    pika::util::detail::invoke_fused(
+                        pika::util::detail::bind_front(
+                            pika::execution::experimental::set_value,
+                            PIKA_MOVE(receiver)),
+                        PIKA_FORWARD(Ts, ts));
+                }
+            };
+
+            template <typename Error>
+            void set_error_scheduler_sender(Error&& error) noexcept
+            {
+                scheduler_op_state.reset();
+                pika::execution::experimental::set_error(
+                    PIKA_MOVE(receiver), PIKA_FORWARD(Error, error));
+            }
+
+            void set_stopped_scheduler_sender() noexcept
+            {
+                scheduler_op_state.reset();
+                pika::execution::experimental::set_stopped(PIKA_MOVE(receiver));
+            }
+
+            void set_value_scheduler_sender() noexcept
+            {
+                scheduler_op_state.reset();
+                pika::detail::visit(
+                    scheduler_sender_value_visitor{PIKA_MOVE(receiver)},
+                    PIKA_MOVE(ts));
+            }
+
+            friend void tag_invoke(pika::execution::experimental::start_t,
+                operation_state& os) noexcept
+            {
+                pika::execution::experimental::start(os.sender_os);
             }
         };
-    }    // namespace schedule_from_detail
 
+        template <typename Receiver>
+        friend operation_state<Receiver> tag_invoke(
+            pika::execution::experimental::connect_t,
+            schedule_from_sender_type&& s, Receiver&& receiver)
+        {
+            return {PIKA_MOVE(s.predecessor_sender), PIKA_MOVE(s.scheduler),
+                PIKA_FORWARD(Receiver, receiver)};
+        }
+
+        template <typename Receiver>
+        friend operation_state<Receiver> tag_invoke(
+            pika::execution::experimental::connect_t,
+            schedule_from_sender_type& s, Receiver&& receiver)
+        {
+            return {s.predecessor_sender, s.scheduler,
+                PIKA_FORWARD(Receiver, receiver)};
+        }
+    };
+}    // namespace pika::schedule_from_detail
+
+namespace pika::execution::experimental {
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct schedule_from_t final
       : pika::functional::detail::tag_fallback<schedule_from_t>
     {
@@ -368,5 +373,5 @@ namespace pika { namespace execution { namespace experimental {
                 PIKA_FORWARD(Scheduler, scheduler)};
         }
     } schedule_from{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -43,319 +43,336 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace split_detail {
-        template <typename Receiver>
-        struct error_visitor
-        {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+namespace pika::split_detail {
+    template <typename Receiver>
+    struct error_visitor
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
-            template <typename Error>
-            void operator()(Error const& error)
-            {
-                pika::execution::experimental::set_error(
-                    PIKA_MOVE(receiver), error);
-            }
+        template <typename Error>
+        void operator()(Error const& error)
+        {
+            pika::execution::experimental::set_error(
+                PIKA_MOVE(receiver), error);
+        }
+    };
+
+    template <typename Receiver>
+    struct value_visitor
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+        template <typename Ts>
+        void operator()(Ts const& ts)
+        {
+            pika::util::detail::invoke_fused(
+                pika::util::detail::bind_front(
+                    pika::execution::experimental::set_value,
+                    PIKA_MOVE(receiver)),
+                ts);
+        }
+    };
+
+    template <typename Sender, typename Allocator>
+    struct split_sender_impl
+    {
+        struct split_sender_type;
+    };
+
+    template <typename Sender, typename Allocator>
+    using split_sender =
+        typename split_sender_impl<Sender, Allocator>::split_sender_type;
+
+    template <typename Sender, typename Allocator>
+    struct split_sender_impl<Sender, Allocator>::split_sender_type
+    {
+        struct split_sender_tag
+        {
         };
 
-        template <typename Receiver>
-        struct value_visitor
-        {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        using allocator_type = Allocator;
 
-            template <typename Ts>
-            void operator()(Ts const& ts)
-            {
-                pika::util::detail::invoke_fused(
-                    pika::util::detail::bind_front(
-                        pika::execution::experimental::set_value,
-                        PIKA_MOVE(receiver)),
-                    ts);
-            }
+        template <typename T>
+        struct add_const_lvalue_reference
+        {
+            using type = std::add_lvalue_reference_t<std::add_const_t<T>>;
         };
 
-        template <typename Sender, typename Allocator>
-        struct split_sender_impl
+        template <typename Tuple>
+        struct value_types_helper
         {
-            struct split_sender_type;
+            using type = pika::util::detail::transform_t<Tuple,
+                add_const_lvalue_reference>;
         };
 
-        template <typename Sender, typename Allocator>
-        using split_sender =
-            typename split_sender_impl<Sender, Allocator>::split_sender_type;
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = pika::util::detail::transform_t<
+            typename pika::execution::experimental::sender_traits<
+                Sender>::template value_types<Tuple, Variant>,
+            value_types_helper>;
 
-        template <typename Sender, typename Allocator>
-        struct split_sender_impl<Sender, Allocator>::split_sender_type
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                pika::util::detail::transform_t<
+                    typename pika::execution::experimental::sender_traits<
+                        Sender>::template error_types<Variant>,
+                    add_const_lvalue_reference>,
+                std::exception_ptr>>;
+
+        static constexpr bool sends_done = false;
+
+        struct shared_state
         {
-            struct split_sender_tag
-            {
-            };
+            struct split_receiver;
 
-            using allocator_type = Allocator;
+            using allocator_type = typename std::allocator_traits<
+                Allocator>::template rebind_alloc<shared_state>;
+            PIKA_NO_UNIQUE_ADDRESS allocator_type alloc;
+            using mutex_type = pika::lcos::local::spinlock;
+            mutex_type mtx;
+            pika::util::atomic_count reference_count{0};
+            std::atomic<bool> start_called{false};
+            std::atomic<bool> predecessor_done{false};
 
-            template <typename T>
-            struct add_const_lvalue_reference
-            {
-                using type = std::add_lvalue_reference_t<std::add_const_t<T>>;
-            };
+            using operation_state_type =
+                std::decay_t<pika::execution::experimental::connect_result_t<
+                    Sender, split_receiver>>;
+            // We store the operation state in an optional so that we can
+            // reset it as soon as the the split_receiver has been signaled.
+            // This is useful to ensure that resources held by the
+            // predecessor work is released as soon as possible.
+            std::optional<operation_state_type> os;
 
             template <typename Tuple>
-            struct value_types_helper
+            struct value_type_helper
             {
-                using type = pika::util::detail::transform_t<Tuple,
-                    add_const_lvalue_reference>;
+                using type = pika::util::detail::transform_t<Tuple, std::decay>;
             };
 
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = pika::util::detail::transform_t<
-                typename pika::execution::experimental::sender_traits<
-                    Sender>::template value_types<Tuple, Variant>,
-                value_types_helper>;
-
-            template <template <typename...> class Variant>
-            using error_types =
+            struct done_type
+            {
+            };
+            using value_type = pika::util::detail::transform_t<
+                typename pika::execution::experimental::sender_traits<Sender>::
+                    template value_types<std::tuple, pika::detail::variant>,
+                value_type_helper>;
+            using error_type =
                 pika::util::detail::unique_t<pika::util::detail::prepend_t<
                     pika::util::detail::transform_t<
-                        typename pika::execution::experimental::sender_traits<
-                            Sender>::template error_types<Variant>,
-                        add_const_lvalue_reference>,
+                        typename pika::execution::experimental::
+                            sender_traits<Sender>::template error_types<
+                                pika::detail::variant>,
+                        std::decay>,
                     std::exception_ptr>>;
+            pika::detail::variant<pika::detail::monostate, done_type,
+                error_type, value_type>
+                v;
 
-            static constexpr bool sends_done = false;
+            using continuation_type =
+                pika::util::detail::unique_function<void()>;
+            pika::detail::small_vector<continuation_type, 1> continuations;
 
-            struct shared_state
+            struct split_receiver
             {
-                struct split_receiver;
+                shared_state& state;
 
-                using allocator_type = typename std::allocator_traits<
-                    Allocator>::template rebind_alloc<shared_state>;
-                PIKA_NO_UNIQUE_ADDRESS allocator_type alloc;
-                using mutex_type = pika::lcos::local::spinlock;
-                mutex_type mtx;
-                pika::util::atomic_count reference_count{0};
-                std::atomic<bool> start_called{false};
-                std::atomic<bool> predecessor_done{false};
+                template <typename Error>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    split_receiver&& r, Error&& error) noexcept
+                {
+                    r.state.v.template emplace<error_type>(
+                        error_type(PIKA_FORWARD(Error, error)));
+                    r.state.set_predecessor_done();
+                }
 
-                using operation_state_type =
-                    std::decay_t<connect_result_t<Sender, split_receiver>>;
-                // We store the operation state in an optional so that we can
-                // reset it as soon as the the split_receiver has been signaled.
-                // This is useful to ensure that resources held by the
-                // predecessor work is released as soon as possible.
-                std::optional<operation_state_type> os;
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    split_receiver&& r) noexcept
+                {
+                    r.state.set_predecessor_done();
+                };
 
+                // This typedef is duplicated from the parent struct. The
+                // parent typedef is not instantiated early enough for use
+                // here.
                 template <typename Tuple>
                 struct value_type_helper
                 {
                     using type =
                         pika::util::detail::transform_t<Tuple, std::decay>;
                 };
-
-                struct done_type
-                {
-                };
                 using value_type = pika::util::detail::transform_t<
                     typename pika::execution::experimental::sender_traits<
                         Sender>::template value_types<std::tuple,
                         pika::detail::variant>,
                     value_type_helper>;
-                using error_type =
-                    pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                        pika::util::detail::transform_t<
-                            typename pika::execution::experimental::
-                                sender_traits<Sender>::template error_types<
-                                    pika::detail::variant>,
-                            std::decay>,
-                        std::exception_ptr>>;
-                pika::detail::variant<pika::detail::monostate, done_type,
-                    error_type, value_type>
-                    v;
 
-                using continuation_type =
-                    pika::util::detail::unique_function<void()>;
-                pika::detail::small_vector<continuation_type, 1> continuations;
-
-                struct split_receiver
+                template <typename... Ts>
+                friend auto tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    split_receiver&& r, Ts&&... ts) noexcept
+                    -> decltype(std::declval<pika::detail::variant<
+                                    pika::detail::monostate, value_type>>()
+                                    .template emplace<value_type>(
+                                        std::make_tuple<>(
+                                            PIKA_FORWARD(Ts, ts)...)),
+                        void())
                 {
-                    shared_state& state;
+                    r.state.v.template emplace<value_type>(
+                        std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
 
-                    template <typename Error>
-                    friend void tag_invoke(
-                        set_error_t, split_receiver&& r, Error&& error) noexcept
-                    {
-                        r.state.v.template emplace<error_type>(
-                            error_type(PIKA_FORWARD(Error, error)));
-                        r.state.set_predecessor_done();
-                    }
+                    r.state.set_predecessor_done();
+                }
+            };
 
-                    friend void tag_invoke(
-                        set_stopped_t, split_receiver&& r) noexcept
-                    {
-                        r.state.set_predecessor_done();
-                    };
+            template <typename Sender_,
+                typename = std::enable_if_t<
+                    !std::is_same<std::decay_t<Sender_>, shared_state>::value>>
+            shared_state(Sender_&& sender, allocator_type const& alloc)
+              : alloc(alloc)
+            {
+                os.emplace(pika::detail::with_result_of([&]() {
+                    return pika::execution::experimental::connect(
+                        PIKA_FORWARD(Sender_, sender), split_receiver{*this});
+                }));
+            }
 
-                    // This typedef is duplicated from the parent struct. The
-                    // parent typedef is not instantiated early enough for use
-                    // here.
-                    template <typename Tuple>
-                    struct value_type_helper
-                    {
-                        using type =
-                            pika::util::detail::transform_t<Tuple, std::decay>;
-                    };
-                    using value_type = pika::util::detail::transform_t<
-                        typename pika::execution::experimental::sender_traits<
-                            Sender>::template value_types<std::tuple,
-                            pika::detail::variant>,
-                        value_type_helper>;
+            ~shared_state()
+            {
+                PIKA_ASSERT_MSG(start_called,
+                    "start was never called on the operation state of "
+                    "split. Did you forget to connect the sender to a "
+                    "receiver, or call start on the operation state?");
+            }
 
-                    template <typename... Ts>
-                    friend auto tag_invoke(
-                        set_value_t, split_receiver&& r, Ts&&... ts) noexcept
-                        -> decltype(std::declval<pika::detail::variant<
-                                        pika::detail::monostate, value_type>>()
-                                        .template emplace<value_type>(
-                                            std::make_tuple<>(
-                                                PIKA_FORWARD(Ts, ts)...)),
-                            void())
-                    {
-                        r.state.v.template emplace<value_type>(
-                            std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
+            template <typename Receiver>
+            struct done_error_value_visitor
+            {
+                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
-                        r.state.set_predecessor_done();
-                    }
-                };
-
-                template <typename Sender_,
-                    typename = std::enable_if_t<!std::is_same<
-                        std::decay_t<Sender_>, shared_state>::value>>
-                shared_state(Sender_&& sender, allocator_type const& alloc)
-                  : alloc(alloc)
+                [[noreturn]] void operator()(pika::detail::monostate) const
                 {
-                    os.emplace(pika::detail::with_result_of([&]() {
-                        return pika::execution::experimental::connect(
-                            PIKA_FORWARD(Sender_, sender),
-                            split_receiver{*this});
-                    }));
+                    PIKA_UNREACHABLE;
                 }
 
-                ~shared_state()
+                void operator()(done_type)
                 {
-                    PIKA_ASSERT_MSG(start_called,
-                        "start was never called on the operation state of "
-                        "split. Did you forget to connect the sender to a "
-                        "receiver, or call start on the operation state?");
+                    pika::execution::experimental::set_stopped(
+                        PIKA_MOVE(receiver));
                 }
 
-                template <typename Receiver>
-                struct done_error_value_visitor
+                void operator()(error_type const& error)
                 {
-                    PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-
-                    [[noreturn]] void operator()(pika::detail::monostate) const
-                    {
-                        PIKA_UNREACHABLE;
-                    }
-
-                    void operator()(done_type)
-                    {
-                        pika::execution::experimental::set_stopped(
-                            PIKA_MOVE(receiver));
-                    }
-
-                    void operator()(error_type const& error)
-                    {
-                        pika::detail::visit(
-                            error_visitor<Receiver>{
-                                PIKA_FORWARD(Receiver, receiver)},
-                            error);
-                    }
-
-                    void operator()(value_type const& ts)
-                    {
-                        pika::detail::visit(
-                            value_visitor<Receiver>{
-                                PIKA_FORWARD(Receiver, receiver)},
-                            ts);
-                    }
-                };
-
-                void set_predecessor_done()
-                {
-                    // We reset the operation state as soon as the predecessor
-                    // is done to release any resources held by it. Any values
-                    // sent by the predecessor have already been stored in the
-                    // shared state by now.
-                    os.reset();
-
-                    predecessor_done = true;
-
-                    {
-                        // We require taking the lock here to synchronize with
-                        // threads attempting to add continuations to the vector
-                        // of continuations. However, it is enough to take it
-                        // once and release it immediately.
-                        //
-                        // Without the lock we may not see writes to the vector.
-                        // With the lock threads attempting to add continuations
-                        // will either:
-                        // - See predecessor_done = true in which case they will
-                        //   call the continuation directly without adding it to
-                        //   the vector of continuations. Accessing the vector
-                        //   below without the lock is safe in this case because
-                        //   the vector is not modified.
-                        // - See predecessor_done = false and proceed to take
-                        //   the lock. If they see predecessor_done after taking
-                        //   the lock they can again release the lock and call
-                        //   the continuation directly. Accessing the vector
-                        //   without the lock is again safe because the vector
-                        //   is not modified.
-                        // - See predecessor_done = false and proceed to take
-                        //   the lock. If they see predecessor_done is still
-                        //   false after taking the lock, they will proceed to
-                        //   add a continuation to the vector. Since they keep
-                        //   the lock they can safely write to the vector. This
-                        //   thread will not proceed past the lock until they
-                        //   have finished writing to the vector.
-                        //
-                        // Importantly, once this thread has taken and released
-                        // this lock, threads attempting to add continuations to
-                        // the vector must see predecessor_done = true after
-                        // taking the lock in their threads and will not add
-                        // continuations to the vector.
-                        std::unique_lock<mutex_type> l{mtx};
-                    }
-
-                    if (!continuations.empty())
-                    {
-                        // We move the continuations to a local variable to
-                        // release them once all continuations have been called.
-                        // We cannot call clear on continuations after the loop
-                        // because the shared state may already be released by
-                        // the last continuation to run.
-                        auto continuations_local = PIKA_MOVE(continuations);
-                        for (auto const& continuation : continuations_local)
-                        {
-                            continuation();
-                        }
-                    }
+                    pika::detail::visit(error_visitor<Receiver>{PIKA_FORWARD(
+                                            Receiver, receiver)},
+                        error);
                 }
 
-                template <typename Receiver>
-                void add_continuation(Receiver& receiver) = delete;
-
-                template <typename Receiver>
-                void add_continuation(Receiver&& receiver)
+                void operator()(value_type const& ts)
                 {
+                    pika::detail::visit(value_visitor<Receiver>{PIKA_FORWARD(
+                                            Receiver, receiver)},
+                        ts);
+                }
+            };
+
+            void set_predecessor_done()
+            {
+                // We reset the operation state as soon as the predecessor
+                // is done to release any resources held by it. Any values
+                // sent by the predecessor have already been stored in the
+                // shared state by now.
+                os.reset();
+
+                predecessor_done = true;
+
+                {
+                    // We require taking the lock here to synchronize with
+                    // threads attempting to add continuations to the vector
+                    // of continuations. However, it is enough to take it
+                    // once and release it immediately.
+                    //
+                    // Without the lock we may not see writes to the vector.
+                    // With the lock threads attempting to add continuations
+                    // will either:
+                    // - See predecessor_done = true in which case they will
+                    //   call the continuation directly without adding it to
+                    //   the vector of continuations. Accessing the vector
+                    //   below without the lock is safe in this case because
+                    //   the vector is not modified.
+                    // - See predecessor_done = false and proceed to take
+                    //   the lock. If they see predecessor_done after taking
+                    //   the lock they can again release the lock and call
+                    //   the continuation directly. Accessing the vector
+                    //   without the lock is again safe because the vector
+                    //   is not modified.
+                    // - See predecessor_done = false and proceed to take
+                    //   the lock. If they see predecessor_done is still
+                    //   false after taking the lock, they will proceed to
+                    //   add a continuation to the vector. Since they keep
+                    //   the lock they can safely write to the vector. This
+                    //   thread will not proceed past the lock until they
+                    //   have finished writing to the vector.
+                    //
+                    // Importantly, once this thread has taken and released
+                    // this lock, threads attempting to add continuations to
+                    // the vector must see predecessor_done = true after
+                    // taking the lock in their threads and will not add
+                    // continuations to the vector.
+                    std::unique_lock<mutex_type> l{mtx};
+                }
+
+                if (!continuations.empty())
+                {
+                    // We move the continuations to a local variable to
+                    // release them once all continuations have been called.
+                    // We cannot call clear on continuations after the loop
+                    // because the shared state may already be released by
+                    // the last continuation to run.
+                    auto continuations_local = PIKA_MOVE(continuations);
+                    for (auto const& continuation : continuations_local)
+                    {
+                        continuation();
+                    }
+                }
+            }
+
+            template <typename Receiver>
+            void add_continuation(Receiver& receiver) = delete;
+
+            template <typename Receiver>
+            void add_continuation(Receiver&& receiver)
+            {
+                if (predecessor_done)
+                {
+                    // If we read predecessor_done here it means that one of
+                    // set_error/set_stopped/set_value has been called and
+                    // values/errors have been stored into the shared state.
+                    // We can trigger the continuation directly.
+                    // TODO: Should this preserve the scheduler? It does not
+                    // if we call set_* inline.
+                    pika::detail::visit(
+                        done_error_value_visitor<Receiver>{
+                            PIKA_FORWARD(Receiver, receiver)},
+                        v);
+                }
+                else
+                {
+                    // If predecessor_done is false, we have to take the
+                    // lock to potentially add the continuation to the
+                    // vector of continuations.
+                    std::unique_lock<mutex_type> l{mtx};
+
                     if (predecessor_done)
                     {
-                        // If we read predecessor_done here it means that one of
-                        // set_error/set_stopped/set_value has been called and
-                        // values/errors have been stored into the shared state.
-                        // We can trigger the continuation directly.
-                        // TODO: Should this preserve the scheduler? It does not
-                        // if we call set_* inline.
+                        // By the time the lock has been taken,
+                        // predecessor_done might already be true and we can
+                        // release the lock early and call the continuation
+                        // directly again.
+                        l.unlock();
                         pika::detail::visit(
                             done_error_value_visitor<Receiver>{
                                 PIKA_FORWARD(Receiver, receiver)},
@@ -363,155 +380,140 @@ namespace pika { namespace execution { namespace experimental {
                     }
                     else
                     {
-                        // If predecessor_done is false, we have to take the
-                        // lock to potentially add the continuation to the
-                        // vector of continuations.
-                        std::unique_lock<mutex_type> l{mtx};
-
-                        if (predecessor_done)
-                        {
-                            // By the time the lock has been taken,
-                            // predecessor_done might already be true and we can
-                            // release the lock early and call the continuation
-                            // directly again.
-                            l.unlock();
-                            pika::detail::visit(
-                                done_error_value_visitor<Receiver>{
-                                    PIKA_FORWARD(Receiver, receiver)},
-                                v);
-                        }
-                        else
-                        {
-                            // If predecessor_done is still false, we add the
-                            // continuation to the vector of continuations. This
-                            // has to be done while holding the lock, since
-                            // other threads may also try to add continuations
-                            // to the vector and the vector is not threadsafe in
-                            // itself. The continuation will be called later
-                            // when set_error/set_stopped/set_value is called.
-                            continuations.emplace_back(
-                                [this,
-                                    receiver = PIKA_FORWARD(
-                                        Receiver, receiver)]() mutable {
-                                    pika::detail::visit(
-                                        done_error_value_visitor<Receiver>{
-                                            PIKA_MOVE(receiver)},
-                                        v);
-                                });
-                        }
+                        // If predecessor_done is still false, we add the
+                        // continuation to the vector of continuations. This
+                        // has to be done while holding the lock, since
+                        // other threads may also try to add continuations
+                        // to the vector and the vector is not threadsafe in
+                        // itself. The continuation will be called later
+                        // when set_error/set_stopped/set_value is called.
+                        continuations.emplace_back(
+                            [this,
+                                receiver = PIKA_FORWARD(
+                                    Receiver, receiver)]() mutable {
+                                pika::detail::visit(
+                                    done_error_value_visitor<Receiver>{
+                                        PIKA_MOVE(receiver)},
+                                    v);
+                            });
                     }
                 }
+            }
 
-                void start() & noexcept
+            void start() & noexcept
+            {
+                if (!start_called.exchange(true))
                 {
-                    if (!start_called.exchange(true))
-                    {
-                        PIKA_ASSERT(os.has_value());
-                        pika::execution::experimental::start(os.value());
-                    }
+                    PIKA_ASSERT(os.has_value());
+                    pika::execution::experimental::start(os.value());
                 }
+            }
 
-                friend void intrusive_ptr_add_ref(shared_state* p)
+            friend void intrusive_ptr_add_ref(shared_state* p)
+            {
+                ++p->reference_count;
+            }
+
+            friend void intrusive_ptr_release(shared_state* p)
+            {
+                if (--p->reference_count == 0)
                 {
-                    ++p->reference_count;
+                    allocator_type other_alloc(p->alloc);
+                    std::allocator_traits<allocator_type>::destroy(
+                        other_alloc, p);
+                    std::allocator_traits<allocator_type>::deallocate(
+                        other_alloc, p, 1);
                 }
+            }
+        };
 
-                friend void intrusive_ptr_release(shared_state* p)
-                {
-                    if (--p->reference_count == 0)
-                    {
-                        allocator_type other_alloc(p->alloc);
-                        std::allocator_traits<allocator_type>::destroy(
-                            other_alloc, p);
-                        std::allocator_traits<allocator_type>::deallocate(
-                            other_alloc, p, 1);
-                    }
-                }
-            };
+        pika::intrusive_ptr<shared_state> state;
 
+        template <typename Sender_>
+        split_sender_type(Sender_&& sender, Allocator const& allocator)
+        {
+            using allocator_type = Allocator;
+            using other_allocator = typename std::allocator_traits<
+                allocator_type>::template rebind_alloc<shared_state>;
+            using allocator_traits = std::allocator_traits<other_allocator>;
+            using unique_ptr = std::unique_ptr<shared_state,
+                pika::detail::allocator_deleter<other_allocator>>;
+
+            other_allocator alloc(allocator);
+            unique_ptr p(allocator_traits::allocate(alloc, 1),
+                pika::detail::allocator_deleter<other_allocator>{alloc});
+
+            new (p.get())
+                shared_state{PIKA_FORWARD(Sender_, sender), allocator};
+            state = p.release();
+        }
+
+        split_sender_type(split_sender_type const&) = default;
+        split_sender_type& operator=(split_sender_type const&) = default;
+        split_sender_type(split_sender_type&&) = default;
+        split_sender_type& operator=(split_sender_type&&) = default;
+
+        template <typename Receiver>
+        struct operation_state
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
             pika::intrusive_ptr<shared_state> state;
 
-            template <typename Sender_>
-            split_sender_type(Sender_&& sender, Allocator const& allocator)
+            template <typename Receiver_>
+            operation_state(
+                Receiver_&& receiver, pika::intrusive_ptr<shared_state> state)
+              : receiver(PIKA_FORWARD(Receiver_, receiver))
+              , state(PIKA_MOVE(state))
             {
-                using allocator_type = Allocator;
-                using other_allocator = typename std::allocator_traits<
-                    allocator_type>::template rebind_alloc<shared_state>;
-                using allocator_traits = std::allocator_traits<other_allocator>;
-                using unique_ptr = std::unique_ptr<shared_state,
-                    pika::detail::allocator_deleter<other_allocator>>;
-
-                other_allocator alloc(allocator);
-                unique_ptr p(allocator_traits::allocate(alloc, 1),
-                    pika::detail::allocator_deleter<other_allocator>{alloc});
-
-                new (p.get())
-                    shared_state{PIKA_FORWARD(Sender_, sender), allocator};
-                state = p.release();
             }
 
-            split_sender_type(split_sender_type const&) = default;
-            split_sender_type& operator=(split_sender_type const&) = default;
-            split_sender_type(split_sender_type&&) = default;
-            split_sender_type& operator=(split_sender_type&&) = default;
+            operation_state(operation_state&&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
 
-            template <typename Receiver>
-            struct operation_state
+            friend void tag_invoke(pika::execution::experimental::start_t,
+                operation_state& os) noexcept
             {
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                pika::intrusive_ptr<shared_state> state;
-
-                template <typename Receiver_>
-                operation_state(Receiver_&& receiver,
-                    pika::intrusive_ptr<shared_state> state)
-                  : receiver(PIKA_FORWARD(Receiver_, receiver))
-                  , state(PIKA_MOVE(state))
-                {
-                }
-
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
-                {
-                    os.state->start();
-                    os.state->add_continuation(PIKA_MOVE(os.receiver));
-                }
-            };
-
-            template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                connect_t, split_sender_type&& s, Receiver&& receiver)
-            {
-                return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
-            }
-
-            template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                connect_t, split_sender_type& s, Receiver&& receiver)
-            {
-                return {PIKA_FORWARD(Receiver, receiver), s.state};
+                os.state->start();
+                os.state->add_continuation(PIKA_MOVE(os.receiver));
             }
         };
 
-        template <typename Sender, typename Enable = void>
-        struct is_split_sender_impl : std::false_type
+        template <typename Receiver>
+        friend operation_state<Receiver> tag_invoke(
+            pika::execution::experimental::connect_t, split_sender_type&& s,
+            Receiver&& receiver)
         {
-        };
+            return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
+        }
 
-        template <typename Sender>
-        struct is_split_sender_impl<Sender,
-            std::void_t<typename Sender::split_sender_tag>> : std::true_type
+        template <typename Receiver>
+        friend operation_state<Receiver> tag_invoke(
+            pika::execution::experimental::connect_t, split_sender_type& s,
+            Receiver&& receiver)
         {
-        };
+            return {PIKA_FORWARD(Receiver, receiver), s.state};
+        }
+    };
 
-        template <typename Sender>
-        inline constexpr bool is_split_sender_v =
-            is_split_sender_impl<std::decay_t<Sender>>::value;
-    }    // namespace split_detail
+    template <typename Sender, typename Enable = void>
+    struct is_split_sender_impl : std::false_type
+    {
+    };
 
+    template <typename Sender>
+    struct is_split_sender_impl<Sender,
+        std::void_t<typename Sender::split_sender_tag>> : std::true_type
+    {
+    };
+
+    template <typename Sender>
+    inline constexpr bool is_split_sender_v =
+        is_split_sender_impl<std::decay_t<Sender>>::value;
+}    // namespace pika::split_detail
+
+namespace pika::execution::experimental {
     inline constexpr struct split_t final
       : pika::functional::detail::tag_fallback<split_t>
     {
@@ -575,5 +577,5 @@ namespace pika { namespace execution { namespace experimental {
             return detail::partial_algorithm<split_t, Allocator>{allocator};
         }
     } split{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -24,172 +24,167 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace then_detail {
-        template <typename Receiver, typename F>
-        struct then_receiver_impl
+namespace pika::then_detail {
+    template <typename Receiver, typename F>
+    struct then_receiver_impl
+    {
+        struct then_receiver_type;
+    };
+
+    template <typename Receiver, typename F>
+    using then_receiver =
+        typename then_receiver_impl<Receiver, F>::then_receiver_type;
+
+    template <typename Receiver, typename F>
+    struct then_receiver_impl<Receiver, F>::then_receiver_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+        template <typename Error>
+        friend void tag_invoke(pika::execution::experimental::set_error_t,
+            then_receiver_type&& r, Error&& error) noexcept
         {
-            struct then_receiver_type;
-        };
+            pika::execution::experimental::set_error(
+                PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
+        }
 
-        template <typename Receiver, typename F>
-        using then_receiver =
-            typename then_receiver_impl<Receiver, F>::then_receiver_type;
-
-        template <typename Receiver, typename F>
-        struct then_receiver_impl<Receiver, F>::then_receiver_type
+        friend void tag_invoke(pika::execution::experimental::set_stopped_t,
+            then_receiver_type&& r) noexcept
         {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            pika::execution::experimental::set_stopped(PIKA_MOVE(r.receiver));
+        }
 
-            template <typename Error>
-            friend void tag_invoke(
-                set_error_t, then_receiver_type&& r, Error&& error) noexcept
-            {
-                pika::execution::experimental::set_error(
-                    PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, then_receiver_type&& r) noexcept
-            {
-                pika::execution::experimental::set_stopped(
-                    PIKA_MOVE(r.receiver));
-            }
-
-        private:
-            template <typename... Ts>
-            void set_value_helper(Ts&&... ts) noexcept
-            {
-                pika::detail::try_catch_exception_ptr(
-                    [&]() {
-                        if constexpr (std::is_void_v<pika::util::detail::
-                                              invoke_result_t<F, Ts...>>)
-                        {
-                        // Certain versions of GCC with optimizations fail on
-                        // the move with an internal compiler error.
+    private:
+        template <typename... Ts>
+        void set_value_helper(Ts&&... ts) noexcept
+        {
+            pika::detail::try_catch_exception_ptr(
+                [&]() {
+                    if constexpr (std::is_void_v<pika::util::detail::
+                                          invoke_result_t<F, Ts...>>)
+                    {
+                    // Certain versions of GCC with optimizations fail on
+                    // the move with an internal compiler error.
 #if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
+                        PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...);
+#else
+                        PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...);
+#endif
+                        pika::execution::experimental::set_value(
+                            PIKA_MOVE(receiver));
+                    }
+                    else
+                    {
+                    // Certain versions of GCC with optimizations fail on
+                    // the move with an internal compiler error.
+#if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
+                        auto&& result =
                             PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...);
 #else
+                        auto&& result =
                             PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...);
 #endif
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(receiver));
-                        }
-                        else
-                        {
-                        // Certain versions of GCC with optimizations fail on
-                        // the move with an internal compiler error.
-#if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
-                            auto&& result = PIKA_INVOKE(
-                                std::move(f), PIKA_FORWARD(Ts, ts)...);
-#else
-                            auto&& result = PIKA_INVOKE(
-                                PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...);
-#endif
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(receiver), PIKA_MOVE(result));
-                        }
-                    },
-                    [&](std::exception_ptr ep) {
-                        pika::execution::experimental::set_error(
-                            PIKA_MOVE(receiver), PIKA_MOVE(ep));
-                    });
-            }
+                        pika::execution::experimental::set_value(
+                            PIKA_MOVE(receiver), PIKA_MOVE(result));
+                    }
+                },
+                [&](std::exception_ptr ep) {
+                    pika::execution::experimental::set_error(
+                        PIKA_MOVE(receiver), PIKA_MOVE(ep));
+                });
+        }
 
-            template <typename... Ts>
-            friend void tag_invoke(
-                set_value_t, then_receiver_type&& r, Ts&&... ts) noexcept
-            {
-                // GCC 7 fails with an internal compiler error unless the actual
-                // body is in a helper function.
-                r.set_value_helper(PIKA_FORWARD(Ts, ts)...);
-            }
+        template <typename... Ts>
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            then_receiver_type&& r, Ts&&... ts) noexcept
+        {
+            // GCC 7 fails with an internal compiler error unless the actual
+            // body is in a helper function.
+            r.set_value_helper(PIKA_FORWARD(Ts, ts)...);
+        }
+    };
+
+    template <typename Sender, typename F>
+    struct then_sender_impl
+    {
+        struct then_sender_type;
+    };
+
+    template <typename Sender, typename F>
+    using then_sender = typename then_sender_impl<Sender, F>::then_sender_type;
+
+    template <typename Sender, typename F>
+    struct then_sender_impl<Sender, F>::then_sender_type
+    {
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+        template <typename Tuple>
+        struct invoke_result_helper;
+
+        template <template <typename...> class Tuple, typename... Ts>
+        struct invoke_result_helper<Tuple<Ts...>>
+        {
+            using result_type = pika::util::detail::invoke_result_t<F, Ts...>;
+            using type = std::conditional_t<std::is_void<result_type>::value,
+                Tuple<>, Tuple<result_type>>;
         };
 
-        template <typename Sender, typename F>
-        struct then_sender_impl
-        {
-            struct then_sender_type;
-        };
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types =
+            pika::util::detail::unique_t<pika::util::detail::transform_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template value_types<Tuple, Variant>,
+                invoke_result_helper>>;
 
-        template <typename Sender, typename F>
-        using then_sender =
-            typename then_sender_impl<Sender, F>::then_sender_type;
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
 
-        template <typename Sender, typename F>
-        struct then_sender_impl<Sender, F>::then_sender_type
-        {
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+        static constexpr bool sends_done = false;
 
-            template <typename Tuple>
-            struct invoke_result_helper;
-
-            template <template <typename...> class Tuple, typename... Ts>
-            struct invoke_result_helper<Tuple<Ts...>>
-            {
-                using result_type =
-                    pika::util::detail::invoke_result_t<F, Ts...>;
-                using type =
-                    std::conditional_t<std::is_void<result_type>::value,
-                        Tuple<>, Tuple<result_type>>;
-            };
-
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types =
-                pika::util::detail::unique_t<pika::util::detail::transform_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template value_types<Tuple, Variant>,
-                    invoke_result_helper>>;
-
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template error_types<Variant>,
-                    std::exception_ptr>>;
-
-            static constexpr bool sends_done = false;
-
-            template <typename CPO,
-                // clang-format off
+        template <typename CPO,
+            // clang-format off
                 PIKA_CONCEPT_REQUIRES_(
                     pika::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     pika::execution::experimental::detail::has_completion_scheduler_v<
                         CPO, std::decay_t<Sender>>)
-                // clang-format on
-                >
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::get_completion_scheduler_t<CPO>,
-                then_sender_type const& sender)
-            {
-                return pika::execution::experimental::get_completion_scheduler<
-                    CPO>(sender.sender);
-            }
+            // clang-format on
+            >
+        friend constexpr auto tag_invoke(
+            pika::execution::experimental::get_completion_scheduler_t<CPO>,
+            then_sender_type const& sender)
+        {
+            return pika::execution::experimental::get_completion_scheduler<CPO>(
+                sender.sender);
+        }
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, then_sender_type&& s, Receiver&& receiver)
-            {
-                return pika::execution::experimental::connect(
-                    PIKA_MOVE(s.sender),
-                    then_receiver<Receiver, F>{
-                        PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f)});
-            }
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            then_sender_type&& s, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(PIKA_MOVE(s.sender),
+                then_receiver<Receiver, F>{
+                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f)});
+        }
 
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, then_sender_type& r, Receiver&& receiver)
-            {
-                return pika::execution::experimental::connect(r.sender,
-                    then_receiver<Receiver, F>{
-                        PIKA_FORWARD(Receiver, receiver), r.f});
-            }
-        };
-    }    // namespace then_detail
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            then_sender_type& r, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(r.sender,
+                then_receiver<Receiver, F>{
+                    PIKA_FORWARD(Receiver, receiver), r.f});
+        }
+    };
+}    // namespace pika::then_detail
 
+namespace pika::execution::experimental {
     inline constexpr struct then_t final
       : pika::functional::detail::tag_fallback<then_t>
     {
@@ -214,5 +209,5 @@ namespace pika { namespace execution { namespace experimental {
             return detail::partial_algorithm<then_t, F>{PIKA_FORWARD(F, f)};
         }
     } then{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -31,394 +31,389 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace when_all_detail {
-        // This is a receiver to be connected to the ith predecessor sender
-        // passed to when_all. When set_value is called, it will emplace the
-        // values sent into the appropriate position in the pack used to store
-        // values from all predecessor senders.
-        template <typename OperationState>
-        struct when_all_receiver_impl
+namespace pika::when_all_impl {
+    // This is a receiver to be connected to the ith predecessor sender
+    // passed to when_all. When set_value is called, it will emplace the
+    // values sent into the appropriate position in the pack used to store
+    // values from all predecessor senders.
+    template <typename OperationState>
+    struct when_all_receiver_impl
+    {
+        struct when_all_receiver_type;
+    };
+
+    template <typename OperationState>
+    using when_all_receiver =
+        typename when_all_receiver_impl<OperationState>::when_all_receiver_type;
+
+    template <typename OperationState>
+    struct when_all_receiver_impl<OperationState>::when_all_receiver_type
+    {
+        std::decay_t<OperationState>& op_state;
+
+        when_all_receiver_type(std::decay_t<OperationState>& op_state)
+          : op_state(op_state)
         {
-            struct when_all_receiver_type;
-        };
+        }
 
-        template <typename OperationState>
-        using when_all_receiver = typename when_all_receiver_impl<
-            OperationState>::when_all_receiver_type;
-
-        template <typename OperationState>
-        struct when_all_receiver_impl<OperationState>::when_all_receiver_type
+        template <typename Error>
+        friend void tag_invoke(pika::execution::experimental::set_error_t,
+            when_all_receiver_type&& r, Error&& error) noexcept
         {
-            std::decay_t<OperationState>& op_state;
-
-            when_all_receiver_type(std::decay_t<OperationState>& op_state)
-              : op_state(op_state)
+            if (!r.op_state.set_stopped_error_called.exchange(true))
             {
+                try
+                {
+                    r.op_state.error = PIKA_FORWARD(Error, error);
+                }
+                catch (...)
+                {
+                    // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                    r.op_state.error = std::current_exception();
+                }
             }
 
-            template <typename Error>
-            friend void tag_invoke(
-                set_error_t, when_all_receiver_type&& r, Error&& error) noexcept
+            r.op_state.finish();
+        }
+
+        friend void tag_invoke(pika::execution::experimental::set_stopped_t,
+            when_all_receiver_type&& r) noexcept
+        {
+            r.op_state.set_stopped_error_called = true;
+            r.op_state.finish();
+        };
+
+        template <typename... Ts, std::size_t... Is>
+        auto set_value_helper(pika::util::detail::index_pack<Is...>, Ts&&... ts)
+            -> decltype((std::declval<typename OperationState::
+                                 value_types_storage_type>()
+                                .template get<OperationState::i_storage_offset +
+                                    Is>()
+                                .emplace(PIKA_FORWARD(Ts, ts)),
+                            ...),
+                void())
+        {
+            // op_state.ts holds values from all predecessor senders. We
+            // emplace the values using the offset calculated while
+            // constructing the operation state.
+            (op_state.ts.template get<OperationState::i_storage_offset + Is>()
+                    .emplace(PIKA_FORWARD(Ts, ts)),
+                ...);
+        }
+
+        using index_pack_type = typename pika::util::detail::make_index_pack<
+            OperationState::sender_pack_size>::type;
+
+        template <typename... Ts>
+        auto set_value(Ts&&... ts) noexcept
+            -> decltype(set_value_helper(
+                            index_pack_type{}, PIKA_FORWARD(Ts, ts)...),
+                void())
+        {
+            if constexpr (OperationState::sender_pack_size > 0)
             {
-                if (!r.op_state.set_stopped_error_called.exchange(true))
+                if (!op_state.set_stopped_error_called)
                 {
                     try
                     {
-                        r.op_state.error = PIKA_FORWARD(Error, error);
+                        set_value_helper(
+                            index_pack_type{}, PIKA_FORWARD(Ts, ts)...);
                     }
                     catch (...)
                     {
-                        // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                        r.op_state.error = std::current_exception();
-                    }
-                }
-
-                r.op_state.finish();
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, when_all_receiver_type&& r) noexcept
-            {
-                r.op_state.set_stopped_error_called = true;
-                r.op_state.finish();
-            };
-
-            template <typename... Ts, std::size_t... Is>
-            auto set_value_helper(
-                pika::util::detail::index_pack<Is...>, Ts&&... ts)
-                -> decltype((std::declval<typename OperationState::
-                                     value_types_storage_type>()
-                                    .template get<
-                                        OperationState::i_storage_offset + Is>()
-                                    .emplace(PIKA_FORWARD(Ts, ts)),
-                                ...),
-                    void())
-            {
-                // op_state.ts holds values from all predecessor senders. We
-                // emplace the values using the offset calculated while
-                // constructing the operation state.
-                (op_state.ts
-                        .template get<OperationState::i_storage_offset + Is>()
-                        .emplace(PIKA_FORWARD(Ts, ts)),
-                    ...);
-            }
-
-            using index_pack_type =
-                typename pika::util::detail::make_index_pack<
-                    OperationState::sender_pack_size>::type;
-
-            template <typename... Ts>
-            auto set_value(Ts&&... ts) noexcept
-                -> decltype(set_value_helper(
-                                index_pack_type{}, PIKA_FORWARD(Ts, ts)...),
-                    void())
-            {
-                if constexpr (OperationState::sender_pack_size > 0)
-                {
-                    if (!op_state.set_stopped_error_called)
-                    {
-                        try
+                        if (!op_state.set_stopped_error_called.exchange(true))
                         {
-                            set_value_helper(
-                                index_pack_type{}, PIKA_FORWARD(Ts, ts)...);
-                        }
-                        catch (...)
-                        {
-                            if (!op_state.set_stopped_error_called.exchange(
-                                    true))
-                            {
-                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state.error = std::current_exception();
-                            }
+                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                            op_state.error = std::current_exception();
                         }
                     }
                 }
-
-                op_state.finish();
             }
-        };
 
-        // Due to what appears to be a bug in clang this is not a hidden friend
-        // of when_all_receiver. The trailing decltype for SFINAE in the member
-        // set_value would give an error about accessing an incomplete type, if
-        // the member set_value were a hidden friend tag_invoke overload
-        // instead. Note that the receiver is unconstrained. That is because
-        // OperationState in when_all_receiver<OperationState> cannot be deduced
-        // when when_all_receiver is an alias template. Since this is in a
-        // unique namespace nothing but when_all_receiver should ever find this
-        // overload.
-        template <typename Receiver, typename... Ts>
-        auto tag_invoke(set_value_t, Receiver&& r, Ts&&... ts) noexcept
-            -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
+            op_state.finish();
+        }
+    };
+
+    // Due to what appears to be a bug in clang this is not a hidden friend
+    // of when_all_receiver. The trailing decltype for SFINAE in the member
+    // set_value would give an error about accessing an incomplete type, if
+    // the member set_value were a hidden friend tag_invoke overload
+    // instead. Note that the receiver is unconstrained. That is because
+    // OperationState in when_all_receiver<OperationState> cannot be deduced
+    // when when_all_receiver is an alias template. Since this is in a
+    // unique namespace nothing but when_all_receiver should ever find this
+    // overload.
+    template <typename Receiver, typename... Ts>
+    auto tag_invoke(pika::execution::experimental::set_value_t, Receiver&& r,
+        Ts&&... ts) noexcept
+        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
+    {
+        r.set_value(PIKA_FORWARD(Ts, ts)...);
+    }
+
+    template <typename... Senders>
+    struct when_all_sender_impl
+    {
+        struct when_all_sender_type;
+    };
+
+    template <typename... Senders>
+    using when_all_sender =
+        typename when_all_sender_impl<Senders...>::when_all_sender_type;
+
+    template <typename... Senders>
+    struct when_all_sender_impl<Senders...>::when_all_sender_type
+    {
+        using senders_type =
+            pika::util::detail::member_pack_for<std::decay_t<Senders>...>;
+        senders_type senders;
+
+        template <typename... Senders_>
+        explicit constexpr when_all_sender_type(Senders_&&... senders)
+          : senders(
+                std::piecewise_construct, PIKA_FORWARD(Senders_, senders)...)
         {
-            r.set_value(PIKA_FORWARD(Ts, ts)...);
         }
 
-        template <typename... Senders>
-        struct when_all_sender_impl
+        template <typename Sender>
+        struct value_types_helper
         {
-            struct when_all_sender_type;
+            using value_types =
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template value_types<pika::util::detail::pack,
+                    pika::util::detail::pack>;
+            using type =
+                pika::execution::experimental::detail::single_result_non_void_t<
+                    value_types>;
         };
 
-        template <typename... Senders>
-        using when_all_sender =
-            typename when_all_sender_impl<Senders...>::when_all_sender_type;
+        template <typename Sender>
+        using value_types_helper_t = typename value_types_helper<Sender>::type;
 
-        template <typename... Senders>
-        struct when_all_sender_impl<Senders...>::when_all_sender_type
-        {
-            using senders_type =
-                pika::util::detail::member_pack_for<std::decay_t<Senders>...>;
-            senders_type senders;
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = pika::util::detail::concat_inner_packs_t<
+            pika::util::detail::concat_t<
+                typename pika::execution::experimental::sender_traits<
+                    Senders>::template value_types<Tuple, Variant>...>>;
 
-            template <typename... Senders_>
-            explicit constexpr when_all_sender_type(Senders_&&... senders)
-              : senders(std::piecewise_construct,
-                    PIKA_FORWARD(Senders_, senders)...)
-            {
-            }
+        template <template <typename...> class Variant>
+        using error_types = pika::util::detail::unique_concat_t<
+            pika::util::detail::transform_t<
+                typename pika::execution::experimental::sender_traits<
+                    Senders>::template error_types<Variant>,
+                std::decay>...,
+            Variant<std::exception_ptr>>;
 
-            template <typename Sender>
-            struct value_types_helper
-            {
-                using value_types =
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template value_types<pika::util::detail::pack,
-                        pika::util::detail::pack>;
-                using type = detail::single_result_non_void_t<value_types>;
-            };
+        static constexpr bool sends_done = false;
 
-            template <typename Sender>
-            using value_types_helper_t =
-                typename value_types_helper<Sender>::type;
+        static constexpr std::size_t num_predecessors = sizeof...(Senders);
+        static_assert(num_predecessors > 0,
+            "when_all expects at least one predecessor sender");
 
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types = pika::util::detail::concat_inner_packs_t<
-                pika::util::detail::concat_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Senders>::template value_types<Tuple, Variant>...>>;
-
-            template <template <typename...> class Variant>
-            using error_types = pika::util::detail::unique_concat_t<
-                pika::util::detail::transform_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Senders>::template error_types<Variant>,
-                    std::decay>...,
-                Variant<std::exception_ptr>>;
-
-            static constexpr bool sends_done = false;
-
-            static constexpr std::size_t num_predecessors = sizeof...(Senders);
-            static_assert(num_predecessors > 0,
-                "when_all expects at least one predecessor sender");
-
-            template <std::size_t I>
-            static constexpr std::size_t sender_pack_size_at_index =
-                detail::single_variant_t<typename sender_traits<
+        template <std::size_t I>
+        static constexpr std::size_t sender_pack_size_at_index =
+            pika::execution::experimental::detail::single_variant_t<
+                typename pika::execution::experimental::sender_traits<
                     pika::util::detail::at_index_t<I, Senders...>>::
+                    template value_types<pika::util::detail::pack,
+                        pika::util::detail::pack>>::size;
+
+        template <typename Receiver, typename SendersPack,
+            std::size_t I = num_predecessors - 1>
+        struct operation_state;
+
+        template <typename Receiver, typename SendersPack>
+        struct operation_state<Receiver, SendersPack, 0>
+        {
+            // The index of the sender that this operation state handles.
+            static constexpr std::size_t i = 0;
+            // The offset at which we start to emplace values sent by the
+            // ith predecessor sender.
+            static constexpr std::size_t i_storage_offset = 0;
+#if !defined(PIKA_CUDA_VERSION)
+            // The number of values sent by the ith predecessor sender.
+            static constexpr std::size_t sender_pack_size =
+                sender_pack_size_at_index<i>;
+#else
+            // nvcc does not like using the helper sender_pack_size_at_index
+            // here and complains about incmplete types. Lifting the helper
+            // explicitly in here works.
+            static constexpr std::size_t sender_pack_size =
+                pika::execution::experimental::detail::single_variant_t<
+                    typename pika::execution::experimental::sender_traits<
+                        pika::util::detail::at_index_t<i, Senders...>>::
                         template value_types<pika::util::detail::pack,
                             pika::util::detail::pack>>::size;
+#endif
 
-            template <typename Receiver, typename SendersPack,
-                std::size_t I = num_predecessors - 1>
-            struct operation_state;
+            // Number of predecessor senders that have not yet called any of
+            // the set signals.
+            std::atomic<std::size_t> predecessors_remaining = num_predecessors;
 
-            template <typename Receiver, typename SendersPack>
-            struct operation_state<Receiver, SendersPack, 0>
+            template <typename T>
+            struct add_optional
             {
-                // The index of the sender that this operation state handles.
-                static constexpr std::size_t i = 0;
-                // The offset at which we start to emplace values sent by the
-                // ith predecessor sender.
-                static constexpr std::size_t i_storage_offset = 0;
-#if !defined(PIKA_CUDA_VERSION)
-                // The number of values sent by the ith predecessor sender.
-                static constexpr std::size_t sender_pack_size =
-                    sender_pack_size_at_index<i>;
-#else
-                // nvcc does not like using the helper sender_pack_size_at_index
-                // here and complains about incmplete types. Lifting the helper
-                // explicitly in here works.
-                static constexpr std::size_t sender_pack_size =
-                    detail::single_variant_t<typename sender_traits<
-                        pika::util::detail::at_index_t<i, Senders...>>::
-                            template value_types<pika::util::detail::pack,
-                                pika::util::detail::pack>>::size;
-#endif
+                using type = std::optional<std::decay_t<T>>;
+            };
+            using value_types_storage_type = pika::util::detail::change_pack_t<
+                pika::util::detail::member_pack_for,
+                pika::util::detail::transform_t<
+                    pika::util::detail::concat_pack_of_packs_t<value_types<
+                        pika::util::detail::pack, pika::util::detail::pack>>,
+                    add_optional>>;
+            // Values sent by all predecessor senders are stored here in the
+            // base-case operation state. They are stored in a
+            // member_pack<optional<T0>, ..., optional<Tn>>, where T0, ...,
+            // Tn are the types of the values sent by all predecessor
+            // senders.
+            value_types_storage_type ts;
 
-                // Number of predecessor senders that have not yet called any of
-                // the set signals.
-                std::atomic<std::size_t> predecessors_remaining =
-                    num_predecessors;
+            std::optional<error_types<pika::detail::variant>> error;
+            std::atomic<bool> set_stopped_error_called{false};
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
-                template <typename T>
-                struct add_optional
-                {
-                    using type = std::optional<std::decay_t<T>>;
-                };
-                using value_types_storage_type =
-                    pika::util::detail::change_pack_t<
-                        pika::util::detail::member_pack_for,
-                        pika::util::detail::transform_t<
-                            pika::util::detail::concat_pack_of_packs_t<
-                                value_types<pika::util::detail::pack,
-                                    pika::util::detail::pack>>,
-                            add_optional>>;
-                // Values sent by all predecessor senders are stored here in the
-                // base-case operation state. They are stored in a
-                // member_pack<optional<T0>, ..., optional<Tn>>, where T0, ...,
-                // Tn are the types of the values sent by all predecessor
-                // senders.
-                value_types_storage_type ts;
+            using operation_state_type =
+                std::decay_t<decltype(pika::execution::experimental::connect(
+                    std::declval<SendersPack>().template get<i>(),
+                    when_all_receiver<operation_state>(
+                        std::declval<std::decay_t<operation_state>&>())))>;
+            operation_state_type op_state;
 
-                std::optional<error_types<pika::detail::variant>> error;
-                std::atomic<bool> set_stopped_error_called{false};
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-
-                using operation_state_type = std::decay_t<
-                    decltype(pika::execution::experimental::connect(
-                        std::declval<SendersPack>().template get<i>(),
-                        when_all_receiver<operation_state>(
-                            std::declval<std::decay_t<operation_state>&>())))>;
-                operation_state_type op_state;
-
-                template <typename Receiver_, typename Senders_>
-                operation_state(Receiver_&& receiver, Senders_&& senders)
-                  : receiver(PIKA_FORWARD(Receiver_, receiver))
-                  , op_state(pika::execution::experimental::connect(
+            template <typename Receiver_, typename Senders_>
+            operation_state(Receiver_&& receiver, Senders_&& senders)
+              : receiver(PIKA_FORWARD(Receiver_, receiver))
+              , op_state(pika::execution::experimental::connect(
 #if defined(PIKA_CUDA_VERSION)
-                        std::forward<Senders_>(senders).template get<i>(),
+                    std::forward<Senders_>(senders).template get<i>(),
 #else
-                        PIKA_FORWARD(Senders_, senders).template get<i>(),
+                    PIKA_FORWARD(Senders_, senders).template get<i>(),
 #endif
-                        when_all_receiver<operation_state>(*this)))
-                {
-                }
+                    when_all_receiver<operation_state>(*this)))
+            {
+            }
 
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
+            operation_state(operation_state&&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
 
-                void start() & noexcept
-                {
-                    pika::execution::experimental::start(op_state);
-                }
+            void start() & noexcept
+            {
+                pika::execution::experimental::start(op_state);
+            }
 
-                template <std::size_t... Is, typename... Ts>
-                void set_value_helper(pika::util::detail::member_pack<
-                    pika::util::detail::index_pack<Is...>, Ts...>& ts)
-                {
-                    pika::execution::experimental::set_value(
-                        PIKA_MOVE(receiver),
-                        PIKA_MOVE(*(ts.template get<Is>()))...);
-                }
+            template <std::size_t... Is, typename... Ts>
+            void set_value_helper(pika::util::detail::member_pack<
+                pika::util::detail::index_pack<Is...>, Ts...>& ts)
+            {
+                pika::execution::experimental::set_value(PIKA_MOVE(receiver),
+                    PIKA_MOVE(*(ts.template get<Is>()))...);
+            }
 
-                void finish() noexcept
+            void finish() noexcept
+            {
+                if (--predecessors_remaining == 0)
                 {
-                    if (--predecessors_remaining == 0)
+                    if (!set_stopped_error_called)
                     {
-                        if (!set_stopped_error_called)
-                        {
-                            set_value_helper(ts);
-                        }
-                        else if (error)
-                        {
-                            pika::detail::visit(
-                                [this](auto&& error) {
-                                    pika::execution::experimental::set_error(
-                                        PIKA_MOVE(receiver),
-                                        PIKA_FORWARD(decltype(error), error));
-                                },
-                                PIKA_MOVE(error.value()));
-                        }
-                        else
-                        {
-                            pika::execution::experimental::set_stopped(
-                                PIKA_MOVE(receiver));
-                        }
+                        set_value_helper(ts);
+                    }
+                    else if (error)
+                    {
+                        pika::detail::visit(
+                            [this](auto&& error) {
+                                pika::execution::experimental::set_error(
+                                    PIKA_MOVE(receiver),
+                                    PIKA_FORWARD(decltype(error), error));
+                            },
+                            PIKA_MOVE(error.value()));
+                    }
+                    else
+                    {
+                        pika::execution::experimental::set_stopped(
+                            PIKA_MOVE(receiver));
                     }
                 }
-            };
-
-            template <typename Receiver, typename SendersPack, std::size_t I>
-            struct operation_state
-              : operation_state<Receiver, SendersPack, I - 1>
-            {
-                using base_type = operation_state<Receiver, SendersPack, I - 1>;
-
-                // The index of the sender that this operation state handles.
-                static constexpr std::size_t i = I;
-                // The number of values sent by the ith predecessor sender.
-                static constexpr std::size_t sender_pack_size =
-                    sender_pack_size_at_index<i>;
-                // The offset at which we start to emplace values sent by the
-                // ith predecessor sender.
-                static constexpr std::size_t i_storage_offset =
-                    base_type::i_storage_offset + base_type::sender_pack_size;
-
-                using operation_state_type = std::decay_t<
-                    decltype(pika::execution::experimental::connect(
-                        PIKA_FORWARD(SendersPack, senders).template get<i>(),
-                        when_all_receiver<operation_state>(
-                            std::declval<std::decay_t<operation_state>&>())))>;
-                operation_state_type op_state;
-
-                template <typename Receiver_, typename SendersPack_>
-                operation_state(Receiver_&& receiver, SendersPack_&& senders)
-                  : base_type(PIKA_FORWARD(Receiver_, receiver),
-                        PIKA_FORWARD(SendersPack, senders))
-                  , op_state(pika::execution::experimental::connect(
-#if defined(PIKA_CUDA_VERSION)
-                        std::forward<SendersPack_>(senders).template get<i>(),
-#else
-                        PIKA_FORWARD(SendersPack_, senders).template get<i>(),
-#endif
-                        when_all_receiver<operation_state>(*this)))
-                {
-                }
-
-                operation_state(operation_state&&) = delete;
-                operation_state& operator=(operation_state&&) = delete;
-                operation_state(operation_state const&) = delete;
-                operation_state& operator=(operation_state const&) = delete;
-
-                void start() & noexcept
-                {
-                    base_type::start();
-                    pika::execution::experimental::start(op_state);
-                }
-            };
-
-            template <typename Receiver, typename SendersPack>
-            friend void tag_invoke(start_t,
-                operation_state<Receiver, SendersPack, num_predecessors - 1>&
-                    os) noexcept
-            {
-                os.start();
-            }
-
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, when_all_sender_type&& s, Receiver&& receiver)
-            {
-                return operation_state<Receiver, senders_type&&,
-                    num_predecessors - 1>(
-                    PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.senders));
-            }
-
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, when_all_sender_type& s, Receiver&& receiver)
-            {
-                return operation_state<Receiver, senders_type&,
-                    num_predecessors - 1>(receiver, s.senders);
             }
         };
-    }    // namespace when_all_detail
 
+        template <typename Receiver, typename SendersPack, std::size_t I>
+        struct operation_state : operation_state<Receiver, SendersPack, I - 1>
+        {
+            using base_type = operation_state<Receiver, SendersPack, I - 1>;
+
+            // The index of the sender that this operation state handles.
+            static constexpr std::size_t i = I;
+            // The number of values sent by the ith predecessor sender.
+            static constexpr std::size_t sender_pack_size =
+                sender_pack_size_at_index<i>;
+            // The offset at which we start to emplace values sent by the
+            // ith predecessor sender.
+            static constexpr std::size_t i_storage_offset =
+                base_type::i_storage_offset + base_type::sender_pack_size;
+
+            using operation_state_type =
+                std::decay_t<decltype(pika::execution::experimental::connect(
+                    PIKA_FORWARD(SendersPack, senders).template get<i>(),
+                    when_all_receiver<operation_state>(
+                        std::declval<std::decay_t<operation_state>&>())))>;
+            operation_state_type op_state;
+
+            template <typename Receiver_, typename SendersPack_>
+            operation_state(Receiver_&& receiver, SendersPack_&& senders)
+              : base_type(PIKA_FORWARD(Receiver_, receiver),
+                    PIKA_FORWARD(SendersPack, senders))
+              , op_state(pika::execution::experimental::connect(
+#if defined(PIKA_CUDA_VERSION)
+                    std::forward<SendersPack_>(senders).template get<i>(),
+#else
+                    PIKA_FORWARD(SendersPack_, senders).template get<i>(),
+#endif
+                    when_all_receiver<operation_state>(*this)))
+            {
+            }
+
+            operation_state(operation_state&&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
+
+            void start() & noexcept
+            {
+                base_type::start();
+                pika::execution::experimental::start(op_state);
+            }
+        };
+
+        template <typename Receiver, typename SendersPack>
+        friend void tag_invoke(pika::execution::experimental::start_t,
+            operation_state<Receiver, SendersPack, num_predecessors - 1>&
+                os) noexcept
+        {
+            os.start();
+        }
+
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            when_all_sender_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver, senders_type&&,
+                num_predecessors - 1>(
+                PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.senders));
+        }
+
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            when_all_sender_type& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver, senders_type&,
+                num_predecessors - 1>(receiver, s.senders);
+        }
+    };
+}    // namespace pika::when_all_impl
+
+namespace pika::execution::experimental {
     inline constexpr struct when_all_t final
       : pika::functional::detail::tag_fallback<when_all_t>
     {
@@ -432,9 +427,9 @@ namespace pika { namespace execution { namespace experimental {
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
             when_all_t, Senders&&... senders)
         {
-            return when_all_detail::when_all_sender<Senders...>{
+            return pika::when_all_impl::when_all_sender<Senders...>{
                 PIKA_FORWARD(Senders, senders)...};
         }
     } when_all{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -41,91 +41,89 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace execution { namespace experimental {
-    namespace detail {
-        /// This sender represents bulk work that will be performed using the
-        /// thread_pool_scheduler.
-        ///
-        /// The work is chunked into a number of chunks larger than the number
-        /// of worker threads available on the underlying thread pool. The
-        /// chunks are then assigned to worker thread-specific thread-safe index
-        /// queues. One pika thread is spawned for each underlying worker (OS)
-        /// thread. The pika thread is responsible for work in one queue. If the
-        /// queue is empty, no pika thread will be spawned. Once the pika thread
-        /// has finished working on its own queue, it will attempt to steal work
-        /// from other queues. Since predecessor sender must complete on an pika
-        /// thread (the completion scheduler is a thread_pool_scheduler;
-        /// otherwise the customization defined in this file is not chosen) it
-        /// will be reused as one of the worker threads.
-        template <typename Sender, typename Shape, typename F>
-        class thread_pool_bulk_sender
+namespace pika::thread_pool_bulk_detail {
+    /// This sender represents bulk work that will be performed using the
+    /// thread_pool_scheduler.
+    ///
+    /// The work is chunked into a number of chunks larger than the number
+    /// of worker threads available on the underlying thread pool. The
+    /// chunks are then assigned to worker thread-specific thread-safe index
+    /// queues. One pika thread is spawned for each underlying worker (OS)
+    /// thread. The pika thread is responsible for work in one queue. If the
+    /// queue is empty, no pika thread will be spawned. Once the pika thread
+    /// has finished working on its own queue, it will attempt to steal work
+    /// from other queues. Since predecessor sender must complete on an pika
+    /// thread (the completion scheduler is a thread_pool_scheduler;
+    /// otherwise the customization defined in this file is not chosen) it
+    /// will be reused as one of the worker threads.
+    template <typename Sender, typename Shape, typename F>
+    class thread_pool_bulk_sender
+    {
+    private:
+        pika::execution::experimental::thread_pool_scheduler scheduler;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+        using size_type = decltype(pika::util::size(shape));
+
+    public:
+        template <typename Sender_, typename Shape_, typename F_>
+        thread_pool_bulk_sender(
+            pika::execution::experimental::thread_pool_scheduler&& scheduler,
+            Sender_&& sender, Shape_&& shape, F_&& f)
+          : scheduler(PIKA_MOVE(scheduler))
+          , sender(PIKA_FORWARD(Sender_, sender))
+          , shape(PIKA_FORWARD(Shape_, shape))
+          , f(PIKA_FORWARD(F_, f))
         {
-        private:
-            thread_pool_scheduler scheduler;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
-            PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-
-            using size_type = decltype(pika::util::size(shape));
-
-        public:
-            template <typename Sender_, typename Shape_, typename F_>
-            thread_pool_bulk_sender(thread_pool_scheduler&& scheduler,
-                Sender_&& sender, Shape_&& shape, F_&& f)
-              : scheduler(PIKA_MOVE(scheduler))
-              , sender(PIKA_FORWARD(Sender_, sender))
-              , shape(PIKA_FORWARD(Shape_, shape))
-              , f(PIKA_FORWARD(F_, f))
-            {
-            }
-            thread_pool_bulk_sender(thread_pool_bulk_sender&&) = default;
-            thread_pool_bulk_sender(thread_pool_bulk_sender const&) = default;
-            thread_pool_bulk_sender& operator=(
-                thread_pool_bulk_sender&&) = default;
-            thread_pool_bulk_sender& operator=(
-                thread_pool_bulk_sender const&) = default;
+        }
+        thread_pool_bulk_sender(thread_pool_bulk_sender&&) = default;
+        thread_pool_bulk_sender(thread_pool_bulk_sender const&) = default;
+        thread_pool_bulk_sender& operator=(thread_pool_bulk_sender&&) = default;
+        thread_pool_bulk_sender& operator=(
+            thread_pool_bulk_sender const&) = default;
 
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types =
-                pika::execution::experimental::value_types_of_t<Sender,
-                    pika::execution::experimental::detail::empty_env, Tuple,
-                    Variant>;
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types =
+            pika::execution::experimental::value_types_of_t<Sender,
+                pika::execution::experimental::detail::empty_env, Tuple,
+                Variant>;
 
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    pika::execution::experimental::error_types_of_t<Sender,
-                        pika::execution::experimental::detail::empty_env,
-                        Variant>,
-                    std::exception_ptr>>;
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
+                pika::execution::experimental::error_types_of_t<Sender,
+                    pika::execution::experimental::detail::empty_env, Variant>,
+                std::exception_ptr>>;
 
-            using completion_signatures =
-                pika::execution::experimental::make_completion_signatures<
-                    Sender, pika::execution::experimental::detail::empty_env,
-                    pika::execution::experimental::completion_signatures<
-                        pika::execution::experimental::set_error_t(
-                            std::exception_ptr)>>;
+        using completion_signatures =
+            pika::execution::experimental::make_completion_signatures<Sender,
+                pika::execution::experimental::detail::empty_env,
+                pika::execution::experimental::completion_signatures<
+                    pika::execution::experimental::set_error_t(
+                        std::exception_ptr)>>;
 #else
-            template <template <typename...> class Tuple,
-                template <typename...> class Variant>
-            using value_types =
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types =
+            typename pika::execution::experimental::sender_traits<
+                Sender>::template value_types<Tuple, Variant>;
+
+        template <template <typename...> class Variant>
+        using error_types =
+            pika::util::detail::unique_t<pika::util::detail::prepend_t<
                 typename pika::execution::experimental::sender_traits<
-                    Sender>::template value_types<Tuple, Variant>;
+                    Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
 
-            template <template <typename...> class Variant>
-            using error_types =
-                pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template error_types<Variant>,
-                    std::exception_ptr>>;
-
-            static constexpr bool sends_done = false;
+        static constexpr bool sends_done = false;
 #endif
 
-            template <typename CPO,
-                // clang-format off
+        template <typename CPO,
+            // clang-format off
                 PIKA_CONCEPT_REQUIRES_(
                     pika::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     (std::is_same_v<CPO, pika::execution::experimental::set_value_t> ||
@@ -135,454 +133,458 @@ namespace pika { namespace execution { namespace experimental {
                         pika::execution::experimental::detail::has_completion_scheduler_v<
                                 pika::execution::experimental::set_stopped_t,
                                 std::decay_t<Sender>>))
-                // clang-format on
-                >
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::get_completion_scheduler_t<CPO>,
-                thread_pool_bulk_sender const& s) noexcept
+            // clang-format on
+            >
+        friend constexpr auto tag_invoke(
+            pika::execution::experimental::get_completion_scheduler_t<CPO>,
+            thread_pool_bulk_sender const& s) noexcept
+        {
+            if constexpr (std::is_same_v<std::decay_t<CPO>,
+                              pika::execution::experimental::set_value_t>)
             {
-                if constexpr (std::is_same_v<std::decay_t<CPO>,
-                                  pika::execution::experimental::set_value_t>)
-                {
-                    return s.scheduler;
-                }
-                else
-                {
-                    return pika::execution::experimental::
-                        get_completion_scheduler<CPO>(s);
-                }
+                return s.scheduler;
             }
-
-        private:
-            template <typename Receiver>
-            struct operation_state
+            else
             {
-                struct bulk_receiver
-                {
-                    operation_state* op_state;
+                return pika::execution::experimental::get_completion_scheduler<
+                    CPO>(s);
+            }
+        }
 
-                    template <typename E>
-                    friend void tag_invoke(
-                        set_error_t, bulk_receiver&& r, E&& e) noexcept
+    private:
+        template <typename Receiver>
+        struct operation_state
+        {
+            struct bulk_receiver
+            {
+                operation_state* op_state;
+
+                template <typename E>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_error_t,
+                    bulk_receiver&& r, E&& e) noexcept
+                {
+                    pika::execution::experimental::set_error(
+                        PIKA_MOVE(r.op_state->receiver), PIKA_FORWARD(E, e));
+                }
+
+                friend void tag_invoke(
+                    pika::execution::experimental::set_stopped_t,
+                    bulk_receiver&& r) noexcept
+                {
+                    pika::execution::experimental::set_stopped(
+                        PIKA_MOVE(r.op_state->receiver));
+                };
+
+                struct task_function;
+
+                struct set_value_loop_visitor
+                {
+                    operation_state* const op_state;
+                    task_function const* const task_f;
+
+                    void operator()(pika::detail::monostate const&) const
                     {
-                        pika::execution::experimental::set_error(
-                            PIKA_MOVE(r.op_state->receiver),
-                            PIKA_FORWARD(E, e));
+                        PIKA_UNREACHABLE;
                     }
 
-                    friend void tag_invoke(
-                        set_stopped_t, bulk_receiver&& r) noexcept
+                    // Perform the work in one chunk indexed by index.  The
+                    // index represents a range of indices (iterators) in
+                    // the given shape.
+                    template <typename Ts>
+                    void do_work_chunk(Ts& ts, std::uint32_t const index) const
                     {
-                        pika::execution::experimental::set_stopped(
-                            PIKA_MOVE(r.op_state->receiver));
-                    };
-
-                    struct task_function;
-
-                    struct set_value_loop_visitor
-                    {
-                        operation_state* const op_state;
-                        task_function const* const task_f;
-
-                        void operator()(pika::detail::monostate const&) const
-                        {
-                            PIKA_UNREACHABLE;
-                        }
-
-                        // Perform the work in one chunk indexed by index.  The
-                        // index represents a range of indices (iterators) in
-                        // the given shape.
-                        template <typename Ts>
-                        void do_work_chunk(
-                            Ts& ts, std::uint32_t const index) const
-                        {
-                            auto const i_begin = static_cast<size_type>(index) *
-                                task_f->chunk_size;
-                            auto const i_end =
-                                (std::min)(static_cast<size_type>(index + 1) *
-                                        task_f->chunk_size,
-                                    task_f->n);
-                            auto it = pika::util::begin(op_state->shape);
-                            std::advance(it, i_begin);
-                            for (std::uint32_t i = i_begin; i < i_end; ++i)
-                            {
-                                pika::util::detail::invoke_fused(
-                                    pika::util::detail::bind_front(
-                                        op_state->f, *it),
-                                    ts);
-                                ++it;
-                            }
-                        }
-
-                        // Visit the values sent from the predecessor sender.
-                        // This function first tries to handle all chunks in the
-                        // queue owned by worker_thread. It then tries to steal
-                        // chunks from neighboring threads.
-                        template <typename Ts,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<Ts>, pika::detail::monostate>>>
-                        void operator()(Ts& ts) const
-                        {
-                            auto& local_queue =
-                                op_state->queues[task_f->worker_thread].data_;
-
-                            // Handle local queue first
-                            std::optional<std::uint32_t> index;
-                            while ((index = local_queue.pop_left()))
-                            {
-                                do_work_chunk(ts, index.value());
-                            }
-
-                            // Then steal from neighboring queues
-                            for (std::uint32_t offset = 1;
-                                 offset < op_state->num_worker_threads;
-                                 ++offset)
-                            {
-                                std::size_t neighbor_worker_thread =
-                                    (task_f->worker_thread + offset) %
-                                    op_state->num_worker_threads;
-                                auto& neighbor_queue =
-                                    op_state->queues[neighbor_worker_thread]
-                                        .data_;
-
-                                while ((index = neighbor_queue.pop_right()))
-                                {
-                                    do_work_chunk(ts, index.value());
-                                }
-                            }
-                        }
-                    };
-
-                    struct set_value_end_loop_visitor
-                    {
-                        operation_state* const op_state;
-
-                        void operator()(pika::detail::monostate&&) const
-                        {
-                            std::terminate();
-                        }
-
-                        // Visit the values sent from the predecessor sender.
-                        // This function is called once all worker threads have
-                        // processed their chunks and the connected receiver
-                        // should be signalled.
-                        template <typename Ts,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<Ts>, pika::detail::monostate>>>
-                        void operator()(Ts&& ts) const
+                        auto const i_begin =
+                            static_cast<size_type>(index) * task_f->chunk_size;
+                        auto const i_end =
+                            (std::min)(static_cast<size_type>(index + 1) *
+                                    task_f->chunk_size,
+                                task_f->n);
+                        auto it = pika::util::begin(op_state->shape);
+                        std::advance(it, i_begin);
+                        for (std::uint32_t i = i_begin; i < i_end; ++i)
                         {
                             pika::util::detail::invoke_fused(
                                 pika::util::detail::bind_front(
-                                    pika::execution::experimental::set_value,
-                                    PIKA_MOVE(op_state->receiver)),
-                                PIKA_FORWARD(Ts, ts));
+                                    op_state->f, *it),
+                                ts);
+                            ++it;
                         }
-                    };
-
-                    // This struct encapsulates the work done by one worker thread.
-                    struct task_function
-                    {
-                        operation_state* const op_state;
-                        size_type const n;
-                        std::uint32_t const chunk_size;
-                        std::uint32_t const worker_thread;
-
-                        // Visit the values sent by the predecessor sender.
-                        void do_work() const
-                        {
-                            pika::detail::visit(
-                                set_value_loop_visitor{op_state, this},
-                                op_state->ts);
-                        }
-
-                        // Store an exception and mark that an exception was
-                        // thrown in the operation state. This function assumes
-                        // that there is a current exception.
-                        void store_exception() const
-                        {
-                            if (!op_state->exception_thrown.exchange(true))
-                            {
-                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state->exception = std::current_exception();
-                            }
-                        }
-
-                        // Finish the work for one worker thread. If this is not
-                        // the last worker thread to finish, it will only
-                        // decrement the counter. If it is the last thread it
-                        // will call set_error if there is an exception.
-                        // Otherwise it will call set_value on the connected
-                        // receiver.
-                        void finish() const
-                        {
-                            if (--(op_state->tasks_remaining) == 0)
-                            {
-                                if (op_state->exception_thrown)
-                                {
-                                    PIKA_ASSERT(
-                                        op_state->exception.has_value());
-                                    pika::execution::experimental::set_error(
-                                        PIKA_MOVE(op_state->receiver),
-                                        PIKA_MOVE(op_state->exception.value()));
-                                }
-                                else
-                                {
-                                    pika::detail::visit(
-                                        set_value_end_loop_visitor{op_state},
-                                        PIKA_MOVE(op_state->ts));
-                                }
-                            }
-                        }
-
-                        // Entry point for the worker thread. It will attempt to
-                        // do its local work, catch any exceptions, and then
-                        // call set_value or set_error on the connected
-                        // receiver.
-                        void operator()()
-                        {
-                            try
-                            {
-                                // If f has a different annotation than the
-                                // current annotation it will be used for the
-                                // duration of the work and reset once done.
-                                // Otherwise the current annotation will be
-                                // used.
-                                pika::scoped_annotation ann(op_state->f);
-                                do_work();
-                            }
-                            catch (...)
-                            {
-                                store_exception();
-                            }
-
-                            finish();
-                        };
-                    };
-
-                    // Compute a chunk size given a number of worker threads and
-                    // a total number of items n. Returns a power-of-2 chunk
-                    // size that produces at most 8 and at least 4 chunks per
-                    // worker thread.
-                    static constexpr std::uint32_t get_chunk_size(
-                        std::uint32_t const num_threads, size_type const n)
-                    {
-                        std::uint32_t chunk_size = 1;
-                        while (chunk_size * num_threads * 8 < n)
-                        {
-                            chunk_size *= 2;
-                        }
-                        return chunk_size;
                     }
 
-                    // Initialize a queue for a worker thread.
-                    void init_queue(std::uint32_t const worker_thread,
-                        std::uint32_t const num_chunks)
+                    // Visit the values sent from the predecessor sender.
+                    // This function first tries to handle all chunks in the
+                    // queue owned by worker_thread. It then tries to steal
+                    // chunks from neighboring threads.
+                    template <typename Ts,
+                        typename = std::enable_if_t<!std::is_same_v<
+                            std::decay_t<Ts>, pika::detail::monostate>>>
+                    void operator()(Ts& ts) const
                     {
-                        auto& queue = op_state->queues[worker_thread].data_;
-                        auto const part_begin = static_cast<std::uint32_t>(
-                            (worker_thread * num_chunks) /
-                            op_state->num_worker_threads);
-                        auto const part_end = static_cast<std::uint32_t>(
-                            ((worker_thread + 1) * num_chunks) /
-                            op_state->num_worker_threads);
-                        queue.reset(part_begin, part_end);
-                    }
+                        auto& local_queue =
+                            op_state->queues[task_f->worker_thread].data_;
 
-                    // Spawn a task which will process a number of chunks. If
-                    // the queue contains no chunks no task will be spawned.
-                    void do_work_task(size_type const n,
-                        std::uint32_t const chunk_size,
-                        std::uint32_t const worker_thread) const
-                    {
-                        task_function task_f{
-                            this->op_state, n, chunk_size, worker_thread};
-
-                        auto& queue = op_state->queues[worker_thread].data_;
-                        if (queue.empty())
+                        // Handle local queue first
+                        std::optional<std::uint32_t> index;
+                        while ((index = local_queue.pop_left()))
                         {
-                            // If the queue is empty we don't spawn a task. We
-                            // only signal that this "task" is ready.
-                            task_f.finish();
-                            return;
+                            do_work_chunk(ts, index.value());
                         }
 
-                        // Only apply hint if none was given.
-                        auto hint = get_hint(op_state->scheduler);
-                        if (hint == pika::execution::thread_schedule_hint())
+                        // Then steal from neighboring queues
+                        for (std::uint32_t offset = 1;
+                             offset < op_state->num_worker_threads; ++offset)
                         {
-                            hint = pika::execution::thread_schedule_hint(
-                                pika::execution::thread_schedule_hint_mode::
-                                    thread,
-                                worker_thread);
-                        }
+                            std::size_t neighbor_worker_thread =
+                                (task_f->worker_thread + offset) %
+                                op_state->num_worker_threads;
+                            auto& neighbor_queue =
+                                op_state->queues[neighbor_worker_thread].data_;
 
-                        // Get the current thread description and apply it to
-                        // the spawned task. Since this is a customization of
-                        // bulk for thread_pool_scheduler we must currently be
-                        // running on a pika thread.
-                        PIKA_ASSERT(pika::threads::detail::get_self_id());
-                        pika::util::detail::thread_description desc =
-                            pika::threads::detail::get_thread_description(
-                                pika::threads::detail::get_self_id());
-
-                        // Spawn the task.
-                        threads::detail::thread_init_data data(
-                            threads::detail::make_thread_function_nullary(
-                                PIKA_MOVE(task_f)),
-                            desc, get_priority(op_state->scheduler), hint,
-                            get_stacksize(op_state->scheduler));
-                        threads::detail::register_work(
-                            data, op_state->scheduler.get_thread_pool());
-                    }
-
-                    // Do the work on the worker thread that called set_value
-                    // from the predecessor sender. This thread participates in
-                    // the work and does not need a new task since it already
-                    // runs on a task.
-                    void do_work_local(size_type n, std::uint32_t chunk_size,
-                        std::uint32_t worker_thread) const
-                    {
-                        task_function{
-                            this->op_state, n, chunk_size, worker_thread}();
-                    }
-
-                    using range_value_type = pika::traits::iter_value_t<
-                        pika::traits::range_iterator_t<Shape>>;
-
-                    template <typename... Ts>
-                    friend void tag_invoke(
-                        set_value_t, bulk_receiver&& r, Ts&&... ts) noexcept
-                    {
-                        // Don't spawn tasks if there is no work to be done
-                        auto const n = pika::util::size(r.op_state->shape);
-                        if (n == 0)
-                        {
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(r.op_state->receiver),
-                                PIKA_FORWARD(Ts, ts)...);
-                            return;
-                        }
-
-                        // Calculate chunk size and number of chunks
-                        auto const chunk_size =
-                            get_chunk_size(r.op_state->num_worker_threads, n);
-                        auto const num_chunks =
-                            (n + chunk_size - 1) / chunk_size;
-
-                        // Store sent values in the operation state
-                        r.op_state->ts.template emplace<std::tuple<Ts...>>(
-                            PIKA_FORWARD(Ts, ts)...);
-
-                        // Initialize the queues for all worker threads so that
-                        // worker threads can start stealing immediately when
-                        // they start.
-                        for (std::size_t worker_thread = 0;
-                             worker_thread < r.op_state->num_worker_threads;
-                             ++worker_thread)
-                        {
-                            r.init_queue(worker_thread, num_chunks);
-                        }
-
-                        // Spawn the worker threads for all except the local queue.
-                        auto const local_worker_thread =
-                            pika::get_local_worker_thread_num();
-                        for (std::size_t worker_thread = 0;
-                             worker_thread < r.op_state->num_worker_threads;
-                             ++worker_thread)
-                        {
-                            // The queue for the local thread is handled later
-                            // inline.
-                            if (worker_thread == local_worker_thread)
+                            while ((index = neighbor_queue.pop_right()))
                             {
-                                continue;
+                                do_work_chunk(ts, index.value());
                             }
-
-                            r.do_work_task(n, chunk_size, worker_thread);
                         }
-
-                        // Handle the queue for the local thread.
-                        r.do_work_local(n, chunk_size, local_worker_thread);
-                    }
-
-                    friend constexpr pika::execution::experimental::detail::
-                        empty_env
-                        tag_invoke(pika::execution::experimental::get_env_t,
-                            bulk_receiver const&) noexcept
-                    {
-                        return {};
                     }
                 };
 
-                using operation_state_type =
-                    pika::execution::experimental::connect_result_t<Sender,
-                        bulk_receiver>;
-
-                thread_pool_scheduler scheduler;
-                operation_state_type op_state;
-                std::size_t num_worker_threads =
-                    scheduler.get_thread_pool()->get_os_thread_count();
-                std::vector<pika::concurrency::detail::cache_aligned_data<
-                    pika::concurrency::detail::contiguous_index_queue<>>>
-                    queues{num_worker_threads};
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                std::atomic<decltype(pika::util::size(shape))> tasks_remaining{
-                    num_worker_threads};
-                pika::util::detail::prepend_t<
-                    value_types<std::tuple, pika::detail::variant>,
-                    pika::detail::monostate>
-                    ts;
-                std::atomic<bool> exception_thrown{false};
-                std::optional<std::exception_ptr> exception;
-
-                template <typename Sender_, typename Shape_, typename F_,
-                    typename Receiver_>
-                operation_state(thread_pool_scheduler&& scheduler,
-                    Sender_&& sender, Shape_&& shape, F_&& f,
-                    Receiver_&& receiver)
-                  : scheduler(PIKA_MOVE(scheduler))
-                  , op_state(pika::execution::experimental::connect(
-                        PIKA_FORWARD(Sender_, sender), bulk_receiver{this}))
-                  , shape(PIKA_FORWARD(Shape_, shape))
-                  , f(PIKA_FORWARD(F_, f))
-                  , receiver(PIKA_FORWARD(Receiver_, receiver))
+                struct set_value_end_loop_visitor
                 {
+                    operation_state* const op_state;
+
+                    void operator()(pika::detail::monostate&&) const
+                    {
+                        std::terminate();
+                    }
+
+                    // Visit the values sent from the predecessor sender.
+                    // This function is called once all worker threads have
+                    // processed their chunks and the connected receiver
+                    // should be signalled.
+                    template <typename Ts,
+                        typename = std::enable_if_t<!std::is_same_v<
+                            std::decay_t<Ts>, pika::detail::monostate>>>
+                    void operator()(Ts&& ts) const
+                    {
+                        pika::util::detail::invoke_fused(
+                            pika::util::detail::bind_front(
+                                pika::execution::experimental::set_value,
+                                PIKA_MOVE(op_state->receiver)),
+                            PIKA_FORWARD(Ts, ts));
+                    }
+                };
+
+                // This struct encapsulates the work done by one worker thread.
+                struct task_function
+                {
+                    operation_state* const op_state;
+                    size_type const n;
+                    std::uint32_t const chunk_size;
+                    std::uint32_t const worker_thread;
+
+                    // Visit the values sent by the predecessor sender.
+                    void do_work() const
+                    {
+                        pika::detail::visit(
+                            set_value_loop_visitor{op_state, this},
+                            op_state->ts);
+                    }
+
+                    // Store an exception and mark that an exception was
+                    // thrown in the operation state. This function assumes
+                    // that there is a current exception.
+                    void store_exception() const
+                    {
+                        if (!op_state->exception_thrown.exchange(true))
+                        {
+                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                            op_state->exception = std::current_exception();
+                        }
+                    }
+
+                    // Finish the work for one worker thread. If this is not
+                    // the last worker thread to finish, it will only
+                    // decrement the counter. If it is the last thread it
+                    // will call set_error if there is an exception.
+                    // Otherwise it will call set_value on the connected
+                    // receiver.
+                    void finish() const
+                    {
+                        if (--(op_state->tasks_remaining) == 0)
+                        {
+                            if (op_state->exception_thrown)
+                            {
+                                PIKA_ASSERT(op_state->exception.has_value());
+                                pika::execution::experimental::set_error(
+                                    PIKA_MOVE(op_state->receiver),
+                                    PIKA_MOVE(op_state->exception.value()));
+                            }
+                            else
+                            {
+                                pika::detail::visit(
+                                    set_value_end_loop_visitor{op_state},
+                                    PIKA_MOVE(op_state->ts));
+                            }
+                        }
+                    }
+
+                    // Entry point for the worker thread. It will attempt to
+                    // do its local work, catch any exceptions, and then
+                    // call set_value or set_error on the connected
+                    // receiver.
+                    void operator()()
+                    {
+                        try
+                        {
+                            // If f has a different annotation than the
+                            // current annotation it will be used for the
+                            // duration of the work and reset once done.
+                            // Otherwise the current annotation will be
+                            // used.
+                            pika::scoped_annotation ann(op_state->f);
+                            do_work();
+                        }
+                        catch (...)
+                        {
+                            store_exception();
+                        }
+
+                        finish();
+                    };
+                };
+
+                // Compute a chunk size given a number of worker threads and
+                // a total number of items n. Returns a power-of-2 chunk
+                // size that produces at most 8 and at least 4 chunks per
+                // worker thread.
+                static constexpr std::uint32_t get_chunk_size(
+                    std::uint32_t const num_threads, size_type const n)
+                {
+                    std::uint32_t chunk_size = 1;
+                    while (chunk_size * num_threads * 8 < n)
+                    {
+                        chunk_size *= 2;
+                    }
+                    return chunk_size;
                 }
 
-                friend void tag_invoke(start_t, operation_state& os) noexcept
+                // Initialize a queue for a worker thread.
+                void init_queue(std::uint32_t const worker_thread,
+                    std::uint32_t const num_chunks)
                 {
-                    pika::execution::experimental::start(os.op_state);
+                    auto& queue = op_state->queues[worker_thread].data_;
+                    auto const part_begin = static_cast<std::uint32_t>(
+                        (worker_thread * num_chunks) /
+                        op_state->num_worker_threads);
+                    auto const part_end = static_cast<std::uint32_t>(
+                        ((worker_thread + 1) * num_chunks) /
+                        op_state->num_worker_threads);
+                    queue.reset(part_begin, part_end);
+                }
+
+                // Spawn a task which will process a number of chunks. If
+                // the queue contains no chunks no task will be spawned.
+                void do_work_task(size_type const n,
+                    std::uint32_t const chunk_size,
+                    std::uint32_t const worker_thread) const
+                {
+                    task_function task_f{
+                        this->op_state, n, chunk_size, worker_thread};
+
+                    auto& queue = op_state->queues[worker_thread].data_;
+                    if (queue.empty())
+                    {
+                        // If the queue is empty we don't spawn a task. We
+                        // only signal that this "task" is ready.
+                        task_f.finish();
+                        return;
+                    }
+
+                    // Only apply hint if none was given.
+                    auto hint = pika::execution::experimental::get_hint(
+                        op_state->scheduler);
+                    if (hint == pika::execution::thread_schedule_hint())
+                    {
+                        hint = pika::execution::thread_schedule_hint(
+                            pika::execution::thread_schedule_hint_mode::thread,
+                            worker_thread);
+                    }
+
+                    // Get the current thread description and apply it to
+                    // the spawned task. Since this is a customization of
+                    // bulk for thread_pool_scheduler we must currently be
+                    // running on a pika thread.
+                    PIKA_ASSERT(pika::threads::detail::get_self_id());
+                    pika::util::detail::thread_description desc =
+                        pika::threads::detail::get_thread_description(
+                            pika::threads::detail::get_self_id());
+
+                    // Spawn the task.
+                    threads::detail::thread_init_data data(
+                        threads::detail::make_thread_function_nullary(
+                            PIKA_MOVE(task_f)),
+                        desc,
+                        pika::execution::experimental::get_priority(
+                            op_state->scheduler),
+                        hint,
+                        pika::execution::experimental::get_stacksize(
+                            op_state->scheduler));
+                    threads::detail::register_work(
+                        data, op_state->scheduler.get_thread_pool());
+                }
+
+                // Do the work on the worker thread that called set_value
+                // from the predecessor sender. This thread participates in
+                // the work and does not need a new task since it already
+                // runs on a task.
+                void do_work_local(size_type n, std::uint32_t chunk_size,
+                    std::uint32_t worker_thread) const
+                {
+                    task_function{
+                        this->op_state, n, chunk_size, worker_thread}();
+                }
+
+                using range_value_type = pika::traits::iter_value_t<
+                    pika::traits::range_iterator_t<Shape>>;
+
+                template <typename... Ts>
+                friend void tag_invoke(
+                    pika::execution::experimental::set_value_t,
+                    bulk_receiver&& r, Ts&&... ts) noexcept
+                {
+                    // Don't spawn tasks if there is no work to be done
+                    auto const n = pika::util::size(r.op_state->shape);
+                    if (n == 0)
+                    {
+                        pika::execution::experimental::set_value(
+                            PIKA_MOVE(r.op_state->receiver),
+                            PIKA_FORWARD(Ts, ts)...);
+                        return;
+                    }
+
+                    // Calculate chunk size and number of chunks
+                    auto const chunk_size =
+                        get_chunk_size(r.op_state->num_worker_threads, n);
+                    auto const num_chunks = (n + chunk_size - 1) / chunk_size;
+
+                    // Store sent values in the operation state
+                    r.op_state->ts.template emplace<std::tuple<Ts...>>(
+                        PIKA_FORWARD(Ts, ts)...);
+
+                    // Initialize the queues for all worker threads so that
+                    // worker threads can start stealing immediately when
+                    // they start.
+                    for (std::size_t worker_thread = 0;
+                         worker_thread < r.op_state->num_worker_threads;
+                         ++worker_thread)
+                    {
+                        r.init_queue(worker_thread, num_chunks);
+                    }
+
+                    // Spawn the worker threads for all except the local queue.
+                    auto const local_worker_thread =
+                        pika::get_local_worker_thread_num();
+                    for (std::size_t worker_thread = 0;
+                         worker_thread < r.op_state->num_worker_threads;
+                         ++worker_thread)
+                    {
+                        // The queue for the local thread is handled later
+                        // inline.
+                        if (worker_thread == local_worker_thread)
+                        {
+                            continue;
+                        }
+
+                        r.do_work_task(n, chunk_size, worker_thread);
+                    }
+
+                    // Handle the queue for the local thread.
+                    r.do_work_local(n, chunk_size, local_worker_thread);
+                }
+
+                friend constexpr pika::execution::experimental::detail::
+                    empty_env
+                    tag_invoke(pika::execution::experimental::get_env_t,
+                        bulk_receiver const&) noexcept
+                {
+                    return {};
                 }
             };
 
-        public:
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, thread_pool_bulk_sender&& s, Receiver&& receiver)
+            using operation_state_type =
+                pika::execution::experimental::connect_result_t<Sender,
+                    bulk_receiver>;
+
+            pika::execution::experimental::thread_pool_scheduler scheduler;
+            operation_state_type op_state;
+            std::size_t num_worker_threads =
+                scheduler.get_thread_pool()->get_os_thread_count();
+            std::vector<pika::concurrency::detail::cache_aligned_data<
+                pika::concurrency::detail::contiguous_index_queue<>>>
+                queues{num_worker_threads};
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            std::atomic<decltype(pika::util::size(shape))> tasks_remaining{
+                num_worker_threads};
+            pika::util::detail::prepend_t<
+                value_types<std::tuple, pika::detail::variant>,
+                pika::detail::monostate>
+                ts;
+            std::atomic<bool> exception_thrown{false};
+            std::optional<std::exception_ptr> exception;
+
+            template <typename Sender_, typename Shape_, typename F_,
+                typename Receiver_>
+            operation_state(
+                pika::execution::experimental::thread_pool_scheduler&&
+                    scheduler,
+                Sender_&& sender, Shape_&& shape, F_&& f, Receiver_&& receiver)
+              : scheduler(PIKA_MOVE(scheduler))
+              , op_state(pika::execution::experimental::connect(
+                    PIKA_FORWARD(Sender_, sender), bulk_receiver{this}))
+              , shape(PIKA_FORWARD(Shape_, shape))
+              , f(PIKA_FORWARD(F_, f))
+              , receiver(PIKA_FORWARD(Receiver_, receiver))
             {
-                return operation_state<std::decay_t<Receiver>>{
-                    PIKA_MOVE(s.scheduler), PIKA_MOVE(s.sender),
-                    PIKA_MOVE(s.shape), PIKA_MOVE(s.f),
-                    PIKA_FORWARD(Receiver, receiver)};
             }
 
-            template <typename Receiver>
-            auto tag_invoke(
-                connect_t, thread_pool_bulk_sender& s, Receiver&& receiver)
+            friend void tag_invoke(pika::execution::experimental::start_t,
+                operation_state& os) noexcept
             {
-                return operation_state<std::decay_t<Receiver>>{s.scheduler,
-                    s.sender, s.shape, s.f, PIKA_FORWARD(Receiver, receiver)};
+                pika::execution::experimental::start(os.op_state);
             }
         };
-    }    // namespace detail
 
+    public:
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            thread_pool_bulk_sender&& s, Receiver&& receiver)
+        {
+            return operation_state<std::decay_t<Receiver>>{
+                PIKA_MOVE(s.scheduler), PIKA_MOVE(s.sender), PIKA_MOVE(s.shape),
+                PIKA_MOVE(s.f), PIKA_FORWARD(Receiver, receiver)};
+        }
+
+        template <typename Receiver>
+        auto tag_invoke(pika::execution::experimental::connect_t,
+            thread_pool_bulk_sender& s, Receiver&& receiver)
+        {
+            return operation_state<std::decay_t<Receiver>>{s.scheduler,
+                s.sender, s.shape, s.f, PIKA_FORWARD(Receiver, receiver)};
+        }
+    };
+}    // namespace pika::thread_pool_bulk_detail
+
+namespace pika::execution::experimental {
     template <typename Sender, typename Shape, typename F,
         PIKA_CONCEPT_REQUIRES_(std::is_integral_v<std::decay_t<Shape>>)>
     constexpr auto tag_invoke(bulk_t, thread_pool_scheduler scheduler,
         Sender&& sender, Shape&& shape, F&& f)
     {
-        return detail::thread_pool_bulk_sender<std::decay_t<Sender>,
+        return thread_pool_bulk_detail::thread_pool_bulk_sender<
+            std::decay_t<Sender>,
             pika::util::detail::counting_shape_type<std::decay_t<Shape>>,
             std::decay_t<F>>{PIKA_MOVE(scheduler), PIKA_FORWARD(Sender, sender),
             pika::util::detail::make_counting_shape(shape), PIKA_FORWARD(F, f)};
@@ -593,9 +595,9 @@ namespace pika { namespace execution { namespace experimental {
     constexpr auto tag_invoke(bulk_t, thread_pool_scheduler scheduler,
         Sender&& sender, Shape&& shape, F&& f)
     {
-        return detail::thread_pool_bulk_sender<std::decay_t<Sender>,
-            std::decay_t<Shape>, std::decay_t<F>>{PIKA_MOVE(scheduler),
-            PIKA_FORWARD(Sender, sender), PIKA_FORWARD(Shape, shape),
-            PIKA_FORWARD(F, f)};
+        return thread_pool_bulk_detail::thread_pool_bulk_sender<
+            std::decay_t<Sender>, std::decay_t<Shape>, std::decay_t<F>>{
+            PIKA_MOVE(scheduler), PIKA_FORWARD(Sender, sender),
+            PIKA_FORWARD(Shape, shape), PIKA_FORWARD(F, f)};
     }
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental


### PR DESCRIPTION
The dumb approach to #433. Reduces nesting locally since the detail namespaces are anyway implementation details.

On the `thread_pool_scheduler_test` the binary size went from around 61MB to 56MB with these changes (in debug mode).