### PR TITLE
Add `+p2300` variant to Piz Daint Jenkins CI configurations

### DIFF
--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -11,7 +11,7 @@ hwloc_version="2.6.0"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-broadwell"
 
-spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version}"
+spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} +p2300 ^boost@${boost_version} ^hwloc@${hwloc_version}"
 
 configure_extra_options+=" -DCMAKE_CXX_FLAGS=-stdlib=libc++"
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"

--- a/.jenkins/cscs/env-clang-14-cuda.sh
+++ b/.jenkins/cscs/env-clang-14-cuda.sh
@@ -12,7 +12,7 @@ cuda_version="11.5.0"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-haswell"
 
-spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^cuda@${cuda_version} +allow-unsupported-compilers ^hwloc@${hwloc_version}"
+spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} +p2300 ^boost@${boost_version} ^cuda@${cuda_version} +allow-unsupported-compilers ^hwloc@${hwloc_version}"
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"


### PR DESCRIPTION
I've updated the Piz Daint spack commit to include the `p2300` and `whip` packages. This PR doesn't actually attempt to use them, but just adds them to the environment for #436 and #423. Will do ault separately.

@aurianer note that I haven't constrained the P2300 commit in any way. If you rebase #436 and it turns out that there are now build problems, it may due to bugs in P2300 that are not there in the pinned commit in `pika_setup_p2300.cmake`. We can either try an older commit or ideally try to fix the problems, if there are any.