### PR TITLE
Fix CMake options for clang-14-cuda Jenkins config

### DIFF
--- a/.jenkins/cscs/env-clang-14-cuda.sh
+++ b/.jenkins/cscs/env-clang-14-cuda.sh
@@ -15,6 +15,14 @@ spack_arch="cray-cnl7-haswell"
 spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} +p2300 ^boost@${boost_version} ^cuda@${cuda_version} +allow-unsupported-compilers ^hwloc@${hwloc_version}"
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
+configure_extra_options+=" -DPIKA_WITH_CUDA=ON"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
 configure_extra_options+=" -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 configure_extra_options+=" -DPIKA_WITH_P2300_REFERENCE_IMPLEMENTATION=ON"
+configure_extra_options+=" -DCMAKE_CUDA_COMPILER=c++"
+configure_extra_options+=" -DCMAKE_CUDA_ARCHITECTURES=60"
+
+# The build unit test with pika in Debug and the hello_world project in Debug
+# mode hangs on this configuration. Release-Debug, Debug-Release, and
+# Release-Release do not hang.
+configure_extra_options+=" -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF"

--- a/.jenkins/cscs/slurm-constraint-clang-14-cuda.sh
+++ b/.jenkins/cscs/slurm-constraint-clang-14-cuda.sh
@@ -4,4 +4,4 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-configuration_slurm_constraint="mc"
+configuration_slurm_constraint="gpu"

--- a/cmake/pika_setup_cuda.cmake
+++ b/cmake/pika_setup_cuda.cmake
@@ -5,11 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(PIKA_WITH_CUDA AND NOT TARGET Cuda::cuda)
-
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(PIKA_WITH_CLANG_CUDA ON)
-  endif()
-
   # Check and set CUDA standard
   if(NOT PIKA_FIND_PACKAGE)
     if(DEFINED CMAKE_CUDA_STANDARD AND NOT CMAKE_CUDA_STANDARD STREQUAL
@@ -27,6 +22,10 @@ if(PIKA_WITH_CUDA AND NOT TARGET Cuda::cuda)
   set(CMAKE_CUDA_EXTENSIONS OFF)
 
   enable_language(CUDA)
+
+  if(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+    set(PIKA_WITH_CLANG_CUDA ON)
+  endif()
 
   if(NOT PIKA_FIND_PACKAGE)
     # The cmake variables are supposed to be cached no need to redefine them

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -9,6 +9,7 @@
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
 #include <pika/async_cuda/cuda_scheduler.hpp>
+#include <pika/errors/try_catch_exception_ptr.hpp>
 #include <pika/execution/algorithms/detail/partial_algorithm.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>

--- a/libs/pika/async_cuda/tests/performance/CMakeLists.txt
+++ b/libs/pika/async_cuda/tests/performance/CMakeLists.txt
@@ -4,7 +4,11 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(benchmarks cuda_scheduler_throughput synchronize)
+set(benchmarks cuda_scheduler_throughput)
+
+if(NOT PIKA_WITH_CLANG_CUDA)
+  list(APPEND benchmarks synchronize)
+endif()
 
 set(synchronize_GPU ON)
 set(cuda_scheduler_throughput_PARAMETERS THREADS 1)

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -376,5 +376,9 @@ int main(int argc, char** argv)
     pika::init_params init_args;
     init_args.desc_cmdline = cmdline;
 
+#if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
+    PIKA_TEST(true);
+#endif
+
     return pika::init(pika_main, argc, argv, init_args);
 }


### PR DESCRIPTION
Actually fixes #302. I never actually enabled CUDA on the clang 14 configuration. I expect this to fail at the moment. I have not tried the build myself.