### PR TITLE
Don't use hipcc as `CXX` in `linux_hip` GitHub actions workflow

### DIFF
--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/hip/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-hip:2
+    container: pikaorg/pika-ci-hip:3
     steps:
     - uses: actions/checkout@v2
     - name: Update apt repositories for ccache


### PR DESCRIPTION
`CXX` is no longer set to `hipcc` in version 3 of the CI image.