### PR TITLE
Make signal handlers optional

### DIFF
--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -755,7 +755,15 @@ namespace pika::detail {
             else
             {
                 if (option == "startup")
+                {
                     debug::detail::attach_debugger();
+                }
+                else if (option == "exception")
+                {
+                    // Signal handlers need to be installed to be able to attach
+                    // the debugger on uncaught exceptions
+                    ini_config_.emplace_back("pika.install_signal_handlers!=1");
+                }
 
                 ini_config_.emplace_back("pika.attach_debugger!=" + option);
             }

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -349,7 +349,7 @@ namespace pika {
         }
 
         ////////////////////////////////////////////////////////////////////////
-        void init_environment()
+        void init_environment(detail::command_line_handling& cmdline)
         {
             PIKA_UNUSED(pika::detail::filesystem::initial_path());
 
@@ -373,7 +373,12 @@ namespace pika {
                 &pika::detail::register_locks_predicate);
 #endif
 #if !defined(PIKA_HAVE_DISABLED_SIGNAL_EXCEPTION_HANDLERS)
-            set_error_handlers();
+            if (pika::detail::get_entry_as<bool>(
+                    cmdline.rtcfg_, "pika.install_signal_handlers", false))
+            {
+                set_signal_handlers();
+            }
+
 #endif
             pika::threads::detail::set_get_default_pool(
                 &pika::detail::get_default_pool);
@@ -421,8 +426,6 @@ namespace pika {
             int argc, const char* const* argv, init_params const& params,
             bool blocking)
         {
-            init_environment();
-
             int result = 0;
             try
             {
@@ -463,6 +466,8 @@ namespace pika {
                             params.rp_mode, cmdline.rtcfg_, affinity_data);
 
                     activate_global_options(cmdline);
+
+                    init_environment(cmdline);
 
                     // check whether pika should be exited at this point
                     // (parse_result is returning a result > 0, if the program options

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -461,7 +461,7 @@ namespace pika {
         std::condition_variable wait_condition_;
     };
 
-    PIKA_EXPORT void set_error_handlers();
+    PIKA_EXPORT void set_signal_handlers();
 
     namespace detail {
         PIKA_EXPORT char const* get_runtime_state_name(pika::runtime_state st);

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -206,7 +206,7 @@ namespace pika {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    void set_error_handlers()
+    void set_signal_handlers()
     {
 #if defined(PIKA_WINDOWS)
         // Set console control handler to allow server to be stopped.

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -150,6 +150,7 @@ namespace pika { namespace util {
             "default_scheduler_mode = ${PIKA_DEFAULT_SCHEDULER_MODE}",
 
             "install_signal_handlers = ${PIKA_INSTALL_SIGNAL_HANDLERS:0}",
+            "diagnostics_on_terminate = ${PIKA_DIAGNOSTICS_ON_TERMINATE:1}",
             "attach_debugger = ${PIKA_ATTACH_DEBUGGER:0}",
             "exception_verbosity = ${PIKA_EXCEPTION_VERBOSITY:1}",
             "trace_depth = ${PIKA_TRACE_DEPTH:" PIKA_PP_STRINGIZE(

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -149,7 +149,8 @@ namespace pika { namespace util {
 #endif
             "default_scheduler_mode = ${PIKA_DEFAULT_SCHEDULER_MODE}",
 
-            "attach_debugger = ${PIKA_ATTACH_DEBUGGER}",
+            "install_signal_handlers = ${PIKA_INSTALL_SIGNAL_HANDLERS:0}",
+            "attach_debugger = ${PIKA_ATTACH_DEBUGGER:0}",
             "exception_verbosity = ${PIKA_EXCEPTION_VERBOSITY:1}",
             "trace_depth = ${PIKA_TRACE_DEPTH:" PIKA_PP_STRINGIZE(
                 PIKA_PP_EXPAND(PIKA_HAVE_THREAD_BACKTRACE_DEPTH)) "}",


### PR DESCRIPTION
Fixes #406.

Adds a configuration option `pika.install_signal_handlers` which defaults to off (`0`). Only forces the signal handlers to be installed if `--pika:attach-debugger=exception`. Also adds a missing default entry for `pika.diagnostics_on_terminate`.