### PR TITLE
Add `set_stopped_t()` to `(unique_)any_sender` completion signatures

### DIFF
--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -773,7 +773,8 @@ namespace pika::execution::experimental {
         using completion_signatures =
             pika::execution::experimental::completion_signatures<
                 pika::execution::experimental::set_value_t(Ts...),
-                pika::execution::experimental::set_error_t(std::exception_ptr)>;
+                pika::execution::experimental::set_error_t(std::exception_ptr),
+                pika::execution::experimental::set_stopped_t()>;
 
         template <typename R>
         friend detail::any_operation_state tag_invoke(
@@ -854,7 +855,8 @@ namespace pika::execution::experimental {
         using completion_signatures =
             pika::execution::experimental::completion_signatures<
                 pika::execution::experimental::set_value_t(Ts...),
-                pika::execution::experimental::set_error_t(std::exception_ptr)>;
+                pika::execution::experimental::set_error_t(std::exception_ptr),
+                pika::execution::experimental::set_stopped_t()>;
 
         template <typename R>
         friend detail::any_operation_state tag_invoke(

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -588,6 +588,24 @@ void test_unique_any_sender_set_error()
     }
 }
 
+// (unique_)any_sender instantiates a set_stopped call, and should also
+// advertise that it can complete with set_stopped. transfer from the P2300
+// reference implementation is one algorithm that requires that the advertised
+// signatures match what is actuallly instantiated so we use that as a test
+// here. This will fail to compile if (unique_)any_sender doesn't have
+// set_stopped_t in its completion signatures.
+void test_any_sender_set_stopped()
+{
+    ex::any_sender<> as{ex::just()};
+    tt::sync_wait(ex::transfer(std::move(as), ex::std_thread_scheduler{}));
+}
+
+void test_unique_any_sender_set_stopped()
+{
+    ex::any_sender<> as{ex::just()};
+    tt::sync_wait(ex::transfer(std::move(as), ex::std_thread_scheduler{}));
+}
+
 // This tests that the empty vtable types used in the implementation of any_*
 // are not destroyed too early. We use ensure_started inside the function to
 // trigger the use of the empty vtables for any_receiver and
@@ -724,6 +742,10 @@ int main()
     // Failure paths
     test_any_sender_set_error();
     test_unique_any_sender_set_error();
+
+    // set_stopped
+    test_any_sender_set_stopped();
+    test_unique_any_sender_set_stopped();
 
     // Test use of *any_* in globals
     test_globals();


### PR DESCRIPTION
Without #289 we need to pessimistically expect that all senders that get wrapped in a `(unique_)any_sender` may signal `set_stopped_t()`. This is one more tiny step towards using the reference implementation in DLA-Future.