### PR TITLE
Run MPI tests with MPICH on Jenkins and fix error handling tests with MPICH

### DIFF
--- a/.jenkins/cscs/env-cce.sh
+++ b/.jenkins/cscs/env-cce.sh
@@ -11,7 +11,7 @@ hwloc_version="2.0.3"
 spack_compiler="cce@${cce_version}"
 spack_arch="cray-cnl7-broadwell"
 
-spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version}"
+spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^cray-mpich ^hwloc@${hwloc_version}"
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-cce.sh
+++ b/.jenkins/cscs/env-cce.sh
@@ -16,4 +16,8 @@ spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
+configure_extra_options+=" -DPIKA_WITH_MPI=ON"
+configure_extra_options+=" -DMPIEXEC_EXECUTABLE=$(which srun)"
 configure_extra_options+=" -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+
+export MPICH_MAX_THREAD_SAFETY=multiple


### PR DESCRIPTION
Attempt to fix #418 and #164.

For #418 we'll see what slurm says about launching jobs within jobs.

For #164 the problem seems to have been that OpenMPI and MPICH simply seem to have different definitions of what they consider to be errors. OpenMPI considers `-1` as a root rank to be a problem. MPICH doesn't. They both seem to consider `MPI_DATATYPE_NULL` as a data type to be an error, however, so I've updated the error-handling tests to use that instead to trigger errors. OpenMPI and MPICH also print different error messages, so they have to be handled separately.