### PR TITLE
Enable tests for `ensure_started` from P2300 reference implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
     docker:
-      - image: pikaorg/pika-ci-base:9
+      - image: pikaorg/pika-ci-base:10
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:8
+    container: pikaorg/pika-ci-base:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:8
+    container: pikaorg/pika-ci-base:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/fetchcontent/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:8
+    container: pikaorg/pika-ci-base:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/sanitizers/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:8
+    container: pikaorg/pika-ci-base:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/tracy/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:8
+    container: pikaorg/pika-ci-base:10
 
     steps:
     - name: Check out Tracy

--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -30,9 +30,6 @@ auto tag_invoke(ex::ensure_started_t, custom_sender_tag_invoke s,
 
 int main()
 {
-    // TODO: ensure_started doesn't have a default implementation in the
-    // reference implementation.
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     // Success path
     {
         std::atomic<bool> set_value_called{false};
@@ -167,6 +164,9 @@ int main()
         PIKA_TEST(set_error_called);
     }
 
+    // We don't test internal implementation details of the P2300 reference
+    // implementation
+#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     // Chained ensure_started calls do not create new shared states
     {
         std::atomic<bool> receiver_set_value_called{false};
@@ -195,6 +195,7 @@ int main()
         ex::start(os);
         PIKA_TEST(receiver_set_value_called);
     }
+#endif
 
     // It's allowed to discard the sender from ensure_started
     {
@@ -204,10 +205,6 @@ int main()
     {
         test_adl_isolation(ex::ensure_started(my_namespace::my_sender{}));
     }
-#else
-    // No tests with the P2300 reference implementation
-    PIKA_TEST(true);
-#endif
 
     return 0;
 }

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -692,8 +692,6 @@ void test_when_all_vector()
 
 void test_ensure_started()
 {
-    // TODO: No default implementation in P2300 reference implementation.
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     ex::std_thread_scheduler sched{};
 
     {
@@ -711,6 +709,9 @@ void test_ensure_started()
         PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
+    // TODO: The split sender in the P2300 reference implementation is not
+    // copyable.
+#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     {
         auto s =
             ex::transfer_just(sched, 42) | ex::ensure_started() | ex::split();
@@ -719,17 +720,18 @@ void test_ensure_started()
         PIKA_TEST_EQ(tt::sync_wait(s), 42);
         PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
+#endif
 
     // It's allowed to discard the sender from ensure_started
     {
         ex::schedule(ex::std_thread_scheduler{}) | ex::ensure_started();
     }
-#endif
 }
 
 void test_ensure_started_when_all()
 {
-    // TODO: No default implementation in P2300 reference implementation.
+    // TODO: The split sender in the P2300 reference implementation is not
+    // copyable.
 #if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     ex::std_thread_scheduler sched{};
 

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1019,8 +1019,6 @@ void test_future_sender()
 
 void test_ensure_started()
 {
-    // TODO: No default implementation in P2300 reference implementation.
-#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     ex::thread_pool_scheduler sched{};
 
     {
@@ -1038,6 +1036,9 @@ void test_ensure_started()
         PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
 
+    // TODO: The split sender in the P2300 reference implementation is not
+    // copyable.
+#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     {
         auto s =
             ex::transfer_just(sched, 42) | ex::ensure_started() | ex::split();
@@ -1046,17 +1047,18 @@ void test_ensure_started()
         PIKA_TEST_EQ(tt::sync_wait(s), 42);
         PIKA_TEST_EQ(tt::sync_wait(std::move(s)), 42);
     }
+#endif
 
     // It's allowed to discard the sender from ensure_started
     {
         ex::schedule(ex::thread_pool_scheduler{}) | ex::ensure_started();
     }
-#endif
 }
 
 void test_ensure_started_when_all()
 {
-    // TODO: No default implementation in P2300 reference implementation.
+    // TODO: The split sender in the P2300 reference implementation is not
+    // copyable.
 #if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     ex::thread_pool_scheduler sched{};
 


### PR DESCRIPTION
Fixes #294. `ensure_started` now has a default implementation in the reference implementation. Not all the `ensure_started` tests can be enabled yet, because they also use `split`, which is not yet copyable in the reference implementation.

The CI environment still need to be updated for this to work there.

- [x] update spack environments
- [x] update CI container image