### PR TITLE
Change `PenaltyReturnTypeOnItsOwnLine` to smaller value in clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -100,7 +100,7 @@ PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyReturnTypeOnItsOwnLine: 20
 PointerAlignment: Left
 ReflowComments: false
 SortIncludes:    true

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -107,8 +107,8 @@ namespace executor_example {
         }
 
         template <typename F, typename Future, typename... Ts>
-        decltype(auto) then_execute(
-            F&& f, Future&& predecessor, Ts&&... ts) const
+        decltype(auto)
+        then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
         {
             return pika::parallel::execution::then_execute(exec_,
                 hook_wrapper<F>{*this, std::forward<F>(f)},
@@ -126,8 +126,8 @@ namespace executor_example {
 
         // BulkOneWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        decltype(auto) bulk_sync_execute(
-            F&& f, S const& shape, Ts&&... ts) const
+        decltype(auto)
+        bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
         {
             return pika::parallel::execution::bulk_sync_execute(exec_,
                 hook_wrapper<F>{*this, std::forward<F>(f)}, shape,
@@ -136,8 +136,8 @@ namespace executor_example {
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        decltype(auto) bulk_async_execute(
-            F&& f, S const& shape, Ts&&... ts) const
+        decltype(auto)
+        bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
         {
             return pika::parallel::execution::bulk_async_execute(exec_,
                 hook_wrapper<F>{*this, std::forward<F>(f)}, shape,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/adjacent_difference.hpp
@@ -185,8 +185,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename OutIter, typename Op>
-        static OutIter sequential(
-            ExPolicy, InIter first, Sent last, OutIter dest, Op&& op)
+        static OutIter
+        sequential(ExPolicy, InIter first, Sent last, OutIter dest, Op&& op)
         {
             return sequential_adjacent_difference<ExPolicy>(
                 first, last, dest, PIKA_FORWARD(Op, op));
@@ -194,8 +194,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter1, typename Sent,
             typename FwdIter2, typename Op>
-        static typename algorithm_result<ExPolicy, FwdIter2>::type parallel(
-            ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
+        static typename algorithm_result<ExPolicy, FwdIter2>::type
+        parallel(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
             Op&& op)
         {
             using zip_iterator =

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/adjacent_find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/adjacent_find.hpp
@@ -154,8 +154,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent_,
             typename Pred, typename Proj>
-        static InIter sequential(
-            ExPolicy, InIter first, Sent_ last, Pred&& pred, Proj&& proj)
+        static InIter
+        sequential(ExPolicy, InIter first, Sent_ last, Pred&& pred, Proj&& proj)
         {
             return std::adjacent_find(first, last,
                 invoke_projected<Pred, Proj>(
@@ -164,8 +164,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename Sent_,
             typename Pred, typename Proj>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent_ last, Pred&& pred,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent_ last, Pred&& pred,
             Proj&& proj)
         {
             using zip_iterator = pika::util::zip_iterator<FwdIter, FwdIter>;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/all_any_none.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/all_any_none.hpp
@@ -265,8 +265,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj>
-        static bool sequential(
-            ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+        static bool
+        sequential(ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
         {
             return detail::sequential_find_if<ExPolicy>(first, last,
                        invoke_projected<F, Proj>(PIKA_FORWARD(F, f),
@@ -322,8 +322,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj>
-        static bool sequential(
-            ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+        static bool
+        sequential(ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
         {
             return detail::sequential_find_if<ExPolicy>(first, last,
                        invoke_projected<F, Proj>(PIKA_FORWARD(F, f),
@@ -379,8 +379,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj>
-        static bool sequential(
-            ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+        static bool
+        sequential(ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
         {
             return detail::sequential_find_if_not<ExPolicy>(first, last,
                        PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj)) == last;
@@ -457,8 +457,8 @@ namespace pika {
                 pika::traits::is_iterator<InIter>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            none_of_t, InIter first, InIter last, F&& f)
+        friend bool
+        tag_fallback_invoke(none_of_t, InIter first, InIter last, F&& f)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Required at least input iterator.");
@@ -501,8 +501,8 @@ namespace pika {
                 pika::traits::is_iterator<InIter>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            any_of_t, InIter first, InIter last, F&& f)
+        friend bool
+        tag_fallback_invoke(any_of_t, InIter first, InIter last, F&& f)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Required at least input iterator.");
@@ -545,8 +545,8 @@ namespace pika {
                 pika::traits::is_iterator<InIter>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            all_of_t, InIter first, InIter last, F&& f)
+        friend bool
+        tag_fallback_invoke(all_of_t, InIter first, InIter last, F&& f)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/copy.hpp
@@ -351,8 +351,8 @@ namespace pika { namespace parallel {
             }
 
             template <typename ExPolicy, typename InIter, typename OutIter>
-            static constexpr in_out_result<InIter, OutIter> sequential(
-                ExPolicy, InIter first, std::size_t count, OutIter dest)
+            static constexpr in_out_result<InIter, OutIter>
+            sequential(ExPolicy, InIter first, std::size_t count, OutIter dest)
             {
                 in_out_result<InIter, OutIter> result =
                     copy_n<ExPolicy>(first, count, dest);
@@ -421,9 +421,9 @@ namespace pika { namespace parallel {
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename Pred,
                 typename Proj = projection_identity>
-            static in_out_result<InIter1, OutIter> sequential(ExPolicy,
-                InIter1 first, InIter2 last, OutIter dest, Pred&& pred,
-                Proj&& proj /* = Proj()*/)
+            static in_out_result<InIter1, OutIter>
+            sequential(ExPolicy, InIter1 first, InIter2 last, OutIter dest,
+                Pred&& pred, Proj&& proj /* = Proj()*/)
             {
                 return sequential_copy_if(first, last, dest,
                     PIKA_FORWARD(Pred, pred), PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/destroy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/destroy.hpp
@@ -187,8 +187,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Iter, typename Sent>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last)
         {
             return parallel_sequential_destroy_n(PIKA_FORWARD(ExPolicy, policy),
                 first, detail::distance(first, last));
@@ -231,8 +231,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Iter>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, std::size_t count)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, std::size_t count)
         {
             return parallel_sequential_destroy_n(
                 PIKA_FORWARD(ExPolicy, policy), first, count);
@@ -322,8 +322,8 @@ namespace pika {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            destroy_n_t, FwdIter first, Size count)
+        friend FwdIter
+        tag_fallback_invoke(destroy_n_t, FwdIter first, Size count)
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/adjacent_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/adjacent_difference.hpp
@@ -27,9 +27,9 @@ namespace pika::parallel::detail {
     {
     private:
         template <typename InIter, typename Sent, typename OutIter, typename Op>
-        friend inline OutIter tag_fallback_invoke(
-            sequential_adjacent_difference_t<ExPolicy>, InIter first, Sent last,
-            OutIter dest, Op&& op)
+        friend inline OutIter
+        tag_fallback_invoke(sequential_adjacent_difference_t<ExPolicy>,
+            InIter first, Sent last, OutIter dest, Op&& op)
         {
             if (first == last)
                 return dest;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/dispatch.hpp
@@ -118,8 +118,8 @@ namespace pika::parallel::detail {
         // main sequential dispatch entry points
 
         template <typename ExPolicy, typename... Args>
-        constexpr algorithm_result_t<ExPolicy, local_result_type> call2(
-            ExPolicy&& policy, std::true_type, Args&&... args) const
+        constexpr algorithm_result_t<ExPolicy, local_result_type>
+        call2(ExPolicy&& policy, std::true_type, Args&&... args) const
         {
             using result_handler =
                 algorithm_result<ExPolicy, local_result_type>;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/fill.hpp
@@ -51,8 +51,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename T>
-    constexpr Iter sequential_fill_n_helper(
-        Iter first, std::size_t count, T const& value)
+    constexpr Iter
+    sequential_fill_n_helper(Iter first, std::size_t count, T const& value)
     {
         return std::fill_n(first, count, value);
     }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/find.hpp
@@ -29,9 +29,9 @@ namespace pika::parallel::detail {
     private:
         template <typename Iterator, typename Sentinel, typename T,
             typename Proj = projection_identity>
-        friend inline constexpr Iterator tag_fallback_invoke(
-            sequential_find_t<ExPolicy>, Iterator first, Sentinel last,
-            T const& value, Proj proj = Proj())
+        friend inline constexpr Iterator
+        tag_fallback_invoke(sequential_find_t<ExPolicy>, Iterator first,
+            Sentinel last, T const& value, Proj proj = Proj())
         {
             for (; first != last; ++first)
             {
@@ -44,8 +44,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename T, typename Proj>
-        friend inline constexpr void tag_fallback_invoke(
-            sequential_find_t<ExPolicy>, std::size_t base_idx,
+        friend inline constexpr void
+        tag_fallback_invoke(sequential_find_t<ExPolicy>, std::size_t base_idx,
             FwdIter part_begin, std::size_t part_count, Token& tok,
             T const& val, Proj&& proj)
         {
@@ -74,9 +74,9 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename T,
         typename Proj>
-    inline constexpr void sequential_find(std::size_t base_idx,
-        FwdIter part_begin, std::size_t part_count, Token& tok, T const& val,
-        Proj&& proj)
+    inline constexpr void
+    sequential_find(std::size_t base_idx, FwdIter part_begin,
+        std::size_t part_count, Token& tok, T const& val, Proj&& proj)
     {
         return sequential_find_t<ExPolicy>{}(base_idx, part_begin, part_count,
             tok, val, PIKA_FORWARD(Proj, proj));
@@ -91,9 +91,9 @@ namespace pika::parallel::detail {
     private:
         template <typename Iterator, typename Sentinel, typename Pred,
             typename Proj = projection_identity>
-        friend inline constexpr Iterator tag_fallback_invoke(
-            sequential_find_if_t<ExPolicy>, Iterator first, Sentinel last,
-            Pred pred, Proj proj = Proj())
+        friend inline constexpr Iterator
+        tag_fallback_invoke(sequential_find_if_t<ExPolicy>, Iterator first,
+            Sentinel last, Pred pred, Proj proj = Proj())
         {
             for (; first != last; ++first)
             {
@@ -106,8 +106,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
-        friend inline constexpr void tag_fallback_invoke(
-            sequential_find_if_t<ExPolicy>, FwdIter part_begin,
+        friend inline constexpr void
+        tag_fallback_invoke(sequential_find_if_t<ExPolicy>, FwdIter part_begin,
             std::size_t part_count, Token& tok, F&& op, Proj&& proj)
         {
             loop_n<std::decay_t<ExPolicy>>(part_begin, part_count, tok,
@@ -120,10 +120,10 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
-        friend inline constexpr void tag_fallback_invoke(
-            sequential_find_if_t<ExPolicy>, std::size_t base_idx,
-            FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-            Proj&& proj)
+        friend inline constexpr void
+        tag_fallback_invoke(sequential_find_if_t<ExPolicy>,
+            std::size_t base_idx, FwdIter part_begin, std::size_t part_count,
+            Token& tok, F&& f, Proj&& proj)
         {
             loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
@@ -159,9 +159,9 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
         typename Proj>
-    inline constexpr void sequential_find_if(std::size_t base_idx,
-        FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-        Proj&& proj)
+    inline constexpr void
+    sequential_find_if(std::size_t base_idx, FwdIter part_begin,
+        std::size_t part_count, Token& tok, F&& f, Proj&& proj)
     {
         return sequential_find_if_t<ExPolicy>{}(base_idx, part_begin,
             part_count, tok, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj));
@@ -177,9 +177,9 @@ namespace pika::parallel::detail {
     private:
         template <typename Iterator, typename Sentinel, typename Pred,
             typename Proj = projection_identity>
-        friend inline constexpr Iterator tag_fallback_invoke(
-            sequential_find_if_not_t<ExPolicy>, Iterator first, Sentinel last,
-            Pred pred, Proj proj = Proj())
+        friend inline constexpr Iterator
+        tag_fallback_invoke(sequential_find_if_not_t<ExPolicy>, Iterator first,
+            Sentinel last, Pred pred, Proj proj = Proj())
         {
             for (; first != last; ++first)
             {
@@ -206,10 +206,10 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
-        friend inline constexpr void tag_fallback_invoke(
-            sequential_find_if_not_t<ExPolicy>, std::size_t base_idx,
-            FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-            Proj&& proj)
+        friend inline constexpr void
+        tag_fallback_invoke(sequential_find_if_not_t<ExPolicy>,
+            std::size_t base_idx, FwdIter part_begin, std::size_t part_count,
+            Token& tok, F&& f, Proj&& proj)
         {
             loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
@@ -245,9 +245,9 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
         typename Proj>
-    inline constexpr void sequential_find_if_not(std::size_t base_idx,
-        FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-        Proj&& proj)
+    inline constexpr void
+    sequential_find_if_not(std::size_t base_idx, FwdIter part_begin,
+        std::size_t part_count, Token& tok, F&& f, Proj&& proj)
     {
         return sequential_find_if_not_t<ExPolicy>{}(base_idx, part_begin,
             part_count, tok, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/generate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/generate.hpp
@@ -50,8 +50,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename F>
-    constexpr Iter sequential_generate_n_helper(
-        Iter first, std::size_t count, F&& f)
+    constexpr Iter
+    sequential_generate_n_helper(Iter first, std::size_t count, F&& f)
     {
         return std::generate_n(first, count, f);
     }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/parallel_stable_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/parallel_stable_sort.hpp
@@ -46,8 +46,8 @@ namespace pika::parallel::detail {
 
         // / brief Perform sorting operation
         template <typename Exec>
-        Iter operator()(
-            Exec&& exec, std::uint32_t nthreads, std::size_t chunk_size);
+        Iter
+        operator()(Exec&& exec, std::uint32_t nthreads, std::size_t chunk_size);
 
         /// \brief destructor of the typename. The utility is to destroy the
         ///        temporary buffer used in the sorting process

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/pivot.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/pivot.hpp
@@ -26,8 +26,8 @@ namespace pika::parallel::detail {
     /// \param comp : object for comparing two values
     /// \return iterator to mid value
     template <typename Iter, typename Comp>
-    inline constexpr Iter mid3(
-        Iter iter_1, Iter iter_2, Iter iter_3, Comp&& comp)
+    inline constexpr Iter
+    mid3(Iter iter_1, Iter iter_2, Iter iter_3, Comp&& comp)
     {
         return PIKA_INVOKE(comp, *iter_1, *iter_2) ?
             (PIKA_INVOKE(comp, *iter_2, *iter_3) ?
@@ -52,9 +52,9 @@ namespace pika::parallel::detail {
     /// \param iter_9   iterator to the ninth value
     /// \return iterator to the mid value
     template <typename Iter, typename Comp>
-    inline constexpr Iter mid9(Iter iter_1, Iter iter_2, Iter iter_3,
-        Iter iter_4, Iter iter_5, Iter iter_6, Iter iter_7, Iter iter_8,
-        Iter iter_9, Comp&& comp)
+    inline constexpr Iter
+    mid9(Iter iter_1, Iter iter_2, Iter iter_3, Iter iter_4, Iter iter_5,
+        Iter iter_6, Iter iter_7, Iter iter_8, Iter iter_9, Comp&& comp)
     {
         return mid3(mid3(iter_1, iter_2, iter_3, comp),
             mid3(iter_4, iter_5, iter_6, comp),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/rotate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/rotate.hpp
@@ -20,8 +20,8 @@ namespace pika::parallel::detail {
 
     // provide implementation of std::rotate supporting iterators/sentinels
     template <typename Iter, typename Sent>
-    inline constexpr void sequential_rotate_helper(
-        Iter first, Iter new_first, Sent last)
+    inline constexpr void
+    sequential_rotate_helper(Iter first, Iter new_first, Sent last)
     {
         Iter next = new_first;
         while (first != next)
@@ -43,8 +43,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename Iter, typename Sent>
-    inline constexpr in_out_result<Iter, Sent> sequential_rotate(
-        Iter first, Iter new_first, Sent last)
+    inline constexpr in_out_result<Iter, Sent>
+    sequential_rotate(Iter first, Iter new_first, Sent last)
     {
         if (first != new_first && new_first != last)
             sequential_rotate_helper(first, new_first, last);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/sample_sort.hpp
@@ -162,9 +162,9 @@ namespace pika::parallel::detail {
 
     template <typename Iter, typename Sent, typename Compare>
     template <typename Exec>
-    void sample_sort_helper<Iter, Sent, Compare>::operator()(Exec&& exec,
-        Iter first, Sent last, value_type* paux, std::size_t naux,
-        std::size_t chunk_size)
+    void
+    sample_sort_helper<Iter, Sent, Compare>::operator()(Exec&& exec, Iter first,
+        Sent last, value_type* paux, std::size_t naux, std::size_t chunk_size)
     {
         global_range = range_it(first, last);
 
@@ -262,8 +262,8 @@ namespace pika::parallel::detail {
     /// \remarks
     template <typename Iter, typename Sent, typename Compare>
     template <typename Exec>
-    void sample_sort_helper<Iter, Sent, Compare>::initial_configuration(
-        Exec& exec)
+    void
+    sample_sort_helper<Iter, Sent, Compare>::initial_configuration(Exec& exec)
     {
         std::vector<range_it> vmem_thread;
         std::vector<range_buf> vbuf_thread;
@@ -421,8 +421,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename Exec, typename Iter, typename Sent>
-    void sample_sort(
-        Exec&& exec, Iter first, Sent last, std::uint32_t num_threads)
+    void
+    sample_sort(Exec&& exec, Iter first, Sent last, std::uint32_t num_threads)
     {
         using value_type = typename std::iterator_traits<Iter>::value_type;
         using compare = std::less<value_type>;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/search.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/search.hpp
@@ -40,9 +40,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter2, typename Sent2,
             typename Pred, typename Proj1, typename Proj2>
-        static FwdIter sequential(ExPolicy, FwdIter first, Sent last,
-            FwdIter2 s_first, Sent2 s_last, Pred&& op, Proj1&& proj1,
-            Proj2&& proj2)
+        static FwdIter
+        sequential(ExPolicy, FwdIter first, Sent last, FwdIter2 s_first,
+            Sent2 s_last, Pred&& op, Proj1&& proj1, Proj2&& proj2)
         {
             for (;; ++first)
             {
@@ -62,8 +62,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter2, typename Sent2,
             typename Pred, typename Proj1, typename Proj2>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, FwdIter2 s_first,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, FwdIter2 s_first,
             Sent2 s_last, Pred&& op, Proj1&& proj1, Proj2&& proj2)
         {
             using reference = typename std::iterator_traits<FwdIter>::reference;
@@ -159,9 +159,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter2, typename Pred,
             typename Proj1, typename Proj2>
-        static FwdIter sequential(ExPolicy, FwdIter first, std::size_t count,
-            FwdIter2 s_first, FwdIter2 s_last, Pred&& op, Proj1&& proj1,
-            Proj2&& proj2)
+        static FwdIter
+        sequential(ExPolicy, FwdIter first, std::size_t count, FwdIter2 s_first,
+            FwdIter2 s_last, Pred&& op, Proj1&& proj1, Proj2&& proj2)
         {
             return std::search(first, std::next(first, count), s_first, s_last,
                 compare_projected<Pred&, Proj1&, Proj2&>(op, proj1, proj2));
@@ -169,8 +169,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter2, typename Pred,
             typename Proj1, typename Proj2>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, std::size_t count,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, std::size_t count,
             FwdIter2 s_first, FwdIter2 s_last, Pred&& op, Proj1&& proj1,
             Proj2&& proj2)
         {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/detail/upper_lower_bound.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/detail/upper_lower_bound.hpp
@@ -48,8 +48,8 @@ namespace pika::parallel::detail {
 
     template <typename Iter, typename Sent, typename T, typename F,
         typename Proj>
-    constexpr Iter lower_bound(
-        Iter first, Sent last, T&& value, F&& f, Proj&& proj)
+    constexpr Iter
+    lower_bound(Iter first, Sent last, T&& value, F&& f, Proj&& proj)
     {
         using difference_type =
             typename std::iterator_traits<Iter>::difference_type;
@@ -106,8 +106,8 @@ namespace pika::parallel::detail {
 
     template <typename Iter, typename Sent, typename T, typename F,
         typename Proj>
-    constexpr Iter upper_bound(
-        Iter first, Sent last, T&& value, F&& f, Proj&& proj)
+    constexpr Iter
+    upper_bound(Iter first, Sent last, T&& value, F&& f, Proj&& proj)
     {
         using difference_type =
             typename std::iterator_traits<Iter>::difference_type;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/ends_with.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/ends_with.hpp
@@ -174,9 +174,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Pred, typename Proj1,
             typename Proj2>
-        static bool sequential(ExPolicy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
-            Proj2&& proj2)
+        static bool
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Pred&& pred, Proj1&& proj1, Proj2&& proj2)
         {
             const auto drop = detail::distance(first1, last1) -
                 detail::distance(first2, last2);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/equal.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/equal.hpp
@@ -239,8 +239,8 @@ namespace pika::parallel ::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename F, typename Proj1,
             typename Proj2>
-        static typename algorithm_result<ExPolicy, bool>::type parallel(
-            ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        static typename algorithm_result<ExPolicy, bool>::type
+        parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
             Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             using difference_type1 =
@@ -332,9 +332,9 @@ namespace pika::parallel ::detail {
 
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename F>
-        static typename algorithm_result<ExPolicy, bool>::type parallel(
-            ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1, FwdIter2 first2,
-            F&& f)
+        static typename algorithm_result<ExPolicy, bool>::type
+        parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, F&& f)
         {
             if (first1 == last1)
             {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/fill.hpp
@@ -152,8 +152,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename InIter, typename Sent, typename T>
-        PIKA_HOST_DEVICE static InIter sequential(
-            ExPolicy&& policy, InIter first, Sent last, T const& val)
+        PIKA_HOST_DEVICE static InIter
+        sequential(ExPolicy&& policy, InIter first, Sent last, T const& val)
         {
             return detail::sequential_fill(
                 PIKA_FORWARD(ExPolicy, policy), first, last, val);
@@ -161,8 +161,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename T>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, T const& val)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, T const& val)
         {
             if (first == last)
             {
@@ -246,8 +246,8 @@ namespace pika {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            fill_t, FwdIter first, FwdIter last, T const& value)
+        friend void
+        tag_fallback_invoke(fill_t, FwdIter first, FwdIter last, T const& value)
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
@@ -298,8 +298,8 @@ namespace pika {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            fill_n_t, FwdIter first, Size count, T const& value)
+        friend FwdIter
+        tag_fallback_invoke(fill_n_t, FwdIter first, Size count, T const& value)
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/find.hpp
@@ -422,8 +422,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Proj = projection_identity>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, T const& val,
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, T const& val,
             Proj&& proj = Proj())
         {
             using result = algorithm_result<ExPolicy, Iter>;
@@ -491,8 +491,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = projection_identity>
-        static constexpr Iter sequential(
-            ExPolicy, Iter first, Sent last, F&& f, Proj&& proj = Proj())
+        static constexpr Iter
+        sequential(ExPolicy, Iter first, Sent last, F&& f, Proj&& proj = Proj())
         {
             return sequential_find_if<ExPolicy>(
                 first, last, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj));
@@ -500,8 +500,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = projection_identity>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, F&& f,
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, F&& f,
             Proj&& proj = Proj())
         {
             using result = algorithm_result<ExPolicy, Iter>;
@@ -569,8 +569,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = projection_identity>
-        static constexpr Iter sequential(
-            ExPolicy, Iter first, Sent last, F&& f, Proj&& proj = Proj())
+        static constexpr Iter
+        sequential(ExPolicy, Iter first, Sent last, F&& f, Proj&& proj = Proj())
         {
             return sequential_find_if_not<ExPolicy>(
                 first, last, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj));
@@ -578,8 +578,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = projection_identity>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, F&& f,
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, F&& f,
             Proj&& proj = Proj())
         {
             using result = algorithm_result<ExPolicy, Iter>;
@@ -716,8 +716,8 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Pred, typename Proj1,
             typename Proj2>
-        static typename algorithm_result<ExPolicy, Iter1>::type parallel(
-            ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        static typename algorithm_result<ExPolicy, Iter1>::type
+        parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
             Sent2 last2, Pred&& op, Proj1&& proj1, Proj2&& proj2)
         {
             using result_type = algorithm_result<ExPolicy, Iter1>;
@@ -817,9 +817,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename Pred, typename Proj1, typename Proj2>
-        static InIter1 sequential(ExPolicy, InIter1 first, InIter1 last,
-            InIter2 s_first, InIter2 s_last, Pred&& op, Proj1&& proj1,
-            Proj2&& proj2)
+        static InIter1
+        sequential(ExPolicy, InIter1 first, InIter1 last, InIter2 s_first,
+            InIter2 s_last, Pred&& op, Proj1&& proj1, Proj2&& proj2)
         {
             if (first == last)
                 return last;
@@ -944,8 +944,8 @@ namespace pika {
                 pika::traits::is_iterator<InIter>::value
             )>
         // clang-format on
-        friend InIter tag_fallback_invoke(
-            find_t, InIter first, InIter last, T const& val)
+        friend InIter
+        tag_fallback_invoke(find_t, InIter first, InIter last, T const& val)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
@@ -995,8 +995,8 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend InIter tag_fallback_invoke(
-            find_if_t, InIter first, InIter last, F&& f)
+        friend InIter
+        tag_fallback_invoke(find_if_t, InIter first, InIter last, F&& f)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
@@ -1046,8 +1046,8 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            find_if_not_t, FwdIter first, FwdIter last, F&& f)
+        friend FwdIter
+        tag_fallback_invoke(find_if_not_t, FwdIter first, FwdIter last, F&& f)
         {
             static_assert(pika::traits::is_input_iterator<FwdIter>::value,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/for_each.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/for_each.hpp
@@ -335,8 +335,8 @@ namespace pika::parallel::detail {
         for_each_iteration& operator=(for_each_iteration&&) = default;
 
         template <typename Iter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void operator()(
-            Iter part_begin, std::size_t part_size, std::size_t)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        operator()(Iter part_begin, std::size_t part_size, std::size_t)
         {
             loop_n<execution_policy_type>(part_begin, part_size,
                 for_each_invoke_projected<fun_type, proj_type>{f_, proj_});
@@ -383,8 +383,8 @@ namespace pika::parallel::detail {
         for_each_iteration& operator=(for_each_iteration&&) = default;
 
         template <typename Iter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void operator()(
-            Iter part_begin, std::size_t part_size, std::size_t)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        operator()(Iter part_begin, std::size_t part_size, std::size_t)
         {
             loop_n_ind<execution_policy_type>(part_begin, part_size, f_);
         }
@@ -527,8 +527,8 @@ namespace pika {
                 pika::traits::is_iterator<InIter>::value
             )>
         // clang-format on
-        friend F tag_fallback_invoke(
-            pika::for_each_t, InIter first, InIter last, F&& f)
+        friend F
+        tag_fallback_invoke(pika::for_each_t, InIter first, InIter last, F&& f)
         {
             static_assert((pika::traits::is_input_iterator<InIter>::value),
                 "Requires at least input iterator.");
@@ -583,8 +583,8 @@ namespace pika {
                 pika::traits::is_input_iterator<InIter>::value
             )>
         // clang-format on
-        friend InIter tag_fallback_invoke(
-            pika::for_each_n_t, InIter first, Size count, F&& f)
+        friend InIter
+        tag_fallback_invoke(pika::for_each_n_t, InIter first, Size count, F&& f)
         {
             static_assert((pika::traits::is_input_iterator<InIter>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop.hpp
@@ -178,8 +178,8 @@ namespace pika {
     ///           otherwise.
     ///
     template <typename ExPolicy, typename I, typename... Args>
-    typename pika::parallel::detail::algorithm_result<ExPolicy>::type for_loop(
-        ExPolicy&& policy, std::decay_t<I> first, I last, Args&&... args);
+    typename pika::parallel::detail::algorithm_result<ExPolicy>::type
+    for_loop(ExPolicy&& policy, std::decay_t<I> first, I last, Args&&... args);
 
     /// The for_loop_strided implements loop functionality over a range
     /// specified by integral or iterator bounds. For the iterator case, these
@@ -265,8 +265,8 @@ namespace pika {
     /// Remarks: If \a f returns a result, the result is ignored.
     ///
     template <typename I, typename S, typename... Args>
-    void for_loop_strided(
-        std::decay_t<I> first, I last, S stride, Args&&... args);
+    void
+    for_loop_strided(std::decay_t<I> first, I last, S stride, Args&&... args);
 
     /// The for_loop_strided implements loop functionality over a range
     /// specified by integral or iterator bounds. For the iterator case, these
@@ -774,17 +774,17 @@ namespace pika {
         }
 
         template <typename... Ts, std::size_t... Is, typename F, typename B>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void invoke_iteration(
-            std::tuple<Ts...>& args, pika::util::detail::index_pack<Is...>,
-            F&& f, B part_begin)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        invoke_iteration(std::tuple<Ts...>& args,
+            pika::util::detail::index_pack<Is...>, F&& f, B part_begin)
         {
             PIKA_INVOKE(PIKA_FORWARD(F, f), part_begin,
                 std::get<Is>(args).iteration_value()...);
         }
 
         template <typename... Ts, std::size_t... Is>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void next_iteration(
-            std::tuple<Ts...>& args,
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        next_iteration(std::tuple<Ts...>& args,
             pika::util::detail::index_pack<Is...>) noexcept
         {
             int const _sequencer[] = {
@@ -793,9 +793,9 @@ namespace pika {
         }
 
         template <typename... Ts, std::size_t... Is>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void exit_iteration(
-            std::tuple<Ts...>& args, pika::util::detail::index_pack<Is...>,
-            std::size_t size) noexcept
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        exit_iteration(std::tuple<Ts...>& args,
+            pika::util::detail::index_pack<Is...>, std::size_t size) noexcept
         {
             int const _sequencer[] = {
                 0, (std::get<Is>(args).exit_iteration(size), 0)...};
@@ -912,16 +912,16 @@ namespace pika {
             }
 
             template <typename B>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void operator()(
-                B part_begin, std::size_t part_steps)
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+            operator()(B part_begin, std::size_t part_steps)
             {
                 PIKA_ASSERT(stride_ == 1);
                 loop_n<std::decay_t<ExPolicy>>(part_begin, part_steps, f_);
             }
 
             template <typename B>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void operator()(
-                B part_begin, std::size_t part_steps, std::size_t)
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+            operator()(B part_begin, std::size_t part_steps, std::size_t)
             {
                 if (stride_ == 1)
                 {
@@ -1071,8 +1071,8 @@ namespace pika {
 
             template <typename ExPolicy, typename B, typename Size, typename S,
                 typename F, typename... Ts>
-            static typename algorithm_result<ExPolicy>::type parallel(
-                ExPolicy&& policy, B first, Size size, S stride, F&& f,
+            static typename algorithm_result<ExPolicy>::type
+            parallel(ExPolicy&& policy, B first, Size size, S stride, F&& f,
                 Ts&&... ts)
             {
                 if (size == 0)
@@ -1124,9 +1124,9 @@ namespace pika {
         // reshuffle arguments, last argument is function object, will go first
         template <typename ExPolicy, typename B, typename E, typename S,
             std::size_t... Is, typename... Args>
-        typename algorithm_result<ExPolicy>::type for_loop(ExPolicy&& policy,
-            B first, E last, S stride, pika::util::detail::index_pack<Is...>,
-            Args&&... args)
+        typename algorithm_result<ExPolicy>::type
+        for_loop(ExPolicy&& policy, B first, E last, S stride,
+            pika::util::detail::index_pack<Is...>, Args&&... args)
         {
             // stride shall not be zero
             PIKA_ASSERT(stride != 0);
@@ -1155,9 +1155,9 @@ namespace pika {
         // reshuffle arguments, last argument is function object, will go first
         template <typename ExPolicy, typename B, typename Size, typename S,
             std::size_t... Is, typename... Args>
-        typename algorithm_result<ExPolicy>::type for_loop_n(ExPolicy&& policy,
-            B first, Size size, S stride, pika::util::detail::index_pack<Is...>,
-            Args&&... args)
+        typename algorithm_result<ExPolicy>::type
+        for_loop_n(ExPolicy&& policy, B first, Size size, S stride,
+            pika::util::detail::index_pack<Is...>, Args&&... args)
         {
             // stride shall not be zero
             PIKA_ASSERT(stride != 0);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/for_loop_induction.hpp
@@ -222,8 +222,8 @@ namespace pika {
 
     /// \cond NOINTERNAL
     template <typename T>
-    PIKA_FORCEINLINE constexpr parallel::detail::induction_helper<T> induction(
-        T&& value)
+    PIKA_FORCEINLINE constexpr parallel::detail::induction_helper<T>
+    induction(T&& value)
     {
         return parallel::detail::induction_helper<T>(PIKA_FORWARD(T, value));
     }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/generate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/generate.hpp
@@ -162,16 +162,16 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F>
-        static constexpr Iter sequential(
-            ExPolicy&& policy, Iter first, Sent last, F&& f)
+        static constexpr Iter
+        sequential(ExPolicy&& policy, Iter first, Sent last, F&& f)
         {
             return sequential_generate(PIKA_FORWARD(ExPolicy, policy), first,
                 last, PIKA_FORWARD(F, f));
         }
 
         template <typename ExPolicy, typename Iter, typename Sent, typename F>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, F&& f)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, F&& f)
         {
             auto f1 = [policy, f = PIKA_FORWARD(F, f)](
                           Iter part_begin, std::size_t part_size) mutable {
@@ -200,16 +200,16 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename InIter, typename F>
-        static FwdIter sequential(
-            ExPolicy&& policy, InIter first, std::size_t count, F&& f)
+        static FwdIter
+        sequential(ExPolicy&& policy, InIter first, std::size_t count, F&& f)
         {
             return sequential_generate_n(
                 PIKA_FORWARD(ExPolicy, policy), first, count, f);
         }
 
         template <typename ExPolicy, typename F>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
         {
             auto f1 = [policy, f = PIKA_FORWARD(F, f)](
                           FwdIter part_begin, std::size_t part_size) mutable {
@@ -259,8 +259,8 @@ namespace pika {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            generate_t, FwdIter first, FwdIter last, F&& f)
+        friend FwdIter
+        tag_fallback_invoke(generate_t, FwdIter first, FwdIter last, F&& f)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");
@@ -308,8 +308,8 @@ namespace pika {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            generate_n_t, FwdIter first, Size count, F&& f)
+        friend FwdIter
+        tag_fallback_invoke(generate_n_t, FwdIter first, Size count, F&& f)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/includes.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/includes.hpp
@@ -206,8 +206,8 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename F, typename Proj1,
             typename Proj2>
-        static typename algorithm_result<ExPolicy, bool>::type parallel(
-            ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        static typename algorithm_result<ExPolicy, bool>::type
+        parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
             Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             if (first1 == last1)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/inclusive_scan.hpp
@@ -517,8 +517,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename OutIter, typename Op>
-        static constexpr in_out_result<InIter, OutIter> sequential(
-            ExPolicy, InIter first, Sent last, OutIter dest, Op&& op)
+        static constexpr in_out_result<InIter, OutIter>
+        sequential(ExPolicy, InIter first, Sent last, OutIter dest, Op&& op)
         {
             return sequential_inclusive_scan_noinit(
                 first, last, dest, PIKA_FORWARD(Op, op));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/is_heap.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/is_heap.hpp
@@ -250,8 +250,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Comp, typename Proj>
-        static bool sequential(
-            ExPolicy&&, Iter first, Sent last, Comp&& comp, Proj&& proj)
+        static bool
+        sequential(ExPolicy&&, Iter first, Sent last, Comp&& comp, Proj&& proj)
         {
             return sequential_is_heap(first, last, PIKA_FORWARD(Comp, comp),
                 PIKA_FORWARD(Proj, proj));
@@ -271,8 +271,8 @@ namespace pika::parallel::detail {
     // is_heap_until
     // sequential is_heap_until with projection function
     template <typename Iter, typename Sent, typename Comp, typename Proj>
-    Iter sequential_is_heap_until(
-        Iter first, Sent last, Comp&& comp, Proj&& proj)
+    Iter
+    sequential_is_heap_until(Iter first, Sent last, Comp&& comp, Proj&& proj)
     {
         using difference_type =
             typename std::iterator_traits<Iter>::difference_type;
@@ -359,8 +359,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Comp, typename Proj>
-        static Iter sequential(
-            ExPolicy&&, Iter first, Sent last, Comp&& comp, Proj&& proj)
+        static Iter
+        sequential(ExPolicy&&, Iter first, Sent last, Comp&& comp, Proj&& proj)
         {
             return sequential_is_heap_until(first, last,
                 PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/is_sorted.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/is_sorted.hpp
@@ -257,16 +257,16 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Pred, typename Proj>
-        static bool sequential(
-            ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
+        static bool
+        sequential(ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
         {
             return is_sorted_sequential(first, last, PIKA_FORWARD(Pred, pred),
                 PIKA_FORWARD(Proj, proj));
         }
 
         template <typename ExPolicy, typename Pred, typename Proj>
-        static typename algorithm_result<ExPolicy, bool>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        static typename algorithm_result<ExPolicy, bool>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
             Proj&& proj)
         {
             using difference_type =
@@ -336,16 +336,16 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Pred, typename Proj>
-        static FwdIter sequential(
-            ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
+        static FwdIter
+        sequential(ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
         {
             return is_sorted_until_sequential(first, last,
                 PIKA_FORWARD(Pred, pred), PIKA_FORWARD(Proj, proj));
         }
 
         template <typename ExPolicy, typename Pred, typename Proj>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
             Proj&& proj)
         {
             using reference = typename std::iterator_traits<FwdIter>::reference;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/lexicographical_compare.hpp
@@ -194,9 +194,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename InIter1, typename Sent1,
             typename InIter2, typename Sent2, typename Pred, typename Proj1,
             typename Proj2>
-        static bool sequential(ExPolicy, InIter1 first1, Sent1 last1,
-            InIter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
-            Proj2&& proj2)
+        static bool
+        sequential(ExPolicy, InIter1 first1, Sent1 last1, InIter2 first2,
+            Sent2 last2, Pred&& pred, Proj1&& proj1, Proj2&& proj2)
         {
             for (; (first1 != last1) && (first2 != last2);
                  ++first1, (void) ++first2)
@@ -304,9 +304,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(pika::lexicographical_compare_t,
-            InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
-            Pred&& pred = Pred())
+        friend bool
+        tag_fallback_invoke(pika::lexicographical_compare_t, InIter1 first1,
+            InIter1 last1, InIter2 first2, InIter2 last2, Pred&& pred = Pred())
         {
             static_assert(pika::traits::is_input_iterator<InIter1>::value,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/make_heap.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/make_heap.hpp
@@ -233,8 +233,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename RndIter, typename Sent,
             typename Comp, typename Proj>
-        static RndIter sequential(
-            ExPolicy, RndIter first, Sent last, Comp&& comp, Proj&& proj)
+        static RndIter
+        sequential(ExPolicy, RndIter first, Sent last, Comp&& comp, Proj&& proj)
         {
             return sequential_make_heap(first, last, PIKA_FORWARD(Comp, comp),
                 PIKA_FORWARD(Proj, proj));
@@ -373,8 +373,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename RndIter, typename Sent,
             typename Comp, typename Proj>
-        static typename algorithm_result<ExPolicy, RndIter>::type parallel(
-            ExPolicy&& policy, RndIter first, Sent last, Comp&& comp,
+        static typename algorithm_result<ExPolicy, RndIter>::type
+        parallel(ExPolicy&& policy, RndIter first, Sent last, Comp&& comp,
             Proj&& proj)
         {
             return make_heap_thread(PIKA_FORWARD(ExPolicy, policy), first, last,
@@ -483,8 +483,8 @@ namespace pika {
                 pika::traits::is_iterator<RndIter>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            make_heap_t, RndIter first, RndIter last)
+        friend void
+        tag_fallback_invoke(make_heap_t, RndIter first, RndIter last)
         {
             static_assert(
                 pika::traits::is_random_access_iterator<RndIter>::value,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/merge.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/merge.hpp
@@ -206,9 +206,9 @@ namespace pika::parallel::detail {
     // sequential merge with projection function.
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename OutIter, typename Comp, typename Proj1, typename Proj2>
-    constexpr in_in_out_result<Iter1, Iter2, OutIter> sequential_merge(
-        Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, OutIter dest,
-        Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+    constexpr in_in_out_result<Iter1, Iter2, OutIter>
+    sequential_merge(Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+        OutIter dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
     {
         if (first1 != last1 && first2 != last2)
         {
@@ -248,8 +248,8 @@ namespace pika::parallel::detail {
         // upper_bound with projection function.
         template <typename Iter, typename Sent, typename T, typename Comp,
             typename Proj>
-        static constexpr Iter call(
-            Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
+        static constexpr Iter
+        call(Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
         {
             return detail::upper_bound(first, last, value,
                 PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj, proj));
@@ -263,8 +263,8 @@ namespace pika::parallel::detail {
         // lower_bound with projection function.
         template <typename Iter, typename Sent, typename T, typename Comp,
             typename Proj>
-        static constexpr Iter call(
-            Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
+        static constexpr Iter
+        call(Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
         {
             return detail::lower_bound(first, last, value,
                 PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj, proj));
@@ -366,9 +366,9 @@ namespace pika::parallel::detail {
     template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
         typename Sent2, typename Iter3, typename Comp, typename Proj1,
         typename Proj2>
-    pika::future<in_in_out_result<Iter1, Iter2, Iter3>> parallel_merge(
-        ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
-        Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+    pika::future<in_in_out_result<Iter1, Iter2, Iter3>>
+    parallel_merge(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
     {
         using result_type = in_in_out_result<Iter1, Iter2, Iter3>;
 
@@ -420,9 +420,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Iter3, typename Comp,
             typename Proj1, typename Proj2>
-        static in_in_out_result<Iter1, Iter2, Iter3> sequential(ExPolicy,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-            Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        static in_in_out_result<Iter1, Iter2, Iter3>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_merge(first1, last1, first2, last2, dest,
                 PIKA_FORWARD(Comp, comp), PIKA_FORWARD(Proj1, proj1),
@@ -649,9 +649,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Comp, typename Proj>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Iter middle, Sent last, Comp&& comp,
-            Proj&& proj)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Iter middle, Sent last,
+            Comp&& comp, Proj&& proj)
         {
             using result = algorithm_result<ExPolicy, Iter>;
 

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/minmax.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/minmax.hpp
@@ -279,8 +279,8 @@ namespace pika {
     ///           to the last such element is returned.
     ///
     template <typename FwdIter, typename F>
-    minmax_element_result<FwdIter> minmax_element(
-        FwdIter first, FwdIter last, F&& f);
+    minmax_element_result<FwdIter>
+    minmax_element(FwdIter first, FwdIter last, F&& f);
 
     /////////////////////////////////////////////////////////////////////////////
     /// Finds the largest element in the range [first, last) using the given

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/mismatch.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/mismatch.hpp
@@ -200,9 +200,9 @@ namespace pika::parallel::detail {
     ///////////////////////////////////////////////////////////////////////
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename F, typename Proj1, typename Proj2>
-    constexpr in_in_result<Iter1, Iter2> sequential_mismatch_binary(
-        Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, F&& f,
-        Proj1&& proj1, Proj2&& proj2)
+    constexpr in_in_result<Iter1, Iter2>
+    sequential_mismatch_binary(Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
     {
         while (first1 != last1 && first2 != last2 &&
             PIKA_INVOKE(
@@ -225,9 +225,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename F, typename Proj1,
             typename Proj2>
-        static constexpr in_in_result<Iter1, Iter2> sequential(ExPolicy,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, F&& f,
-            Proj1&& proj1, Proj2&& proj2)
+        static constexpr in_in_result<Iter1, Iter2>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_mismatch_binary(first1, last1, first2, last2,
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Proj1, proj1),
@@ -331,8 +331,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename I1, typename I2>
-    pika::future<std::pair<I1, I2>> get_pair(
-        pika::future<in_in_result<I1, I2>>&& f)
+    pika::future<std::pair<I1, I2>>
+    get_pair(pika::future<in_in_result<I1, I2>>&& f)
     {
         return pika::make_future<std::pair<I1, I2>>(
             PIKA_MOVE(f), [](in_in_result<I1, I2>&& p) -> std::pair<I1, I2> {
@@ -352,8 +352,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter1, typename Sent,
             typename InIter2, typename F>
-        static constexpr IterPair sequential(
-            ExPolicy, InIter1 first1, Sent last1, InIter2 first2, F&& f)
+        static constexpr IterPair
+        sequential(ExPolicy, InIter1 first1, Sent last1, InIter2 first2, F&& f)
         {
             while (first1 != last1 && PIKA_INVOKE(f, *first1, *first2))
             {
@@ -364,9 +364,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter1, typename Sent,
             typename FwdIter2, typename F>
-        static algorithm_result_t<ExPolicy, IterPair> parallel(
-            ExPolicy&& policy, FwdIter1 first1, Sent last1, FwdIter2 first2,
-            F&& f)
+        static algorithm_result_t<ExPolicy, IterPair>
+        parallel(ExPolicy&& policy, FwdIter1 first1, Sent last1,
+            FwdIter2 first2, F&& f)
         {
             if (first1 == last1)
             {
@@ -554,9 +554,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend std::pair<FwdIter1, FwdIter2> tag_fallback_invoke(mismatch_t,
-            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
-            Pred&& op)
+        friend std::pair<FwdIter1, FwdIter2>
+        tag_fallback_invoke(mismatch_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, Pred&& op)
         {
             static_assert((pika::traits::is_forward_iterator_v<FwdIter1>),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/nth_element.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/nth_element.hpp
@@ -262,8 +262,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename RandomIt, typename Sent,
             typename Pred, typename Proj>
-        static algorithm_result_t<ExPolicy, RandomIt> parallel(
-            ExPolicy&& policy, RandomIt first, RandomIt nth, Sent last,
+        static algorithm_result_t<ExPolicy, RandomIt>
+        parallel(ExPolicy&& policy, RandomIt first, RandomIt nth, Sent last,
             Pred&& pred, Proj&& proj)
         {
             auto end = detail::advance_to_sentinel(first, last);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort.hpp
@@ -483,9 +483,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Comp, typename Proj>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Iter middle, Sent last, Comp&& comp,
-            Proj&& proj)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Iter middle, Sent last,
+            Comp&& comp, Proj&& proj)
         {
             try
             {
@@ -522,9 +522,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend RandIter tag_fallback_invoke(pika::partial_sort_t,
-            RandIter first, RandIter middle, RandIter last,
-            Comp&& comp = Comp())
+        friend RandIter
+        tag_fallback_invoke(pika::partial_sort_t, RandIter first,
+            RandIter middle, RandIter last, Comp&& comp = Comp())
         {
             static_assert(
                 pika::traits::is_random_access_iterator<RandIter>::value,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/partial_sort_copy.hpp
@@ -204,9 +204,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename InIter, typename Sent1,
             typename RandIter, typename Sent2, typename Compare, typename Proj1,
             typename Proj2>
-        static in_out_result<InIter, RandIter> sequential(ExPolicy,
-            InIter first, Sent1 last, RandIter d_first, Sent2 d_last,
-            Compare&& comp, Proj1&& proj1, Proj2&& proj2)
+        static in_out_result<InIter, RandIter>
+        sequential(ExPolicy, InIter first, Sent1 last, RandIter d_first,
+            Sent2 d_last, Compare&& comp, Proj1&& proj1, Proj2&& proj2)
         {
             auto last_iter = advance_to_sentinel(first, last);
             auto d_last_iter = advance_to_sentinel(d_first, d_last);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/partition.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/partition.hpp
@@ -520,9 +520,9 @@ namespace pika::parallel::detail {
     {
         template <typename ExPolicy, typename RandIter, typename F,
             typename Proj>
-        pika::future<RandIter> operator()(ExPolicy&& policy, RandIter first,
-            RandIter last, std::size_t size, F&& f, Proj&& proj,
-            std::size_t chunks)
+        pika::future<RandIter>
+        operator()(ExPolicy&& policy, RandIter first, RandIter last,
+            std::size_t size, F&& f, Proj&& proj, std::size_t chunks)
         {
             if (chunks < 2)
             {
@@ -587,8 +587,8 @@ namespace pika::parallel::detail {
     };
 
     template <typename BidirIter, typename Sent, typename F, typename Proj>
-    static BidirIter stable_partition_seq(
-        BidirIter first, Sent last, F&& f, Proj&& proj)
+    static BidirIter
+    stable_partition_seq(BidirIter first, Sent last, F&& f, Proj&& proj)
     {
         using value_type = typename std::iterator_traits<BidirIter>::value_type;
         std::vector<value_type> falseValues;
@@ -624,8 +624,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename BidirIter, typename Sent,
             typename F, typename Proj>
-        static BidirIter sequential(
-            ExPolicy&&, BidirIter first, Sent last, F&& f, Proj&& proj)
+        static BidirIter
+        sequential(ExPolicy&&, BidirIter first, Sent last, F&& f, Proj&& proj)
         {
             return stable_partition_seq(
                 first, last, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj, proj));
@@ -732,8 +732,8 @@ namespace pika::parallel::detail {
     template <typename FwdIter, typename Pred, typename Proj,
         PIKA_CONCEPT_REQUIRES_(pika::traits::is_forward_iterator_v<FwdIter> &&
             !pika::traits::is_bidirectional_iterator_v<FwdIter>)>
-    FwdIter sequential_partition(
-        FwdIter first, FwdIter last, Pred&& pred, Proj&& proj)
+    FwdIter
+    sequential_partition(FwdIter first, FwdIter last, Pred&& pred, Proj&& proj)
     {
         while (first != last && PIKA_INVOKE(pred, PIKA_INVOKE(proj, *first)))
             ++first;
@@ -968,8 +968,8 @@ namespace pika::parallel::detail {
         // If dest is previous to first, the range [first, last) can be
         //     successfully moved to the range [dest, dest+distance(first, last)).
         template <class FwdIter1, class FwdIter2>
-        static FwdIter2 swap_ranges_forward(
-            FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        static FwdIter2
+        swap_ranges_forward(FwdIter1 first, FwdIter1 last, FwdIter2 dest)
         {
             while (first != last)
             {
@@ -1028,9 +1028,9 @@ namespace pika::parallel::detail {
         // Performs sequential sub-partitioning to remaining blocks for
         //     reducing the number and size of remaining blocks.
         template <typename FwdIter, typename Pred, typename Proj>
-        static void collapse_remaining_blocks(
-            std::vector<block<FwdIter>>& remaining_blocks, Pred& pred,
-            Proj& proj)
+        static void
+        collapse_remaining_blocks(std::vector<block<FwdIter>>& remaining_blocks,
+            Pred& pred, Proj& proj)
         {
             if (remaining_blocks.empty())
                 return;
@@ -1219,9 +1219,9 @@ namespace pika::parallel::detail {
         // The function which merges remaining blocks into
         //     one block which is adjacent to boundary.
         template <typename FwdIter>
-        static block<FwdIter> merge_remaining_blocks(
-            std::vector<block<FwdIter>>& remaining_blocks, FwdIter boundary,
-            FwdIter first)
+        static block<FwdIter>
+        merge_remaining_blocks(std::vector<block<FwdIter>>& remaining_blocks,
+            FwdIter boundary, FwdIter first)
         {
             if (remaining_blocks.empty())
                 return {boundary, boundary};
@@ -1359,8 +1359,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Sent, typename Pred,
             typename Proj = projection_identity>
-        static FwdIter sequential(
-            ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
+        static FwdIter
+        sequential(ExPolicy, FwdIter first, Sent last, Pred&& pred, Proj&& proj)
         {
             auto last_iter = detail::advance_to_sentinel(first, last);
             return sequential_partition(first, last_iter,
@@ -1369,8 +1369,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Sent, typename Pred,
             typename Proj = projection_identity>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
             Proj&& proj)
         {
             using algorithm_result = algorithm_result<ExPolicy, FwdIter>;
@@ -1399,9 +1399,9 @@ namespace pika::parallel::detail {
     // sequential partition_copy with projection function
     template <typename InIter, typename OutIter1, typename OutIter2,
         typename Pred, typename Proj>
-    std::tuple<InIter, OutIter1, OutIter2> sequential_partition_copy(
-        InIter first, InIter last, OutIter1 dest_true, OutIter2 dest_false,
-        Pred&& pred, Proj&& proj)
+    std::tuple<InIter, OutIter1, OutIter2>
+    sequential_partition_copy(InIter first, InIter last, OutIter1 dest_true,
+        OutIter2 dest_false, Pred&& pred, Proj&& proj)
     {
         while (first != last)
         {
@@ -1427,9 +1427,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename InIter, typename Sent,
             typename OutIter1, typename OutIter2, typename Pred,
             typename Proj = projection_identity>
-        static std::tuple<InIter, OutIter1, OutIter2> sequential(ExPolicy,
-            InIter first, Sent last, OutIter1 dest_true, OutIter2 dest_false,
-            Pred&& pred, Proj&& proj)
+        static std::tuple<InIter, OutIter1, OutIter2>
+        sequential(ExPolicy, InIter first, Sent last, OutIter1 dest_true,
+            OutIter2 dest_false, Pred&& pred, Proj&& proj)
         {
             auto last_iter = detail::advance_to_sentinel(first, last);
             return sequential_partition_copy(first, last_iter, dest_true,
@@ -1673,9 +1673,9 @@ namespace pika {
                     parallel::detail::projected<Proj, FwdIter1>>
             )>
         // clang-format on
-        friend std::pair<FwdIter2, FwdIter3> tag_fallback_invoke(
-            pika::partition_copy_t, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest_true, FwdIter3 dest_false, Pred&& pred,
+        friend std::pair<FwdIter2, FwdIter3>
+        tag_fallback_invoke(pika::partition_copy_t, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest_true, FwdIter3 dest_false, Pred&& pred,
             Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_forward_iterator_v<FwdIter1>),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/reduce.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/reduce.hpp
@@ -250,8 +250,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename T_, typename Reduce>
-        static T sequential(
-            ExPolicy, InIterB first, InIterE last, T_&& init, Reduce&& r)
+        static T
+        sequential(ExPolicy, InIterB first, InIterE last, T_&& init, Reduce&& r)
         {
             return detail::accumulate(
                 first, last, PIKA_FORWARD(T_, init), PIKA_FORWARD(Reduce, r));
@@ -259,8 +259,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
             typename T_, typename Reduce>
-        static typename algorithm_result<ExPolicy, T>::type parallel(
-            ExPolicy&& policy, FwdIterB first, FwdIterE last, T_&& init,
+        static typename algorithm_result<ExPolicy, T>::type
+        parallel(ExPolicy&& policy, FwdIterB first, FwdIterE last, T_&& init,
             Reduce&& r)
         {
             if (first == last)
@@ -386,8 +386,8 @@ namespace pika {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend T tag_fallback_invoke(
-            pika::reduce_t, FwdIter first, FwdIter last, T init)
+        friend T
+        tag_fallback_invoke(pika::reduce_t, FwdIter first, FwdIter last, T init)
         {
             static_assert(pika::traits::is_input_iterator<FwdIter>::value,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/reduce_by_key.hpp
@@ -167,8 +167,8 @@ namespace pika {
         // Zip iterator has 3 iterators inside
         // Iter1, key type : Iter2, value type : Iter3, state type
         template <typename ZIter, typename iKey, typename iVal>
-        parallel::detail::in_out_result<iKey, iVal> make_pair_result(
-            ZIter zipiter, iKey key_start, iVal val_start)
+        parallel::detail::in_out_result<iKey, iVal>
+        make_pair_result(ZIter zipiter, iKey key_start, iVal val_start)
         {
             // the iterator we want is 'second' part of pair type (from copy_if)
             auto t = zipiter.out.get_iterator_tuple();

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/remove.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/remove.hpp
@@ -270,8 +270,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Pred, typename Proj>
-        static Iter sequential(
-            ExPolicy, Iter first, Sent last, Pred&& pred, Proj&& proj)
+        static Iter
+        sequential(ExPolicy, Iter first, Sent last, Pred&& pred, Proj&& proj)
         {
             return sequential_remove_if(first, last, PIKA_FORWARD(Pred, pred),
                 PIKA_FORWARD(Proj, proj));

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/remove_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/remove_copy.hpp
@@ -51,8 +51,8 @@ namespace pika {
     ///           iterator to the element past the last element copied.
     ///
     template <typename InIter, typename OutIter, typename T>
-    FwdIter remove_copy(
-        InIter first, InIter last, OutIter dest, T const& value);
+    FwdIter
+    remove_copy(InIter first, InIter last, OutIter dest, T const& value);
 
     /// Copies the elements in the range, defined by [first, last), to another
     /// range beginning at \a dest. Copies only the elements for which the
@@ -167,8 +167,8 @@ namespace pika {
     ///           iterator to the element past the last element copied.
     ///
     template <typename InIter, typename OutIter, typename Pred>
-    FwdIter remove_copy_if(
-        InIter first, InIter last, OutIter dest, Pred&& pred);
+    FwdIter
+    remove_copy_if(InIter first, InIter last, OutIter dest, Pred&& pred);
 
     /// Copies the elements in the range, defined by [first, last), to another
     /// range beginning at \a dest. Copies only the elements for which the

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/replace.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/replace.hpp
@@ -41,8 +41,8 @@ namespace pika {
     /// \returns  The \a replace algorithm returns a \a void.
     ///
     template <typename Initer, typename T>
-    void replace(
-        InIter first, InIter last, T const& old_value, T const& new_value);
+    void
+    replace(InIter first, InIter last, T const& old_value, T const& new_value);
 
     /// Replaces all elements satisfying specific criteria with \a new_value
     /// in the range [first, last).
@@ -88,8 +88,8 @@ namespace pika {
     ///           returns \a void otherwise.
     ///
     template <typename ExPolicy, typename FwdIter, typename T>
-    typename parallel::detail::algorithm_result<ExPolicy, void>::type replace(
-        ExPolicy&& policy, FwdIter first, FwdIter last, T const& old_value,
+    typename parallel::detail::algorithm_result<ExPolicy, void>::type
+    replace(ExPolicy&& policy, FwdIter first, FwdIter last, T const& old_value,
         T const& new_value);
 
     /// Replaces all elements satisfying specific criteria (for which predicate
@@ -527,9 +527,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename T1, typename T2,
             typename Proj>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, FwdIter last, T1 const& old_value,
-            T2 const& new_value, Proj&& proj)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, FwdIter last,
+            T1 const& old_value, T2 const& new_value, Proj&& proj)
         {
             using type = typename std::iterator_traits<FwdIter>::value_type;
 
@@ -587,8 +587,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename F, typename T, typename Proj>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, F&& f,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, F&& f,
             T const& new_value, Proj&& proj)
         {
             using type = typename std::iterator_traits<FwdIter>::value_type;
@@ -614,9 +614,9 @@ namespace pika::parallel::detail {
     // sequential replace_copy
     template <typename InIter, typename Sent, typename OutIter, typename T,
         typename Proj>
-    inline in_out_result<InIter, OutIter> sequential_replace_copy(InIter first,
-        Sent sent, OutIter dest, T const& old_value, T const& new_value,
-        Proj&& proj)
+    inline in_out_result<InIter, OutIter>
+    sequential_replace_copy(InIter first, Sent sent, OutIter dest,
+        T const& old_value, T const& new_value, Proj&& proj)
     {
         for (/* */; first != sent; ++first)
         {
@@ -638,9 +638,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename OutIter, typename T, typename Proj>
-        static in_out_result<InIter, OutIter> sequential(ExPolicy, InIter first,
-            Sent sent, OutIter dest, T const& old_value, T const& new_value,
-            Proj&& proj)
+        static in_out_result<InIter, OutIter>
+        sequential(ExPolicy, InIter first, Sent sent, OutIter dest,
+            T const& old_value, T const& new_value, Proj&& proj)
         {
             return sequential_replace_copy(first, sent, dest, old_value,
                 new_value, PIKA_FORWARD(Proj, proj));
@@ -680,9 +680,9 @@ namespace pika::parallel::detail {
     // sequential replace_copy_if
     template <typename InIter, typename Sent, typename OutIter, typename F,
         typename T, typename Proj>
-    inline in_out_result<InIter, OutIter> sequential_replace_copy_if(
-        InIter first, Sent sent, OutIter dest, F&& f, T const& new_value,
-        Proj&& proj)
+    inline in_out_result<InIter, OutIter>
+    sequential_replace_copy_if(InIter first, Sent sent, OutIter dest, F&& f,
+        T const& new_value, Proj&& proj)
     {
         for (/* */; first != sent; ++first)
         {
@@ -875,9 +875,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend OutIter tag_fallback_invoke(pika::replace_copy_if_t,
-            InIter first, InIter last, OutIter dest, Pred&& pred,
-            T const& new_value)
+        friend OutIter
+        tag_fallback_invoke(pika::replace_copy_if_t, InIter first, InIter last,
+            OutIter dest, Pred&& pred, T const& new_value)
         {
             static_assert((pika::traits::is_input_iterator<InIter>::value),
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/reverse.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/reverse.hpp
@@ -74,8 +74,8 @@ namespace pika {
     ///           returns \a void otherwise.
     ///
     template <typename ExPolicy, typename BidirIter>
-    typename parallel::detail::algorithm_result<ExPolicy, void>::type reverse(
-        ExPolicy&& policy, BidirIter first, BidirIter last);
+    typename parallel::detail::algorithm_result<ExPolicy, void>::type
+    reverse(ExPolicy&& policy, BidirIter first, BidirIter last);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Copies the elements from the range [first, last) to another range
@@ -212,8 +212,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename BidirIter, typename Sent>
-        constexpr static BidirIter sequential(
-            ExPolicy, BidirIter first, Sent last)
+        constexpr static BidirIter
+        sequential(ExPolicy, BidirIter first, Sent last)
         {
             auto last2{pika::ranges::next(first, last)};
             for (auto tail{last2}; !(first == tail || first == --tail); ++first)
@@ -228,8 +228,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename BidirIter, typename Sent>
-        static typename algorithm_result<ExPolicy, BidirIter>::type parallel(
-            ExPolicy&& policy, BidirIter first, Sent last)
+        static typename algorithm_result<ExPolicy, BidirIter>::type
+        parallel(ExPolicy&& policy, BidirIter first, Sent last)
         {
             auto last2{pika::ranges::next(first, last)};
             using destination_iterator = std::reverse_iterator<BidirIter>;
@@ -258,8 +258,8 @@ namespace pika::parallel::detail {
 
     // sequential reverse_copy
     template <typename BidirIt, typename Sent, typename OutIter>
-    constexpr inline in_out_result<BidirIt, OutIter> sequential_reverse_copy(
-        BidirIt first, Sent last, OutIter dest)
+    constexpr inline in_out_result<BidirIt, OutIter>
+    sequential_reverse_copy(BidirIt first, Sent last, OutIter dest)
     {
         auto iter{pika::ranges::next(first, last)};
         while (first != iter)
@@ -279,8 +279,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename BidirIter, typename Sent,
             typename OutIter>
-        constexpr static in_out_result<BidirIter, OutIter> sequential(
-            ExPolicy, BidirIter first, Sent last, OutIter dest_first)
+        constexpr static in_out_result<BidirIter, OutIter>
+        sequential(ExPolicy, BidirIter first, Sent last, OutIter dest_first)
         {
             return sequential_reverse_copy(first, last, dest_first);
         }
@@ -322,8 +322,8 @@ namespace pika {
                 pika::traits::is_iterator<BidirIter>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            pika::reverse_t, BidirIter first, BidirIter last)
+        friend void
+        tag_fallback_invoke(pika::reverse_t, BidirIter first, BidirIter last)
         {
             static_assert(
                 (pika::traits::is_bidirectional_iterator<BidirIter>::value),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/rotate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/rotate.hpp
@@ -206,8 +206,8 @@ namespace pika::parallel::detail {
     // rotate
     /// \cond NOINTERNAL
     template <typename ExPolicy, typename FwdIter, typename Sent>
-    pika::future<in_out_result<FwdIter, Sent>> rotate_helper(
-        ExPolicy policy, FwdIter first, FwdIter new_first, Sent last)
+    pika::future<in_out_result<FwdIter, Sent>>
+    rotate_helper(ExPolicy policy, FwdIter first, FwdIter new_first, Sent last)
     {
         using non_seq = std::false_type;
 
@@ -244,15 +244,15 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename InIter, typename Sent>
-        static IterPair sequential(
-            ExPolicy, InIter first, InIter new_first, Sent last)
+        static IterPair
+        sequential(ExPolicy, InIter first, InIter new_first, Sent last)
         {
             return sequential_rotate(first, new_first, last);
         }
 
         template <typename ExPolicy, typename FwdIter, typename Sent>
-        static typename algorithm_result<ExPolicy, IterPair>::type parallel(
-            ExPolicy&& policy, FwdIter first, FwdIter new_first, Sent last)
+        static typename algorithm_result<ExPolicy, IterPair>::type
+        parallel(ExPolicy&& policy, FwdIter first, FwdIter new_first, Sent last)
         {
             return algorithm_result<ExPolicy, IterPair>::get(rotate_helper(
                 PIKA_FORWARD(ExPolicy, policy), first, new_first, last));
@@ -279,9 +279,9 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2>
-    pika::future<in_out_result<FwdIter1, FwdIter2>> rotate_copy_helper(
-        ExPolicy policy, FwdIter1 first, FwdIter1 new_first, Sent last,
-        FwdIter2 dest_first)
+    pika::future<in_out_result<FwdIter1, FwdIter2>>
+    rotate_copy_helper(ExPolicy policy, FwdIter1 first, FwdIter1 new_first,
+        Sent last, FwdIter2 dest_first)
     {
         using non_seq = std::false_type;
 

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/search.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/search.hpp
@@ -372,9 +372,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(pika::search_n_t, FwdIter first,
-            std::size_t count, FwdIter2 s_first, FwdIter2 s_last,
-            Pred&& op = Pred())
+        friend FwdIter
+        tag_fallback_invoke(pika::search_n_t, FwdIter first, std::size_t count,
+            FwdIter2 s_first, FwdIter2 s_last, Pred&& op = Pred())
         {
             return pika::parallel::detail::search_n<FwdIter, FwdIter>().call(
                 pika::execution::seq, first, count, s_first, s_last,

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/set_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/set_difference.hpp
@@ -133,9 +133,9 @@ namespace pika::parallel::detail {
     // set_difference
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Iter3, typename Comp, typename Proj1, typename Proj2>
-    constexpr in_out_result<Iter1, Iter3> sequential_set_difference(
-        Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-        Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+    constexpr in_out_result<Iter1, Iter3>
+    sequential_set_difference(Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
     {
         while (first1 != last1)
         {
@@ -175,9 +175,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Iter3, typename F,
             typename Proj1, typename Proj2>
-        static in_out_result<Iter1, Iter3> sequential(ExPolicy, Iter1 first1,
-            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest, F&& f,
-            Proj1&& proj1, Proj2&& proj2)
+        static in_out_result<Iter1, Iter3>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_set_difference(first1, last1, first2, last2, dest,
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Proj1, proj1),
@@ -312,9 +312,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend FwdIter3 tag_fallback_invoke(set_difference_t, FwdIter1 first1,
-            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
-            Pred&& op = Pred())
+        friend FwdIter3
+        tag_fallback_invoke(set_difference_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
         {
             static_assert((pika::traits::is_input_iterator<FwdIter1>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/set_intersection.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/set_intersection.hpp
@@ -132,9 +132,9 @@ namespace pika::parallel::detail {
     // set_intersection
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Iter3, typename Comp, typename Proj1, typename Proj2>
-    constexpr in_in_out_result<Iter1, Iter2, Iter3> sequential_set_intersection(
-        Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-        Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+    constexpr in_in_out_result<Iter1, Iter2, Iter3>
+    sequential_set_intersection(Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
     {
         while (first1 != last1 && first2 != last2)
         {
@@ -169,9 +169,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Iter3, typename F,
             typename Proj1, typename Proj2>
-        static in_in_out_result<Iter1, Iter2, Iter3> sequential(ExPolicy,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-            F&& f, Proj1&& proj1, Proj2&& proj2)
+        static in_in_out_result<Iter1, Iter2, Iter3>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_set_intersection(first1, last1, first2, last2,
                 dest, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj1, proj1),
@@ -291,9 +291,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend FwdIter3 tag_fallback_invoke(set_intersection_t, FwdIter1 first1,
-            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
-            Pred&& op = Pred())
+        friend FwdIter3
+        tag_fallback_invoke(set_intersection_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
         {
             static_assert((pika::traits::is_input_iterator<FwdIter1>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/set_symmetric_difference.hpp
@@ -188,9 +188,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Iter3, typename F,
             typename Proj1, typename Proj2>
-        static in_in_out_result<Iter1, Iter2, Iter3> sequential(ExPolicy,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-            F&& f, Proj1&& proj1, Proj2&& proj2)
+        static in_in_out_result<Iter1, Iter2, Iter3>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_set_symmetric_difference(first1, last1, first2,
                 last2, dest, PIKA_FORWARD(F, f), PIKA_FORWARD(Proj1, proj1),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/set_union.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/set_union.hpp
@@ -133,9 +133,9 @@ namespace pika::parallel::detail {
     // set_union
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Iter3, typename Comp, typename Proj1, typename Proj2>
-    constexpr in_in_out_result<Iter1, Iter2, Iter3> sequential_set_union(
-        Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-        Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+    constexpr in_in_out_result<Iter1, Iter2, Iter3>
+    sequential_set_union(Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+        Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
     {
         for (; first1 != last1; ++dest)
         {
@@ -179,9 +179,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Iter3, typename F,
             typename Proj1, typename Proj2>
-        static in_in_out_result<Iter1, Iter2, Iter3> sequential(ExPolicy,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-            F&& f, Proj1&& proj1, Proj2&& proj2)
+        static in_in_out_result<Iter1, Iter2, Iter3>
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return sequential_set_union(first1, last1, first2, last2, dest,
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Proj1, proj1),
@@ -316,9 +316,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend FwdIter3 tag_fallback_invoke(set_union_t, FwdIter1 first1,
-            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
-            Pred&& op = Pred())
+        friend FwdIter3
+        tag_fallback_invoke(set_union_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
         {
             static_assert((pika::traits::is_input_iterator<FwdIter1>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/shift_left.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/shift_left.hpp
@@ -157,8 +157,8 @@ namespace pika::parallel::detail {
         from https://github.com/danra/shift_proposal */
 
     template <typename FwdIter, typename Sent, typename Size>
-    static constexpr FwdIter sequential_shift_left(
-        FwdIter first, Sent last, Size n, std::size_t dist)
+    static constexpr FwdIter
+    sequential_shift_left(FwdIter first, Sent last, Size n, std::size_t dist)
     {
         auto mid = std::next(first, n);
 
@@ -196,8 +196,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Sent, typename Size>
-        static typename algorithm_result<ExPolicy, FwdIter2>::type parallel(
-            ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
+        static typename algorithm_result<ExPolicy, FwdIter2>::type
+        parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
         {
             auto dist = static_cast<std::size_t>((distance) (first, last));
             if (n <= 0 || static_cast<std::size_t>(n) >= dist)
@@ -225,8 +225,8 @@ namespace pika {
             PIKA_CONCEPT_REQUIRES_(
                 pika::traits::is_iterator<FwdIter>::value)>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            shift_left_t, FwdIter first, FwdIter last, Size n)
+        friend FwdIter
+        tag_fallback_invoke(shift_left_t, FwdIter first, FwdIter last, Size n)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/shift_right.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/shift_right.hpp
@@ -237,8 +237,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Sent, typename Size>
-        static typename algorithm_result<ExPolicy, FwdIter2>::type parallel(
-            ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
+        static typename algorithm_result<ExPolicy, FwdIter2>::type
+        parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
         {
             auto dist = static_cast<std::size_t>((distance) (first, last));
             if (n <= 0 || static_cast<std::size_t>(n) >= dist)
@@ -267,8 +267,8 @@ namespace pika {
             PIKA_CONCEPT_REQUIRES_(
                 pika::traits::is_iterator<FwdIter>::value)>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            shift_right_t, FwdIter first, FwdIter last, Size n)
+        friend FwdIter
+        tag_fallback_invoke(shift_right_t, FwdIter first, FwdIter last, Size n)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/sort.hpp
@@ -449,8 +449,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Sent, typename Comp,
             typename Proj>
-        static typename algorithm_result<ExPolicy, RandomIt>::type parallel(
-            ExPolicy&& policy, RandomIt first, Sent last_s, Comp&& comp,
+        static typename algorithm_result<ExPolicy, RandomIt>::type
+        parallel(ExPolicy&& policy, RandomIt first, Sent last_s, Comp&& comp,
             Proj&& proj)
         {
             auto last = advance_to_sentinel(first, last_s);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/stable_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/stable_sort.hpp
@@ -288,9 +288,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Sentinel, typename Compare,
             typename Proj>
-        static typename algorithm_result<ExPolicy, RandomIt>::type parallel(
-            ExPolicy&& policy, RandomIt first, Sentinel last, Compare&& compare,
-            Proj&& proj)
+        static typename algorithm_result<ExPolicy, RandomIt>::type
+        parallel(ExPolicy&& policy, RandomIt first, Sentinel last,
+            Compare&& compare, Proj&& proj)
         {
             using algorithm_result = algorithm_result<ExPolicy, RandomIt>;
             using compare_type = compare_projected<Compare&, Proj&>;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/starts_with.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/starts_with.hpp
@@ -32,8 +32,8 @@
 
 namespace pika::parallel::detail {
     template <typename FwdIter1, typename FwdIter2, typename Sent2>
-    bool get_starts_with_result(
-        in_in_result<FwdIter1, FwdIter2>&& p, Sent2 last2)
+    bool
+    get_starts_with_result(in_in_result<FwdIter1, FwdIter2>&& p, Sent2 last2)
     {
         return p.in2 == last2;
     }
@@ -57,9 +57,9 @@ namespace pika::parallel::detail {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2, typename Sent2, typename Pred, typename Proj1,
             typename Proj2>
-        static bool sequential(ExPolicy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
-            Proj2&& proj2)
+        static bool
+        sequential(ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Pred&& pred, Proj1&& proj1, Proj2&& proj2)
         {
             auto dist1 = (distance) (first1, last1);
             auto dist2 = (distance) (first2, last2);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/swap_ranges.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/swap_ranges.hpp
@@ -160,8 +160,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter1, typename Sent,
             typename FwdIter2>
-        static constexpr FwdIter2 sequential(
-            ExPolicy, FwdIter1 first1, Sent last1, FwdIter2 first2)
+        static constexpr FwdIter2
+        sequential(ExPolicy, FwdIter1 first1, Sent last1, FwdIter2 first2)
         {
             while (first1 != last1)
             {
@@ -176,8 +176,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
             typename FwdIter2, typename Sent2>
-        static constexpr swap_ranges_result<FwdIter1, FwdIter2> sequential(
-            ExPolicy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
+        static constexpr swap_ranges_result<FwdIter1, FwdIter2>
+        sequential(ExPolicy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
             Sent2 last2)
         {
             while (first1 != last1 && first2 != last2)

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/transform.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/transform.hpp
@@ -353,9 +353,9 @@ namespace pika::parallel::detail {
         // sequential execution with non-trivial projection
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename OutIter, typename F, typename Proj>
-        PIKA_HOST_DEVICE static in_out_result<InIterB, OutIter> sequential(
-            ExPolicy&& policy, InIterB first, InIterE last, OutIter dest, F&& f,
-            Proj&& proj)
+        PIKA_HOST_DEVICE static in_out_result<InIterB, OutIter>
+        sequential(ExPolicy&& policy, InIterB first, InIterE last, OutIter dest,
+            F&& f, Proj&& proj)
         {
             return transform_loop(PIKA_FORWARD(ExPolicy, policy), first, last,
                 dest, transform_projected<F, Proj>(f, proj));
@@ -364,9 +364,9 @@ namespace pika::parallel::detail {
         // sequential execution without projection
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename OutIter, typename F>
-        PIKA_HOST_DEVICE static in_out_result<InIterB, OutIter> sequential(
-            ExPolicy&& policy, InIterB first, InIterE last, OutIter dest, F&& f,
-            projection_identity)
+        PIKA_HOST_DEVICE static in_out_result<InIterB, OutIter>
+        sequential(ExPolicy&& policy, InIterB first, InIterE last, OutIter dest,
+            F&& f, projection_identity)
         {
             return transform_loop_ind(PIKA_FORWARD(ExPolicy, policy), first,
                 last, dest, PIKA_FORWARD(F, f));
@@ -410,8 +410,8 @@ namespace pika::parallel::detail {
         std::decay_t<Proj2>& proj2_;
 
         template <typename Iter1, typename Iter2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE auto operator()(
-            Iter1 curr1, Iter2 curr2)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE auto
+        operator()(Iter1 curr1, Iter2 curr2)
         {
             return PIKA_INVOKE(
                 f_, PIKA_INVOKE(proj1_, *curr1), PIKA_INVOKE(proj2_, *curr2));
@@ -431,8 +431,8 @@ namespace pika::parallel::detail {
         proj2_type proj2_;
 
         template <typename F_, typename Proj1_, typename Proj2_>
-        PIKA_HOST_DEVICE transform_binary_iteration(
-            F_&& f, Proj1_&& proj1, Proj2_&& proj2)
+        PIKA_HOST_DEVICE
+        transform_binary_iteration(F_&& f, Proj1_&& proj1, Proj2_&& proj2)
           : f_(PIKA_FORWARD(F_, f))
           , proj1_(PIKA_FORWARD(Proj1_, proj1))
           , proj2_(PIKA_FORWARD(Proj2_, proj2))
@@ -550,8 +550,8 @@ namespace pika::parallel::detail {
         // sequential execution with non-trivial projection
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
-        static in_in_out_result<InIter1, InIter2, OutIter> sequential(
-            ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+        static in_in_out_result<InIter1, InIter2, OutIter>
+        sequential(ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
             OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return transform_binary_loop<ExPolicy>(first1, last1, first2, dest,
@@ -561,8 +561,8 @@ namespace pika::parallel::detail {
         // sequential execution without projection
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F>
-        static in_in_out_result<InIter1, InIter2, OutIter> sequential(
-            ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+        static in_in_out_result<InIter1, InIter2, OutIter>
+        sequential(ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
             OutIter dest, F&& f, projection_identity, projection_identity)
         {
             return transform_binary_loop_ind<ExPolicy>(
@@ -613,8 +613,8 @@ namespace pika::parallel::detail {
         // sequential execution with non-trivial projection
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
-        static in_in_out_result<InIter1, InIter2, OutIter> sequential(
-            ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+        static in_in_out_result<InIter1, InIter2, OutIter>
+        sequential(ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
             InIter2 last2, OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
         {
             return transform_binary_loop<ExPolicy>(first1, last1, first2, last2,
@@ -625,8 +625,8 @@ namespace pika::parallel::detail {
         // sequential execution without projection
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F>
-        static in_in_out_result<InIter1, InIter2, OutIter> sequential(
-            ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+        static in_in_out_result<InIter1, InIter2, OutIter>
+        sequential(ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
             InIter2 last2, OutIter dest, F&& f, projection_identity,
             projection_identity)
         {

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/transform_exclusive_scan.hpp
@@ -290,9 +290,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename Conv, typename T, typename OutIter, typename Op>
-        static constexpr in_out_result<InIter, OutIter> sequential(ExPolicy,
-            InIter first, Sent last, OutIter dest, Conv&& conv, T&& init,
-            Op&& op)
+        static constexpr in_out_result<InIter, OutIter>
+        sequential(ExPolicy, InIter first, Sent last, OutIter dest, Conv&& conv,
+            T&& init, Op&& op)
         {
             return sequential_transform_exclusive_scan(first, last, dest,
                 PIKA_FORWARD(Conv, conv), PIKA_FORWARD(T, init),

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/transform_inclusive_scan.hpp
@@ -492,9 +492,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename OutIter, typename Conv, typename T, typename Op>
-        static constexpr in_out_result<InIter, OutIter> sequential(ExPolicy,
-            InIter first, Sent last, OutIter dest, Conv&& conv, T&& init,
-            Op&& op)
+        static constexpr in_out_result<InIter, OutIter>
+        sequential(ExPolicy, InIter first, Sent last, OutIter dest, Conv&& conv,
+            T&& init, Op&& op)
         {
             return sequential_transform_inclusive_scan(first, last, dest,
                 PIKA_FORWARD(Conv, conv), PIKA_FORWARD(T, init),
@@ -626,9 +626,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend OutIter tag_fallback_invoke(pika::transform_inclusive_scan_t,
-            InIter first, InIter last, OutIter dest, BinOp&& binary_op,
-            UnOp&& unary_op)
+        friend OutIter
+        tag_fallback_invoke(pika::transform_inclusive_scan_t, InIter first,
+            InIter last, OutIter dest, BinOp&& binary_op, UnOp&& unary_op)
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/transform_reduce.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/transform_reduce.hpp
@@ -294,8 +294,8 @@ namespace pika::parallel::detail {
         convert_type convert_;
 
         template <typename Reduce_, typename Convert_>
-        PIKA_HOST_DEVICE transform_reduce_iteration(
-            Reduce_&& reduce, Convert_&& convert)
+        PIKA_HOST_DEVICE
+        transform_reduce_iteration(Reduce_&& reduce, Convert_&& convert)
           : reduce_(PIKA_FORWARD(Reduce_, reduce))
           , convert_(PIKA_FORWARD(Convert_, convert))
         {
@@ -305,15 +305,15 @@ namespace pika::parallel::detail {
         transform_reduce_iteration(transform_reduce_iteration const&) = default;
         transform_reduce_iteration(transform_reduce_iteration&&) = default;
 #else
-        PIKA_HOST_DEVICE transform_reduce_iteration(
-            transform_reduce_iteration const& rhs)
+        PIKA_HOST_DEVICE
+        transform_reduce_iteration(transform_reduce_iteration const& rhs)
           : reduce_(rhs.reduce_)
           , convert_(rhs.convert_)
         {
         }
 
-        PIKA_HOST_DEVICE transform_reduce_iteration(
-            transform_reduce_iteration&& rhs)
+        PIKA_HOST_DEVICE
+        transform_reduce_iteration(transform_reduce_iteration&& rhs)
           : reduce_(PIKA_MOVE(rhs.reduce_))
           , convert_(PIKA_MOVE(rhs.convert_))
         {
@@ -364,9 +364,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent, typename T_,
             typename Reduce, typename Convert>
-        static typename algorithm_result<ExPolicy, T>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, T_&& init, Reduce&& r,
-            Convert&& conv)
+        static typename algorithm_result<ExPolicy, T>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, T_&& init,
+            Reduce&& r, Convert&& conv)
         {
             if (first == last)
             {
@@ -414,8 +414,8 @@ namespace pika::parallel::detail {
         value_type& part_sum_;
 
         template <typename Iter1, typename Iter2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void operator()(
-            Iter1 it1, Iter2 it2)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr void
+        operator()(Iter1 it1, Iter2 it2)
         {
             part_sum_ =
                 PIKA_INVOKE(op1_, part_sum_, PIKA_INVOKE(op2_, *it1, *it2));
@@ -482,9 +482,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Iter2, typename T_, typename Op1, typename Op2>
-        static typename algorithm_result<ExPolicy, T>::type parallel(
-            ExPolicy&& policy, Iter first1, Sent last1, Iter2 first2, T_&& init,
-            Op1&& op1, Op2&& op2)
+        static typename algorithm_result<ExPolicy, T>::type
+        parallel(ExPolicy&& policy, Iter first1, Sent last1, Iter2 first2,
+            T_&& init, Op1&& op1, Op2&& op2)
         {
             using result = algorithm_result<ExPolicy, T>;
             using zip_iterator = pika::util::zip_iterator<Iter, Iter2>;
@@ -806,9 +806,9 @@ namespace pika {
                 >
             )>
         // clang-format on
-        friend T tag_fallback_invoke(transform_reduce_t, InIter1 first1,
-            InIter1 last1, InIter2 first2, T init, Reduce&& red_op,
-            Convert&& conv_op)
+        friend T
+        tag_fallback_invoke(transform_reduce_t, InIter1 first1, InIter1 last1,
+            InIter2 first2, T init, Reduce&& red_op, Convert&& conv_op)
         {
             static_assert(pika::traits::is_input_iterator<InIter1>::value,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_copy.hpp
@@ -220,8 +220,8 @@ namespace pika::parallel::detail {
     /// \cond NOINTERNAL
     ///////////////////////////////////////////////////////////////////////
     template <typename InIter1, typename FwdIter2, typename Cond>
-    in_out_result<InIter1, FwdIter2> sequential_uninitialized_copy(
-        InIter1 first, FwdIter2 dest, Cond cond)
+    in_out_result<InIter1, FwdIter2>
+    sequential_uninitialized_copy(InIter1 first, FwdIter2 dest, Cond cond)
     {
         using value_type = typename std::iterator_traits<FwdIter2>::value_type;
 
@@ -246,9 +246,9 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename InIter1, typename InIter2>
-    in_out_result<InIter1, InIter2> sequential_uninitialized_copy_n(
-        InIter1 first, std::size_t count, InIter2 dest,
-        util::cancellation_token<util::detail::no_data>& tok)
+    in_out_result<InIter1, InIter2>
+    sequential_uninitialized_copy_n(InIter1 first, std::size_t count,
+        InIter2 dest, util::cancellation_token<util::detail::no_data>& tok)
     {
         using value_type = typename std::iterator_traits<InIter2>::value_type;
 
@@ -328,8 +328,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter1, typename Sent,
             typename FwdIter2>
-        static in_out_result<InIter1, FwdIter2> sequential(
-            ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
+        static in_out_result<InIter1, FwdIter2>
+        sequential(ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
         {
             return sequential_uninitialized_copy(
                 first, dest, [last](InIter1 first, FwdIter2) -> bool {
@@ -403,8 +403,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename InIter, typename FwdIter2>
-        static in_out_result<InIter, FwdIter2> sequential(
-            ExPolicy, InIter first, std::size_t count, FwdIter2 dest)
+        static in_out_result<InIter, FwdIter2>
+        sequential(ExPolicy, InIter first, std::size_t count, FwdIter2 dest)
         {
             using value_type =
                 typename std::iterator_traits<FwdIter2>::value_type;

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_default_construct.hpp
@@ -296,8 +296,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Sent>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last)
         {
             return parallel_sequential_uninitialized_default_construct_n(
                 PIKA_FORWARD(ExPolicy, policy), first,
@@ -313,8 +313,8 @@ namespace pika::parallel::detail {
     // provide our own implementation of std::uninitialized_default_construct as some
     // versions of MSVC horribly fail at compiling it for some types T
     template <typename InIter>
-    InIter std_uninitialized_default_construct_n(
-        InIter first, std::size_t count)
+    InIter
+    std_uninitialized_default_construct_n(InIter first, std::size_t count)
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
 
@@ -354,8 +354,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, std::size_t count)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, std::size_t count)
         {
             return parallel_sequential_uninitialized_default_construct_n(
                 PIKA_FORWARD(ExPolicy, policy), first, count);
@@ -424,9 +424,9 @@ namespace pika {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            pika::uninitialized_default_construct_n_t, FwdIter first,
-            Size count)
+        friend FwdIter
+        tag_fallback_invoke(pika::uninitialized_default_construct_n_t,
+            FwdIter first, Size count)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_fill.hpp
@@ -297,8 +297,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Sent, typename T>
-        static typename algorithm_result<ExPolicy, Iter>::type parallel(
-            ExPolicy&& policy, Iter first, Sent last, T const& value)
+        static typename algorithm_result<ExPolicy, Iter>::type
+        parallel(ExPolicy&& policy, Iter first, Sent last, T const& value)
         {
             if (first == last)
                 return algorithm_result<ExPolicy, Iter>::get(PIKA_MOVE(first));
@@ -351,8 +351,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename T>
-        static Iter sequential(
-            ExPolicy, Iter first, std::size_t count, T const& value)
+        static Iter
+        sequential(ExPolicy, Iter first, std::size_t count, T const& value)
         {
             return std_uninitialized_fill_n(first, count, value);
         }

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_move.hpp
@@ -224,8 +224,8 @@ namespace pika::parallel::detail {
     /// \cond NOINTERNAL
     ///////////////////////////////////////////////////////////////////////
     template <typename InIter1, typename FwdIter2, typename Cond>
-    in_out_result<InIter1, FwdIter2> sequential_uninitialized_move(
-        InIter1 first, FwdIter2 dest, Cond cond)
+    in_out_result<InIter1, FwdIter2>
+    sequential_uninitialized_move(InIter1 first, FwdIter2 dest, Cond cond)
     {
         using value_type = typename std::iterator_traits<FwdIter2>::value_type;
 
@@ -251,9 +251,9 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename InIter1, typename InIter2>
-    in_out_result<InIter1, InIter2> sequential_uninitialized_move_n(
-        InIter1 first, std::size_t count, InIter2 dest,
-        util::cancellation_token<util::detail::no_data>& tok)
+    in_out_result<InIter1, InIter2>
+    sequential_uninitialized_move_n(InIter1 first, std::size_t count,
+        InIter2 dest, util::cancellation_token<util::detail::no_data>& tok)
     {
         using value_type = typename std::iterator_traits<InIter2>::value_type;
 
@@ -332,8 +332,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter1, typename Sent,
             typename FwdIter2>
-        static in_out_result<InIter1, FwdIter2> sequential(
-            ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
+        static in_out_result<InIter1, FwdIter2>
+        sequential(ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
         {
             return sequential_uninitialized_move(
                 first, dest, [last](InIter1 first, FwdIter2) -> bool {
@@ -401,8 +401,8 @@ namespace pika::parallel::detail {
     // provide our own implementation of std::uninitialized_move_n as some
     // versions of MSVC horribly fail at compiling it for some types T
     template <typename InIter1, typename InIter2>
-    in_out_result<InIter1, InIter2> std_uninitialized_move_n(
-        InIter1 first, std::size_t count, InIter2 d_first)
+    in_out_result<InIter1, InIter2>
+    std_uninitialized_move_n(InIter1 first, std::size_t count, InIter2 d_first)
     {
         using value_type = typename std::iterator_traits<InIter2>::value_type;
 
@@ -435,8 +435,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename InIter1, typename InIter2>
-        static IterPair sequential(
-            ExPolicy, InIter1 first, std::size_t count, InIter2 dest)
+        static IterPair
+        sequential(ExPolicy, InIter1 first, std::size_t count, InIter2 dest)
         {
             return std_uninitialized_move_n(first, count, dest);
         }
@@ -518,9 +518,9 @@ namespace pika {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend std::pair<InIter, FwdIter> tag_fallback_invoke(
-            pika::uninitialized_move_n_t, InIter first, Size count,
-            FwdIter dest)
+        friend std::pair<InIter, FwdIter>
+        tag_fallback_invoke(pika::uninitialized_move_n_t, InIter first,
+            Size count, FwdIter dest)
         {
             static_assert(pika::traits::is_input_iterator<InIter>::value,
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/uninitialized_value_construct.hpp
@@ -298,8 +298,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy, typename Sent>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last)
         {
             return parallel_sequential_uninitialized_value_construct_n(
                 PIKA_FORWARD(ExPolicy, policy), first,
@@ -355,8 +355,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename ExPolicy>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, std::size_t count)
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, std::size_t count)
         {
             return parallel_sequential_uninitialized_value_construct_n(
                 PIKA_FORWARD(ExPolicy, policy), first, count);

--- a/libs/pika/algorithms/include/pika/parallel/algorithms/unique.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/algorithms/unique.hpp
@@ -497,8 +497,8 @@ namespace pika::parallel::detail {
 
     // sequential unique with projection function
     template <typename FwdIter, typename Sent, typename Pred, typename Proj>
-    FwdIter sequential_unique(
-        FwdIter first, Sent last, Pred&& pred, Proj&& proj)
+    FwdIter
+    sequential_unique(FwdIter first, Sent last, Pred&& pred, Proj&& proj)
     {
         if (first == last)
             return first;
@@ -531,8 +531,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename InIter, typename Sent,
             typename Pred, typename Proj>
-        static InIter sequential(
-            ExPolicy, InIter first, Sent last, Pred&& pred, Proj&& proj)
+        static InIter
+        sequential(ExPolicy, InIter first, Sent last, Pred&& pred, Proj&& proj)
         {
             return sequential_unique(first, last, PIKA_FORWARD(Pred, pred),
                 PIKA_FORWARD(Proj, proj));
@@ -540,8 +540,8 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename Pred, typename Proj>
-        static typename algorithm_result<ExPolicy, FwdIter>::type parallel(
-            ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        static typename algorithm_result<ExPolicy, FwdIter>::type
+        parallel(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
             Proj&& proj)
         {
             using zip_iterator = pika::util::zip_iterator<FwdIter, bool*>;
@@ -943,9 +943,9 @@ namespace pika {
                     parallel::detail::projected<Proj, InIter>>::value
             )>
         // clang-format on
-        friend OutIter tag_fallback_invoke(pika::unique_copy_t, InIter first,
-            InIter last, OutIter dest, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend OutIter
+        tag_fallback_invoke(pika::unique_copy_t, InIter first, InIter last,
+            OutIter dest, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/adjacent_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/adjacent_difference.hpp
@@ -173,8 +173,8 @@ namespace pika { namespace ranges {
     template <typename Rng,
         typename Proj = pika::parallel::detail::projection_identity,
         typename Pred = detail::equal_to>
-    typename pika::traits::range_traits<Rng>::iterator_type adjacent_difference(
-        ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+    typename pika::traits::range_traits<Rng>::iterator_type
+    adjacent_difference(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
         Proj&& proj = Proj());
 
     /// Searches the range rng for two consecutive identical elements.

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/adjacent_find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/adjacent_find.hpp
@@ -174,8 +174,8 @@ namespace pika { namespace ranges {
     template <typename Rng,
         typename Proj = pika::parallel::detail::projection_identity,
         typename Pred = detail::equal_to>
-    typename pika::traits::range_traits<Rng>::iterator_type adjacent_find(
-        ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+    typename pika::traits::range_traits<Rng>::iterator_type
+    adjacent_find(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
         Proj&& proj = Proj());
 
     /// Searches the range rng for two consecutive identical elements.
@@ -289,9 +289,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(pika::ranges::adjacent_find_t,
-            FwdIter first, Sent last, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::adjacent_find_t, FwdIter first,
+            Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return pika::parallel::detail::adjacent_find<FwdIter, FwdIter>()
                 .call(pika::execution::seq, first, last,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/all_any_none.hpp
@@ -309,8 +309,8 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            none_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        friend bool
+        tag_fallback_invoke(none_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
         {
             using iterator_type =
                 typename pika::traits::range_iterator<Rng>::type;
@@ -421,8 +421,8 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            any_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        friend bool
+        tag_fallback_invoke(any_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
         {
             using iterator_type =
                 typename pika::traits::range_iterator<Rng>::type;
@@ -533,8 +533,8 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(
-            all_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        friend bool
+        tag_fallback_invoke(all_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
         {
             using iterator_type =
                 typename pika::traits::range_iterator<Rng>::type;

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/copy.hpp
@@ -623,9 +623,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend ranges::copy_if_result<FwdIter1, FwdIter> tag_fallback_invoke(
-            pika::ranges::copy_if_t, FwdIter1 iter, Sent1 sent, FwdIter dest,
-            Pred&& pred, Proj&& proj = Proj())
+        friend ranges::copy_if_result<FwdIter1, FwdIter>
+        tag_fallback_invoke(pika::ranges::copy_if_t, FwdIter1 iter, Sent1 sent,
+            FwdIter dest, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/destroy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/destroy.hpp
@@ -248,8 +248,8 @@ namespace pika::ranges {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            destroy_n_t, FwdIter first, Size count)
+        friend FwdIter
+        tag_fallback_invoke(destroy_n_t, FwdIter first, Size count)
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/exclusive_scan.hpp
@@ -63,8 +63,8 @@ namespace pika { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T>
-    exclusive_scan_result<InIter, OutIter> exclusive_scan(
-        InIter first, Sent last, OutIter dest, T init);
+    exclusive_scan_result<InIter, OutIter>
+    exclusive_scan(InIter first, Sent last, OutIter dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -206,8 +206,8 @@ namespace pika { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T,
         typename Op>
-    exclusive_scan_result<InIter, OutIter> exclusive_scan(
-        InIter first, Sent last, OutIter dest, T init, Op&& op);
+    exclusive_scan_result<InIter, OutIter>
+    exclusive_scan(InIter first, Sent last, OutIter dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -344,8 +344,8 @@ namespace pika { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T>
-    exclusive_scan_result<traits::range_iterator_t<Rng>, O> exclusive_scan(
-        Rng&& rng, O dest, T init);
+    exclusive_scan_result<traits::range_iterator_t<Rng>, O>
+    exclusive_scan(Rng&& rng, O dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -477,8 +477,8 @@ namespace pika { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T, typename Op>
-    exclusive_scan_result<traits::range_iterator_t<Rng>, O> exclusive_scan(
-        Rng&& rng, O dest, T init, Op&& op);
+    exclusive_scan_result<traits::range_iterator_t<Rng>, O>
+    exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -609,9 +609,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend exclusive_scan_result<InIter, OutIter> tag_fallback_invoke(
-            pika::ranges::exclusive_scan_t, InIter first, Sent last,
-            OutIter dest, T init, Op&& op = Op())
+        friend exclusive_scan_result<InIter, OutIter>
+        tag_fallback_invoke(pika::ranges::exclusive_scan_t, InIter first,
+            Sent last, OutIter dest, T init, Op&& op = Op())
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/fill.hpp
@@ -177,8 +177,8 @@ namespace pika::ranges {
                 pika::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            fill_t, Rng&& rng, T const& value)
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(fill_t, Rng&& rng, T const& value)
         {
             using iterator_type =
                 typename pika::traits::range_traits<Rng>::iterator_type;
@@ -199,8 +199,8 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend Iter tag_fallback_invoke(
-            fill_t, Iter first, Sent last, T const& value)
+        friend Iter
+        tag_fallback_invoke(fill_t, Iter first, Sent last, T const& value)
         {
             static_assert(pika::traits::is_forward_iterator<Iter>::value,
                 "Requires at least forward iterator.");
@@ -314,8 +314,8 @@ namespace pika::ranges {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            fill_n_t, FwdIter first, Size count, T const& value)
+        friend FwdIter
+        tag_fallback_invoke(fill_n_t, FwdIter first, Size count, T const& value)
         {
             static_assert((pika::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/for_each.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/for_each.hpp
@@ -59,8 +59,8 @@ namespace pika { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename F,
         typename Proj = parallel::detail::projection_identity>
-    pika::ranges::for_each_result<InIter, F> for_each(
-        InIter first, Sent last, F&& f, Proj&& proj = Proj());
+    pika::ranges::for_each_result<InIter, F>
+    for_each(InIter first, Sent last, F&& f, Proj&& proj = Proj());
 
     /// Applies \a f to the result of dereferencing every iterator in the
     /// range [first, last).
@@ -304,8 +304,8 @@ namespace pika { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename F,
         typename Proj = parallel::detail::projection_identity>
-    pika::ranges::for_each_result<InIter, F> for_each(
-        InIter first, Sent last, F&& f, Proj&& proj = Proj());
+    pika::ranges::for_each_result<InIter, F>
+    for_each(InIter first, Sent last, F&& f, Proj&& proj = Proj());
 
     /// Applies \a f to the result of dereferencing every iterator in the range
     /// [first, first + count), starting from first and proceeding to
@@ -412,9 +412,9 @@ namespace pika::ranges {
                     pika::execution::sequenced_policy, F,
                     pika::parallel::detail::projected<Proj, InIter>>::value)>
         // clang-format on
-        friend for_each_result<InIter, F> tag_fallback_invoke(
-            pika::ranges::for_each_t, InIter first, Sent last, F&& f,
-            Proj&& proj = Proj())
+        friend for_each_result<InIter, F>
+        tag_fallback_invoke(pika::ranges::for_each_t, InIter first, Sent last,
+            F&& f, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_forward_iterator<InIter>::value),
                 "Requires at least forward iterator.");
@@ -521,9 +521,9 @@ namespace pika::ranges {
                     pika::execution::sequenced_policy, F,
                     pika::parallel::detail::projected<Proj, InIter>>::value)>
         // clang-format on
-        friend for_each_n_result<InIter, F> tag_fallback_invoke(
-            pika::ranges::for_each_n_t, InIter first, Size count, F&& f,
-            Proj&& proj = Proj())
+        friend for_each_n_result<InIter, F>
+        tag_fallback_invoke(pika::ranges::for_each_n_t, InIter first,
+            Size count, F&& f, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<InIter>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/for_loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/for_loop.hpp
@@ -179,8 +179,8 @@ namespace pika { namespace ranges {
     ///           otherwise.
     ///
     template <typename ExPolicy, typename Iter, typename Sent, typename... Args>
-    typename pika::parallel::detail::algorithm_result<ExPolicy>::type for_loop(
-        ExPolicy&& policy, Iter first, Sent last, Args&&... args);
+    typename pika::parallel::detail::algorithm_result<ExPolicy>::type
+    for_loop(ExPolicy&& policy, Iter first, Sent last, Args&&... args);
 
     /// The for_loop implements loop functionality over a range specified by
     /// a range. These algorithms resemble for_each from the
@@ -347,8 +347,8 @@ namespace pika { namespace ranges {
     ///           otherwise.
     ///
     template <typename ExPolicy, typename Rng, typename... Args>
-    typename pika::parallel::detail::algorithm_result<ExPolicy>::type for_loop(
-        ExPolicy&& policy, Rng&& rng, Args&&... args);
+    typename pika::parallel::detail::algorithm_result<ExPolicy>::type
+    for_loop(ExPolicy&& policy, Rng&& rng, Args&&... args);
 
     /// The for_loop_strided implements loop functionality over a range specified by
     /// iterator bounds. These algorithms resemble for_each from the
@@ -806,8 +806,8 @@ namespace pika::ranges {
                 pika::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            pika::ranges::for_loop_t, Rng&& rng, Args&&... args)
+        friend void
+        tag_fallback_invoke(pika::ranges::for_loop_t, Rng&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/generate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/generate.hpp
@@ -273,8 +273,8 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend Iter tag_fallback_invoke(
-            generate_t, Iter first, Sent last, F&& f)
+        friend Iter
+        tag_fallback_invoke(generate_t, Iter first, Sent last, F&& f)
         {
             static_assert(pika::traits::is_forward_iterator<Iter>::value,
                 "Required at least forward iterator.");
@@ -322,8 +322,8 @@ namespace pika::ranges {
                 pika::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            generate_n_t, FwdIter first, Size count, F&& f)
+        friend FwdIter
+        tag_fallback_invoke(generate_n_t, FwdIter first, Size count, F&& f)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/inclusive_scan.hpp
@@ -895,9 +895,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend inclusive_scan_result<InIter, OutIter> tag_fallback_invoke(
-            pika::ranges::inclusive_scan_t, InIter first, Sent last,
-            OutIter dest, Op&& op = Op())
+        friend inclusive_scan_result<InIter, OutIter>
+        tag_fallback_invoke(pika::ranges::inclusive_scan_t, InIter first,
+            Sent last, OutIter dest, Op&& op = Op())
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
@@ -1016,9 +1016,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend inclusive_scan_result<InIter, OutIter> tag_fallback_invoke(
-            pika::ranges::inclusive_scan_t, InIter first, Sent last,
-            OutIter dest, Op&& op, T init)
+        friend inclusive_scan_result<InIter, OutIter>
+        tag_fallback_invoke(pika::ranges::inclusive_scan_t, InIter first,
+            Sent last, OutIter dest, Op&& op, T init)
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/is_sorted.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/is_sorted.hpp
@@ -406,8 +406,8 @@ namespace pika { namespace ranges {
     ///
     template <typename Rng, typename Pred = pika::parallel::detail::less,
         typename Proj = pika::parallel::detail::projection_identity>
-    typename pika::traits::range_iterator<Rng>::type is_sorted_until(
-        ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+    typename pika::traits::range_iterator<Rng>::type
+    is_sorted_until(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
         Proj&& proj = Proj());
 
     /// Returns the first element in the range rng that is not sorted.
@@ -520,9 +520,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(pika::ranges::is_sorted_t,
-            FwdIter first, Sent last, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend bool
+        tag_fallback_invoke(pika::ranges::is_sorted_t, FwdIter first, Sent last,
+            Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return pika::parallel::detail::is_sorted<FwdIter, Sent>().call(
                 pika::execution::seq, first, last, PIKA_FORWARD(Pred, pred),
@@ -628,9 +628,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(pika::ranges::is_sorted_until_t,
-            FwdIter first, Sent last, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::is_sorted_until_t, FwdIter first,
+            Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return pika::parallel::detail::is_sorted_until<FwdIter, Sent>()
                 .call(pika::execution::seq, first, last,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/minmax.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/minmax.hpp
@@ -65,8 +65,8 @@ namespace pika {
     ///
     template <typename FwdIter, typename Sent, typename F,
         typename Proj = pika::parallel::detail::projection_identity>
-    FwdIter min_element(
-        FwdIter first, Sent last, F&& f = F(), Proj&& proj = Proj());
+    FwdIter
+    min_element(FwdIter first, Sent last, F&& f = F(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
     /// Finds the smallest element in the range [first, last) using the given
@@ -115,8 +115,8 @@ namespace pika {
     ///
     template <typename Rng, typename F,
         typename Proj = pika::parallel::detail::projection_identity>
-    pika::traits::range_iterator_t<Rng> min_element(
-        Rng&& rng, F&& f = F(), Proj&& proj = Proj());
+    pika::traits::range_iterator_t<Rng>
+    min_element(Rng&& rng, F&& f = F(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
     /// Finds the smallest element in the range [first, last) using the given
@@ -315,8 +315,8 @@ namespace pika {
     ///
     template <typename FwdIter, typename Sent, typename F,
         typename Proj = pika::parallel::detail::projection_identity>
-    FwdIter max_element(
-        FwdIter first, Sent sent, F&& f = F(), Proj&& proj = Proj());
+    FwdIter
+    max_element(FwdIter first, Sent sent, F&& f = F(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
     /// Finds the greatest element in the range [first, last) using the given
@@ -366,8 +366,8 @@ namespace pika {
     ///
     template <typename Rng, typename F,
         typename Proj = pika::parallel::detail::projection_identity>
-    pika::traits::range_iterator_t<Rng> max_element(
-        Rng&& rng, F&& f = F(), Proj&& proj = Proj());
+    pika::traits::range_iterator_t<Rng>
+    max_element(Rng&& rng, F&& f = F(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
     /// Finds the greatest element in the range [first, last) using the given
@@ -572,8 +572,8 @@ namespace pika {
     ///
     template <typename FwdIter, typename Sent, typename F,
         typename Proj = pika::parallel::detail::projection_identity>
-    minmax_element_result<FwdIter, FwdIter> minmax_element(
-        FwdIter first, Sent last, F&& f = F(), Proj&& proj = Proj());
+    minmax_element_result<FwdIter, FwdIter>
+    minmax_element(FwdIter first, Sent last, F&& f = F(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
     /// Finds the greatest element in the range [first, last) using the given
@@ -849,8 +849,8 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::min_element_t, Rng&& rng, F&& f = F(),
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::min_element_t, Rng&& rng, F&& f = F(),
             Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_forward_iterator_v<
@@ -970,8 +970,8 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::max_element_t, Rng&& rng, F&& f = F(),
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::max_element_t, Rng&& rng, F&& f = F(),
             Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_forward_iterator_v<
@@ -1066,9 +1066,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend minmax_element_result<FwdIter> tag_fallback_invoke(
-            pika::ranges::minmax_element_t, FwdIter first, Sent last,
-            F&& f = F(), Proj&& proj = Proj())
+        friend minmax_element_result<FwdIter>
+        tag_fallback_invoke(pika::ranges::minmax_element_t, FwdIter first,
+            Sent last, F&& f = F(), Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_forward_iterator_v<FwdIter>),
                 "Required at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/mismatch.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/mismatch.hpp
@@ -331,9 +331,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend mismatch_result<Iter1, Iter2> tag_fallback_invoke(mismatch_t,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        friend mismatch_result<Iter1, Iter2>
+        tag_fallback_invoke(mismatch_t, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             static_assert((pika::traits::is_forward_iterator<Iter1>::value),

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/move.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/move.hpp
@@ -199,8 +199,8 @@ namespace pika::ranges {
                 pika::traits::is_iterator<Iter2>::value
             )>
         // clang-format on
-        friend move_result<Iter1, Iter2> tag_fallback_invoke(
-            move_t, Iter1 first, Sent1 last, Iter2 dest)
+        friend move_result<Iter1, Iter2>
+        tag_fallback_invoke(move_t, Iter1 first, Sent1 last, Iter2 dest)
         {
             return pika::parallel::detail::transfer<
                 pika::parallel::detail::move_algo<Iter1, Iter2>>(

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/nth_element.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/nth_element.hpp
@@ -318,9 +318,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend RandomIt tag_fallback_invoke(pika::ranges::nth_element_t,
-            RandomIt first, RandomIt nth, Sent last, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend RandomIt
+        tag_fallback_invoke(pika::ranges::nth_element_t, RandomIt first,
+            RandomIt nth, Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_random_access_iterator_v<RandomIt>,
                 "Requires at least random access iterator.");
@@ -373,8 +373,8 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::nth_element_t, Rng&& rng,
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::nth_element_t, Rng&& rng,
             pika::traits::range_iterator_t<Rng> nth, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/partial_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/partial_sort.hpp
@@ -349,8 +349,8 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::partial_sort_t, Rng&& rng,
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::partial_sort_t, Rng&& rng,
             pika::traits::range_iterator_t<Rng> middle,
             Compare&& comp = Compare(), Proj&& proj = Proj())
         {

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/partial_sort_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/partial_sort_copy.hpp
@@ -366,9 +366,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend partial_sort_copy_result<InIter, RandIter> tag_fallback_invoke(
-            pika::ranges::partial_sort_copy_t, InIter first, Sent1 last,
-            RandIter r_first, Sent2 r_last, Comp&& comp = Comp(),
+        friend partial_sort_copy_result<InIter, RandIter>
+        tag_fallback_invoke(pika::ranges::partial_sort_copy_t, InIter first,
+            Sent1 last, RandIter r_first, Sent2 r_last, Comp&& comp = Comp(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/partition.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/partition.hpp
@@ -995,9 +995,9 @@ namespace pika::ranges {
                     parallel::detail::projected<Proj, FwdIter>>
         )>
         // clang-format on
-        friend subrange_t<FwdIter> tag_fallback_invoke(
-            pika::ranges::partition_t, FwdIter first, Sent last, Pred&& pred,
-            Proj&& proj = Proj())
+        friend subrange_t<FwdIter>
+        tag_fallback_invoke(pika::ranges::partition_t, FwdIter first, Sent last,
+            Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
@@ -1117,9 +1117,9 @@ namespace pika::ranges {
                     parallel::detail::projected<Proj, BidirIter>>
         )>
         // clang-format on
-        friend subrange_t<BidirIter> tag_fallback_invoke(
-            pika::ranges::stable_partition_t, BidirIter first, Sent last,
-            Pred&& pred, Proj&& proj = Proj())
+        friend subrange_t<BidirIter>
+        tag_fallback_invoke(pika::ranges::stable_partition_t, BidirIter first,
+            Sent last, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_bidirectional_iterator_v<BidirIter>,
                 "Requires at least bidirectional iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/reduce.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/reduce.hpp
@@ -598,8 +598,8 @@ namespace pika::ranges {
                 pika::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend T tag_fallback_invoke(
-            pika::ranges::reduce_t, Rng&& rng, T init, F&& f)
+        friend T
+        tag_fallback_invoke(pika::ranges::reduce_t, Rng&& rng, T init, F&& f)
         {
             static_assert(
                 pika::traits::is_input_iterator<typename pika::traits::

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove.hpp
@@ -51,8 +51,8 @@ namespace pika { namespace ranges {
     ///
     template <typename FwdIter, typename Sent, typename T,
         typename Proj = parallel::detail::projection_identity>
-    subrange_t<FwdIter, Sent> remove(
-        FwdIter first, Sent last, T const& value, Proj&& proj = Proj());
+    subrange_t<FwdIter, Sent>
+    remove(FwdIter first, Sent last, T const& value, Proj&& proj = Proj());
 
     /// Removes all elements that are equal to \a value from the range
     /// [first, last) and and returns a subrange [ret, last), where ret
@@ -149,8 +149,8 @@ namespace pika { namespace ranges {
     ///
     template <typename Rng, typename T,
         typename Proj = parallel::detail::projection_identity>
-    subrange_t<typename pika::traits::range_iterator<Rng>::type> remove(
-        Rng&& rng, T const& value, Proj&& proj = Proj());
+    subrange_t<typename pika::traits::range_iterator<Rng>::type>
+    remove(Rng&& rng, T const& value, Proj&& proj = Proj());
 
     /// Removes all elements that are equal to \a value from the range
     /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
@@ -262,8 +262,8 @@ namespace pika { namespace ranges {
     ///
     template <typename FwdIter, typename Sent, typename Pred,
         typename Proj = pika::parallel::detail::projection_identity>
-    subrange_t<FwdIter, Sent> remove_if(
-        FwdIter first, Sent sent, Pred&& pred, Proj&& proj = Proj());
+    subrange_t<FwdIter, Sent>
+    remove_if(FwdIter first, Sent sent, Pred&& pred, Proj&& proj = Proj());
 
     /// Removes all elements for which predicate \a pred returns true
     /// from the range [first, last) and returns a subrange [ret, last),
@@ -388,8 +388,8 @@ namespace pika { namespace ranges {
     ///
     template <typename Rng, typename T,
         typename Proj = parallel::detail::projection_identity>
-    subrange_t<typename pika::traits::range_iterator<Rng>::type> remove_if(
-        Rng&& rng, Pred&& pred, Proj&& proj = Proj());
+    subrange_t<typename pika::traits::range_iterator<Rng>::type>
+    remove_if(Rng&& rng, Pred&& pred, Proj&& proj = Proj());
 
     /// Removes all elements that are equal to \a value from the range
     /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
@@ -503,9 +503,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend subrange_t<Iter, Sent> tag_fallback_invoke(
-            pika::ranges::remove_if_t, Iter first, Sent sent, Pred&& pred,
-            Proj&& proj = Proj())
+        friend subrange_t<Iter, Sent>
+        tag_fallback_invoke(pika::ranges::remove_if_t, Iter first, Sent sent,
+            Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");
@@ -627,9 +627,9 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend subrange_t<Iter, Sent> tag_fallback_invoke(
-            pika::ranges::remove_t, Iter first, Sent last, T const& value,
-            Proj&& proj = Proj())
+        friend subrange_t<Iter, Sent>
+        tag_fallback_invoke(pika::ranges::remove_t, Iter first, Sent last,
+            T const& value, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/remove_copy.hpp
@@ -614,9 +614,9 @@ namespace pika::ranges {
                 >
             )>
         // clang-format on
-        friend remove_copy_if_result<I, O> tag_fallback_invoke(
-            pika::ranges::remove_copy_if_t, I first, Sent last, O dest,
-            Pred&& pred, Proj&& proj = Proj())
+        friend remove_copy_if_result<I, O>
+        tag_fallback_invoke(pika::ranges::remove_copy_if_t, I first, Sent last,
+            O dest, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<I>::value),
                 "Required input iterator.");
@@ -744,9 +744,9 @@ namespace pika::ranges {
                 pika::parallel::detail::is_projected<Proj, I>::value
             )>
         // clang-format on
-        friend remove_copy_result<I, O> tag_fallback_invoke(
-            pika::ranges::remove_copy_t, I first, Sent last, O dest,
-            T const& value, Proj&& proj = Proj())
+        friend remove_copy_result<I, O>
+        tag_fallback_invoke(pika::ranges::remove_copy_t, I first, Sent last,
+            O dest, T const& value, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<I>::value),
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/replace.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/replace.hpp
@@ -543,9 +543,9 @@ namespace pika { namespace ranges {
     template <typename Initer, typename Sent, typename OutIter, typename T1,
         typename T2,
         typename Proj = pika::parallel::detail::projection_identity>
-    replace_copy_result<InIter, OutIter> replace_copy(InIter first, Sent sent,
-        OutIter dest, T1 const& old_value, T2 const& new_value,
-        Proj&& proj = Proj());
+    replace_copy_result<InIter, OutIter>
+    replace_copy(InIter first, Sent sent, OutIter dest, T1 const& old_value,
+        T2 const& new_value, Proj&& proj = Proj());
 
     /// Copies the all elements from the range rbg to another range
     /// beginning at \a dest replacing all elements satisfying a specific
@@ -818,9 +818,9 @@ namespace pika { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter, typename Pred,
         typename T, typename Proj = pika::parallel::detail::projection_identity>
-    replace_copy_if_result<InIter, OutIter> replace_copy_if(InIter first,
-        Sent sent, OutIter dest, Pred&& pred, T const& new_value,
-        Proj&& proj = Proj());
+    replace_copy_if_result<InIter, OutIter>
+    replace_copy_if(InIter first, Sent sent, OutIter dest, Pred&& pred,
+        T const& new_value, Proj&& proj = Proj());
 
     /// Copies the all elements from the range rng to another range
     /// beginning at \a dest replacing all elements satisfying a specific
@@ -1233,9 +1233,9 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend Iter tag_fallback_invoke(pika::ranges::replace_t, Iter first,
-            Sent sent, T1 const& old_value, T2 const& new_value,
-            Proj&& proj = Proj())
+        friend Iter
+        tag_fallback_invoke(pika::ranges::replace_t, Iter first, Sent sent,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
         {
             static_assert((pika::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/reverse.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/reverse.hpp
@@ -198,8 +198,8 @@ namespace pika { namespace ranges {
     ///           copied.
     ///
     template <typename Iter, typename Sent, typename OutIter>
-    reverse_copy_result<Iter, OutIter> reverse_copy(
-        Iter first, Sent last, OutIter result);
+    reverse_copy_result<Iter, OutIter>
+    reverse_copy(Iter first, Sent last, OutIter result);
 
     /// Uses \a rng as the source range, as if using \a util::begin(rng) as
     /// \a first and \a ranges::end(rng) as \a last.
@@ -399,8 +399,8 @@ namespace pika::ranges {
             pika::traits::is_sentinel_for<Sent, Iter>::value
         )>
         // clang-format on
-        friend Iter tag_fallback_invoke(
-            pika::ranges::reverse_t, Iter first, Sent sent)
+        friend Iter
+        tag_fallback_invoke(pika::ranges::reverse_t, Iter first, Sent sent)
         {
             static_assert(
                 (pika::traits::is_bidirectional_iterator<Iter>::value),

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/rotate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/rotate.hpp
@@ -227,8 +227,8 @@ namespace pika { namespace ranges {
     ///           the element past the last element copied.
     ///
     template <typename FwdIter, typename Sent, typename OutIter>
-    rotate_copy_result<FwdIter, OutIter> rotate_copy(
-        FwdIter first, FwdIter middle, Sent last, OutIter dest_first);
+    rotate_copy_result<FwdIter, OutIter>
+    rotate_copy(FwdIter first, FwdIter middle, Sent last, OutIter dest_first);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Copies the elements from the range [first, last), to another range
@@ -518,9 +518,9 @@ namespace pika::ranges {
                 pika::traits::is_iterator_v<OutIter>
             )>
         // clang-format on
-        friend rotate_copy_result<FwdIter, OutIter> tag_fallback_invoke(
-            pika::ranges::rotate_copy_t, FwdIter first, FwdIter middle,
-            Sent last, OutIter dest_first)
+        friend rotate_copy_result<FwdIter, OutIter>
+        tag_fallback_invoke(pika::ranges::rotate_copy_t, FwdIter first,
+            FwdIter middle, Sent last, OutIter dest_first)
         {
             static_assert((pika::traits::is_forward_iterator_v<FwdIter>),
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/search.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/search.hpp
@@ -277,9 +277,9 @@ namespace pika::ranges {
         typename Pred = pika::ranges::equal_to,
         typename Proj1 = pika::parallel::detail::projection_identity,
         typename Proj2 = pika::parallel::detail::projection_identity>
-    typename pika::traits::range_iterator<Rng1>::type search(Rng1&& rng1,
-        Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2());
+    typename pika::traits::range_iterator<Rng1>::type
+    search(Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
     /// Uses a provided predicate to compare elements.
@@ -527,10 +527,10 @@ namespace pika::ranges {
         typename Sent2, typename Pred = pika::ranges::equal_to,
         typename Proj1 = pika::parallel::detail::projection_identity,
         typename Proj2 = pika::parallel::detail::projection_identity>
-    typename algorithm_result<ExPolicy, FwdIter>::type search_n(
-        ExPolicy&& policy, FwdIter first, std::size_t count, FwdIter2 s_first,
-        Sent2 s_last, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2());
+    typename algorithm_result<ExPolicy, FwdIter>::type
+    search_n(ExPolicy&& policy, FwdIter first, std::size_t count,
+        FwdIter2 s_first, Sent2 s_last, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
     /// Uses a provided predicate to compare elements.
@@ -600,8 +600,8 @@ namespace pika::ranges {
         typename Pred = pika::ranges::equal_to,
         typename Proj1 = pika::parallel::detail::projection_identity,
         typename Proj2 = pika::parallel::detail::projection_identity>
-    typename pika::traits::range_iterator<Rng1>::type search_n(Rng1&& rng1,
-        std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
+    typename pika::traits::range_iterator<Rng1>::type
+    search_n(Rng1&& rng1, std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
         Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
     /// Searches the range [first, last) for any elements in the range [s_first, s_last).
@@ -718,10 +718,10 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(pika::ranges::search_t,
-            FwdIter first, Sent last, FwdIter2 s_first, Sent2 s_last,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::search_t, FwdIter first, Sent last,
+            FwdIter2 s_first, Sent2 s_last, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             return pika::parallel::detail::search<FwdIter, Sent>().call(
                 pika::execution::seq, first, last, s_first, s_last,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_difference.hpp
@@ -392,9 +392,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend set_difference_result<Iter1, Iter3> tag_fallback_invoke(
-            set_difference_t, Iter1 first1, Sent1 last1, Iter2 first2,
-            Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        friend set_difference_result<Iter1, Iter3>
+        tag_fallback_invoke(set_difference_t, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((pika::traits::is_input_iterator<Iter1>::value),

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_intersection.hpp
@@ -396,9 +396,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend set_intersection_result<Iter1, Iter2, Iter3> tag_fallback_invoke(
-            set_intersection_t, Iter1 first1, Sent1 last1, Iter2 first2,
-            Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        friend set_intersection_result<Iter1, Iter2, Iter3>
+        tag_fallback_invoke(set_intersection_t, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((pika::traits::is_input_iterator<Iter1>::value),

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_union.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/set_union.hpp
@@ -395,10 +395,10 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend set_union_result<Iter1, Iter2, Iter3> tag_fallback_invoke(
-            set_union_t, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
-            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        friend set_union_result<Iter1, Iter2, Iter3>
+        tag_fallback_invoke(set_union_t, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((pika::traits::is_input_iterator<Iter1>::value),
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/shift_left.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/shift_left.hpp
@@ -254,8 +254,8 @@ namespace pika::ranges {
                 pika::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::shift_left_t, Rng&& rng, Size n)
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::shift_left_t, Rng&& rng, Size n)
         {
             static_assert(pika::traits::is_forward_iterator_v<
                               pika::traits::range_iterator_t<Rng>>,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/shift_right.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/shift_right.hpp
@@ -254,8 +254,8 @@ namespace pika::ranges {
                 pika::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend pika::traits::range_iterator_t<Rng> tag_fallback_invoke(
-            pika::ranges::shift_right_t, Rng&& rng, Size n)
+        friend pika::traits::range_iterator_t<Rng>
+        tag_fallback_invoke(pika::ranges::shift_right_t, Rng&& rng, Size n)
         {
             static_assert(pika::traits::is_forward_iterator_v<
                               pika::traits::range_iterator_t<Rng>>,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/sort.hpp
@@ -304,9 +304,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend RandomIt tag_fallback_invoke(pika::ranges::sort_t,
-            RandomIt first, Sent last, Comp&& comp = Comp(),
-            Proj&& proj = Proj())
+        friend RandomIt
+        tag_fallback_invoke(pika::ranges::sort_t, RandomIt first, Sent last,
+            Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert(
                 pika::traits::is_random_access_iterator<RandomIt>::value,

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/stable_sort.hpp
@@ -304,9 +304,9 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend RandomIt tag_fallback_invoke(pika::ranges::stable_sort_t,
-            RandomIt first, Sent last, Comp&& comp = Comp(),
-            Proj&& proj = Proj())
+        friend RandomIt
+        tag_fallback_invoke(pika::ranges::stable_sort_t, RandomIt first,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_random_access_iterator_v<RandomIt>,
                 "Requires a random access iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/starts_with.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/starts_with.hpp
@@ -311,10 +311,10 @@ namespace pika::ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(pika::ranges::starts_with_t,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
-            Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        friend bool
+        tag_fallback_invoke(pika::ranges::starts_with_t, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Pred&& pred = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert(pika::traits::is_input_iterator_v<Iter1>,
                 "Required at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/swap_ranges.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/swap_ranges.hpp
@@ -247,9 +247,9 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent2, InIter2>::value
             )>
         // clang-format on
-        friend swap_ranges_result<InIter1, InIter2> tag_fallback_invoke(
-            pika::ranges::swap_ranges_t, InIter1 first1, Sent1 last1,
-            InIter2 first2, Sent2 last2)
+        friend swap_ranges_result<InIter1, InIter2>
+        tag_fallback_invoke(pika::ranges::swap_ranges_t, InIter1 first1,
+            Sent1 last1, InIter2 first2, Sent2 last2)
         {
             static_assert(pika::traits::is_input_iterator_v<InIter1>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/transform_reduce.hpp
@@ -568,8 +568,8 @@ namespace pika::ranges {
                 pika::traits::is_iterator<Iter2>::value
             )>
         // clang-format on
-        friend T tag_fallback_invoke(
-            transform_reduce_t, Rng&& rng, Iter2 first2, T init)
+        friend T
+        tag_fallback_invoke(transform_reduce_t, Rng&& rng, Iter2 first2, T init)
         {
             using iterator_type =
                 typename pika::traits::range_iterator<Rng>::type;

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_copy.hpp
@@ -51,8 +51,8 @@ namespace pika { namespace ranges {
     ///           the last element copied.
     ///
     template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
-    pika::parallel::detail::in_out_result<InIter, FwdIter> uninitialized_copy(
-        InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
+    pika::parallel::detail::in_out_result<InIter, FwdIter>
+    uninitialized_copy(InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
 
     /// Copies the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_default_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_default_construct.hpp
@@ -285,9 +285,9 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            pika::ranges::uninitialized_default_construct_t, FwdIter first,
-            Sent last)
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::uninitialized_default_construct_t,
+            FwdIter first, Sent last)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");
@@ -377,9 +377,9 @@ namespace pika::ranges {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            pika::ranges::uninitialized_default_construct_n_t, FwdIter first,
-            Size count)
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::uninitialized_default_construct_n_t,
+            FwdIter first, Size count)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_fill.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_fill.hpp
@@ -118,8 +118,8 @@ namespace pika { namespace ranges {
     ///           the last element copied.
     ///
     template <typename Rng, typename T>
-    typename pika::traits::range_traits<Rng>::iterator_type uninitialized_fill(
-        Rng&& rng, T const& value);
+    typename pika::traits::range_traits<Rng>::iterator_type
+    uninitialized_fill(Rng&& rng, T const& value);
 
     /// Copies the given \a value to an uninitialized memory area, defined by
     /// the range [first, last). If an exception is thrown during the

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_move.hpp
@@ -52,8 +52,8 @@ namespace pika { namespace ranges {
     ///           the last element moved.
     ///
     template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
-    pika::parallel::detail::in_out_result<InIter, FwdIter> uninitialized_move(
-        InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
+    pika::parallel::detail::in_out_result<InIter, FwdIter>
+    uninitialized_move(InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
 
     /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_value_construct.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/uninitialized_value_construct.hpp
@@ -285,9 +285,9 @@ namespace pika::ranges {
                 pika::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            pika::ranges::uninitialized_value_construct_t, FwdIter first,
-            Sent last)
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::uninitialized_value_construct_t,
+            FwdIter first, Sent last)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");
@@ -376,9 +376,9 @@ namespace pika::ranges {
                 pika::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
-            pika::ranges::uninitialized_value_construct_n_t, FwdIter first,
-            Size count)
+        friend FwdIter
+        tag_fallback_invoke(pika::ranges::uninitialized_value_construct_n_t,
+            FwdIter first, Size count)
         {
             static_assert(pika::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/container_algorithms/unique.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/container_algorithms/unique.hpp
@@ -628,8 +628,8 @@ namespace pika::ranges {
                     parallel::detail::projected<Proj, FwdIter>>::value
             )>
         // clang-format on
-        friend subrange_t<FwdIter, Sent> tag_fallback_invoke(
-            pika::ranges::unique_t, FwdIter first, Sent last,
+        friend subrange_t<FwdIter, Sent>
+        tag_fallback_invoke(pika::ranges::unique_t, FwdIter first, Sent last,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_forward_iterator_v<FwdIter>,
@@ -767,9 +767,9 @@ namespace pika::ranges {
                     parallel::detail::projected<Proj, InIter>>::value
             )>
         // clang-format on
-        friend unique_copy_result<InIter, O> tag_fallback_invoke(
-            pika::ranges::unique_copy_t, InIter first, Sent last, O dest,
-            Pred&& pred = Pred(), Proj&& proj = Proj())
+        friend unique_copy_result<InIter, O>
+        tag_fallback_invoke(pika::ranges::unique_copy_t, InIter first,
+            Sent last, O dest, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             static_assert(pika::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");

--- a/libs/pika/algorithms/include/pika/parallel/datapar/adjacent_difference.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/adjacent_difference.hpp
@@ -28,8 +28,8 @@ namespace pika::parallel::detail {
     struct datapar_adjacent_difference
     {
         template <typename InIter, typename OutIter, typename Op>
-        static inline OutIter call(
-            InIter first, InIter last, OutIter dest, Op&& op)
+        static inline OutIter
+        call(InIter first, InIter last, OutIter dest, Op&& op)
         {
             if (first == last)
                 return dest;

--- a/libs/pika/algorithms/include/pika/parallel/datapar/find.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/find.hpp
@@ -30,8 +30,8 @@ namespace pika::parallel::detail {
     {
         template <typename Iterator, typename Sentinel, typename T,
             typename Proj>
-        static inline Iterator call(
-            Iterator first, Sentinel last, T const& val, Proj proj)
+        static inline Iterator
+        call(Iterator first, Sentinel last, T const& val, Proj proj)
         {
             int offset = 0;
             util::cancellation_token<> tok;
@@ -52,9 +52,9 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename T, typename Proj>
-        static inline constexpr void call(std::size_t base_idx,
-            FwdIter part_begin, std::size_t part_count, Token& tok,
-            T const& val, Proj&& proj)
+        static inline constexpr void
+        call(std::size_t base_idx, FwdIter part_begin, std::size_t part_count,
+            Token& tok, T const& val, Proj&& proj)
         {
             loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&val, &proj, &tok](auto& v, std::size_t i) -> void {
@@ -95,8 +95,8 @@ namespace pika::parallel::detail {
     {
         template <typename Iterator, typename Sentinel, typename Pred,
             typename Proj>
-        static inline Iterator call(
-            Iterator first, Sentinel last, Pred pred, Proj proj)
+        static inline Iterator
+        call(Iterator first, Sentinel last, Pred pred, Proj proj)
         {
             int offset = 0;
             util::cancellation_token<> tok;
@@ -131,9 +131,9 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
-        static inline constexpr void call(std::size_t base_idx,
-            FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-            Proj&& proj)
+        static inline constexpr void
+        call(std::size_t base_idx, FwdIter part_begin, std::size_t part_count,
+            Token& tok, F&& f, Proj&& proj)
         {
             loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
@@ -184,8 +184,8 @@ namespace pika::parallel::detail {
     {
         template <typename Iterator, typename Sentinel, typename Pred,
             typename Proj>
-        static inline Iterator call(
-            Iterator first, Sentinel last, Pred pred, Proj proj)
+        static inline Iterator
+        call(Iterator first, Sentinel last, Pred pred, Proj proj)
         {
             int offset = 0;
             util::cancellation_token<> tok;
@@ -221,9 +221,9 @@ namespace pika::parallel::detail {
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
-        static inline constexpr void call(std::size_t base_idx,
-            FwdIter part_begin, std::size_t part_count, Token& tok, F&& f,
-            Proj&& proj)
+        static inline constexpr void
+        call(std::size_t base_idx, FwdIter part_begin, std::size_t part_count,
+            Token& tok, F&& f, Proj&& proj)
         {
             loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {

--- a/libs/pika/algorithms/include/pika/parallel/datapar/generate.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/generate.hpp
@@ -82,8 +82,8 @@ namespace pika::parallel::detail {
     struct datapar_generate
     {
         template <typename ExPolicy, typename Iter, typename Sent, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter call(
-            ExPolicy&&, Iter first, Sent last, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter
+        call(ExPolicy&&, Iter first, Sent last, F&& f)
         {
             std::size_t count = std::distance(first, last);
             return datapar_generate_helper<Iter>::call(
@@ -105,8 +105,8 @@ namespace pika::parallel::detail {
     struct datapar_generate_n
     {
         template <typename ExPolicy, typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter call(
-            ExPolicy&&, Iter first, std::size_t count, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter
+        call(ExPolicy&&, Iter first, std::size_t count, F&& f)
         {
             return datapar_generate_helper<Iter>::call(
                 first, count, PIKA_FORWARD(F, f));

--- a/libs/pika/algorithms/include/pika/parallel/datapar/iterator_helpers.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/iterator_helpers.hpp
@@ -275,8 +275,8 @@ namespace pika::parallel::detail {
         using V = typename traits::detail::vector_pack_type<value_type>::type;
 
         template <typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call1(
-            F&& f, Iter& it, std::size_t base_idx)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call1(F&& f, Iter& it, std::size_t base_idx)
         {
             V1 tmp(
                 traits::detail::vector_pack_load<V1, value_type>::aligned(it));
@@ -285,8 +285,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void callv(
-            F&& f, Iter& it, std::size_t base_idx)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        callv(F&& f, Iter& it, std::size_t base_idx)
         {
             V tmp(traits::detail::vector_pack_load<V, value_type>::aligned(it));
             PIKA_INVOKE(f, tmp, base_idx);
@@ -314,8 +314,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static std::size_t callv(
-            F&& f, Iter& it)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static std::size_t
+        callv(F&& f, Iter& it)
         {
             V tmp(traits::detail::vector_pack_load<V, value_type>::aligned(it));
             PIKA_INVOKE(f, &tmp);
@@ -423,8 +423,8 @@ namespace pika::parallel::detail {
     struct invoke_vectorized_inout1
     {
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_aligned(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_aligned(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -440,8 +440,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_unaligned(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_unaligned(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -462,8 +462,8 @@ namespace pika::parallel::detail {
     struct invoke_vectorized_inout1_ind
     {
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_aligned(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_aligned(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -479,8 +479,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_unaligned(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_unaligned(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -502,8 +502,8 @@ namespace pika::parallel::detail {
     {
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_aligned(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_aligned(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             static_assert(traits::detail::vector_pack_size<V1>::value ==
                     traits::detail::vector_pack_size<V2>::value,
@@ -530,8 +530,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_unaligned(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_unaligned(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             static_assert(traits::detail::vector_pack_size<V1>::value ==
                     traits::detail::vector_pack_size<V2>::value,
@@ -564,8 +564,8 @@ namespace pika::parallel::detail {
     {
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_aligned(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_aligned(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             static_assert(traits::detail::vector_pack_size<V1>::value ==
                     traits::detail::vector_pack_size<V2>::value,
@@ -592,8 +592,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call_unaligned(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call_unaligned(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             static_assert(traits::detail::vector_pack_size<V1>::value ==
                     traits::detail::vector_pack_size<V2>::value,
@@ -624,8 +624,8 @@ namespace pika::parallel::detail {
     struct datapar_transform_loop_step
     {
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call1(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call1(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -640,8 +640,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call1(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call1(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter1>::value_type value_type1;
@@ -661,8 +661,8 @@ namespace pika::parallel::detail {
 
         ///////////////////////////////////////////////////////////////////
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void callv(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        callv(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -677,8 +677,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void callv(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        callv(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter1>::value_type value1_type;
@@ -700,8 +700,8 @@ namespace pika::parallel::detail {
     struct datapar_transform_loop_step_ind
     {
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call1(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call1(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -716,8 +716,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void call1(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        call1(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter1>::value_type value_type1;
@@ -737,8 +737,8 @@ namespace pika::parallel::detail {
 
         ///////////////////////////////////////////////////////////////////
         template <typename F, typename InIter, typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void callv(
-            F&& f, InIter& it, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        callv(F&& f, InIter& it, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
@@ -753,8 +753,8 @@ namespace pika::parallel::detail {
 
         template <typename F, typename InIter1, typename InIter2,
             typename OutIter>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void callv(
-            F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        callv(F&& f, InIter1& it1, InIter2& it2, OutIter& dest)
         {
             typedef
                 typename std::iterator_traits<InIter1>::value_type value1_type;

--- a/libs/pika/algorithms/include/pika/parallel/datapar/loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/loop.hpp
@@ -508,8 +508,8 @@ namespace pika::parallel::detail {
         using V = typename traits::detail::vector_pack_type<value_type>::type;
 
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter call(
-            std::size_t base_idx, Iter it, std::size_t count, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Iter
+        call(std::size_t base_idx, Iter it, std::size_t count, F&& f)
         {
             std::size_t len = count;
 

--- a/libs/pika/algorithms/include/pika/parallel/datapar/zip_iterator.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/datapar/zip_iterator.hpp
@@ -32,8 +32,8 @@ namespace pika::parallel::detail {
     struct is_data_aligned_impl<pika::util::zip_iterator<Iter...>>
     {
         template <std::size_t... Is>
-        static PIKA_FORCEINLINE bool call(
-            pika::util::zip_iterator<Iter...> const& it,
+        static PIKA_FORCEINLINE bool
+        call(pika::util::zip_iterator<Iter...> const& it,
             pika::util::detail::index_pack<Is...>)
         {
             auto const& t = it.get_iterator_tuple();
@@ -96,8 +96,8 @@ namespace pika::parallel::traits::detail {
         }
 
         template <typename... Iter>
-        static value_type unaligned(
-            pika::util::zip_iterator<Iter...> const& iter)
+        static value_type
+        unaligned(pika::util::zip_iterator<Iter...> const& iter)
         {
             return traits::detail::unaligned_pack<value_type>(
                 iter, pika::util::detail::make_index_pack<sizeof...(Iter)>());
@@ -105,8 +105,8 @@ namespace pika::parallel::traits::detail {
     };
 
     template <typename Tuple, typename... Iter, std::size_t... Is>
-    void aligned_pack(Tuple& value,
-        pika::util::zip_iterator<Iter...> const& iter,
+    void
+    aligned_pack(Tuple& value, pika::util::zip_iterator<Iter...> const& iter,
         pika::util::detail::index_pack<Is...>)
     {
         auto const& t = iter.get_iterator_tuple();
@@ -119,8 +119,8 @@ namespace pika::parallel::traits::detail {
     }
 
     template <typename Tuple, typename... Iter, std::size_t... Is>
-    void unaligned_pack(Tuple& value,
-        pika::util::zip_iterator<Iter...> const& iter,
+    void
+    unaligned_pack(Tuple& value, pika::util::zip_iterator<Iter...> const& iter,
         pika::util::detail::index_pack<Is...>)
     {
         auto const& t = iter.get_iterator_tuple();
@@ -136,16 +136,16 @@ namespace pika::parallel::traits::detail {
     struct vector_pack_store<std::tuple<Vector...>, ValueType>
     {
         template <typename V, typename... Iter>
-        static void aligned(
-            V& value, pika::util::zip_iterator<Iter...> const& iter)
+        static void
+        aligned(V& value, pika::util::zip_iterator<Iter...> const& iter)
         {
             traits::detail::aligned_pack(value, iter,
                 pika::util::detail::make_index_pack_t<sizeof...(Iter)>());
         }
 
         template <typename V, typename... Iter>
-        static void unaligned(
-            V& value, pika::util::zip_iterator<Iter...> const& iter)
+        static void
+        unaligned(V& value, pika::util::zip_iterator<Iter...> const& iter)
         {
             traits::detail::unaligned_pack(value, iter,
                 pika::util::detail::make_index_pack<sizeof...(Iter)>());

--- a/libs/pika/algorithms/include/pika/parallel/task_block.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/task_block.hpp
@@ -491,7 +491,7 @@ namespace pika::parallel {
 /// \cond NOINTERNAL
 namespace std {
     template <typename ExPolicy>
-    pika::parallel::task_block<ExPolicy>* addressof(
-        pika::parallel::task_block<ExPolicy>&) = delete;
+    pika::parallel::task_block<ExPolicy>*
+    addressof(pika::parallel::task_block<ExPolicy>&) = delete;
 }
 /// \endcond

--- a/libs/pika/algorithms/include/pika/parallel/util/detail/chunk_size.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/detail/chunk_size.hpp
@@ -178,10 +178,10 @@ namespace pika::parallel::detail {
     template <typename ExPolicy, typename Future, typename F1, typename FwdIter,
         typename Stride>
     // requires traits::is_future<Future>
-    std::vector<std::tuple<FwdIter, std::size_t>> get_bulk_iteration_shape(
-        std::true_type /*has_variable_chunk_size*/, ExPolicy&& policy,
-        std::vector<Future>& /*workitems*/, F1&& /*f1*/, FwdIter& first,
-        std::size_t& count, Stride s)
+    std::vector<std::tuple<FwdIter, std::size_t>>
+    get_bulk_iteration_shape(std::true_type /*has_variable_chunk_size*/,
+        ExPolicy&& policy, std::vector<Future>& /*workitems*/, F1&& /*f1*/,
+        FwdIter& first, std::size_t& count, Stride s)
     {
         using tuple_type = std::tuple<FwdIter, std::size_t>;
 

--- a/libs/pika/algorithms/include/pika/parallel/util/detail/chunk_size_iterator.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/detail/chunk_size_iterator.hpp
@@ -74,9 +74,9 @@ namespace pika::parallel::detail {
     public:
         chunk_size_iterator() = default;
 
-        PIKA_HOST_DEVICE chunk_size_iterator(Iterator it,
-            std::size_t chunk_size, std::size_t count = 0,
-            std::size_t current = 0)
+        PIKA_HOST_DEVICE
+        chunk_size_iterator(Iterator it, std::size_t chunk_size,
+            std::size_t count = 0, std::size_t current = 0)
           : data_(it, (std::min)(chunk_size, count))
           , chunk_size_(chunk_size)
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
@@ -113,8 +113,8 @@ namespace pika::parallel::detail {
                 chunk_size_ == other.chunk_size_ && current_ == other.current_;
         }
 
-        PIKA_HOST_DEVICE typename base_type::reference dereference()
-            const noexcept
+        PIKA_HOST_DEVICE typename base_type::reference
+        dereference() const noexcept
         {
             return data_;
         }
@@ -206,8 +206,8 @@ namespace pika::parallel::detail {
             typename Enable = std::enable_if_t<
                 pika::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        PIKA_HOST_DEVICE std::ptrdiff_t distance_to(
-            chunk_size_iterator const& rhs) const
+        PIKA_HOST_DEVICE std::ptrdiff_t
+        distance_to(chunk_size_iterator const& rhs) const
         {
             return static_cast<std::ptrdiff_t>(
                 ((rhs.iterator() - iterator()) + chunk_size_ - 1) /
@@ -304,8 +304,8 @@ namespace pika::parallel::detail {
                 chunk_size_ == other.chunk_size_ && current_ == other.current_;
         }
 
-        PIKA_HOST_DEVICE typename base_type::reference dereference()
-            const noexcept
+        PIKA_HOST_DEVICE typename base_type::reference
+        dereference() const noexcept
         {
             return data_;
         }
@@ -400,8 +400,8 @@ namespace pika::parallel::detail {
             typename Enable = std::enable_if_t<
                 pika::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        PIKA_HOST_DEVICE std::ptrdiff_t distance_to(
-            chunk_size_idx_iterator const& rhs) const
+        PIKA_HOST_DEVICE std::ptrdiff_t
+        distance_to(chunk_size_idx_iterator const& rhs) const
         {
             return static_cast<std::ptrdiff_t>(
                 ((rhs.iterator() - iterator()) + chunk_size_ - 1) /

--- a/libs/pika/algorithms/include/pika/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/detail/handle_local_exceptions.hpp
@@ -285,8 +285,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename T, typename Cleanup>
-        static void call_with_cleanup(
-            std::vector<pika::future<T>> const& workitems,
+        static void
+        call_with_cleanup(std::vector<pika::future<T>> const& workitems,
             std::list<std::exception_ptr>&, Cleanup&&, bool = true)
         {
 #if defined(PIKA_COMPUTE_DEVICE_CODE)
@@ -371,8 +371,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename T, typename Cleanup>
-        static void call_with_cleanup(
-            std::vector<pika::future<T>> const& workitems,
+        static void
+        call_with_cleanup(std::vector<pika::future<T>> const& workitems,
             std::list<std::exception_ptr>&, Cleanup&&, bool = true)
         {
 #if defined(PIKA_COMPUTE_DEVICE_CODE)

--- a/libs/pika/algorithms/include/pika/parallel/util/detail/sender_util.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/detail/sender_util.hpp
@@ -105,8 +105,8 @@ namespace pika::detail {
                         std::decay_t<Predecessor>>>
             )>
         // clang-format on
-        friend auto tag_fallback_invoke(
-            Tag, Predecessor&& predecessor, ExPolicy&& policy)
+        friend auto
+        tag_fallback_invoke(Tag, Predecessor&& predecessor, ExPolicy&& policy)
         {
             return detail::then_with_bound_algorithm<Tag>(
                 PIKA_FORWARD(Predecessor, predecessor),

--- a/libs/pika/algorithms/include/pika/parallel/util/foreach_partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/foreach_partitioner.hpp
@@ -182,8 +182,8 @@ namespace pika::parallel::detail {
 
     private:
         template <typename F, typename FwdIter>
-        static pika::future<FwdIter> reduce(
-            std::shared_ptr<scoped_parameters>&& scoped_params,
+        static pika::future<FwdIter>
+        reduce(std::shared_ptr<scoped_parameters>&& scoped_params,
             std::vector<pika::future<Result>>&& inititems,
             std::vector<pika::future<Result>>&& workitems,
             std::list<std::exception_ptr>&& errors, F&& f, FwdIter last)

--- a/libs/pika/algorithms/include/pika/parallel/util/loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/loop.hpp
@@ -74,8 +74,8 @@ namespace pika::parallel::detail {
         loop_optimization_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename Iter>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr bool loop_optimization(
-        Iter it1, Iter it2)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr bool
+    loop_optimization(Iter it1, Iter it2)
     {
         return loop_optimization_t<ExPolicy>{}(it1, it2);
     }
@@ -88,8 +88,8 @@ namespace pika::parallel::detail {
     {
         ///////////////////////////////////////////////////////////////////
         template <typename Begin, typename End, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin call(
-            Begin it, End end, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin
+        call(Begin it, End end, F&& f)
         {
             for (/**/; it != end; ++it)
             {
@@ -100,8 +100,8 @@ namespace pika::parallel::detail {
 
         template <typename Begin, typename End, typename CancelToken,
             typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin call(
-            Begin it, End end, CancelToken& tok, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin
+        call(Begin it, End end, CancelToken& tok, F&& f)
         {
             for (/**/; it != end; ++it)
             {
@@ -137,8 +137,8 @@ namespace pika::parallel::detail {
     inline constexpr loop_t loop = loop_t{};
 #else
     template <typename ExPolicy, typename Begin, typename End, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin loop(
-        ExPolicy&& policy, Begin begin, End end, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin
+    loop(ExPolicy&& policy, Begin begin, End end, F&& f)
     {
         return loop_t{}(
             PIKA_FORWARD(ExPolicy, policy), begin, end, PIKA_FORWARD(F, f));
@@ -146,8 +146,8 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename Begin, typename End,
         typename CancelToken, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin loop(
-        ExPolicy&& policy, Begin begin, End end, CancelToken& tok, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin
+    loop(ExPolicy&& policy, Begin begin, End end, CancelToken& tok, F&& f)
     {
         return loop_t{}(PIKA_FORWARD(ExPolicy, policy), begin, end, tok,
             PIKA_FORWARD(F, f));
@@ -161,8 +161,8 @@ namespace pika::parallel::detail {
     {
         ///////////////////////////////////////////////////////////////////
         template <typename Begin, typename End, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin call(
-            Begin it, End end, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin
+        call(Begin it, End end, F&& f)
         {
             for (/**/; it != end; ++it)
             {
@@ -173,8 +173,8 @@ namespace pika::parallel::detail {
 
         template <typename Begin, typename End, typename CancelToken,
             typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin call(
-            Begin it, End end, CancelToken& tok, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Begin
+        call(Begin it, End end, CancelToken& tok, F&& f)
         {
             for (/**/; it != end; ++it)
             {
@@ -211,8 +211,8 @@ namespace pika::parallel::detail {
     inline constexpr loop_ind_t loop_ind = loop_ind_t{};
 #else
     template <typename ExPolicy, typename Begin, typename End, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin loop_ind(
-        ExPolicy&& policy, Begin begin, End end, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin
+    loop_ind(ExPolicy&& policy, Begin begin, End end, F&& f)
     {
         return loop_ind_t{}(
             PIKA_FORWARD(ExPolicy, policy), begin, end, PIKA_FORWARD(F, f));
@@ -220,8 +220,8 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename Begin, typename End,
         typename CancelToken, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin loop_ind(
-        ExPolicy&& policy, Begin begin, End end, CancelToken& tok, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Begin
+    loop_ind(ExPolicy&& policy, Begin begin, End end, CancelToken& tok, F&& f)
     {
         return loop_ind_t{}(PIKA_FORWARD(ExPolicy, policy), begin, end, tok,
             PIKA_FORWARD(F, f));
@@ -271,8 +271,8 @@ namespace pika::parallel::detail {
 #else
     template <typename ExPolicy, typename VecOnly, typename Begin1,
         typename End1, typename Begin2, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr std::pair<Begin1, Begin2> loop2(
-        VecOnly&& v, Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr std::pair<Begin1, Begin2>
+    loop2(VecOnly&& v, Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
     {
         return loop2_t<ExPolicy>{}(
             PIKA_FORWARD(VecOnly, v), begin1, end1, begin2, PIKA_FORWARD(F, f));
@@ -286,8 +286,8 @@ namespace pika::parallel::detail {
         ///////////////////////////////////////////////////////////////////
         // handle sequences of non-futures
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, F&& f, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, F&& f, std::false_type)
         {
             std::size_t count(num & std::size_t(-4));                  // -V112
             for (std::size_t i = 0; i < count; (void) ++it, i += 4)    // -V112
@@ -305,8 +305,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, F&& f, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, F&& f, std::true_type)
         {
             while (num >= 4)
             {
@@ -344,8 +344,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, CancelToken& tok, F&& f, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, CancelToken& tok, F&& f, std::false_type)
         {
             std::size_t count(num & std::size_t(-4));                  // -V112
             for (std::size_t i = 0; i < count; (void) ++it, i += 4)    // -V112
@@ -367,8 +367,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, CancelToken& tok, F&& f, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, CancelToken& tok, F&& f, std::true_type)
         {
             while (num >= 4)
             {
@@ -446,16 +446,16 @@ namespace pika::parallel::detail {
     inline constexpr loop_n_t<ExPolicy> loop_n = loop_n_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename Iter, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_n(
-        Iter it, std::size_t count, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_n(Iter it, std::size_t count, F&& f)
     {
         return loop_n_t<ExPolicy>{}(it, count, PIKA_FORWARD(F, f));
     }
 
     template <typename ExPolicy, typename Iter, typename CancelToken,
         typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_n(
-        Iter it, std::size_t count, CancelToken& tok, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_n(Iter it, std::size_t count, CancelToken& tok, F&& f)
     {
         return loop_n_t<ExPolicy>{}(it, count, tok, PIKA_FORWARD(F, f));
     }
@@ -480,8 +480,8 @@ namespace pika::parallel::detail {
         extract_value_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename T>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T const& extract_value(
-        T const& v)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T const&
+    extract_value(T const& v)
     {
         return extract_value_t<ExPolicy>{}(v);
     }
@@ -515,15 +515,15 @@ namespace pika::parallel::detail {
         accumulate_values_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename F, typename T>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T const& accumulate_values(
-        F&& f, T const& v)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T const&
+    accumulate_values(F&& f, T const& v)
     {
         return accumulate_values_t<ExPolicy>{}(PIKA_FORWARD(F, f), v);
     }
 
     template <typename ExPolicy, typename F, typename T, typename T1>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T accumulate_values(
-        F&& f, T&& v, T1&& init)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T
+    accumulate_values(F&& f, T&& v, T1&& init)
     {
         return accumulate_values_t<ExPolicy>{}(
             PIKA_FORWARD(F, f), PIKA_FORWARD(T1, v), PIKA_FORWARD(T, init));
@@ -538,8 +538,8 @@ namespace pika::parallel::detail {
         ///////////////////////////////////////////////////////////////////
         // handle sequences of non-futures
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, F&& f, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, F&& f, std::false_type)
         {
             std::size_t count(num & std::size_t(-4));                  // -V112
             for (std::size_t i = 0; i < count; (void) ++it, i += 4)    // -V112
@@ -558,8 +558,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, F&& f, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, F&& f, std::true_type)
         {
             while (num >= 4)
             {
@@ -597,8 +597,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, CancelToken& tok, F&& f, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, CancelToken& tok, F&& f, std::false_type)
         {
             std::size_t count(num & std::size_t(-4));                  // -V112
             for (std::size_t i = 0; i < count; (void) ++it, i += 4)    // -V112
@@ -620,8 +620,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            Iter it, std::size_t num, CancelToken& tok, F&& f, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(Iter it, std::size_t num, CancelToken& tok, F&& f, std::true_type)
         {
             while (num >= 4)
             {
@@ -700,16 +700,16 @@ namespace pika::parallel::detail {
         loop_n_ind_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename Iter, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_n_ind(
-        Iter it, std::size_t count, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_n_ind(Iter it, std::size_t count, F&& f)
     {
         return loop_n_ind_t<ExPolicy>{}(it, count, PIKA_FORWARD(F, f));
     }
 
     template <typename ExPolicy, typename Iter, typename CancelToken,
         typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_n_ind(
-        Iter it, std::size_t count, CancelToken& tok, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_n_ind(Iter it, std::size_t count, CancelToken& tok, F&& f)
     {
         return loop_n_ind_t<ExPolicy>{}(it, count, tok, PIKA_FORWARD(F, f));
     }
@@ -744,8 +744,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename FwdIter, typename F, typename Cleanup>
-        static FwdIter call(
-            Iter it, Iter last, FwdIter dest, F&& f, Cleanup&& cleanup)
+        static FwdIter
+        call(Iter it, Iter last, FwdIter dest, F&& f, Cleanup&& cleanup)
         {
             FwdIter base = dest;
             try
@@ -767,8 +767,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename F, typename Cleanup>
-    PIKA_FORCEINLINE constexpr Iter loop_with_cleanup(
-        Iter it, Iter last, F&& f, Cleanup&& cleanup)
+    PIKA_FORCEINLINE constexpr Iter
+    loop_with_cleanup(Iter it, Iter last, F&& f, Cleanup&& cleanup)
     {
         using cat = typename std::iterator_traits<Iter>::iterator_category;
         return loop_with_cleanup_impl<cat>::call(
@@ -791,8 +791,8 @@ namespace pika::parallel::detail {
     {
         ///////////////////////////////////////////////////////////////////
         template <typename FwdIter, typename F, typename Cleanup>
-        static FwdIter call(
-            FwdIter it, std::size_t num, F&& f, Cleanup&& cleanup)
+        static FwdIter
+        call(FwdIter it, std::size_t num, F&& f, Cleanup&& cleanup)
         {
             FwdIter base = it;
             try
@@ -823,8 +823,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename FwdIter, typename F, typename Cleanup>
-        static FwdIter call(
-            Iter it, std::size_t num, FwdIter dest, F&& f, Cleanup&& cleanup)
+        static FwdIter
+        call(Iter it, std::size_t num, FwdIter dest, F&& f, Cleanup&& cleanup)
         {
             FwdIter base = dest;
             try
@@ -938,8 +938,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename F, typename Cleanup>
-    PIKA_FORCEINLINE constexpr Iter loop_with_cleanup_n(
-        Iter it, std::size_t count, F&& f, Cleanup&& cleanup)
+    PIKA_FORCEINLINE constexpr Iter
+    loop_with_cleanup_n(Iter it, std::size_t count, F&& f, Cleanup&& cleanup)
     {
         using cat = typename std::iterator_traits<Iter>::iterator_category;
         return loop_with_cleanup_n_impl<cat>::call(
@@ -966,9 +966,9 @@ namespace pika::parallel::detail {
 
     template <typename Iter, typename FwdIter, typename CancelToken, typename F,
         typename Cleanup>
-    PIKA_FORCEINLINE constexpr FwdIter loop_with_cleanup_n_with_token(Iter it,
-        std::size_t count, FwdIter dest, CancelToken& tok, F&& f,
-        Cleanup&& cleanup)
+    PIKA_FORCEINLINE constexpr FwdIter
+    loop_with_cleanup_n_with_token(Iter it, std::size_t count, FwdIter dest,
+        CancelToken& tok, F&& f, Cleanup&& cleanup)
     {
         using cat = typename std::iterator_traits<Iter>::iterator_category;
         return loop_with_cleanup_n_impl<cat>::call_with_token(it, count, dest,
@@ -983,8 +983,8 @@ namespace pika::parallel::detail {
         ///////////////////////////////////////////////////////////////////
         // handle sequences of non-futures
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            std::size_t base_idx, Iter it, std::size_t num, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(std::size_t base_idx, Iter it, std::size_t num, F&& f)
         {
             std::size_t count(num & std::size_t(-4));    // -V112
 
@@ -1003,8 +1003,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            std::size_t base_idx, Iter it, std::size_t count, CancelToken& tok,
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(std::size_t base_idx, Iter it, std::size_t count, CancelToken& tok,
             F&& f)
         {
             for (/**/; count != 0; (void) --count, ++it, ++base_idx)
@@ -1025,8 +1025,8 @@ namespace pika::parallel::detail {
         ///////////////////////////////////////////////////////////////////
         // handle sequences of non-futures
         template <typename Iter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            std::size_t base_idx, Iter it, std::size_t num, F&& f)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(std::size_t base_idx, Iter it, std::size_t num, F&& f)
         {
             while (num >= 4)
             {
@@ -1064,8 +1064,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename Iter, typename CancelToken, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter call(
-            std::size_t base_idx, Iter it, std::size_t num, CancelToken& tok,
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr Iter
+        call(std::size_t base_idx, Iter it, std::size_t num, CancelToken& tok,
             F&& f)
         {
             while (num >= 4)
@@ -1140,8 +1140,8 @@ namespace pika::parallel::detail {
         loop_idx_n_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename Iter, typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_idx_n(
-        std::size_t base_idx, Iter it, std::size_t count, F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_idx_n(std::size_t base_idx, Iter it, std::size_t count, F&& f)
     {
         return loop_idx_n_t<ExPolicy>{}(
             base_idx, it, count, PIKA_FORWARD(F, f));
@@ -1149,9 +1149,9 @@ namespace pika::parallel::detail {
 
     template <typename ExPolicy, typename Iter, typename CancelToken,
         typename F>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter loop_idx_n(
-        std::size_t base_idx, Iter it, std::size_t count, CancelToken& tok,
-        F&& f)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iter
+    loop_idx_n(std::size_t base_idx, Iter it, std::size_t count,
+        CancelToken& tok, F&& f)
     {
         return loop_idx_n_t<ExPolicy>{}(
             base_idx, it, count, tok, PIKA_FORWARD(F, f));

--- a/libs/pika/algorithms/include/pika/parallel/util/merge_four.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/merge_four.hpp
@@ -55,9 +55,9 @@ namespace pika::parallel::detail {
     /// \return range with all the elements move with the size adjusted
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Compare>
-    range<Iter1, Sent1> full_merge4(range<Iter1, Sent1>& rdest,
-        range<Iter2, Sent2> vrange_input[4], std::uint32_t nrange_input,
-        Compare comp)
+    range<Iter1, Sent1>
+    full_merge4(range<Iter1, Sent1>& rdest, range<Iter2, Sent2> vrange_input[4],
+        std::uint32_t nrange_input, Compare comp)
     {
         using range1_t = range<Iter1, Sent1>;
         using type1 = typename std::iterator_traits<Iter1>::value_type;

--- a/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/partitioner.hpp
@@ -38,8 +38,8 @@
 
 namespace pika::parallel::detail {
     template <typename Result, typename ExPolicy, typename FwdIter, typename F>
-    std::vector<pika::future<Result>> partition(
-        ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
+    std::vector<pika::future<Result>>
+    partition(ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
     {
         // estimate a chunk size based on number of cores used
         using parameters_type =
@@ -101,8 +101,8 @@ namespace pika::parallel::detail {
     template <typename Result, typename ExPolicy, typename FwdIter,
         typename Data, typename F>
     // requires is_container<Data>
-    std::vector<pika::future<Result>> partition_with_data(ExPolicy&& policy,
-        FwdIter first, std::size_t count,
+    std::vector<pika::future<Result>>
+    partition_with_data(ExPolicy&& policy, FwdIter first, std::size_t count,
         std::vector<std::size_t> const& chunk_sizes, Data&& data, F&& f)
     {
         PIKA_ASSERT(pika::util::size(data) >= pika::util::size(chunk_sizes));
@@ -388,8 +388,8 @@ namespace pika::parallel::detail {
 
     private:
         template <typename F>
-        static pika::future<R> reduce(
-            std::shared_ptr<scoped_parameters>&& scoped_params,
+        static pika::future<R>
+        reduce(std::shared_ptr<scoped_parameters>&& scoped_params,
             std::vector<pika::future<Result>>&& workitems,
             std::list<std::exception_ptr>&& errors, F&& f)
         {

--- a/libs/pika/algorithms/include/pika/parallel/util/partitioner_with_cleanup.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/partitioner_with_cleanup.hpp
@@ -150,8 +150,8 @@ namespace pika::parallel::detail {
 
     private:
         template <typename F, typename Cleanup>
-        static pika::future<R> reduce(
-            std::shared_ptr<scoped_parameters>&& scoped_params,
+        static pika::future<R>
+        reduce(std::shared_ptr<scoped_parameters>&& scoped_params,
             std::vector<pika::future<Result>>&& workitems,
             std::list<std::exception_ptr>&& errors, F&& f, Cleanup&& cleanup)
         {

--- a/libs/pika/algorithms/include/pika/parallel/util/prefetching.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/prefetching.hpp
@@ -278,8 +278,8 @@ namespace pika::parallel::detail {
         struct loop_n_helper
         {
             template <typename Itr, typename... Ts, typename F, typename Pred>
-            static constexpr prefetching_iterator<Itr, Ts...> call(
-                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
+            static constexpr prefetching_iterator<Itr, Ts...>
+            call(prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
                 Pred)
             {
                 using index_pack_type =
@@ -312,8 +312,8 @@ namespace pika::parallel::detail {
 
             template <typename Itr, typename... Ts, typename CancelToken,
                 typename F, typename Pred>
-            static constexpr prefetching_iterator<Itr, Ts...> call(
-                prefetching_iterator<Itr, Ts...> it, std::size_t count,
+            static constexpr prefetching_iterator<Itr, Ts...>
+            call(prefetching_iterator<Itr, Ts...> it, std::size_t count,
                 CancelToken& tok, F&& f, Pred)
             {
                 using index_pack_type =
@@ -363,8 +363,8 @@ namespace pika::parallel::detail {
         struct loop_n_ind_helper
         {
             template <typename Itr, typename... Ts, typename F, typename Pred>
-            static constexpr prefetching_iterator<Itr, Ts...> call(
-                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
+            static constexpr prefetching_iterator<Itr, Ts...>
+            call(prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
                 Pred)
             {
                 using index_pack_type =
@@ -397,8 +397,8 @@ namespace pika::parallel::detail {
 
             template <typename Itr, typename... Ts, typename CancelToken,
                 typename F, typename Pred>
-            static constexpr prefetching_iterator<Itr, Ts...> call(
-                prefetching_iterator<Itr, Ts...> it, std::size_t count,
+            static constexpr prefetching_iterator<Itr, Ts...>
+            call(prefetching_iterator<Itr, Ts...> it, std::size_t count,
                 CancelToken& tok, F&& f, Pred)
             {
                 using index_pack_type =
@@ -497,8 +497,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename End, typename CancelToken, typename F>
-        static iterator_type call(
-            iterator_type it, End end, CancelToken& tok, F&& f)
+        static iterator_type
+        call(iterator_type it, End end, CancelToken& tok, F&& f)
         {
             for (/**/; it != end; ++it)
             {
@@ -557,8 +557,8 @@ namespace pika::parallel::detail {
         }
 
         template <typename End, typename CancelToken, typename F>
-        static iterator_type call(
-            iterator_type it, End end, CancelToken& tok, F&& f)
+        static iterator_type
+        call(iterator_type it, End end, CancelToken& tok, F&& f)
         {
             for (/**/; it != end; ++it)
             {

--- a/libs/pika/algorithms/include/pika/parallel/util/projection_identity.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/projection_identity.hpp
@@ -17,8 +17,8 @@ namespace pika::parallel::detail {
         using is_transparent = std::true_type;
 
         template <typename T>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T&& operator()(
-            T&& val) const noexcept
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr T&&
+        operator()(T&& val) const noexcept
         {
             return PIKA_FORWARD(T, val);
         }

--- a/libs/pika/algorithms/include/pika/parallel/util/range.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/range.hpp
@@ -32,8 +32,8 @@ namespace pika::parallel::detail {
     /// \param [in] it2 : second range
     /// \return  range resulting of the concatenation
     template <typename Iter, typename Sent>
-    range<Iter, Sent> concat(
-        range<Iter, Sent> const& it1, range<Iter, Sent> const& it2)
+    range<Iter, Sent>
+    concat(range<Iter, Sent> const& it1, range<Iter, Sent> const& it2)
     {
         return range<Iter, Sent>(it1.begin(), it2.end());
     }
@@ -43,8 +43,8 @@ namespace pika::parallel::detail {
     /// \param [in] src : range from where move the objects
     /// \return range with the objects moved and the size adjusted
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2>
-    inline range<Iter2, Iter2> init_move(
-        range<Iter2, Sent2> const& dest, range<Iter1, Sent1> const& src)
+    inline range<Iter2, Iter2>
+    init_move(range<Iter2, Sent2> const& dest, range<Iter1, Sent1> const& src)
     {
         using type1 = typename std::iterator_traits<Iter1>::value_type;
         using type2 = typename std::iterator_traits<Iter2>::value_type;
@@ -70,8 +70,8 @@ namespace pika::parallel::detail {
     /// \return range with the objects moved and the size adjusted
     //-----------------------------------------------------------------------------
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2>
-    inline range<Iter2, Sent2> uninit_move(
-        range<Iter2, Sent2> const& dest, range<Iter1, Sent1> const& src)
+    inline range<Iter2, Sent2>
+    uninit_move(range<Iter2, Sent2> const& dest, range<Iter1, Sent1> const& src)
     {
         using type1 = typename std::iterator_traits<Iter1>::value_type;
         using type2 = typename std::iterator_traits<Iter2>::value_type;
@@ -143,9 +143,9 @@ namespace pika::parallel::detail {
     /// \return range with the elements merged and the size adjusted
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Iter3, typename Sent3, typename Compare>
-    inline range<Iter3, Sent3> full_merge(range<Iter3, Sent3> const& dest,
-        range<Iter1, Sent1> const& src1, range<Iter2, Sent2> const& src2,
-        Compare comp)
+    inline range<Iter3, Sent3>
+    full_merge(range<Iter3, Sent3> const& dest, range<Iter1, Sent1> const& src1,
+        range<Iter2, Sent2> const& src2, Compare comp)
     {
         using type1 = typename std::iterator_traits<Iter1>::value_type;
         using type2 = typename std::iterator_traits<Iter2>::value_type;
@@ -199,9 +199,9 @@ namespace pika::parallel::detail {
     /// \return : range with the two buffers merged
     template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
         typename Compare>
-    inline range<Iter2, Sent2> half_merge(range<Iter2, Sent2> const& dest,
-        range<Iter1, Sent1> const& src1, range<Iter2, Sent2> const& src2,
-        Compare comp)
+    inline range<Iter2, Sent2>
+    half_merge(range<Iter2, Sent2> const& dest, range<Iter1, Sent1> const& src1,
+        range<Iter2, Sent2> const& src2, Compare comp)
     {
         using type1 = typename std::iterator_traits<Iter1>::value_type;
         using type2 = typename std::iterator_traits<Iter2>::value_type;

--- a/libs/pika/algorithms/include/pika/parallel/util/ranges_facilities.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/ranges_facilities.hpp
@@ -60,9 +60,9 @@ namespace pika::ranges {
     }
 
     template <typename Iter, typename Sent>
-    constexpr inline Iter next_(Iter first,
-        typename std::iterator_traits<Iter>::difference_type n, Sent bound,
-        std::true_type, std::true_type)
+    constexpr inline Iter
+    next_(Iter first, typename std::iterator_traits<Iter>::difference_type n,
+        Sent bound, std::true_type, std::true_type)
     {
         if (pika::parallel::detail::distance(first, bound) < size_t(n))
         {

--- a/libs/pika/algorithms/include/pika/parallel/util/result_types.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/result_types.hpp
@@ -97,8 +97,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename I, typename O>
-    pika::future<std::pair<I, O>> get_pair(
-        pika::future<in_out_result<I, O>>&& f)
+    pika::future<std::pair<I, O>>
+    get_pair(pika::future<in_out_result<I, O>>&& f)
     {
         return pika::make_future<std::pair<I, O>>(
             PIKA_MOVE(f), [](in_out_result<I, O>&& p) {
@@ -115,15 +115,15 @@ namespace pika::parallel::detail {
 
     // convert a in_out_result into a iterator_range
     template <typename I, typename O>
-    pika::util::iterator_range<I, O> get_subrange(
-        in_out_result<I, O> const& ior)
+    pika::util::iterator_range<I, O>
+    get_subrange(in_out_result<I, O> const& ior)
     {
         return pika::util::iterator_range<I, O>(ior.in, ior.out);
     }
 
     template <typename I, typename O>
-    pika::future<pika::util::iterator_range<I, O>> get_subrange(
-        pika::future<in_out_result<I, O>>&& ior)
+    pika::future<pika::util::iterator_range<I, O>>
+    get_subrange(pika::future<in_out_result<I, O>>&& ior)
     {
         return pika::make_future<pika::util::iterator_range<I, O>>(
             PIKA_MOVE(ior), [](in_out_result<I, O>&& ior) {
@@ -190,8 +190,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename I1, typename I2, typename O>
-    pika::future<O> get_third_element(
-        pika::future<in_in_out_result<I1, I2, O>>&& f)
+    pika::future<O>
+    get_third_element(pika::future<in_in_out_result<I1, I2, O>>&& f)
     {
         return pika::make_future<O>(PIKA_MOVE(f),
             [](in_in_out_result<I1, I2, O>&& p) { return p.out; });
@@ -227,8 +227,8 @@ namespace pika::parallel::detail {
     };
 
     template <typename... Ts>
-    constexpr PIKA_FORCEINLINE in_out_out_result<Ts...> make_in_out_out_result(
-        std::tuple<Ts...>&& t)
+    constexpr PIKA_FORCEINLINE in_out_out_result<Ts...>
+    make_in_out_out_result(std::tuple<Ts...>&& t)
     {
         static_assert(std::tuple_size<std::tuple<Ts...>>::value == 3,
             "size of tuple should be 3 to convert to in_out_out_result");
@@ -239,8 +239,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename... Ts>
-    pika::future<in_out_out_result<Ts...>> make_in_out_out_result(
-        pika::future<std::tuple<Ts...>>&& f)
+    pika::future<in_out_out_result<Ts...>>
+    make_in_out_out_result(pika::future<std::tuple<Ts...>>&& f)
     {
         static_assert(std::tuple_size<std::tuple<Ts...>>::value == 3,
             "size of tuple should be 3 to convert to in_out_out_result");
@@ -279,16 +279,16 @@ namespace pika::parallel::detail {
     };
 
     template <typename Iterator, typename Sentinel = Iterator>
-    pika::util::iterator_range<Iterator, Sentinel> make_subrange(
-        Iterator iterator, Sentinel sentinel)
+    pika::util::iterator_range<Iterator, Sentinel>
+    make_subrange(Iterator iterator, Sentinel sentinel)
     {
         return pika::util::make_iterator_range<Iterator, Sentinel>(
             iterator, sentinel);
     }
 
     template <typename Iterator, typename Sentinel = Iterator>
-    pika::future<pika::util::iterator_range<Iterator, Sentinel>> make_subrange(
-        pika::future<Iterator>&& iterator, Sentinel sentinel)
+    pika::future<pika::util::iterator_range<Iterator, Sentinel>>
+    make_subrange(pika::future<Iterator>&& iterator, Sentinel sentinel)
     {
         return pika::make_future<
             pika::util::iterator_range<Iterator, Sentinel>>(

--- a/libs/pika/algorithms/include/pika/parallel/util/scan_partitioner.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/scan_partitioner.hpp
@@ -60,9 +60,9 @@ namespace pika::parallel::detail {
 
         template <typename ExPolicy_, typename FwdIter, typename T, typename F1,
             typename F2, typename F3, typename F4>
-        static R call(scan_partitioner_normal_tag, ExPolicy_ policy,
-            FwdIter first, std::size_t count, T&& init, F1&& f1, F2&& f2,
-            F3&& f3, F4&& f4)
+        static R
+        call(scan_partitioner_normal_tag, ExPolicy_ policy, FwdIter first,
+            std::size_t count, T&& init, F1&& f1, F2&& f2, F3&& f3, F4&& f4)
         {
 #if defined(PIKA_COMPUTE_DEVICE_CODE)
             PIKA_UNUSED(policy);

--- a/libs/pika/algorithms/include/pika/parallel/util/transfer.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/transfer.hpp
@@ -36,8 +36,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T>
-    PIKA_FORCEINLINE std::enable_if_t<std::is_pointer<T>::value, char*> to_ptr(
-        T ptr) noexcept
+    PIKA_FORCEINLINE std::enable_if_t<std::is_pointer<T>::value, char*>
+    to_ptr(T ptr) noexcept
     {
         return const_cast<char*>(reinterpret_cast<char volatile const*>(ptr));
     }
@@ -76,8 +76,8 @@ namespace pika::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename InIter, typename OutIter>
-    PIKA_FORCEINLINE static in_out_result<InIter, OutIter> copy_memmove(
-        InIter first, std::size_t count, OutIter dest)
+    PIKA_FORCEINLINE static in_out_result<InIter, OutIter>
+    copy_memmove(InIter first, std::size_t count, OutIter dest)
     {
         using data_type = typename std::iterator_traits<InIter>::value_type;
 
@@ -113,8 +113,8 @@ namespace pika::parallel::detail {
     struct copy_helper<pika::detail::trivially_copyable_pointer_tag, Dummy>
     {
         template <typename InIter, typename Sent, typename OutIter>
-        PIKA_FORCEINLINE static in_out_result<InIter, OutIter> call(
-            InIter first, Sent last, OutIter dest)
+        PIKA_FORCEINLINE static in_out_result<InIter, OutIter>
+        call(InIter first, Sent last, OutIter dest)
         {
             return copy_memmove(
                 first, parallel::detail::distance(first, last), dest);
@@ -122,8 +122,8 @@ namespace pika::parallel::detail {
     };
 
     template <typename InIter, typename Sent, typename OutIter>
-    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter> copy(
-        InIter first, Sent last, OutIter dest)
+    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter>
+    copy(InIter first, Sent last, OutIter dest)
     {
         using category = pika::detail::pointer_copy_category_t<
             std::decay_t<
@@ -162,8 +162,8 @@ namespace pika::parallel::detail {
     struct copy_n_helper<pika::detail::trivially_copyable_pointer_tag, Dummy>
     {
         template <typename InIter, typename OutIter>
-        PIKA_FORCEINLINE static in_out_result<InIter, OutIter> call(
-            InIter first, std::size_t count, OutIter dest)
+        PIKA_FORCEINLINE static in_out_result<InIter, OutIter>
+        call(InIter first, std::size_t count, OutIter dest)
         {
             return copy_memmove(first, count, dest);
         }
@@ -205,16 +205,16 @@ namespace pika::parallel::detail {
     struct copy_synchronize_helper
     {
         template <typename InIter, typename OutIter>
-        PIKA_FORCEINLINE static constexpr void call(
-            InIter const&, OutIter const&) noexcept
+        PIKA_FORCEINLINE static constexpr void
+        call(InIter const&, OutIter const&) noexcept
         {
             // do nothing by default (std::memmove is already synchronous)
         }
     };
 
     template <typename InIter, typename OutIter>
-    PIKA_FORCEINLINE constexpr void copy_synchronize(
-        InIter const& first, OutIter const& dest)
+    PIKA_FORCEINLINE constexpr void
+    copy_synchronize(InIter const& first, OutIter const& dest)
     {
         using category =
             pika::detail::pointer_copy_category_t<std::decay_t<InIter>,
@@ -227,8 +227,8 @@ namespace pika::parallel::detail {
     struct move_helper
     {
         template <typename InIter, typename Sent, typename OutIter>
-        PIKA_FORCEINLINE static constexpr in_out_result<InIter, OutIter> call(
-            InIter first, Sent last, OutIter dest)
+        PIKA_FORCEINLINE static constexpr in_out_result<InIter, OutIter>
+        call(InIter first, Sent last, OutIter dest)
         {
             while (first != last)
             {
@@ -245,8 +245,8 @@ namespace pika::parallel::detail {
     struct move_helper<pika::detail::trivially_copyable_pointer_tag, Dummy>
     {
         template <typename InIter, typename Sent, typename OutIter>
-        PIKA_FORCEINLINE static in_out_result<InIter, OutIter> call(
-            InIter first, Sent last, OutIter dest)
+        PIKA_FORCEINLINE static in_out_result<InIter, OutIter>
+        call(InIter first, Sent last, OutIter dest)
         {
             return copy_memmove(
                 first, parallel::detail::distance(first, last), dest);
@@ -254,8 +254,8 @@ namespace pika::parallel::detail {
     };
 
     template <typename InIter, typename Sent, typename OutIter>
-    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter> move(
-        InIter first, Sent last, OutIter dest)
+    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter>
+    move(InIter first, Sent last, OutIter dest)
     {
         using category =
             pika::detail::pointer_move_category_t<std::decay_t<InIter>,
@@ -268,8 +268,8 @@ namespace pika::parallel::detail {
     struct move_n_helper
     {
         template <typename InIter, typename OutIter>
-        PIKA_FORCEINLINE static constexpr in_out_result<InIter, OutIter> call(
-            InIter first, std::size_t num, OutIter dest)
+        PIKA_FORCEINLINE static constexpr in_out_result<InIter, OutIter>
+        call(InIter first, std::size_t num, OutIter dest)
         {
             std::size_t count(num & std::size_t(-4));    // -V112
             for (std::size_t i = 0; i < count; (void) ++first, ++dest, i += 4)
@@ -295,16 +295,16 @@ namespace pika::parallel::detail {
     struct move_n_helper<pika::detail::trivially_copyable_pointer_tag, Dummy>
     {
         template <typename InIter, typename OutIter>
-        PIKA_FORCEINLINE static in_out_result<InIter, OutIter> call(
-            InIter first, std::size_t count, OutIter dest)
+        PIKA_FORCEINLINE static in_out_result<InIter, OutIter>
+        call(InIter first, std::size_t count, OutIter dest)
         {
             return copy_memmove(first, count, dest);
         }
     };
 
     template <typename InIter, typename OutIter>
-    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter> move_n(
-        InIter first, std::size_t count, OutIter dest)
+    PIKA_FORCEINLINE constexpr in_out_result<InIter, OutIter>
+    move_n(InIter first, std::size_t count, OutIter dest)
     {
         using category =
             pika::detail::pointer_move_category_t<std::decay_t<InIter>,

--- a/libs/pika/algorithms/include/pika/parallel/util/transform_loop.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/transform_loop.hpp
@@ -123,10 +123,11 @@ namespace pika::parallel::detail {
     {
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        call(InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
-            F&& f)
+        PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE static constexpr in_in_out_result<InIter1B,
+                InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
+                F&& f)
         {
             for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
             {
@@ -139,10 +140,11 @@ namespace pika::parallel::detail {
 
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        call(InIter1B first1, InIter1E last1, InIter2 first2, InIter2 last2,
-            OutIter dest, F&& f)
+        PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE static constexpr in_in_out_result<InIter1B,
+                InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F&& f)
         {
             for (/* */; first1 != last1 && first2 != last2;
                  (void) ++first1, ++first2, ++dest)
@@ -163,10 +165,12 @@ namespace pika::parallel::detail {
     private:
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        friend PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        tag_fallback_invoke(transform_binary_loop_t<ExPolicy>, InIter1B first1,
-            InIter1E last1, InIter2 first2, OutIter dest, F&& f)
+        friend PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE constexpr in_in_out_result<InIter1B, InIter2,
+                OutIter>
+            tag_fallback_invoke(transform_binary_loop_t<ExPolicy>,
+                InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
+                F&& f)
         {
             return transform_binary_loop_impl<InIter1B, InIter2>::call(
                 first1, last1, first2, dest, PIKA_FORWARD(F, f));
@@ -174,11 +178,12 @@ namespace pika::parallel::detail {
 
         template <typename InIter1B, typename InIter1E, typename InIter2B,
             typename InIter2E, typename OutIter, typename F>
-        friend PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr in_in_out_result<
-            InIter1B, InIter2B, OutIter>
-        tag_fallback_invoke(transform_binary_loop_t<ExPolicy>, InIter1B first1,
-            InIter1E last1, InIter2B first2, InIter2E last2, OutIter dest,
-            F&& f)
+        friend PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE constexpr in_in_out_result<InIter1B, InIter2B,
+                OutIter>
+            tag_fallback_invoke(transform_binary_loop_t<ExPolicy>,
+                InIter1B first1, InIter1E last1, InIter2B first2,
+                InIter2E last2, OutIter dest, F&& f)
         {
             return transform_binary_loop_impl<InIter1B, InIter2B>::call(
                 first1, last1, first2, last2, dest, PIKA_FORWARD(F, f));
@@ -218,10 +223,11 @@ namespace pika::parallel::detail {
     {
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        call(InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
-            F&& f)
+        PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE static constexpr in_in_out_result<InIter1B,
+                InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
+                F&& f)
         {
             for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
             {
@@ -234,10 +240,11 @@ namespace pika::parallel::detail {
 
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        call(InIter1B first1, InIter1E last1, InIter2 first2, InIter2 last2,
-            OutIter dest, F&& f)
+        PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE static constexpr in_in_out_result<InIter1B,
+                InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F&& f)
         {
             for (/* */; first1 != last1 && first2 != last2;
                  (void) ++first1, ++first2, ++dest)
@@ -258,11 +265,12 @@ namespace pika::parallel::detail {
     private:
         template <typename InIter1B, typename InIter1E, typename InIter2,
             typename OutIter, typename F>
-        friend PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr in_in_out_result<
-            InIter1B, InIter2, OutIter>
-        tag_fallback_invoke(transform_binary_loop_ind_t<ExPolicy>,
-            InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
-            F&& f)
+        friend PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE constexpr in_in_out_result<InIter1B, InIter2,
+                OutIter>
+            tag_fallback_invoke(transform_binary_loop_ind_t<ExPolicy>,
+                InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
+                F&& f)
         {
             return transform_binary_loop_ind_impl<InIter1B, InIter2>::call(
                 first1, last1, first2, dest, PIKA_FORWARD(F, f));
@@ -270,11 +278,12 @@ namespace pika::parallel::detail {
 
         template <typename InIter1B, typename InIter1E, typename InIter2B,
             typename InIter2E, typename OutIter, typename F>
-        friend PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr in_in_out_result<
-            InIter1B, InIter2B, OutIter>
-        tag_fallback_invoke(transform_binary_loop_ind_t<ExPolicy>,
-            InIter1B first1, InIter1E last1, InIter2B first2, InIter2E last2,
-            OutIter dest, F&& f)
+        friend PIKA_HOST_DEVICE
+            PIKA_FORCEINLINE constexpr in_in_out_result<InIter1B, InIter2B,
+                OutIter>
+            tag_fallback_invoke(transform_binary_loop_ind_t<ExPolicy>,
+                InIter1B first1, InIter1E last1, InIter2B first2,
+                InIter2E last2, OutIter dest, F&& f)
         {
             return transform_binary_loop_ind_impl<InIter1B, InIter2B>::call(
                 first1, last1, first2, last2, dest, PIKA_FORWARD(F, f));

--- a/libs/pika/algorithms/include/pika/parallel/util/zip_iterator.hpp
+++ b/libs/pika/algorithms/include/pika/parallel/util/zip_iterator.hpp
@@ -43,8 +43,8 @@ namespace pika::parallel::detail {
     }
 
     template <typename ZipIter>
-    pika::future<typename ZipIter::iterator_tuple_type> get_iter_tuple(
-        pika::future<ZipIter>&& zipiter)
+    pika::future<typename ZipIter::iterator_tuple_type>
+    get_iter_tuple(pika::future<ZipIter>&& zipiter)
     {
         using result_type = typename ZipIter::iterator_tuple_type;
         return pika::make_future<result_type>(PIKA_MOVE(zipiter),

--- a/libs/pika/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_merge.cpp
@@ -66,9 +66,9 @@ double run_merge_benchmark_std(int test_count, InIter1 first1, InIter1 last1,
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
     typename FwdIter3>
-double run_merge_benchmark_pika(int test_count, ExPolicy policy,
-    FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
-    FwdIter3 dest)
+double
+run_merge_benchmark_pika(int test_count, ExPolicy policy, FwdIter1 first1,
+    FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest)
 {
     using namespace std::chrono;
     auto time = high_resolution_clock::now();

--- a/libs/pika/algorithms/tests/performance/benchmark_remove.cpp
+++ b/libs/pika/algorithms/tests/performance/benchmark_remove.cpp
@@ -107,9 +107,9 @@ double run_remove_benchmark_std(int test_count, OrgIter org_first,
 ///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename OrgIter, typename FwdIter,
     typename ValueType>
-double run_remove_benchmark_pika(int test_count, ExPolicy policy,
-    OrgIter org_first, OrgIter org_last, FwdIter first, FwdIter last,
-    ValueType value)
+double
+run_remove_benchmark_pika(int test_count, ExPolicy policy, OrgIter org_first,
+    OrgIter org_last, FwdIter first, FwdIter last, ValueType value)
 {
     using namespace std::chrono;
     duration<double> dur(0);

--- a/libs/pika/algorithms/tests/unit/algorithms/test_utils.hpp
+++ b/libs/pika/algorithms/tests/unit/algorithms/test_utils.hpp
@@ -60,8 +60,8 @@ namespace test {
         {
         }
 
-        PIKA_HOST_DEVICE decorated_iterator(
-            BaseIterator base, std::function<void()> f)
+        PIKA_HOST_DEVICE
+        decorated_iterator(BaseIterator base, std::function<void()> f)
           : base_type(base)
           , m_callback(f)
         {

--- a/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
+++ b/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
@@ -191,15 +191,15 @@ namespace pika::detail {
     };
 
     template <typename T>
-    constexpr bool operator==(
-        aligned_allocator<T> const&, aligned_allocator<T> const&)
+    constexpr bool
+    operator==(aligned_allocator<T> const&, aligned_allocator<T> const&)
     {
         return true;
     }
 
     template <typename T>
-    constexpr bool operator!=(
-        aligned_allocator<T> const&, aligned_allocator<T> const&)
+    constexpr bool
+    operator!=(aligned_allocator<T> const&, aligned_allocator<T> const&)
     {
         return false;
     }

--- a/libs/pika/allocator_support/include/pika/allocator_support/internal_allocator.hpp
+++ b/libs/pika/allocator_support/include/pika/allocator_support/internal_allocator.hpp
@@ -105,15 +105,15 @@ namespace pika::detail {
     };
 
     template <typename T>
-    constexpr bool operator==(
-        internal_allocator<T> const&, internal_allocator<T> const&)
+    constexpr bool
+    operator==(internal_allocator<T> const&, internal_allocator<T> const&)
     {
         return true;
     }
 
     template <typename T>
-    constexpr bool operator!=(
-        internal_allocator<T> const&, internal_allocator<T> const&)
+    constexpr bool
+    operator!=(internal_allocator<T> const&, internal_allocator<T> const&)
     {
         return false;
     }

--- a/libs/pika/async/include/pika/async/async_fwd.hpp
+++ b/libs/pika/async/include/pika/async/async_fwd.hpp
@@ -23,7 +23,7 @@ namespace pika {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename F, typename... Ts>
-    PIKA_FORCEINLINE auto async(
-        F&& f, Ts&&... ts) -> decltype(detail::async_action_dispatch<Action,
+    PIKA_FORCEINLINE auto
+    async(F&& f, Ts&&... ts) -> decltype(detail::async_action_dispatch<Action,
         std::decay_t<F>>::call(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...));
 }    // namespace pika

--- a/libs/pika/async_base/include/pika/async_base/dataflow.hpp
+++ b/libs/pika/async_base/include/pika/async_base/dataflow.hpp
@@ -32,8 +32,8 @@ namespace pika {
     }
 
     template <typename Allocator, typename F, typename... Ts>
-    PIKA_FORCEINLINE auto dataflow_alloc(
-        Allocator const& alloc, F&& f, Ts&&... ts)
+    PIKA_FORCEINLINE auto
+    dataflow_alloc(Allocator const& alloc, F&& f, Ts&&... ts)
         -> decltype(detail::dataflow_dispatch<std::decay_t<F>>::call(
             alloc, PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
     {

--- a/libs/pika/async_base/include/pika/async_base/launch_policy.hpp
+++ b/libs/pika/async_base/include/pika/async_base/launch_policy.hpp
@@ -624,8 +624,8 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator&(
-            policy_holder<Left> const& lhs,
+        constexpr inline policy_holder_base
+        operator&(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -635,8 +635,8 @@ namespace pika {
         }
 
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator|(
-            policy_holder<Left> const& lhs,
+        constexpr inline policy_holder_base
+        operator|(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -646,8 +646,8 @@ namespace pika {
         }
 
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator^(
-            policy_holder<Left> const& lhs,
+        constexpr inline policy_holder_base
+        operator^(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -657,8 +657,8 @@ namespace pika {
         }
 
         template <typename Derived>
-        constexpr inline policy_holder<Derived> operator~(
-            policy_holder<Derived> const& p) noexcept
+        constexpr inline policy_holder<Derived>
+        operator~(policy_holder<Derived> const& p) noexcept
         {
             return policy_holder<Derived>(
                 static_cast<launch_policy>(~static_cast<int>(p.policy())),
@@ -881,8 +881,8 @@ namespace pika {
         }
 
         template <typename F>
-        PIKA_FORCEINLINE constexpr bool has_async_policy(
-            detail::policy_holder<F> const& p) noexcept
+        PIKA_FORCEINLINE constexpr bool
+        has_async_policy(detail::policy_holder<F> const& p) noexcept
         {
             return bool(static_cast<int>(p.policy()) &
                 static_cast<int>(detail::launch_policy::async_policies));

--- a/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/future_wait.hpp
@@ -27,15 +27,15 @@ namespace pika::detail {
     struct wait_acquire_future
     {
         template <typename R>
-        PIKA_FORCEINLINE pika::future<R> operator()(
-            pika::future<R>& future) const
+        PIKA_FORCEINLINE pika::future<R>
+        operator()(pika::future<R>& future) const
         {
             return PIKA_MOVE(future);
         }
 
         template <typename R>
-        PIKA_FORCEINLINE pika::shared_future<R> operator()(
-            pika::shared_future<R>& future) const
+        PIKA_FORCEINLINE pika::shared_future<R>
+        operator()(pika::shared_future<R>& future) const
         {
             return future;
         }

--- a/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/split_future.hpp
@@ -55,8 +55,8 @@ namespace pika {
     ///             futures will be exceptional as well.
     ///
     template <typename T>
-    inline std::vector<future<T>> split_future(
-        future<std::vector<T>>&& f, std::size_t size);
+    inline std::vector<future<T>>
+    split_future(future<std::vector<T>>&& f, std::size_t size);
 }    // namespace pika
 
 #else    // DOXYGEN
@@ -175,16 +175,16 @@ namespace pika {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts, std::size_t... Is>
-        PIKA_FORCEINLINE std::tuple<pika::future<Ts>...> split_future_helper(
-            pika::future<std::tuple<Ts...>>&& f,
+        PIKA_FORCEINLINE std::tuple<pika::future<Ts>...>
+        split_future_helper(pika::future<std::tuple<Ts...>>&& f,
             pika::util::detail::index_pack<Is...>)
         {
             return std::make_tuple(extract_nth_future<Is>(f)...);
         }
 
         template <typename... Ts, std::size_t... Is>
-        PIKA_FORCEINLINE std::tuple<pika::future<Ts>...> split_future_helper(
-            pika::shared_future<std::tuple<Ts...>>&& f,
+        PIKA_FORCEINLINE std::tuple<pika::future<Ts>...>
+        split_future_helper(pika::shared_future<std::tuple<Ts...>>&& f,
             pika::util::detail::index_pack<Is...>)
         {
             return std::make_tuple(extract_nth_future<Is>(f)...);
@@ -259,8 +259,8 @@ namespace pika {
         };
 
         template <typename T, typename Future>
-        inline pika::future<T> extract_future_array(
-            std::size_t i, Future& future)
+        inline pika::future<T>
+        extract_future_array(std::size_t i, Future& future)
         {
             using shared_state = split_continuation<T>;
 
@@ -272,8 +272,8 @@ namespace pika {
         }
 
         template <std::size_t N, typename T, typename Future>
-        inline std::array<pika::future<T>, N> split_future_helper_array(
-            Future&& f)
+        inline std::array<pika::future<T>, N>
+        split_future_helper_array(Future&& f)
         {
             std::array<pika::future<T>, N> result;
 
@@ -284,8 +284,8 @@ namespace pika {
         }
 
         template <typename T, typename Future>
-        inline std::vector<pika::future<T>> split_future_helper_vector(
-            Future&& f, std::size_t size)
+        inline std::vector<pika::future<T>>
+        split_future_helper_vector(Future&& f, std::size_t size)
         {
             std::vector<pika::future<T>> result;
             result.reserve(size);
@@ -299,8 +299,8 @@ namespace pika {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    PIKA_FORCEINLINE std::tuple<pika::future<Ts>...> split_future(
-        pika::future<std::tuple<Ts...>>&& f)
+    PIKA_FORCEINLINE std::tuple<pika::future<Ts>...>
+    split_future(pika::future<std::tuple<Ts...>>&& f)
     {
         return detail::split_future_helper(PIKA_MOVE(f),
             typename pika::util::detail::make_index_pack<sizeof...(
@@ -314,8 +314,8 @@ namespace pika {
     }
 
     template <typename... Ts>
-    PIKA_FORCEINLINE std::tuple<pika::future<Ts>...> split_future(
-        pika::shared_future<std::tuple<Ts...>>&& f)
+    PIKA_FORCEINLINE std::tuple<pika::future<Ts>...>
+    split_future(pika::shared_future<std::tuple<Ts...>>&& f)
     {
         return detail::split_future_helper(PIKA_MOVE(f),
             typename pika::util::detail::make_index_pack<sizeof...(
@@ -330,30 +330,30 @@ namespace pika {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T1, typename T2>
-    PIKA_FORCEINLINE std::pair<pika::future<T1>, pika::future<T2>> split_future(
-        pika::future<std::pair<T1, T2>>&& f)
+    PIKA_FORCEINLINE std::pair<pika::future<T1>, pika::future<T2>>
+    split_future(pika::future<std::pair<T1, T2>>&& f)
     {
         return detail::split_future_helper(PIKA_MOVE(f));
     }
 
     template <typename T1, typename T2>
-    PIKA_FORCEINLINE std::pair<pika::future<T1>, pika::future<T2>> split_future(
-        pika::shared_future<std::pair<T1, T2>>&& f)
+    PIKA_FORCEINLINE std::pair<pika::future<T1>, pika::future<T2>>
+    split_future(pika::shared_future<std::pair<T1, T2>>&& f)
     {
         return detail::split_future_helper(PIKA_MOVE(f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <std::size_t N, typename T>
-    PIKA_FORCEINLINE std::array<pika::future<T>, N> split_future(
-        pika::future<std::array<T, N>>&& f)
+    PIKA_FORCEINLINE std::array<pika::future<T>, N>
+    split_future(pika::future<std::array<T, N>>&& f)
     {
         return detail::split_future_helper_array<N, T>(PIKA_MOVE(f));
     }
 
     template <typename T>
-    PIKA_FORCEINLINE std::array<pika::future<void>, 1> split_future(
-        pika::future<std::array<T, 0>>&& f)
+    PIKA_FORCEINLINE std::array<pika::future<void>, 1>
+    split_future(pika::future<std::array<T, 0>>&& f)
     {
         std::array<pika::future<void>, 1> result;
         result[0] = pika::future<void>(PIKA_MOVE(f));
@@ -361,15 +361,15 @@ namespace pika {
     }
 
     template <std::size_t N, typename T>
-    PIKA_FORCEINLINE std::array<pika::future<T>, N> split_future(
-        pika::shared_future<std::array<T, N>>&& f)
+    PIKA_FORCEINLINE std::array<pika::future<T>, N>
+    split_future(pika::shared_future<std::array<T, N>>&& f)
     {
         return detail::split_future_helper_array<N, T>(PIKA_MOVE(f));
     }
 
     template <typename T>
-    PIKA_FORCEINLINE std::array<pika::future<void>, 1> split_future(
-        pika::shared_future<std::array<T, 0>>&& f)
+    PIKA_FORCEINLINE std::array<pika::future<void>, 1>
+    split_future(pika::shared_future<std::array<T, 0>>&& f)
     {
         std::array<pika::future<void>, 1> result;
         result[0] = pika::make_future<void>(PIKA_MOVE(f));
@@ -378,15 +378,15 @@ namespace pika {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    PIKA_FORCEINLINE std::vector<pika::future<T>> split_future(
-        pika::future<std::vector<T>>&& f, std::size_t size)
+    PIKA_FORCEINLINE std::vector<pika::future<T>>
+    split_future(pika::future<std::vector<T>>&& f, std::size_t size)
     {
         return detail::split_future_helper_vector<T>(PIKA_MOVE(f), size);
     }
 
     template <typename T>
-    PIKA_FORCEINLINE std::vector<pika::future<T>> split_future(
-        pika::shared_future<std::vector<T>>&& f, std::size_t size)
+    PIKA_FORCEINLINE std::vector<pika::future<T>>
+    split_future(pika::shared_future<std::vector<T>>&& f, std::size_t size)
     {
         return detail::split_future_helper_vector<T>(PIKA_MOVE(f), size);
     }

--- a/libs/pika/async_combinators/include/pika/async_combinators/when_any.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/when_any.hpp
@@ -45,8 +45,8 @@ namespace pika {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<when_any_result<Container>> when_any(
-        InputIter first, InputIter last);
+    future<when_any_result<Container>>
+    when_any(InputIter first, InputIter last);
 
     /// The function \a when_any is a non-deterministic choice operator. It
     /// OR-composes all future objects given and returns a new future object
@@ -114,8 +114,8 @@ namespace pika {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<when_any_result<Container>> when_any_n(
-        InputIter first, std::size_t count);
+    future<when_any_result<Container>>
+    when_any_n(InputIter first, std::size_t count);
 }    // namespace pika
 
 #else    // DOXYGEN
@@ -223,8 +223,8 @@ namespace pika {
             }
 
             template <typename Future>
-            std::enable_if_t<pika::traits::is_future_v<Future>> operator()(
-                Future& future) const
+            std::enable_if_t<pika::traits::is_future_v<Future>>
+            operator()(Future& future) const
             {
                 std::size_t index =
                     when_.index_.load(std::memory_order_seq_cst);
@@ -275,8 +275,8 @@ namespace pika {
             }
 
             template <typename Tuple, std::size_t... Is>
-            PIKA_FORCEINLINE void apply(
-                Tuple& tuple, pika::util::detail::index_pack<Is...>) const
+            PIKA_FORCEINLINE void
+            apply(Tuple& tuple, pika::util::detail::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
                     (((*this)(std::get<Is>(tuple))), 0)...};
@@ -301,8 +301,8 @@ namespace pika {
         };
 
         template <typename Sequence>
-        PIKA_FORCEINLINE void set_on_completed_callback(
-            detail::when_any<Sequence>& when)
+        PIKA_FORCEINLINE void
+        set_on_completed_callback(detail::when_any<Sequence>& when)
         {
             set_when_any_callback_impl<Sequence> callback(when);
             callback.apply(when.lazy_values_.futures);
@@ -406,8 +406,8 @@ namespace pika {
             std::vector<pika::lcos::detail::future_iterator_traits_t<Iterator>>,
         typename Enable =
             std::enable_if_t<pika::traits::is_iterator_v<Iterator>>>
-    pika::future<pika::when_any_result<Container>> when_any(
-        Iterator begin, Iterator end)
+    pika::future<pika::when_any_result<Container>>
+    when_any(Iterator begin, Iterator end)
     {
         Container values;
         traits::detail::reserve_if_random_access_by_range(values, begin, end);
@@ -427,8 +427,8 @@ namespace pika {
             std::vector<pika::lcos::detail::future_iterator_traits_t<Iterator>>,
         typename Enable =
             std::enable_if_t<pika::traits::is_iterator_v<Iterator>>>
-    pika::future<pika::when_any_result<Container>> when_any_n(
-        Iterator begin, std::size_t count)
+    pika::future<pika::when_any_result<Container>>
+    when_any_n(Iterator begin, std::size_t count)
     {
         Container values;
         traits::detail::reserve_if_reservable(values, count);

--- a/libs/pika/async_combinators/include/pika/async_combinators/when_some.hpp
+++ b/libs/pika/async_combinators/include/pika/async_combinators/when_some.hpp
@@ -63,8 +63,8 @@ namespace pika {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<when_some_result<Container>> when_some(
-        std::size_t n, Iterator first, Iterator last);
+    future<when_some_result<Container>>
+    when_some(std::size_t n, Iterator first, Iterator last);
 
     /// The function \a when_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -132,8 +132,8 @@ namespace pika {
     ///       but the futures held in the output collection may.
     ///
     template <typename... Ts>
-    future<when_some_result<tuple<future<T>...>>> when_some(
-        std::size_t n, Ts&&... futures);
+    future<when_some_result<tuple<future<T>...>>>
+    when_some(std::size_t n, Ts&&... futures);
 
     /// The function \a when_some_n is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -174,8 +174,8 @@ namespace pika {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<when_some_result<Container>> when_some_n(
-        std::size_t n, Iterator first, std::size_t count);
+    future<when_some_result<Container>>
+    when_some_n(std::size_t n, Iterator first, std::size_t count);
 }    // namespace pika
 
 #else    // DOXYGEN
@@ -241,8 +241,8 @@ namespace pika {
             }
 
             template <typename Future>
-            std::enable_if_t<traits::is_future_v<Future>> operator()(
-                Future& future) const
+            std::enable_if_t<traits::is_future_v<Future>>
+            operator()(Future& future) const
             {
                 std::size_t counter =
                     when_.count_.load(std::memory_order_seq_cst);
@@ -300,8 +300,8 @@ namespace pika {
             }
 
             template <typename Tuple, std::size_t... Is>
-            PIKA_FORCEINLINE void apply(
-                Tuple& tuple, util::detail::index_pack<Is...>) const
+            PIKA_FORCEINLINE void
+            apply(Tuple& tuple, util::detail::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
                     (((*this)(std::get<Is>(tuple))), 0)...};
@@ -326,8 +326,8 @@ namespace pika {
         };
 
         template <typename Sequence>
-        PIKA_FORCEINLINE void set_on_completed_callback(
-            detail::when_some<Sequence>& when)
+        PIKA_FORCEINLINE void
+        set_on_completed_callback(detail::when_some<Sequence>& when)
         {
             set_when_some_callback_impl<Sequence> callback(when);
             callback.apply(when.values_.futures);
@@ -457,8 +457,8 @@ namespace pika {
             typename lcos::detail::future_iterator_traits<Iterator>::type>,
         typename Enable =
             std::enable_if_t<pika::traits::is_iterator_v<Iterator>>>
-    pika::future<when_some_result<Container>> when_some(
-        std::size_t n, Iterator begin, Iterator end)
+    pika::future<when_some_result<Container>>
+    when_some(std::size_t n, Iterator begin, Iterator end)
     {
         Container values;
         traits::detail::reserve_if_random_access_by_range(values, begin, end);
@@ -474,8 +474,8 @@ namespace pika {
             typename lcos::detail::future_iterator_traits<Iterator>::type>,
         typename Enable =
             std::enable_if_t<pika::traits::is_iterator_v<Iterator>>>
-    pika::future<when_some_result<Container>> when_some_n(
-        std::size_t n, Iterator begin, std::size_t count)
+    pika::future<when_some_result<Container>>
+    when_some_n(std::size_t n, Iterator begin, std::size_t count)
     {
         Container values;
         traits::detail::reserve_if_reservable(values, count);

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -133,8 +133,8 @@ namespace pika::cuda::experimental {
 #endif
 
             template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                pika::execution::experimental::connect_t,
+            friend operation_state<Receiver>
+            tag_invoke(pika::execution::experimental::connect_t,
                 cuda_scheduler_sender&& s, Receiver&& receiver)
             {
                 return {
@@ -142,8 +142,8 @@ namespace pika::cuda::experimental {
             }
 
             template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                pika::execution::experimental::connect_t,
+            friend operation_state<Receiver>
+            tag_invoke(pika::execution::experimental::connect_t,
                 cuda_scheduler_sender const& s, Receiver&& receiver)
             {
                 return {s.scheduler, PIKA_FORWARD(Receiver, receiver)};

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
@@ -56,8 +56,8 @@ namespace pika::cuda::experimental {
 
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename Shape>
-        PIKA_DEVICE auto shape_dereference_impl(
-            std::false_type, Shape&& shape, int i)
+        PIKA_DEVICE auto
+        shape_dereference_impl(std::false_type, Shape&& shape, int i)
         {
             return pika::util::begin(shape)[i];
         }
@@ -71,8 +71,8 @@ namespace pika::cuda::experimental {
         }
 
         template <typename F, typename Shape, typename Size, typename... Ts>
-        __global__ void bulk_function_kernel_integral(
-            F f, Shape shape, Size n, Ts... ts)
+        __global__ void
+        bulk_function_kernel_integral(F f, Shape shape, Size n, Ts... ts)
         {
             int i = threadIdx.x + blockIdx.x * blockDim.x;
             if (i < static_cast<int>(n))

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_stream.hpp
@@ -51,8 +51,8 @@ namespace pika::cuda::experimental {
 
         PIKA_EXPORT whip::stream_t get() const noexcept;
         PIKA_EXPORT int get_device() const noexcept;
-        PIKA_EXPORT pika::execution::thread_priority get_priority()
-            const noexcept;
+        PIKA_EXPORT pika::execution::thread_priority
+        get_priority() const noexcept;
         PIKA_EXPORT unsigned int get_flags() const noexcept;
 
         /// \cond NOINTERNAL

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -260,8 +260,8 @@ namespace pika::cuda::experimental {
     {
     private:
         template <typename Sender, typename F>
-        friend PIKA_FORCEINLINE auto tag_fallback_invoke(
-            then_on_host_t, Sender&& sender, F&& f)
+        friend PIKA_FORCEINLINE auto
+        tag_fallback_invoke(then_on_host_t, Sender&& sender, F&& f)
         {
             auto completion_sched =
                 pika::execution::experimental::get_completion_scheduler<
@@ -278,8 +278,8 @@ namespace pika::cuda::experimental {
         }
 
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            then_on_host_t, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(then_on_host_t, F&& f)
         {
             return pika::execution::experimental::detail::partial_algorithm<
                 then_on_host_t, F>{PIKA_FORWARD(F, f)};

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -62,8 +62,8 @@ namespace pika::cuda::experimental::then_with_stream_detail {
     }
 
     template <typename R, typename... Ts>
-    void set_value_event_callback_helper(
-        whip::error_t status, R&& r, Ts&&... ts)
+    void
+    set_value_event_callback_helper(whip::error_t status, R&& r, Ts&&... ts)
     {
         static_assert(sizeof...(Ts) <= 1, "Expecting at most one value");
 
@@ -272,8 +272,8 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                     then_with_cuda_stream_receiver const&) = delete;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     then_with_cuda_stream_receiver&& r, Error&& error) noexcept
                 {
                     pika::execution::experimental::set_error(
@@ -702,8 +702,8 @@ namespace pika::cuda::experimental {
         }
 
         template <typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(
-            F&& f, cublasPointerMode_t pointer_mode) const
+        constexpr PIKA_FORCEINLINE auto
+        operator()(F&& f, cublasPointerMode_t pointer_mode) const
         {
             return pika::execution::experimental::detail::partial_algorithm<
                 then_with_cublas_t, F, cublasPointerMode_t>{

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -178,8 +178,8 @@ namespace pika::mpi::experimental {
                     operation_state& op_state;
 
                     template <typename Error>
-                    friend constexpr void tag_invoke(
-                        pika::execution::experimental::set_error_t,
+                    friend constexpr void
+                    tag_invoke(pika::execution::experimental::set_error_t,
                         transform_mpi_receiver&& r, Error&& error) noexcept
                     {
                         pika::execution::experimental::set_error(
@@ -198,8 +198,8 @@ namespace pika::mpi::experimental {
                     template <typename... Ts,
                         typename = std::enable_if_t<
                             is_mpi_request_invocable_v<F, Ts...>>>
-                    friend constexpr void tag_invoke(
-                        pika::execution::experimental::set_value_t,
+                    friend constexpr void
+                    tag_invoke(pika::execution::experimental::set_value_t,
                         transform_mpi_receiver&& r, Ts&&... ts) noexcept
                     {
                         using ts_element_type = std::tuple<std::decay_t<Ts>...>;
@@ -363,8 +363,8 @@ namespace pika::mpi::experimental {
             };
 
             template <typename Receiver>
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::connect_t,
+            friend constexpr auto
+            tag_invoke(pika::execution::experimental::connect_t,
                 transform_mpi_sender_type& s, Receiver&& receiver)
             {
                 return operation_state<Receiver>(
@@ -372,8 +372,8 @@ namespace pika::mpi::experimental {
             }
 
             template <typename Receiver>
-            friend constexpr auto tag_invoke(
-                pika::execution::experimental::connect_t,
+            friend constexpr auto
+            tag_invoke(pika::execution::experimental::connect_t,
                 transform_mpi_sender_type&& s, Receiver&& receiver)
             {
                 return operation_state<Receiver>(
@@ -390,8 +390,8 @@ namespace pika::mpi::experimental {
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(
                 pika::execution::experimental::is_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transform_mpi_t, Sender&& sender, F&& f,
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f,
             mpi::experimental::stream_type s =
                 mpi::experimental::stream_type::automatic)
         {
@@ -403,8 +403,8 @@ namespace pika::mpi::experimental {
         // tag invoke overload for mpi_transform
         //
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transform_mpi_t, F&& f,
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(transform_mpi_t, F&& f,
             mpi::experimental::stream_type s =
                 mpi::experimental::stream_type::automatic)
         {

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -41,8 +41,8 @@ constexpr int debug_level = 0;
 
 // cppcheck-suppress ConfigurationNotChecked
 template <int Level>
-static pika::debug::detail::print_threshold<Level, debug_level> nws_deb(
-    "STORAGE");
+static pika::debug::detail::print_threshold<Level, debug_level>
+    nws_deb("STORAGE");
 
 //----------------------------------------------------------------------------
 //

--- a/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
+++ b/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
@@ -929,8 +929,8 @@ namespace pika::concurrency::detail {
     // Need to forward-declare this swap because it's in a namespace.
     // See http://stackoverflow.com/questions/4492062/why-does-a-c-friend-class-need-a-forward-declaration-only-in-other-namespaces
     template <typename T, typename Traits>
-    inline void swap(
-        typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
+    inline void
+    swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
         typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b)
         MOODYCAMEL_NOEXCEPT;
 
@@ -1300,8 +1300,8 @@ namespace pika::concurrency::detail {
         // instead of copied.
         // Thread-safe.
         template <typename It>
-        bool enqueue_bulk(
-            producer_token_t const& token, It itemFirst, size_t count)
+        bool
+        enqueue_bulk(producer_token_t const& token, It itemFirst, size_t count)
         {
             return inner_enqueue_bulk<CanAlloc>(token, itemFirst, count);
         }
@@ -1533,8 +1533,8 @@ namespace pika::concurrency::detail {
         // were checked (so, the queue is likely but not guaranteed to be empty).
         // Never allocates. Thread-safe.
         template <typename It>
-        size_t try_dequeue_bulk(
-            consumer_token_t& token, It itemFirst, size_t max)
+        size_t
+        try_dequeue_bulk(consumer_token_t& token, It itemFirst, size_t max)
         {
             if (token.desiredProducer == nullptr ||
                 token.lastKnownGlobalOffset !=
@@ -1601,8 +1601,8 @@ namespace pika::concurrency::detail {
         // was checked (so, the queue is likely but not guaranteed to be empty).
         // Never allocates. Thread-safe.
         template <typename U>
-        inline bool try_dequeue_from_producer(
-            producer_token_t const& producer, U& item)
+        inline bool
+        try_dequeue_from_producer(producer_token_t const& producer, U& item)
         {
             return static_cast<ExplicitProducer*>(producer.producer)
                 ->dequeue(item);
@@ -4968,8 +4968,8 @@ namespace pika::concurrency::detail {
     }
 
     template <typename T, typename Traits>
-    inline void swap(
-        typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
+    inline void
+    swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
         typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b)
         MOODYCAMEL_NOEXCEPT
     {

--- a/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_accessor.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/coroutine_accessor.hpp
@@ -35,8 +35,8 @@ namespace pika::threads::coroutines::detail {
     struct coroutine_accessor
     {
         template <typename Coroutine>
-        PIKA_FORCEINLINE static typename Coroutine::impl_ptr get_impl(
-            Coroutine& x)
+        PIKA_FORCEINLINE static typename Coroutine::impl_ptr
+        get_impl(Coroutine& x)
         {
             return x.get_impl();
         }

--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
@@ -169,9 +169,8 @@ namespace pika::threads::coroutines::detail::posix {
 #else    // non-mmap()
 
     //this should be a fine default.
-    static const std::size_t stack_alignment = sizeof(void*) > 16 ?
-        sizeof(void*) :
-        16;
+    static const std::size_t
+        stack_alignment = sizeof(void*) > 16 ? sizeof(void*) : 16;
 
     struct stack_aligner
     {

--- a/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
@@ -132,8 +132,8 @@ namespace pika::threads::detail {
         }
 
         template <typename Char, typename Traits>
-        friend std::basic_ostream<Char, Traits>& operator<<(
-            std::basic_ostream<Char, Traits>& os, thread_id const& id)
+        friend std::basic_ostream<Char, Traits>&
+        operator<<(std::basic_ostream<Char, Traits>& os, thread_id const& id)
         {
             os << id.get();
             return os;

--- a/libs/pika/datastructures/include/pika/datastructures/member_pack.hpp
+++ b/libs/pika/datastructures/include/pika/datastructures/member_pack.hpp
@@ -84,14 +84,14 @@ namespace pika::util::detail {
         return leaf;
     }
     template <std::size_t I, typename T>
-    static constexpr T const& member_get(
-        member_leaf<I, T, false> const& leaf) noexcept
+    static constexpr T const&
+    member_get(member_leaf<I, T, false> const& leaf) noexcept
     {
         return leaf.member;
     }
     template <std::size_t I, typename T>
-    static constexpr T const& member_get(
-        member_leaf<I, T, true> const& leaf) noexcept
+    static constexpr T const&
+    member_get(member_leaf<I, T, true> const& leaf) noexcept
     {
         return leaf;
     }

--- a/libs/pika/datastructures/tests/unit/small_vector.cpp
+++ b/libs/pika/datastructures/tests/unit/small_vector.cpp
@@ -419,9 +419,9 @@ namespace test {
     }
 
     template <typename SeqContainer>
-    void test_insert_range(std::deque<int>& std_deque,
-        SeqContainer& seq_container, std::deque<int> const& input_deque,
-        std::size_t index)
+    void
+    test_insert_range(std::deque<int>& std_deque, SeqContainer& seq_container,
+        std::deque<int> const& input_deque, std::size_t index)
     {
         check_equal_containers(std_deque, seq_container);
 
@@ -748,9 +748,9 @@ namespace test {
     static emplace_int expected[10];
 
     template <typename Container>
-    void test_expected_container(Container const& ec,
-        emplace_int const* expected, unsigned int only_first_n,
-        unsigned int cont_offset = 0)
+    void
+    test_expected_container(Container const& ec, emplace_int const* expected,
+        unsigned int only_first_n, unsigned int cont_offset = 0)
     {
         PIKA_TEST(cont_offset <= ec.size());
         PIKA_TEST(only_first_n <= (ec.size() - cont_offset));

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -86,8 +86,8 @@ namespace pika::debug::detail {
     };
 
     template <typename T>
-    cxxabi_demangle_helper<T> cxx_type_id<T>::typeid_ =
-        cxxabi_demangle_helper<T>();
+    cxxabi_demangle_helper<T>
+        cxx_type_id<T>::typeid_ = cxxabi_demangle_helper<T>();
 #else
     template <typename T>
     using cxx_type_id = type_id<T>;
@@ -111,8 +111,8 @@ namespace pika::debug::detail {
     }
 
     template <typename T, typename... Args>
-    inline std::enable_if_t<sizeof...(Args) != 0, std::string> print_type(
-        const char* delim = "")
+    inline std::enable_if_t<sizeof...(Args) != 0, std::string>
+    print_type(const char* delim = "")
     {
         std::string temp(cxx_type_id<T>::typeid_.type_id());
         return temp + delim + print_type<Args...>(delim);

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -269,8 +269,8 @@ namespace NS_DEBUG {
     };
 
     template <typename TupleType, std::size_t... I>
-    void tuple_print(
-        std::ostream& os, TupleType const& t, std::index_sequence<I...>)
+    void
+    tuple_print(std::ostream& os, TupleType const& t, std::index_sequence<I...>)
     {
         (..., (os << (I == 0 ? "" : " ") << std::get<I>(t)));
     }
@@ -519,8 +519,8 @@ namespace NS_DEBUG {
     };
 
     template <typename T>
-    PIKA_EXPORT void print_array(
-        std::string const& name, T const* data, std::size_t size);
+    PIKA_EXPORT void
+    print_array(std::string const& name, T const* data, std::size_t size);
 
     // when true, debug statements produce valid output
     template <>
@@ -597,8 +597,8 @@ namespace NS_DEBUG {
         }
 
         template <typename T>
-        void array(
-            std::string const& name, T const* data, std::size_t size) const
+        void
+        array(std::string const& name, T const* data, std::size_t size) const
         {
             print_array(name, data, size);
         }
@@ -616,8 +616,8 @@ namespace NS_DEBUG {
         }
 
         template <typename... Args>
-        constexpr timed_var<Args...> make_timer(
-            const double delay, const Args... args) const
+        constexpr timed_var<Args...>
+        make_timer(const double delay, const Args... args) const
         {
             return timed_var<Args...>(delay, args...);
         }

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -301,8 +301,8 @@ namespace NS_DEBUG {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T>
-    PIKA_EXPORT void print_array(
-        std::string const& name, T const* data, std::size_t size)
+    PIKA_EXPORT void
+    print_array(std::string const& name, T const* data, std::size_t size)
     {
         std::cout << str<20>(name.c_str()) << ": {" << dec<4>(size) << "} : ";
         std::copy(data, data + size, std::ostream_iterator<T>(std::cout, ", "));

--- a/libs/pika/errors/include/pika/errors/exception.hpp
+++ b/libs/pika/errors/include/pika/errors/exception.hpp
@@ -301,13 +301,13 @@ namespace pika {
         };
 
         template <typename Exception>
-        PIKA_EXPORT std::exception_ptr get_exception(pika::exception const& e,
-            std::string const& func, std::string const& file, long line,
-            std::string const& auxinfo);
+        PIKA_EXPORT std::exception_ptr
+        get_exception(pika::exception const& e, std::string const& func,
+            std::string const& file, long line, std::string const& auxinfo);
 
         template <typename Exception>
-        PIKA_EXPORT std::exception_ptr construct_lightweight_exception(
-            Exception const& e);
+        PIKA_EXPORT std::exception_ptr
+        construct_lightweight_exception(Exception const& e);
     }    // namespace detail
     /// \endcond
 

--- a/libs/pika/errors/include/pika/errors/exception_info.hpp
+++ b/libs/pika/errors/include/pika/errors/exception_info.hpp
@@ -181,8 +181,8 @@ namespace pika {
     }    // namespace detail
 
     template <typename E>
-    [[noreturn]] void throw_with_info(
-        E&& e, exception_info&& xi = exception_info())
+    [[noreturn]] void
+    throw_with_info(E&& e, exception_info&& xi = exception_info())
     {
         using ED = std::decay_t<E>;
         static_assert(std::is_class<ED>::value && !std::is_final<ED>::value,

--- a/libs/pika/errors/include/pika/errors/throw_exception.hpp
+++ b/libs/pika/errors/include/pika/errors/throw_exception.hpp
@@ -38,8 +38,8 @@ namespace pika::detail {
         exception const& e, std::string const& func);
 
     template <typename Exception>
-    PIKA_EXPORT std::exception_ptr get_exception(Exception const& e,
-        std::string const& func = "<unknown>",
+    PIKA_EXPORT std::exception_ptr
+    get_exception(Exception const& e, std::string const& func = "<unknown>",
         std::string const& file = "<unknown>", long line = -1,
         std::string const& auxinfo = "");
 

--- a/libs/pika/errors/include/pika/errors/try_catch_exception_ptr.hpp
+++ b/libs/pika/errors/include/pika/errors/try_catch_exception_ptr.hpp
@@ -27,8 +27,8 @@ namespace pika::detail {
     /// different worker thread, but we use this nonetheless on Windows since it
     /// doesn't hurt.
     template <typename TryCallable, typename CatchCallable>
-    PIKA_FORCEINLINE decltype(auto) try_catch_exception_ptr(
-        TryCallable&& t, CatchCallable&& c)
+    PIKA_FORCEINLINE decltype(auto)
+    try_catch_exception_ptr(TryCallable&& t, CatchCallable&& c)
     {
         std::exception_ptr ep;
         try

--- a/libs/pika/errors/src/exception.cpp
+++ b/libs/pika/errors/src/exception.cpp
@@ -160,9 +160,9 @@ namespace pika {
 
 namespace pika { namespace detail {
     template <typename Exception>
-    PIKA_EXPORT std::exception_ptr construct_lightweight_exception(
-        Exception const& e, std::string const& func, std::string const& file,
-        long line)
+    PIKA_EXPORT std::exception_ptr
+    construct_lightweight_exception(Exception const& e, std::string const& func,
+        std::string const& file, long line)
     {
         // create a std::exception_ptr object encapsulating the Exception to
         // be thrown and annotate it with all the local information we have
@@ -185,8 +185,8 @@ namespace pika { namespace detail {
     }
 
     template <typename Exception>
-    PIKA_EXPORT std::exception_ptr construct_lightweight_exception(
-        Exception const& e)
+    PIKA_EXPORT std::exception_ptr
+    construct_lightweight_exception(Exception const& e)
     {
         // create a std::exception_ptr object encapsulating the Exception to
         // be thrown and annotate it with all the local information we have
@@ -208,9 +208,9 @@ namespace pika { namespace detail {
         pika::thread_interrupted const&);
 
     template <typename Exception>
-    PIKA_EXPORT std::exception_ptr construct_custom_exception(
-        Exception const& e, std::string const& func, std::string const& file,
-        long line, std::string const& auxinfo)
+    PIKA_EXPORT std::exception_ptr
+    construct_custom_exception(Exception const& e, std::string const& func,
+        std::string const& file, long line, std::string const& auxinfo)
     {
         if (!custom_exception_info_handler)
         {
@@ -253,9 +253,9 @@ namespace pika { namespace detail {
     }
 
     template <typename Exception>
-    PIKA_EXPORT std::exception_ptr get_exception(Exception const& e,
-        std::string const& func, std::string const& file, long line,
-        std::string const& auxinfo)
+    PIKA_EXPORT std::exception_ptr
+    get_exception(Exception const& e, std::string const& func,
+        std::string const& file, long line, std::string const& auxinfo)
     {
         if (is_of_lightweight_pika_category(e))
         {

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -178,8 +178,8 @@ namespace pika::execution::experimental {
                         pika::execution::experimental::set_value_t, Sender,
                         bulk_t, Shape, F>)>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_override_invoke(
-            bulk_t, Sender&& sender, Shape const& shape, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_override_invoke(bulk_t, Sender&& sender, Shape const& shape, F&& f)
         {
             auto scheduler =
                 pika::execution::experimental::get_completion_scheduler<
@@ -195,8 +195,8 @@ namespace pika::execution::experimental {
                 std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            bulk_t, Sender&& sender, Shape const& shape, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(bulk_t, Sender&& sender, Shape const& shape, F&& f)
         {
             return bulk_detail::bulk_sender<Sender,
                 pika::util::detail::counting_shape_type<Shape>, F>{
@@ -212,8 +212,8 @@ namespace pika::execution::experimental {
                 !std::is_integral<std::decay_t<Shape>>::value
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            bulk_t, Sender&& sender, Shape&& shape, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(bulk_t, Sender&& sender, Shape&& shape, F&& f)
         {
             return bulk_detail::bulk_sender<Sender, Shape, F>{
                 PIKA_FORWARD(Sender, sender), PIKA_FORWARD(Shape, shape),
@@ -221,8 +221,8 @@ namespace pika::execution::experimental {
         }
 
         template <typename Shape, typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            bulk_t, Shape&& shape, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(bulk_t, Shape&& shape, F&& f)
         {
             return detail::partial_algorithm<bulk_t, Shape, F>{
                 PIKA_FORWARD(Shape, shape), PIKA_FORWARD(F, f)};

--- a/libs/pika/execution/include/pika/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/detail/partial_algorithm.hpp
@@ -40,8 +40,8 @@ namespace pika {
             partial_algorithm_base const&) = delete;
 
         template <typename U>
-        friend constexpr PIKA_FORCEINLINE auto operator|(
-            U&& u, partial_algorithm_base p)
+        friend constexpr PIKA_FORCEINLINE auto
+        operator|(U&& u, partial_algorithm_base p)
         {
             return Tag{}(
                 PIKA_FORWARD(U, u), PIKA_MOVE(p.ts).template get<Is>()...);

--- a/libs/pika/execution/include/pika/execution/algorithms/detail/predicates.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/detail/predicates.hpp
@@ -22,15 +22,15 @@
 
 namespace pika { namespace parallel { namespace detail {
     template <typename InputIterator, typename Distance>
-    PIKA_HOST_DEVICE constexpr void advance_impl(
-        InputIterator& i, Distance n, std::random_access_iterator_tag)
+    PIKA_HOST_DEVICE constexpr void
+    advance_impl(InputIterator& i, Distance n, std::random_access_iterator_tag)
     {
         i += n;
     }
 
     template <typename InputIterator, typename Distance>
-    PIKA_HOST_DEVICE constexpr void advance_impl(
-        InputIterator& i, Distance n, std::bidirectional_iterator_tag)
+    PIKA_HOST_DEVICE constexpr void
+    advance_impl(InputIterator& i, Distance n, std::bidirectional_iterator_tag)
     {
         if (n < 0)
         {
@@ -45,8 +45,8 @@ namespace pika { namespace parallel { namespace detail {
     }
 
     template <typename InputIterator, typename Distance>
-    PIKA_HOST_DEVICE constexpr void advance_impl(
-        InputIterator& i, Distance n, std::input_iterator_tag)
+    PIKA_HOST_DEVICE constexpr void
+    advance_impl(InputIterator& i, Distance n, std::input_iterator_tag)
     {
 #if defined(PIKA_INTEL_VERSION)
 #pragma warning(push)
@@ -84,16 +84,16 @@ namespace pika { namespace parallel { namespace detail {
             pika::traits::is_iterator<Iterable>::value>::type>
     {
         template <typename Iter1, typename Iter2>
-        PIKA_FORCEINLINE constexpr static std::size_t call(
-            Iter1 iter1, Iter2 iter2)
+        PIKA_FORCEINLINE constexpr static std::size_t
+        call(Iter1 iter1, Iter2 iter2)
         {
             return std::distance(iter1, iter2);
         }
     };
 
     template <typename Iterable>
-    PIKA_FORCEINLINE constexpr std::size_t distance(
-        Iterable iter1, Iterable iter2)
+    PIKA_FORCEINLINE constexpr std::size_t
+    distance(Iterable iter1, Iterable iter2)
     {
         return calculate_distance<std::decay_t<Iterable>>::call(iter1, iter2);
     }
@@ -103,15 +103,15 @@ namespace pika { namespace parallel { namespace detail {
     struct calculate_next
     {
         template <typename T, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T call(
-            T t1, Stride offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T
+        call(T t1, Stride offset)
         {
             return T(t1 + offset);
         }
 
         template <typename T, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T call(
-            T t, std::size_t max_count, Stride& offset, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T
+        call(T t, std::size_t max_count, Stride& offset, std::true_type)
         {
             if (is_negative(offset))
             {
@@ -129,8 +129,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename T, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T call(
-            T t, std::size_t max_count, Stride& offset, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T
+        call(T t, std::size_t max_count, Stride& offset, std::false_type)
         {
             // NVCC seems to have a bug with std::min...
             offset = max_count < offset ? max_count : offset;
@@ -138,8 +138,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename T, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T call(
-            T t, std::size_t max_count, Stride& offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static T
+        call(T t, std::size_t max_count, Stride& offset)
         {
             return call(
                 t, max_count, offset, typename std::is_signed<Stride>::type());
@@ -152,8 +152,8 @@ namespace pika { namespace parallel { namespace detail {
             !pika::traits::is_bidirectional_iterator<Iterable>::value>::type>
     {
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, Stride offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, Stride offset)
         {
 #if (defined(PIKA_HAVE_CUDA) && defined(__CUDACC__)) || defined(PIKA_HAVE_HIP)
             pika::parallel::detail::advance(iter, offset);
@@ -164,8 +164,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, std::size_t max_count, Stride& offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, std::size_t max_count, Stride& offset)
         {
             // anything less than a bidirectional iterator does not support
             // negative offsets
@@ -189,8 +189,8 @@ namespace pika { namespace parallel { namespace detail {
             pika::traits::is_bidirectional_iterator<Iterable>::value>::type>
     {
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, Stride offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, Stride offset)
         {
 #if (defined(PIKA_HAVE_CUDA) && defined(__CUDACC__)) || defined(PIKA_HAVE_HIP)
             pika::parallel::detail::advance(iter, offset);
@@ -201,8 +201,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, std::size_t max_count, Stride& offset, std::true_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, std::size_t max_count, Stride& offset, std::true_type)
         {
             // advance through the end or max number of elements
             if (!is_negative(offset))
@@ -231,8 +231,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, std::size_t max_count, Stride& offset, std::false_type)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, std::size_t max_count, Stride& offset, std::false_type)
         {
             // advance through the end or max number of elements
             // NVCC seems to have a bug with std::min...
@@ -247,8 +247,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter call(
-            Iter iter, std::size_t max_count, Stride& offset)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static Iter
+        call(Iter iter, std::size_t max_count, Stride& offset)
         {
             return call(iter, max_count, offset,
                 typename std::is_signed<Stride>::type());
@@ -256,15 +256,15 @@ namespace pika { namespace parallel { namespace detail {
     };
 
     template <typename Iterable, typename Stride>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iterable next(
-        Iterable iter, Stride offset)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iterable
+    next(Iterable iter, Stride offset)
     {
         return calculate_next<std::decay_t<Iterable>>::call(iter, offset);
     }
 
     template <typename Iterable, typename Stride>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iterable next(
-        Iterable iter, std::size_t max_count, Stride offset)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr Iterable
+    next(Iterable iter, std::size_t max_count, Stride offset)
     {
         return calculate_next<std::decay_t<Iterable>>::call(
             iter, max_count, offset);
@@ -276,8 +276,8 @@ namespace pika { namespace parallel { namespace detail {
         template <typename T1, typename T2,
             typename Enable = std::enable_if_t<
                 pika::detail::is_equality_comparable_with_v<T1, T2>>>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return t1 == t2;
         }
@@ -288,8 +288,8 @@ namespace pika { namespace parallel { namespace detail {
         template <typename T1, typename T2,
             typename Enable = std::enable_if_t<
                 pika::detail::is_equality_comparable_with_v<T1, T2>>>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return t1 != t2;
         }
@@ -308,8 +308,8 @@ namespace pika { namespace parallel { namespace detail {
         }
 
         template <typename T>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T const& t) const -> decltype(std::declval<Value>() == t)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T const& t) const -> decltype(std::declval<Value>() == t)
         {
             return value_ == t;
         }
@@ -321,8 +321,8 @@ namespace pika { namespace parallel { namespace detail {
     struct less
     {
         template <typename T1, typename T2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return PIKA_FORWARD(T1, t1) < PIKA_FORWARD(T2, t2);
         }
@@ -331,8 +331,8 @@ namespace pika { namespace parallel { namespace detail {
     struct greater
     {
         template <typename T1, typename T2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return PIKA_FORWARD(T1, t1) > PIKA_FORWARD(T2, t2);
         }
@@ -341,8 +341,8 @@ namespace pika { namespace parallel { namespace detail {
     struct greater_equal
     {
         template <typename T1, typename T2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return PIKA_FORWARD(T1, t1) >= PIKA_FORWARD(T2, t2);
         }
@@ -351,8 +351,8 @@ namespace pika { namespace parallel { namespace detail {
     struct less_equal
     {
         template <typename T1, typename T2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-            T1&& t1, T2&& t2) const
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+        operator()(T1&& t1, T2&& t2) const
         {
             return PIKA_FORWARD(T1, t1) <= PIKA_FORWARD(T2, t2);
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -174,8 +174,8 @@ namespace pika::ensure_started_detail {
                 pika::intrusive_ptr<shared_state> state;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     ensure_started_receiver&& r, Error&& error) noexcept
                 {
                     r.state->v.template emplace<error_type>(
@@ -209,8 +209,8 @@ namespace pika::ensure_started_detail {
                     pika::detail::monostate>;
 
                 template <typename... Ts>
-                friend auto tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend auto
+                tag_invoke(pika::execution::experimental::set_value_t,
                     ensure_started_receiver&& r, Ts&&... ts) noexcept
                     -> decltype(std::declval<pika::detail::variant<
                                     pika::detail::monostate, value_type>>()
@@ -472,8 +472,8 @@ namespace pika::ensure_started_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t,
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
             ensure_started_sender_type&& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
@@ -505,8 +505,8 @@ namespace pika::execution::experimental {
         template <typename Sender,
             PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender> &&
                 !ensure_started_detail::is_ensure_started_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            ensure_started_t, Sender&& sender)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(ensure_started_t, Sender&& sender)
         {
             return ensure_started_detail::ensure_started_sender<Sender,
                 pika::detail::internal_allocator<>>{
@@ -529,8 +529,8 @@ namespace pika::execution::experimental {
                 ensure_started_detail::is_ensure_started_sender_v<Sender>&&
                     std::is_same_v<typename Sender::allocator_type,
                         std::decay_t<Allocator>>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            ensure_started_t, Sender&& sender, Allocator const&)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(ensure_started_t, Sender&& sender, Allocator const&)
         {
             return PIKA_FORWARD(Sender, sender);
         }
@@ -550,16 +550,16 @@ namespace pika::execution::experimental {
         template <typename Sender,
             PIKA_CONCEPT_REQUIRES_(
                 ensure_started_detail::is_ensure_started_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            ensure_started_t, Sender&& sender)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(ensure_started_t, Sender&& sender)
         {
             return PIKA_FORWARD(Sender, sender);
         }
 
         template <typename Allocator = pika::detail::internal_allocator<>,
             PIKA_CONCEPT_REQUIRES_(pika::detail::is_allocator_v<Allocator>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            ensure_started_t, Allocator const& allocator = {})
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(ensure_started_t, Allocator const& allocator = {})
         {
             return detail::partial_algorithm<ensure_started_t, Allocator>{
                 allocator};

--- a/libs/pika/execution/include/pika/execution/algorithms/execute.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/execute.hpp
@@ -24,8 +24,8 @@ namespace pika { namespace execution { namespace experimental {
     {
     private:
         template <typename Scheduler, typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            execute_t, Scheduler&& scheduler, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(execute_t, Scheduler&& scheduler, F&& f)
         {
             return start_detached(
                 then(schedule(PIKA_FORWARD(Scheduler, scheduler)),

--- a/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
@@ -105,9 +105,9 @@ namespace pika::keep_future_detail {
         keep_future_sender& operator=(keep_future_sender const&) = delete;
 
         template <typename Receiver>
-        friend operation_state<Receiver, future_type> tag_invoke(
-            pika::execution::experimental::connect_t, keep_future_sender&& s,
-            Receiver&& receiver)
+        friend operation_state<Receiver, future_type>
+        tag_invoke(pika::execution::experimental::connect_t,
+            keep_future_sender&& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
         }
@@ -135,17 +135,17 @@ namespace pika::keep_future_detail {
         keep_future_sender& operator=(keep_future_sender const&) = default;
 
         template <typename Receiver>
-        friend operation_state<Receiver, future_type> tag_invoke(
-            pika::execution::experimental::connect_t, keep_future_sender&& s,
-            Receiver&& receiver)
+        friend operation_state<Receiver, future_type>
+        tag_invoke(pika::execution::experimental::connect_t,
+            keep_future_sender&& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver, future_type> tag_invoke(
-            pika::execution::experimental::connect_t, keep_future_sender& s,
-            Receiver&& receiver)
+        friend operation_state<Receiver, future_type>
+        tag_invoke(pika::execution::experimental::connect_t,
+            keep_future_sender& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), s.future};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -195,8 +195,8 @@ namespace pika::let_error_detail {
                 };
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     let_error_predecessor_receiver&& r, Error&& error) noexcept
                 {
                     pika::detail::try_catch_exception_ptr(
@@ -229,8 +229,8 @@ namespace pika::let_error_detail {
                     typename = std::enable_if_t<pika::detail::is_invocable_v<
                         pika::execution::experimental::set_value_t, Receiver&&,
                         Ts...>>>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_value_t,
                     let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
                 {
                     pika::execution::experimental::set_value(
@@ -333,8 +333,8 @@ namespace pika::execution::experimental {
         }
 
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            let_error_t, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(let_error_t, F&& f)
         {
             return detail::partial_algorithm<let_error_t, F>{
                 PIKA_FORWARD(F, f)};

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -180,8 +180,8 @@ namespace pika::let_value_detail {
                 }
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     let_value_predecessor_receiver&& r, Error&& error) noexcept
                 {
                     pika::execution::experimental::set_error(
@@ -290,8 +290,8 @@ namespace pika::let_value_detail {
                 }
 
                 template <typename... Ts>
-                friend auto tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend auto
+                tag_invoke(pika::execution::experimental::set_value_t,
                     let_value_predecessor_receiver&& r, Ts&&... ts) noexcept
                     -> decltype(std::declval<predecessor_ts_type>()
                                     .template emplace<
@@ -361,8 +361,8 @@ namespace pika::execution::experimental {
         }
 
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            let_value_t, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(let_value_t, F&& f)
         {
             return detail::partial_algorithm<let_value_t, F>{
                 PIKA_FORWARD(F, f)};

--- a/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/make_future.hpp
@@ -252,8 +252,8 @@ namespace pika::execution::experimental {
                 pika::detail::is_allocator_v<Allocator>
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            make_future_t, Sender&& sender,
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(make_future_t, Sender&& sender,
             Allocator const& allocator = Allocator{})
         {
             return make_future_detail::make_future(

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -166,8 +166,8 @@ namespace pika::schedule_from_detail {
                 operation_state& op_state;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     predecessor_sender_receiver&& r, Error&& error) noexcept
                 {
                     r.op_state.set_error_predecessor_sender(
@@ -200,8 +200,8 @@ namespace pika::schedule_from_detail {
                     pika::detail::monostate>;
 
                 template <typename... Ts>
-                friend auto tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend auto
+                tag_invoke(pika::execution::experimental::set_value_t,
                     predecessor_sender_receiver&& r, Ts&&... ts) noexcept
                     -> decltype(std::declval<value_type>()
                                     .template emplace<
@@ -260,8 +260,8 @@ namespace pika::schedule_from_detail {
                 operation_state& op_state;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     scheduler_sender_receiver&& r, Error&& error) noexcept
                 {
                     r.op_state.set_error_scheduler_sender(
@@ -335,8 +335,8 @@ namespace pika::schedule_from_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t,
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
             schedule_from_sender_type&& s, Receiver&& receiver)
         {
             return {PIKA_MOVE(s.predecessor_sender), PIKA_MOVE(s.scheduler),
@@ -344,8 +344,8 @@ namespace pika::schedule_from_detail {
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t,
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
             schedule_from_sender_type& s, Receiver&& receiver)
         {
             return {s.predecessor_sender, s.scheduler,

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -179,8 +179,8 @@ namespace pika::split_detail {
                 shared_state& state;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     split_receiver&& r, Error&& error) noexcept
                 {
                     r.state.v.template emplace<error_type>(
@@ -211,8 +211,8 @@ namespace pika::split_detail {
                     value_type_helper>;
 
                 template <typename... Ts>
-                friend auto tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend auto
+                tag_invoke(pika::execution::experimental::set_value_t,
                     split_receiver&& r, Ts&&... ts) noexcept
                     -> decltype(std::declval<pika::detail::variant<
                                     pika::detail::monostate, value_type>>()
@@ -481,17 +481,17 @@ namespace pika::split_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t, split_sender_type&& s,
-            Receiver&& receiver)
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
+            split_sender_type&& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t, split_sender_type& s,
-            Receiver&& receiver)
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
+            split_sender_type& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), s.state};
         }
@@ -521,8 +521,8 @@ namespace pika::execution::experimental {
         template <typename Sender,
             PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender> &&
                 !split_detail::is_split_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            split_t, Sender&& sender)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(split_t, Sender&& sender)
         {
             return split_detail::split_sender<Sender,
                 pika::detail::internal_allocator<>>{
@@ -544,8 +544,8 @@ namespace pika::execution::experimental {
             PIKA_CONCEPT_REQUIRES_(
                 split_detail::is_split_sender_v<Sender>&& std::is_same_v<
                     typename Sender::allocator_type, std::decay_t<Allocator>>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            split_t, Sender&& sender, Allocator const&)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(split_t, Sender&& sender, Allocator const&)
         {
             return PIKA_FORWARD(Sender, sender);
         }
@@ -563,16 +563,16 @@ namespace pika::execution::experimental {
 
         template <typename Sender,
             PIKA_CONCEPT_REQUIRES_(split_detail::is_split_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            split_t, Sender&& sender)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(split_t, Sender&& sender)
         {
             return PIKA_FORWARD(Sender, sender);
         }
 
         template <typename Allocator = pika::detail::internal_allocator<>,
             PIKA_CONCEPT_REQUIRES_(pika::detail::is_allocator_v<Allocator>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            split_t, Allocator const& allocator = {})
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(split_t, Allocator const& allocator = {})
         {
             return detail::partial_algorithm<split_t, Allocator>{allocator};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
@@ -132,8 +132,8 @@ namespace pika::execution::experimental {
                 pika::detail::is_allocator_v<Allocator>
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE void tag_fallback_invoke(
-            start_detached_t, Sender&& sender,
+        friend constexpr PIKA_FORCEINLINE void
+        tag_fallback_invoke(start_detached_t, Sender&& sender,
             Allocator const& allocator = Allocator{})
         {
             using allocator_type = Allocator;

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -251,8 +251,8 @@ namespace pika::this_thread::experimental {
                 pika::execution::experimental::is_sender_v<Sender>
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            sync_wait_t, Sender&& sender)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(sync_wait_t, Sender&& sender)
         {
             using receiver_type = sync_wait_detail::sync_wait_receiver<Sender>;
             using state_type = typename receiver_type::shared_state;

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -195,16 +195,16 @@ namespace pika::execution::experimental {
                 is_sender_v<Sender>
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            then_t, Sender&& sender, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(then_t, Sender&& sender, F&& f)
         {
             return then_detail::then_sender<Sender, F>{
                 PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f)};
         }
 
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            then_t, F&& f)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(then_t, F&& f)
         {
             return detail::partial_algorithm<then_t, F>{PIKA_FORWARD(F, f)};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
@@ -35,8 +35,8 @@ namespace pika { namespace execution { namespace experimental {
                         pika::execution::experimental::set_value_t, Sender,
                         transfer_t, Scheduler>)>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_override_invoke(
-            transfer_t, Sender&& sender, Scheduler&& scheduler)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_override_invoke(transfer_t, Sender&& sender, Scheduler&& scheduler)
         {
             auto completion_scheduler =
                 pika::execution::experimental::get_completion_scheduler<
@@ -61,8 +61,8 @@ namespace pika { namespace execution { namespace experimental {
         }
 
         template <typename Scheduler>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transfer_t, Scheduler&& scheduler)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(transfer_t, Scheduler&& scheduler)
         {
             return detail::partial_algorithm<transfer_t, Scheduler>{
                 PIKA_FORWARD(Scheduler, scheduler)};

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer_just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer_just.hpp
@@ -23,8 +23,8 @@ namespace pika { namespace execution { namespace experimental {
     {
     private:
         template <typename Scheduler, typename... Ts>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transfer_just_t, Scheduler&& scheduler, Ts&&... ts)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(transfer_just_t, Scheduler&& scheduler, Ts&&... ts)
         {
             return transfer(just(PIKA_FORWARD(Ts, ts)...),
                 PIKA_FORWARD(Scheduler, scheduler));

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -424,8 +424,8 @@ namespace pika::execution::experimental {
                 pika::util::detail::all_of_v<is_sender<Senders>...>
             )>
         // clang-format on
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            when_all_t, Senders&&... senders)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(when_all_t, Senders&&... senders)
         {
             return pika::when_all_impl::when_all_sender<Senders...>{
                 PIKA_FORWARD(Senders, senders)...};

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -150,8 +150,8 @@ namespace pika::when_all_vector_detail {
                 std::size_t const i;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     when_all_vector_receiver&& r, Error&& error) noexcept
                 {
                     if (!r.op_state.set_stopped_error_called.exchange(true))
@@ -179,8 +179,8 @@ namespace pika::when_all_vector_detail {
                 };
 
                 template <typename... Ts>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_value_t,
                     when_all_vector_receiver&& r, Ts&&... ts) noexcept
                 {
                     if (!r.op_state.set_stopped_error_called)
@@ -384,8 +384,8 @@ namespace pika::execution::experimental {
     {
     private:
         template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            when_all_vector_t, std::vector<Sender>&& senders)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(when_all_vector_t, std::vector<Sender>&& senders)
         {
             return when_all_vector_detail::when_all_vector_sender<Sender>{
                 PIKA_MOVE(senders)};

--- a/libs/pika/execution/include/pika/execution/detail/future_exec.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/future_exec.hpp
@@ -137,8 +137,8 @@ namespace pika { namespace lcos { namespace detail {
         }
 
         template <typename Allocator, typename F>
-        PIKA_FORCEINLINE static auto call_alloc(
-            Allocator const& alloc, Future&& fut, F&& f)
+        PIKA_FORCEINLINE static auto
+        call_alloc(Allocator const& alloc, Future&& fut, F&& f)
             -> decltype(future_then_dispatch<Future, launch>::call_alloc(
                 alloc, PIKA_MOVE(fut), launch::all, PIKA_FORWARD(F, f)))
         {

--- a/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
+++ b/libs/pika/execution/include/pika/execution/detail/post_policy_dispatch.hpp
@@ -98,8 +98,8 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
     struct post_policy_dispatch
     {
         template <typename F, typename... Ts>
-        static void call(Policy const& policy,
-            pika::detail::thread_description const& desc,
+        static void
+        call(Policy const& policy, pika::detail::thread_description const& desc,
             threads::detail::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             if (policy == launch::sync)

--- a/libs/pika/execution/include/pika/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/dynamic_chunk_size.hpp
@@ -39,8 +39,8 @@ namespace pika { namespace execution {
 
         /// \cond NOINTERNAL
         template <typename Executor, typename F>
-        constexpr std::size_t get_chunk_size(
-            Executor&, F&&, std::size_t, std::size_t) const
+        constexpr std::size_t
+        get_chunk_size(Executor&, F&&, std::size_t, std::size_t) const
         {
             return chunk_size_;
         }

--- a/libs/pika/execution/include/pika/execution/executors/execution.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution.hpp
@@ -79,8 +79,8 @@ namespace pika { namespace parallel { namespace execution {
                 !pika::traits::is_two_way_executor_v<Executor>>>
         {
             template <typename OneWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                std::false_type, OneWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call_impl(std::false_type, OneWayExecutor&& exec, F&& f, Ts&&... ts)
                 -> pika::future<decltype(sync_execute_dispatch(0,
                     PIKA_FORWARD(OneWayExecutor, exec), PIKA_FORWARD(F, f),
                     PIKA_FORWARD(Ts, ts)...))>
@@ -91,8 +91,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename OneWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static pika::future<void> call_impl(
-                std::true_type, OneWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static pika::future<void>
+            call_impl(std::true_type, OneWayExecutor&& exec, F&& f, Ts&&... ts)
             {
                 sync_execute_dispatch(0, PIKA_FORWARD(OneWayExecutor, exec),
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
@@ -250,8 +250,8 @@ namespace pika { namespace parallel { namespace execution {
         }
 
         template <typename TwoWayExecutor, typename F, typename... Ts>
-        PIKA_FORCEINLINE auto async_execute_dispatch(
-            int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE auto
+        async_execute_dispatch(int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
             -> decltype(exec.async_execute(
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
         {
@@ -319,8 +319,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static void call_impl(
-                std::true_type, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static void
+            call_impl(std::true_type, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
             {
                 async_execute_dispatch(0, PIKA_FORWARD(TwoWayExecutor, exec),
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...)
@@ -340,8 +340,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(
-                int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call_impl(int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
                 -> decltype(exec.sync_execute(
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
             {
@@ -350,8 +350,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(TwoWayExecutor&& exec, F&& f, Ts&&... ts)
                 -> decltype(call_impl(0, PIKA_FORWARD(TwoWayExecutor, exec),
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
             {
@@ -457,8 +457,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                TwoWayExecutor&& exec, F&& f, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(TwoWayExecutor&& exec, F&& f, Ts&&... ts)
                 -> decltype(call_impl(0, PIKA_FORWARD(TwoWayExecutor, exec),
                     PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
             {
@@ -495,8 +495,8 @@ namespace pika { namespace parallel { namespace execution {
         // default implementation of the post() customization point
         template <typename NonBlockingOneWayExecutor, typename F,
             typename... Ts>
-        PIKA_FORCEINLINE auto post_dispatch(
-            int, NonBlockingOneWayExecutor&& exec, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE auto
+        post_dispatch(int, NonBlockingOneWayExecutor&& exec, F&& f, Ts&&... ts)
             -> decltype(exec.post(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
         {
             return exec.post(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);
@@ -619,8 +619,8 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(call_impl(0, PIKA_FORWARD(BulkExecutor, exec),
                     PIKA_FORWARD(F, f), shape, PIKA_FORWARD(Ts, ts)...))
             {
@@ -645,8 +645,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(bulk_async_execute_dispatch(0,
                     PIKA_FORWARD(BulkExecutor, exec), PIKA_FORWARD(F, f), shape,
                     PIKA_FORWARD(Ts, ts)...))
@@ -811,8 +811,8 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(call_impl(0, PIKA_FORWARD(BulkExecutor, exec),
                     PIKA_FORWARD(F, f), shape, PIKA_FORWARD(Ts, ts)...))
             {
@@ -941,8 +941,8 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(call_impl(0, PIKA_FORWARD(BulkExecutor, exec),
                     PIKA_FORWARD(F, f), shape, PIKA_FORWARD(Ts, ts)...))
             {
@@ -967,8 +967,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
-            PIKA_FORCEINLINE static auto call(
-                BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call(BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(bulk_sync_execute_dispatch(0,
                     PIKA_FORWARD(BulkExecutor, exec), PIKA_FORWARD(F, f), shape,
                     PIKA_FORWARD(Ts, ts)...))
@@ -1028,9 +1028,9 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts>
-            static pika::future<void> call_impl(std::true_type,
-                BulkExecutor&& exec, F&& f, Shape const& shape,
-                Future&& predecessor, Ts&&... ts)
+            static pika::future<void>
+            call_impl(std::true_type, BulkExecutor&& exec, F&& f,
+                Shape const& shape, Future&& predecessor, Ts&&... ts)
             {
                 auto func = make_fused_bulk_sync_execute_helper<void>(exec,
                     PIKA_FORWARD(F, f), shape,
@@ -1047,9 +1047,9 @@ namespace pika { namespace parallel { namespace execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts>
-            PIKA_FORCEINLINE static auto call_impl(pika::detail::wrap_int,
-                BulkExecutor&& exec, F&& f, Shape const& shape,
-                Future&& predecessor, Ts&&... ts)
+            PIKA_FORCEINLINE static auto
+            call_impl(pika::detail::wrap_int, BulkExecutor&& exec, F&& f,
+                Shape const& shape, Future&& predecessor, Ts&&... ts)
                 -> pika::future<
                     bulk_then_execute_result_t<F, Shape, Future, Ts...>>
             {

--- a/libs/pika/execution/include/pika/execution/executors/execution_information.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_information.hpp
@@ -50,8 +50,8 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            has_pending_closures_t, Executor&& /*exec*/)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(has_pending_closures_t, Executor&& /*exec*/)
         {
             return false;    // assume stateless scheduling
         }
@@ -63,8 +63,8 @@ namespace pika { namespace parallel { namespace execution {
                 has_has_pending_closures<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_invoke(
-            has_pending_closures_t, Executor&& exec)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_invoke(has_pending_closures_t, Executor&& exec)
         {
             return exec.has_pending_closures();
         }
@@ -95,9 +95,9 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_pu_mask_t, Executor&& /*exec*/, threads::detail::topology& topo,
-            std::size_t thread_num)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(get_pu_mask_t, Executor&& /*exec*/,
+            threads::detail::topology& topo, std::size_t thread_num)
         {
             return detail::get_pu_mask(topo, thread_num);
         }
@@ -109,9 +109,9 @@ namespace pika { namespace parallel { namespace execution {
                 has_get_pu_mask<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_invoke(get_pu_mask_t,
-            Executor&& exec, threads::detail::topology& topo,
-            std::size_t thread_num)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_invoke(get_pu_mask_t, Executor&& exec,
+            threads::detail::topology& topo, std::size_t thread_num)
         {
             return exec.get_pu_mask(topo, thread_num);
         }
@@ -148,8 +148,8 @@ namespace pika { namespace parallel { namespace execution {
                 has_set_scheduler_mode<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE void tag_invoke(
-            set_scheduler_mode_t, Executor&& exec, Mode const& mode)
+        friend PIKA_FORCEINLINE void
+        tag_invoke(set_scheduler_mode_t, Executor&& exec, Mode const& mode)
         {
             exec.set_scheduler_mode(mode);
         }

--- a/libs/pika/execution/include/pika/execution/executors/execution_parameters.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_parameters.hpp
@@ -56,9 +56,9 @@ namespace pika { namespace parallel { namespace execution {
                     !check_for_property<Parameters>::value
                 )>
             // clang-format on
-            friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-                derived_propery_t, Executor&& /*exec*/, Parameters&& /*params*/,
-                Property prop)
+            friend PIKA_FORCEINLINE decltype(auto)
+            tag_fallback_invoke(derived_propery_t, Executor&& /*exec*/,
+                Parameters&& /*params*/, Property prop)
             {
                 return std::make_pair(prop, prop);
             }
@@ -72,9 +72,9 @@ namespace pika { namespace parallel { namespace execution {
                     check_for_property<Parameters>::value
                 )>
             // clang-format on
-            friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-                derived_propery_t, Executor&& exec, Parameters&& params,
-                Property /*prop*/)
+            friend PIKA_FORCEINLINE decltype(auto)
+            tag_fallback_invoke(derived_propery_t, Executor&& exec,
+                Parameters&& params, Property /*prop*/)
             {
                 return std::pair<Parameters&&, Executor&&>(
                     PIKA_FORWARD(Parameters, params),
@@ -134,8 +134,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor, typename F>
-            PIKA_FORCEINLINE static std::size_t call(Parameters& params,
-                Executor&& exec, F&& f, std::size_t cores,
+            PIKA_FORCEINLINE static std::size_t
+            call(Parameters& params, Executor&& exec, F&& f, std::size_t cores,
                 std::size_t num_tasks)
             {
                 auto withprop =
@@ -148,9 +148,9 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor, typename F>
-            PIKA_FORCEINLINE static std::size_t call(AnyParameters params,
-                Executor&& exec, F&& f, std::size_t cores,
-                std::size_t num_tasks)
+            PIKA_FORCEINLINE static std::size_t
+            call(AnyParameters params, Executor&& exec, F&& f,
+                std::size_t cores, std::size_t num_tasks)
             {
                 return call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f), cores,
@@ -169,8 +169,8 @@ namespace pika { namespace parallel { namespace execution {
         {
             // default implementation
             template <typename Target>
-            PIKA_FORCEINLINE static std::size_t maximal_number_of_chunks(
-                Target, std::size_t, std::size_t)
+            PIKA_FORCEINLINE static std::size_t
+            maximal_number_of_chunks(Target, std::size_t, std::size_t)
             {
                 // return zero chunks which will tell the implementation to
                 // calculate the number of chunks either based on a
@@ -251,8 +251,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE static void call(
-                Parameters& params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(Parameters& params, Executor&& exec)
             {
                 auto withprop =
                     with_reset_thread_distribution(PIKA_FORWARD(Executor, exec),
@@ -263,8 +263,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor>
-            PIKA_FORCEINLINE static void call(
-                AnyParameters params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(AnyParameters params, Executor&& exec)
             {
                 call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec));
@@ -305,8 +305,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE static std::size_t call(
-                Parameters& params, Executor&& exec)
+            PIKA_FORCEINLINE static std::size_t
+            call(Parameters& params, Executor&& exec)
             {
                 auto withprop =
                     with_processing_units_count(PIKA_FORWARD(Executor, exec),
@@ -317,8 +317,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor>
-            PIKA_FORCEINLINE static std::size_t call(
-                AnyParameters params, Executor&& exec)
+            PIKA_FORCEINLINE static std::size_t
+            call(AnyParameters params, Executor&& exec)
             {
                 return call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec));
@@ -358,8 +358,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE static void call(
-                Parameters& params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(Parameters& params, Executor&& exec)
             {
                 auto withprop =
                     with_mark_begin_execution(PIKA_FORWARD(Executor, exec),
@@ -370,8 +370,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor>
-            PIKA_FORCEINLINE static void call(
-                AnyParameters params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(AnyParameters params, Executor&& exec)
             {
                 call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec));
@@ -411,8 +411,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE static void call(
-                Parameters& params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(Parameters& params, Executor&& exec)
             {
                 auto withprop =
                     with_mark_end_of_scheduling(PIKA_FORWARD(Executor, exec),
@@ -423,8 +423,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor>
-            PIKA_FORCEINLINE static void call(
-                AnyParameters params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(AnyParameters params, Executor&& exec)
             {
                 call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec));
@@ -463,8 +463,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<pika::traits::is_executor_any<Executor_>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE static void call(
-                Parameters& params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(Parameters& params, Executor&& exec)
             {
                 auto withprop =
                     with_mark_end_execution(PIKA_FORWARD(Executor, exec),
@@ -475,8 +475,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename AnyParameters, typename Executor>
-            PIKA_FORCEINLINE static void call(
-                AnyParameters params, Executor&& exec)
+            PIKA_FORCEINLINE static void
+            call(AnyParameters params, Executor&& exec)
             {
                 call(static_cast<Parameters&>(params),
                     PIKA_FORWARD(Executor, exec));
@@ -629,8 +629,8 @@ namespace pika { namespace parallel { namespace execution {
             std::enable_if_t<has_processing_units_count<T>::value>>
         {
             template <typename Executor>
-            PIKA_FORCEINLINE std::size_t processing_units_count(
-                Executor&& exec) const
+            PIKA_FORCEINLINE std::size_t
+            processing_units_count(Executor&& exec) const
             {
                 auto& wrapped =
                     static_cast<unwrapper<Wrapper> const*>(this)->member_.get();

--- a/libs/pika/execution/include/pika/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/execution_parameters_fwd.hpp
@@ -89,9 +89,9 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_chunk_size_t, Parameters&& params, Executor&& exec, F&& f,
-            std::size_t cores, std::size_t num_tasks)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(get_chunk_size_t, Parameters&& params,
+            Executor&& exec, F&& f, std::size_t cores, std::size_t num_tasks)
         {
             return detail::get_chunk_size_fn_helper<
                 pika::detail::decay_unwrap_t<Parameters>,
@@ -125,9 +125,9 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            maximal_number_of_chunks_t, Parameters&& params, Executor&& exec,
-            std::size_t cores, std::size_t num_tasks)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(maximal_number_of_chunks_t, Parameters&& params,
+            Executor&& exec, std::size_t cores, std::size_t num_tasks)
         {
             return detail::maximal_number_of_chunks_fn_helper<
                 pika::detail::decay_unwrap_t<Parameters>,

--- a/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/polymorphic_executor.hpp
@@ -243,8 +243,8 @@ namespace pika { namespace parallel { namespace execution {
             }
 
             template <typename T>
-            static void _deallocate(
-                void* obj, std::size_t storage_size, bool destroy)
+            static void
+            _deallocate(void* obj, std::size_t storage_size, bool destroy)
             {
                 using storage_t =
                     typename std::aligned_storage<sizeof(T), alignof(T)>::type;
@@ -387,8 +387,8 @@ namespace pika { namespace parallel { namespace execution {
 
             // then_execute
             template <typename T>
-            static pika::future<R> _then_execute(void* exec,
-                then_execute_function_type&& f,
+            static pika::future<R>
+            _then_execute(void* exec, then_execute_function_type&& f,
                 pika::shared_future<void> const& predecessor, Ts&&... ts)
             {
                 return execution::then_execute(vtable_base::get<T>(exec),
@@ -440,9 +440,9 @@ namespace pika { namespace parallel { namespace execution {
 
             // bulk_sync_execute
             template <typename T>
-            static std::vector<R> _bulk_sync_execute(void* exec,
-                bulk_sync_execute_function_type&& f, range_proxy const& shape,
-                Ts&&... ts)
+            static std::vector<R>
+            _bulk_sync_execute(void* exec, bulk_sync_execute_function_type&& f,
+                range_proxy const& shape, Ts&&... ts)
             {
                 return execution::bulk_sync_execute(vtable_base::get<T>(exec),
                     PIKA_MOVE(f), shape, PIKA_FORWARD(Ts, ts)...);
@@ -814,8 +814,8 @@ namespace pika { namespace parallel { namespace execution {
         }
 
         template <typename F, typename Future>
-        PIKA_FORCEINLINE pika::future<R> then_execute(
-            F&& f, Future&& predecessor, Ts&&... ts) const
+        PIKA_FORCEINLINE pika::future<R>
+        then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
         {
             using function_type = typename vtable::then_execute_function_type;
 
@@ -827,8 +827,8 @@ namespace pika { namespace parallel { namespace execution {
 
         // BulkOneWayExecutor interface
         template <typename F, typename Shape>
-        PIKA_FORCEINLINE std::vector<R> bulk_sync_execute(
-            F&& f, Shape const& s, Ts&&... ts) const
+        PIKA_FORCEINLINE std::vector<R>
+        bulk_sync_execute(F&& f, Shape const& s, Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_sync_execute_function_type;
@@ -842,8 +842,8 @@ namespace pika { namespace parallel { namespace execution {
 
         // BulkTwoWayExecutor interface
         template <typename F, typename Shape>
-        PIKA_FORCEINLINE std::vector<pika::future<R>> bulk_async_execute(
-            F&& f, Shape const& s, Ts&&... ts) const
+        PIKA_FORCEINLINE std::vector<pika::future<R>>
+        bulk_async_execute(F&& f, Shape const& s, Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_async_execute_function_type;
@@ -856,9 +856,9 @@ namespace pika { namespace parallel { namespace execution {
         }
 
         template <typename F, typename Shape>
-        PIKA_FORCEINLINE pika::future<std::vector<R>> bulk_then_execute(F&& f,
-            Shape const& s, pika::shared_future<void> const& predecessor,
-            Ts&&... ts) const
+        PIKA_FORCEINLINE pika::future<std::vector<R>>
+        bulk_then_execute(F&& f, Shape const& s,
+            pika::shared_future<void> const& predecessor, Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_then_execute_function_type;

--- a/libs/pika/execution/include/pika/execution/executors/rebind_executor.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/rebind_executor.hpp
@@ -75,8 +75,8 @@ namespace pika { namespace parallel { namespace execution {
     struct create_rebound_policy_t
     {
         template <typename ExPolicy, typename Executor, typename Parameters>
-        constexpr decltype(auto) operator()(
-            ExPolicy&&, Executor&& exec, Parameters&& parameters) const
+        constexpr decltype(auto)
+        operator()(ExPolicy&&, Executor&& exec, Parameters&& parameters) const
         {
             using rebound_type =
                 typename rebind_executor<ExPolicy, Executor, Parameters>::type;

--- a/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
+++ b/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
@@ -51,8 +51,8 @@ namespace pika::execution::experimental {
                         pika::functional::is_nothrow_tag_invocable_v<
                             get_forward_progress_guarantee_t,
                             Scheduler const&>)>
-            constexpr forward_progress_guarantee operator()(
-                Scheduler const& scheduler) const noexcept
+            constexpr forward_progress_guarantee
+            operator()(Scheduler const& scheduler) const noexcept
             {
                 return pika::functional::tag_invoke(*this, scheduler);
             }
@@ -61,8 +61,8 @@ namespace pika::execution::experimental {
                 PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler> &&
                     !pika::functional::is_nothrow_tag_invocable_v<
                         get_forward_progress_guarantee_t, Scheduler const&>)>
-            constexpr forward_progress_guarantee operator()(
-                Scheduler const&) const noexcept
+            constexpr forward_progress_guarantee
+            operator()(Scheduler const&) const noexcept
             {
                 return forward_progress_guarantee::weakly_parallel;
             }

--- a/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_all_any_none.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_all_any_none.hpp
@@ -15,24 +15,24 @@
 
 namespace pika::parallel::traits::detail {
     template <typename T, typename Abi>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t all_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t
+    all_of(std::experimental::simd_mask<T, Abi> const& msk)
     {
         return std::experimental::all_of(msk);
     }
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t any_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t
+    any_of(std::experimental::simd_mask<T, Abi> const& msk)
     {
         return std::experimental::any_of(msk);
     }
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t none_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t
+    none_of(std::experimental::simd_mask<T, Abi> const& msk)
     {
         return std::experimental::none_of(msk);
     }

--- a/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_count_bits.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_count_bits.hpp
@@ -16,8 +16,8 @@
 
 namespace pika::parallel::traits::detail {
     template <typename T, typename Abi>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t count_bits(
-        std::experimental::simd_mask<T, Abi> const& mask)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE std::size_t
+    count_bits(std::experimental::simd_mask<T, Abi> const& mask)
     {
         return std::experimental::popcount(mask);
     }

--- a/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_find.hpp
+++ b/libs/pika/execution/include/pika/execution/traits/detail/simd/vector_pack_find.hpp
@@ -15,8 +15,8 @@
 
 namespace pika::parallel::traits::detail {
     template <typename T, typename Abi>
-    PIKA_HOST_DEVICE PIKA_FORCEINLINE int find_first_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+    PIKA_HOST_DEVICE PIKA_FORCEINLINE int
+    find_first_of(std::experimental::simd_mask<T, Abi> const& msk)
     {
         if (std::experimental::any_of(msk))
         {

--- a/libs/pika/execution/tests/include/algorithm_test_utils.hpp
+++ b/libs/pika/execution/tests/include/algorithm_test_utils.hpp
@@ -45,8 +45,8 @@ struct void_sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, void_sender, R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t, void_sender, R&& r)
     {
         return {std::forward<R>(r)};
     }
@@ -89,8 +89,8 @@ struct error_sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, error_sender, R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t, error_sender, R&& r)
     {
         return {std::forward<R>(r)};
     }
@@ -126,9 +126,9 @@ struct const_reference_error_sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, const_reference_error_sender,
-        R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t,
+        const_reference_error_sender, R&& r)
     {
         return {std::forward<R>(r)};
     }
@@ -456,8 +456,8 @@ struct scheduler
     std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
 
     template <typename F>
-    friend void tag_invoke(
-        pika::execution::experimental::execute_t, scheduler s, F&& f)
+    friend void
+    tag_invoke(pika::execution::experimental::execute_t, scheduler s, F&& f)
     {
         s.execute_called.get() = true;
         PIKA_INVOKE(std::forward<F>(f), );
@@ -495,8 +495,8 @@ struct scheduler
         };
 
         template <typename R>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, sender&&, R&& r)
+        friend auto
+        tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -537,8 +537,8 @@ struct scheduler2
     std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
 
     template <typename F>
-    friend void tag_invoke(
-        pika::execution::experimental::execute_t, scheduler2 s, F&& f)
+    friend void
+    tag_invoke(pika::execution::experimental::execute_t, scheduler2 s, F&& f)
     {
         s.execute_called.get() = true;
         PIKA_INVOKE(std::forward<F>(f), );
@@ -576,8 +576,8 @@ struct scheduler2
         };
 
         template <typename R>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, sender&&, R&& r)
+        friend auto
+        tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -735,8 +735,8 @@ namespace my_namespace {
         };
 
         template <typename R>
-        friend operation_state<R> tag_invoke(
-            pika::execution::experimental::connect_t, my_sender, R&& r)
+        friend operation_state<R>
+        tag_invoke(pika::execution::experimental::connect_t, my_sender, R&& r)
         {
             return {std::forward<R>(r)};
         }

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -37,8 +37,8 @@ struct sender
     };
 
     template <typename R>
-    friend operation_state tag_invoke(
-        pika::execution::experimental::connect_t, sender&&, R&&) noexcept
+    friend operation_state
+    tag_invoke(pika::execution::experimental::connect_t, sender&&, R&&) noexcept
     {
         return {};
     }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -66,8 +66,8 @@ struct scheduler_schedule_from
         };
 
         template <typename R>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, sender&&, R&& r)
+        friend auto
+        tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -156,8 +156,8 @@ struct scheduler_transfer
         };
 
         template <typename R>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, sender&&, R&& r)
+        friend auto
+        tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
         {
             return operation_state<R>{std::forward<R>(r)};
         }

--- a/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -108,8 +108,8 @@ struct test_executor_maximal_number_of_chunks
     }
 
     template <typename Parameters>
-    static std::size_t maximal_number_of_chunks(
-        Parameters&&, std::size_t, std::size_t num_tasks)
+    static std::size_t
+    maximal_number_of_chunks(Parameters&&, std::size_t, std::size_t num_tasks)
     {
         ++exec_count;
         return num_tasks;
@@ -127,8 +127,8 @@ namespace pika { namespace parallel { namespace execution {
 struct test_number_of_chunks
 {
     template <typename Executor>
-    std::size_t maximal_number_of_chunks(
-        Executor&&, std::size_t, std::size_t num_tasks)
+    std::size_t
+    maximal_number_of_chunks(Executor&&, std::size_t, std::size_t num_tasks)
     {
         ++params_count;
         return num_tasks;

--- a/libs/pika/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/pika/execution/tests/unit/minimal_async_executor.cpp
@@ -219,8 +219,8 @@ struct test_async_executor4 : test_async_executor1
     using execution_category = pika::execution::parallel_execution_tag;
 
     template <typename F, typename Shape, typename... Ts>
-    static std::vector<pika::future<void>> bulk_async_execute(
-        F f, Shape const& shape, Ts&&... ts)
+    static std::vector<pika::future<void>>
+    bulk_async_execute(F f, Shape const& shape, Ts&&... ts)
     {
         ++count_bulk_async;
         std::vector<pika::future<void>> results;

--- a/libs/pika/execution_base/include/pika/execution_base/agent_ref.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/agent_ref.hpp
@@ -62,8 +62,8 @@ namespace pika { namespace execution_base {
         }
 
         template <typename Clock, typename Duration>
-        void sleep_until(
-            std::chrono::time_point<Clock, Duration> const& sleep_time,
+        void
+        sleep_until(std::chrono::time_point<Clock, Duration> const& sleep_time,
             char const* desc = "pika::execution_base::agent_ref::sleep_until")
         {
             sleep_until(pika::chrono::steady_time_point{sleep_time}, desc);

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -777,9 +777,9 @@ namespace pika::execution::experimental {
                 pika::execution::experimental::set_stopped_t()>;
 
         template <typename R>
-        friend detail::any_operation_state tag_invoke(
-            pika::execution::experimental::connect_t, unique_any_sender&& s,
-            R&& r)
+        friend detail::any_operation_state
+        tag_invoke(pika::execution::experimental::connect_t,
+            unique_any_sender&& s, R&& r)
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing

--- a/libs/pika/execution_base/include/pika/execution_base/execution.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/execution.hpp
@@ -120,8 +120,8 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
         {
             return detail::sync_execute_fn_helper<std::decay_t<Executor>>::call(
                 PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f),
@@ -167,8 +167,8 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
         {
             return detail::async_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -206,9 +206,9 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            then_execute_t, Executor&& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(then_execute_t, Executor&& exec, F&& f,
+            Future&& predecessor, Ts&&... ts)
         {
             return detail::then_execute_fn_helper<std::decay_t<Executor>>::call(
                 PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f),
@@ -247,8 +247,8 @@ namespace pika { namespace parallel { namespace execution {
                 pika::traits::is_executor_any<Executor>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            post_t, Executor&& exec, F&& f, Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(post_t, Executor&& exec, F&& f, Ts&&... ts)
         {
             return detail::post_fn_helper<std::decay_t<Executor>>::call(
                 PIKA_FORWARD(Executor, exec), PIKA_FORWARD(F, f),
@@ -306,9 +306,9 @@ namespace pika { namespace parallel { namespace execution {
                 !std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_sync_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_sync_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Ts&&... ts)
         {
             return detail::bulk_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -322,9 +322,9 @@ namespace pika { namespace parallel { namespace execution {
                 std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_sync_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_sync_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Ts&&... ts)
         {
             return detail::bulk_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -378,9 +378,9 @@ namespace pika { namespace parallel { namespace execution {
                 !std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_async_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_async_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Ts&&... ts)
         {
             return detail::bulk_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -394,9 +394,9 @@ namespace pika { namespace parallel { namespace execution {
                 std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_async_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_async_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Ts&&... ts)
         {
             return detail::bulk_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -455,9 +455,9 @@ namespace pika { namespace parallel { namespace execution {
                 !std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_then_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_then_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Future&& predecessor, Ts&&... ts)
         {
             return detail::bulk_then_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),
@@ -473,9 +473,9 @@ namespace pika { namespace parallel { namespace execution {
                 std::is_integral<Shape>::value
             )>
         // clang-format on
-        friend PIKA_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_then_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+        friend PIKA_FORCEINLINE decltype(auto)
+        tag_fallback_invoke(bulk_then_execute_t, Executor&& exec, F&& f,
+            Shape const& shape, Future&& predecessor, Ts&&... ts)
         {
             return detail::bulk_then_execute_fn_helper<
                 std::decay_t<Executor>>::call(PIKA_FORWARD(Executor, exec),

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -348,8 +348,8 @@ namespace pika { namespace execution { namespace experimental {
         }
 
         template <typename Sender>
-        constexpr bool has_error_types(
-            typename Sender::template error_types<variant_mock>*)
+        constexpr bool
+        has_error_types(typename Sender::template error_types<variant_mock>*)
         {
             return true;
         }

--- a/libs/pika/execution_base/include/pika/execution_base/this_thread.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/this_thread.hpp
@@ -57,8 +57,8 @@ namespace pika { namespace execution_base {
         }
 
         template <class Clock, class Duration>
-        void sleep_until(
-            std::chrono::time_point<Clock, Duration> const& sleep_time,
+        void
+        sleep_until(std::chrono::time_point<Clock, Duration> const& sleep_time,
             char const* desc = "pika::execution_base::this_thread::sleep_for")
         {
             agent().sleep_until(sleep_time, desc);

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -91,9 +91,9 @@ struct non_copyable_sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, non_copyable_sender&& s,
-        R&& r) noexcept
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t,
+        non_copyable_sender&& s, R&& r) noexcept
     {
         return {std::forward<R>(r), std::move(s.ts)};
     }
@@ -152,15 +152,15 @@ struct sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, sender&& s, R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t, sender&& s, R&& r)
     {
         return {std::forward<R>(r), std::move(s.ts)};
     }
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, sender& s, R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t, sender& s, R&& r)
     {
         return {std::forward<R>(r), s.ts};
     }
@@ -257,8 +257,8 @@ struct error_sender
     };
 
     template <typename R>
-    friend operation_state<R> tag_invoke(
-        pika::execution::experimental::connect_t, error_sender, R&& r)
+    friend operation_state<R>
+    tag_invoke(pika::execution::experimental::connect_t, error_sender, R&& r)
     {
         return {std::forward<R>(r)};
     }

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -186,8 +186,8 @@ constexpr bool unspecialized(...)
 }
 
 template <typename Sender>
-constexpr bool unspecialized(
-    typename ex::sender_traits<Sender>::__unspecialized*)
+constexpr bool
+unspecialized(typename ex::sender_traits<Sender>::__unspecialized*)
 {
     return true;
 }

--- a/libs/pika/executors/include/pika/executors/apply.hpp
+++ b/libs/pika/executors/include/pika/executors/apply.hpp
@@ -48,8 +48,8 @@ namespace pika { namespace detail {
             traits::is_two_way_executor<Executor>::value>::type>
     {
         template <typename Executor_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Executor_&& exec, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Executor_&& exec, F&& f, Ts&&... ts)
         {
             parallel::execution::post(PIKA_FORWARD(Executor_, exec),
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);

--- a/libs/pika/executors/include/pika/executors/async.hpp
+++ b/libs/pika/executors/include/pika/executors/async.hpp
@@ -28,8 +28,8 @@ namespace pika { namespace detail {
         std::enable_if_t<!detail::is_action_v<Func>>>
     {
         template <typename Policy_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Policy_&& launch_policy, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Policy_&& launch_policy, F&& f, Ts&&... ts)
             -> decltype(async_launch_policy_dispatch<std::decay_t<F>>::call(
                 PIKA_FORWARD(Policy_, launch_policy), PIKA_FORWARD(F, f),
                 PIKA_FORWARD(Ts, ts)...))
@@ -44,8 +44,8 @@ namespace pika { namespace detail {
     struct async_dispatch<Policy, std::enable_if_t<is_launch_policy_v<Policy>>>
     {
         template <typename Policy_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Policy_&& launch_policy, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Policy_&& launch_policy, F&& f, Ts&&... ts)
             -> decltype(async_dispatch_launch_policy_helper<
                 std::decay_t<F>>::call(PIKA_FORWARD(Policy_, launch_policy),
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
@@ -84,8 +84,8 @@ namespace pika { namespace detail {
             traits::is_two_way_executor_v<Executor>>>
     {
         template <typename Executor_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Executor_&& exec, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Executor_&& exec, F&& f, Ts&&... ts)
         {
             return parallel::execution::async_execute(
                 PIKA_FORWARD(Executor_, exec), PIKA_FORWARD(F, f),

--- a/libs/pika/executors/include/pika/executors/dataflow.hpp
+++ b/libs/pika/executors/include/pika/executors/dataflow.hpp
@@ -265,8 +265,8 @@ namespace pika::detail {
         }
 
         template <typename Futures_>
-        PIKA_FORCEINLINE void finalize(
-            pika::detail::sync_policy, Futures_&& futures)
+        PIKA_FORCEINLINE void
+        finalize(pika::detail::sync_policy, Futures_&& futures)
         {
             // We need to run the completion on a new thread if we are on a
             // non pika thread.
@@ -375,8 +375,8 @@ namespace pika::detail {
 
         /// Finish the dataflow when the traversal has finished
         template <typename Futures_>
-        PIKA_FORCEINLINE void operator()(
-            util::async_traverse_complete_tag, Futures_&& futures)
+        PIKA_FORCEINLINE void
+        operator()(util::async_traverse_complete_tag, Futures_&& futures)
         {
             finalize(policy_, PIKA_FORWARD(Futures_, futures));
         }
@@ -390,8 +390,8 @@ namespace pika::detail {
     template <typename Policy, typename Func, typename... Ts,
         typename Frame = dataflow_frame<std::decay_t<Policy>,
             std::decay_t<Func>, std::tuple<std::decay_t<Ts>...>>>
-    typename Frame::type create_dataflow(
-        Policy&& policy, Func&& func, Ts&&... ts)
+    typename Frame::type
+    create_dataflow(Policy&& policy, Func&& func, Ts&&... ts)
     {
         // Create the data which is used to construct the dataflow_frame
         auto data = Frame::construct_from(
@@ -441,8 +441,8 @@ namespace pika::detail {
     {
         template <typename Allocator, typename Policy_, typename F,
             typename... Ts>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Allocator const& alloc, Policy_&& policy, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Allocator const& alloc, Policy_&& policy, F&& f, Ts&&... ts)
         {
             return detail::create_dataflow_alloc(alloc,
                 PIKA_FORWARD(Policy_, policy), PIKA_FORWARD(F, f),
@@ -456,8 +456,8 @@ namespace pika::detail {
             pika::detail::is_launch_policy<Policy>::value>::type>
     {
         template <typename Allocator, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Allocator const& alloc, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Allocator const& alloc, F&& f, Ts&&... ts)
             -> decltype(dataflow_dispatch_impl<false, Policy>::call(
                 alloc, PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))
         {
@@ -491,8 +491,8 @@ namespace pika::detail {
     {
         template <typename Allocator, typename Executor_, typename F,
             typename... Ts>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Allocator const& alloc, Executor_&& exec, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Allocator const& alloc, Executor_&& exec, F&& f, Ts&&... ts)
         {
             return detail::create_dataflow_alloc(alloc,
                 PIKA_FORWARD(Executor_, exec), PIKA_FORWARD(F, f),
@@ -526,8 +526,8 @@ namespace pika::detail {
                 traits::is_two_way_executor<FD>::value)>::type>
     {
         template <typename Allocator, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Allocator const& alloc, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Allocator const& alloc, F&& f, Ts&&... ts)
             -> decltype(dataflow_dispatch_impl<
                 detail::is_action<std::decay_t<F>>::value, launch>::call(alloc,
                 launch::async, PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))

--- a/libs/pika/executors/include/pika/executors/execution_policy_annotation.hpp
+++ b/libs/pika/executors/include/pika/executors/execution_policy_annotation.hpp
@@ -29,9 +29,9 @@ namespace pika { namespace execution { namespace experimental {
             pika::is_execution_policy_v<ExPolicy>
         )>
     // clang-format on
-    constexpr decltype(auto) tag_invoke(
-        pika::execution::experimental::with_annotation_t, ExPolicy&& policy,
-        char const* annotation)
+    constexpr decltype(auto)
+    tag_invoke(pika::execution::experimental::with_annotation_t,
+        ExPolicy&& policy, char const* annotation)
     {
         auto exec = pika::execution::experimental::with_annotation(
             policy.executor(), annotation);

--- a/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/fork_join_executor.hpp
@@ -369,9 +369,9 @@ namespace pika { namespace execution { namespace experimental {
 
                 template <std::size_t... Is_, typename F_, typename A_,
                     typename Tuple_>
-                static constexpr void invoke_helper(
-                    pika::util::detail::index_pack<Is_...>, F_&& f, A_&& a,
-                    Tuple_&& t)
+                static constexpr void
+                invoke_helper(pika::util::detail::index_pack<Is_...>, F_&& f,
+                    A_&& a, Tuple_&& t)
                 {
                     PIKA_INVOKE(PIKA_FORWARD(F_, f), PIKA_FORWARD(A_, a),
                         std::get<Is_>(PIKA_FORWARD(Tuple_, t))...);
@@ -510,9 +510,9 @@ namespace pika { namespace execution { namespace experimental {
             };
 
             template <typename F, typename S, typename Args>
-            thread_function_helper_type* set_all_states_and_region_data(
-                thread_state state, F& f, S const& shape,
-                Args& argument_pack) noexcept
+            thread_function_helper_type*
+            set_all_states_and_region_data(thread_state state, F& f,
+                S const& shape, Args& argument_pack) noexcept
             {
                 thread_function_helper_type* func = nullptr;
                 if (schedule_ == loop_schedule::static_ || num_threads_ == 1)

--- a/libs/pika/executors/include/pika/executors/scheduler_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/scheduler_executor.hpp
@@ -137,8 +137,8 @@ namespace pika { namespace execution { namespace experimental {
         template <typename Enable = std::enable_if_t<
                       pika::detail::is_invocable_v<with_priority_t,
                           BaseScheduler, pika::execution::thread_priority>>>
-        friend scheduler_executor tag_invoke(
-            pika::execution::experimental::with_priority_t,
+        friend scheduler_executor
+        tag_invoke(pika::execution::experimental::with_priority_t,
             scheduler_executor const& exec,
             pika::execution::thread_priority priority)
         {
@@ -148,8 +148,8 @@ namespace pika { namespace execution { namespace experimental {
         template <
             typename Enable = std::enable_if_t<
                 pika::detail::is_invocable_v<get_priority_t, BaseScheduler>>>
-        friend pika::execution::thread_priority tag_invoke(
-            pika::execution::experimental::get_priority_t,
+        friend pika::execution::thread_priority
+        tag_invoke(pika::execution::experimental::get_priority_t,
             scheduler_executor const& exec)
         {
             return get_priority(exec.sched_);
@@ -158,8 +158,8 @@ namespace pika { namespace execution { namespace experimental {
         template <typename Enable = std::enable_if_t<
                       pika::detail::is_invocable_v<with_stacksize_t,
                           BaseScheduler, pika::execution::thread_stacksize>>>
-        friend scheduler_executor tag_invoke(
-            pika::execution::experimental::with_stacksize_t,
+        friend scheduler_executor
+        tag_invoke(pika::execution::experimental::with_stacksize_t,
             scheduler_executor const& exec,
             pika::execution::thread_stacksize stacksize)
         {
@@ -169,8 +169,8 @@ namespace pika { namespace execution { namespace experimental {
         template <
             typename Enable = std::enable_if_t<
                 pika::detail::is_invocable_v<get_stacksize_t, BaseScheduler>>>
-        friend pika::execution::thread_stacksize tag_invoke(
-            pika::execution::experimental::get_stacksize_t,
+        friend pika::execution::thread_stacksize
+        tag_invoke(pika::execution::experimental::get_stacksize_t,
             scheduler_executor const& exec)
         {
             return get_stacksize(exec.sched_);
@@ -179,8 +179,8 @@ namespace pika { namespace execution { namespace experimental {
         template <typename Enable = std::enable_if_t<
                       pika::detail::is_invocable_v<with_hint_t, BaseScheduler,
                           pika::execution::thread_schedule_hint>>>
-        friend scheduler_executor tag_invoke(
-            pika::execution::experimental::with_hint_t,
+        friend scheduler_executor
+        tag_invoke(pika::execution::experimental::with_hint_t,
             scheduler_executor const& exec,
             pika::execution::thread_schedule_hint hint)
         {
@@ -189,8 +189,8 @@ namespace pika { namespace execution { namespace experimental {
 
         template <typename Enable = std::enable_if_t<
                       pika::detail::is_invocable_v<get_hint_t, BaseScheduler>>>
-        friend pika::execution::thread_schedule_hint tag_invoke(
-            pika::execution::experimental::get_hint_t,
+        friend pika::execution::thread_schedule_hint
+        tag_invoke(pika::execution::experimental::get_hint_t,
             scheduler_executor const& exec)
         {
             return get_hint(exec.sched_);
@@ -199,8 +199,8 @@ namespace pika { namespace execution { namespace experimental {
         template <
             typename Enable = std::enable_if_t<pika::detail::is_invocable_v<
                 with_annotation_t, BaseScheduler, char const*>>>
-        friend scheduler_executor tag_invoke(
-            pika::execution::experimental::with_annotation_t,
+        friend scheduler_executor
+        tag_invoke(pika::execution::experimental::with_annotation_t,
             scheduler_executor const& exec, char const* annotation)
         {
             return scheduler_executor(with_annotation(exec.sched_, annotation));
@@ -209,8 +209,8 @@ namespace pika { namespace execution { namespace experimental {
         template <
             typename Enable = std::enable_if_t<pika::detail::is_invocable_v<
                 with_annotation_t, BaseScheduler, std::string>>>
-        friend scheduler_executor tag_invoke(
-            pika::execution::experimental::with_annotation_t,
+        friend scheduler_executor
+        tag_invoke(pika::execution::experimental::with_annotation_t,
             scheduler_executor const& exec, std::string annotation)
         {
             return scheduler_executor(with_annotation(exec.sched_, annotation));
@@ -219,8 +219,8 @@ namespace pika { namespace execution { namespace experimental {
         template <
             typename Enable = std::enable_if_t<
                 pika::detail::is_invocable_v<get_annotation_t, BaseScheduler>>>
-        friend char const* tag_invoke(
-            pika::execution::experimental::get_annotation_t,
+        friend char const*
+        tag_invoke(pika::execution::experimental::get_annotation_t,
             scheduler_executor const& exec)
         {
             return get_annotation(exec.sched_);

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -92,8 +92,8 @@ namespace pika { namespace execution { namespace experimental {
                         std::exception_ptr)>;
 
             template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(
-                connect_t, sender const&, Receiver&& receiver)
+            friend operation_state<Receiver>
+            tag_invoke(connect_t, sender const&, Receiver&& receiver)
             {
                 return {PIKA_FORWARD(Receiver, receiver)};
             }

--- a/libs/pika/executors/include/pika/executors/sync.hpp
+++ b/libs/pika/executors/include/pika/executors/sync.hpp
@@ -26,8 +26,8 @@ namespace pika { namespace detail {
         std::enable_if_t<!detail::is_action_v<Func>>>
     {
         template <typename Policy_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Policy_&& launch_policy, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Policy_&& launch_policy, F&& f, Ts&&... ts)
             -> decltype(sync_launch_policy_dispatch<std::decay_t<F>>::call(
                 PIKA_FORWARD(Policy_, launch_policy), PIKA_FORWARD(F, f),
                 PIKA_FORWARD(Ts, ts)...))
@@ -42,8 +42,8 @@ namespace pika { namespace detail {
     struct sync_dispatch<Policy, std::enable_if_t<is_launch_policy_v<Policy>>>
     {
         template <typename Policy_, typename F, typename... Ts>
-        PIKA_FORCEINLINE static auto call(
-            Policy_&& launch_policy, F&& f, Ts&&... ts)
+        PIKA_FORCEINLINE static auto
+        call(Policy_&& launch_policy, F&& f, Ts&&... ts)
             -> decltype(sync_dispatch_launch_policy_helper<
                 std::decay_t<F>>::call(PIKA_FORWARD(Policy_, launch_policy),
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...))

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -148,8 +148,8 @@ namespace pika { namespace execution { namespace experimental {
         }
 
         template <typename F>
-        friend void tag_invoke(
-            execute_t, thread_pool_scheduler const& sched, F&& f)
+        friend void
+        tag_invoke(execute_t, thread_pool_scheduler const& sched, F&& f)
         {
             sched.execute(PIKA_FORWARD(F, f), sched.get_fallback_annotation());
         }
@@ -222,16 +222,16 @@ namespace pika { namespace execution { namespace experimental {
                         std::exception_ptr)>;
 
             template <typename Receiver>
-            friend operation_state<Scheduler, Receiver> tag_invoke(
-                connect_t, sender&& s, Receiver&& receiver)
+            friend operation_state<Scheduler, Receiver>
+            tag_invoke(connect_t, sender&& s, Receiver&& receiver)
             {
                 return {PIKA_MOVE(s.scheduler),
                     PIKA_FORWARD(Receiver, receiver), s.fallback_annotation};
             }
 
             template <typename Receiver>
-            friend operation_state<Scheduler, Receiver> tag_invoke(
-                connect_t, sender& s, Receiver&& receiver)
+            friend operation_state<Scheduler, Receiver>
+            tag_invoke(connect_t, sender& s, Receiver&& receiver)
             {
                 return {s.scheduler, PIKA_FORWARD(Receiver, receiver),
                     s.fallback_annotation};

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -160,8 +160,8 @@ namespace pika::thread_pool_bulk_detail {
                 operation_state* op_state;
 
                 template <typename E>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_error_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_error_t,
                     bulk_receiver&& r, E&& e) noexcept
                 {
                     pika::execution::experimental::set_error(
@@ -449,8 +449,8 @@ namespace pika::thread_pool_bulk_detail {
                     pika::traits::range_iterator_t<Shape>>;
 
                 template <typename... Ts>
-                friend void tag_invoke(
-                    pika::execution::experimental::set_value_t,
+                friend void
+                tag_invoke(pika::execution::experimental::set_value_t,
                     bulk_receiver&& r, Ts&&... ts) noexcept
                 {
                     // Don't spawn tasks if there is no work to be done

--- a/libs/pika/executors/tests/unit/created_executor.cpp
+++ b/libs/pika/executors/tests/unit/created_executor.cpp
@@ -33,8 +33,8 @@ struct void_parallel_executor : pika::execution::parallel_executor
     using base_type = pika::execution::parallel_executor;
 
     template <typename F, typename Shape, typename... Ts>
-    std::vector<pika::future<void>> bulk_async_execute(
-        F&& f, Shape const& shape, Ts&&... ts)
+    std::vector<pika::future<void>>
+    bulk_async_execute(F&& f, Shape const& shape, Ts&&... ts)
     {
         std::vector<pika::future<void>> results;
         for (auto const& elem : shape)

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -57,8 +57,8 @@ struct check_context_receiver
     bool& executed;
 
     template <typename E>
-    friend void tag_invoke(
-        ex::set_error_t, check_context_receiver&&, E&&) noexcept
+    friend void
+    tag_invoke(ex::set_error_t, check_context_receiver&&, E&&) noexcept
     {
         PIKA_TEST(false);
     }
@@ -69,8 +69,8 @@ struct check_context_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(
-        ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
+    friend void
+    tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
     {
         PIKA_TEST_NEQ(r.parent_id, std::this_thread::get_id());
         PIKA_TEST_NEQ(std::thread::id(), std::this_thread::get_id());
@@ -239,8 +239,8 @@ struct callback_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(
-        ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
+    friend void
+    tag_invoke(ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
     {
         r.f();
         std::lock_guard l{r.mtx};

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -63,8 +63,8 @@ struct check_context_receiver
     bool& executed;
 
     template <typename E>
-    friend void tag_invoke(
-        ex::set_error_t, check_context_receiver&&, E&&) noexcept
+    friend void
+    tag_invoke(ex::set_error_t, check_context_receiver&&, E&&) noexcept
     {
         PIKA_TEST(false);
     }
@@ -75,8 +75,8 @@ struct check_context_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(
-        ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
+    friend void
+    tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
     {
         PIKA_TEST_NEQ(r.parent_id, pika::this_thread::get_id());
         PIKA_TEST_NEQ(
@@ -247,8 +247,8 @@ struct callback_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(
-        ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
+    friend void
+    tag_invoke(ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
     {
         r.f();
         std::lock_guard l{r.mtx};

--- a/libs/pika/format/include/pika/modules/format.hpp
+++ b/libs/pika/format/include/pika/modules/format.hpp
@@ -199,8 +199,8 @@ namespace pika { namespace util {
         };
 
         template <typename T>
-        void format_value(
-            std::ostream& os, std::string_view spec, T const& value)
+        void
+        format_value(std::ostream& os, std::string_view spec, T const& value)
         {
             if (!spec.empty())
                 throw std::runtime_error("Not a valid format specifier");
@@ -302,8 +302,8 @@ namespace pika { namespace util {
     }    // namespace detail
 
     template <typename Range>
-    detail::format_join<Range> format_join(
-        Range const& range, std::string_view delimiter) noexcept
+    detail::format_join<Range>
+    format_join(Range const& range, std::string_view delimiter) noexcept
     {
         return {range, delimiter};
     }

--- a/libs/pika/format/include/pika/util/from_string.hpp
+++ b/libs/pika/format/include/pika/util/from_string.hpp
@@ -64,8 +64,8 @@ namespace pika { namespace util {
         }
 
         template <typename Char>
-        void check_only_whitespace(
-            std::basic_string<Char> const& s, std::size_t pos)
+        void
+        check_only_whitespace(std::basic_string<Char> const& s, std::size_t pos)
         {
             auto i = s.begin();
             std::advance(i, pos);
@@ -99,8 +99,8 @@ namespace pika { namespace util {
             }
 
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, long long& target)
+            static void
+            call(std::basic_string<Char> const& value, long long& target)
             {
                 std::size_t pos = 0;
                 target = std::stoll(value, &pos);
@@ -108,8 +108,8 @@ namespace pika { namespace util {
             }
 
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, unsigned int& target)
+            static void
+            call(std::basic_string<Char> const& value, unsigned int& target)
             {
                 // there is no std::stoui
                 unsigned long target_long;
@@ -118,8 +118,8 @@ namespace pika { namespace util {
             }
 
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, unsigned long& target)
+            static void
+            call(std::basic_string<Char> const& value, unsigned long& target)
             {
                 std::size_t pos = 0;
                 target = std::stoul(value, &pos);
@@ -152,8 +152,8 @@ namespace pika { namespace util {
             std::enable_if_t<std::is_floating_point<T>::value>>
         {
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, float& target)
+            static void
+            call(std::basic_string<Char> const& value, float& target)
             {
                 std::size_t pos = 0;
                 target = std::stof(value, &pos);
@@ -161,8 +161,8 @@ namespace pika { namespace util {
             }
 
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, double& target)
+            static void
+            call(std::basic_string<Char> const& value, double& target)
             {
                 std::size_t pos = 0;
                 target = std::stod(value, &pos);
@@ -170,8 +170,8 @@ namespace pika { namespace util {
             }
 
             template <typename Char>
-            static void call(
-                std::basic_string<Char> const& value, long double& target)
+            static void
+            call(std::basic_string<Char> const& value, long double& target)
             {
                 std::size_t pos = 0;
                 target = std::stold(value, &pos);

--- a/libs/pika/functional/include/pika/functional/bind.hpp
+++ b/libs/pika/functional/include/pika/functional/bind.hpp
@@ -28,8 +28,8 @@ namespace pika::util::detail {
     struct bind_eval_placeholder
     {
         template <typename T, typename... Us>
-        static constexpr PIKA_HOST_DEVICE decltype(auto) call(
-            T&& /*t*/, Us&&... vs)
+        static constexpr PIKA_HOST_DEVICE decltype(auto)
+        call(T&& /*t*/, Us&&... vs)
         {
             return util::detail::member_pack_for<Us&&...>(
                 std::piecewise_construct, PIKA_FORWARD(Us, vs)...)

--- a/libs/pika/functional/include/pika/functional/deferred_call.hpp
+++ b/libs/pika/functional/include/pika/functional/deferred_call.hpp
@@ -75,9 +75,8 @@ namespace pika::util::detail {
         deferred& operator=(deferred const&) = delete;
 
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE
-            util::detail::invoke_result_t<F, Ts...>
-            operator()()
+        PIKA_HOST_DEVICE
+        PIKA_FORCEINLINE util::detail::invoke_result_t<F, Ts...> operator()()
         {
             return PIKA_INVOKE(
                 PIKA_MOVE(_f), PIKA_MOVE(_args).template get<Is>()...);

--- a/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
+++ b/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
@@ -65,8 +65,8 @@ namespace pika::util::detail {
         }
 
         template <typename T>
-        static void _deallocate(
-            void* obj, std::size_t storage_size, bool destroy)
+        static void
+        _deallocate(void* obj, std::size_t storage_size, bool destroy)
         {
             using storage_t = std::aligned_storage_t<sizeof(T), alignof(T)>;
 

--- a/libs/pika/functional/include/pika/functional/invoke.hpp
+++ b/libs/pika/functional/include/pika/functional/invoke.hpp
@@ -34,8 +34,8 @@ namespace pika::util::detail {
     ///
     /// \note This function is similar to `std::invoke` (C++17)
     template <typename F, typename... Ts>
-    constexpr PIKA_HOST_DEVICE util::detail::invoke_result_t<F, Ts...> invoke(
-        F&& f, Ts&&... vs)
+    constexpr PIKA_HOST_DEVICE util::detail::invoke_result_t<F, Ts...>
+    invoke(F&& f, Ts&&... vs)
     {
         return PIKA_INVOKE(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, vs)...);
     }

--- a/libs/pika/futures/include/pika/futures/future.hpp
+++ b/libs/pika/futures/include/pika/futures/future.hpp
@@ -112,8 +112,8 @@ namespace pika { namespace lcos { namespace detail {
     struct future_get_result
     {
         template <typename SharedState>
-        PIKA_FORCEINLINE static R* call(
-            SharedState const& state, error_code& ec = throws)
+        PIKA_FORCEINLINE static R*
+        call(SharedState const& state, error_code& ec = throws)
         {
             return state->get_result(ec);
         }
@@ -123,8 +123,8 @@ namespace pika { namespace lcos { namespace detail {
     struct future_get_result<util::detail::unused_type>
     {
         template <typename SharedState>
-        PIKA_FORCEINLINE static util::detail::unused_type* call(
-            SharedState const& state, error_code& ec = throws)
+        PIKA_FORCEINLINE static util::detail::unused_type*
+        call(SharedState const& state, error_code& ec = throws)
         {
             return state->get_result_void(ec);
         }
@@ -184,8 +184,8 @@ namespace pika { namespace lcos { namespace detail {
     struct future_then_dispatch
     {
         template <typename F>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Future&& /* fut */, F&& /* f */)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Future&& /* fut */, F&& /* f */)
         {
             // dummy impl to fail compilation if this function is called
             static_assert(sizeof(Future) == 0, "Cannot use the \
@@ -194,8 +194,8 @@ namespace pika { namespace lcos { namespace detail {
         }
 
         template <typename T0, typename F>
-        PIKA_FORCEINLINE static decltype(auto) call(
-            Future&& /* fut */, T0&& /* t */, F&& /* f */)
+        PIKA_FORCEINLINE static decltype(auto)
+        call(Future&& /* fut */, T0&& /* t */, F&& /* f */)
         {
             // dummy impl to fail compilation if this function is called
             static_assert(sizeof(Future) == 0, "Cannot use the \
@@ -225,8 +225,8 @@ namespace pika { namespace lcos { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
-    inline traits::detail::shared_state_ptr_t<void> downcast_to_void(
-        Future& future, bool addref)
+    inline traits::detail::shared_state_ptr_t<void>
+    downcast_to_void(Future& future, bool addref)
     {
         using shared_state_type = traits::detail::shared_state_ptr_t<void>;
         using element_type = typename shared_state_type::element_type;
@@ -639,8 +639,8 @@ namespace pika {
 #endif
 
         template <typename Receiver>
-        friend lcos::detail::operation_state<Receiver, future> tag_invoke(
-            pika::execution::experimental::connect_t, future&& f,
+        friend lcos::detail::operation_state<Receiver, future>
+        tag_invoke(pika::execution::experimental::connect_t, future&& f,
             Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(f)};
@@ -1073,8 +1073,8 @@ namespace pika {
         // Throws: the stored exception, if an exception was stored in the
         //         shared state.
         // Postcondition: valid() == false.
-        typename pika::traits::future_traits<shared_future>::result_type get()
-            const    //-V659
+        typename pika::traits::future_traits<shared_future>::result_type
+        get() const    //-V659
         {
             if (!this->shared_state_)
             {
@@ -1243,22 +1243,22 @@ namespace pika {
     }
 
     template <typename R>
-    pika::shared_future<R>& make_shared_future(
-        pika::shared_future<R>& f) noexcept
+    pika::shared_future<R>&
+    make_shared_future(pika::shared_future<R>& f) noexcept
     {
         return f;
     }
 
     template <typename R>
-    pika::shared_future<R>&& make_shared_future(
-        pika::shared_future<R>&& f) noexcept
+    pika::shared_future<R>&&
+    make_shared_future(pika::shared_future<R>&& f) noexcept
     {
         return PIKA_MOVE(f);
     }
 
     template <typename R>
-    pika::shared_future<R> const& make_shared_future(
-        pika::shared_future<R> const& f) noexcept
+    pika::shared_future<R> const&
+    make_shared_future(pika::shared_future<R> const& f) noexcept
     {
         return f;
     }
@@ -1311,8 +1311,8 @@ namespace pika {
     ///////////////////////////////////////////////////////////////////////////
     // extension: create a pre-initialized future object, with allocator
     template <int DeductionGuard = 0, typename Allocator, typename T>
-    future<pika::detail::decay_unwrap_t<T>> make_ready_future_alloc(
-        Allocator const& a, T&& init)
+    future<pika::detail::decay_unwrap_t<T>>
+    make_ready_future_alloc(Allocator const& a, T&& init)
     {
         return pika::make_ready_future_alloc<pika::detail::decay_unwrap_t<T>>(
             a, PIKA_FORWARD(T, init));
@@ -1320,8 +1320,8 @@ namespace pika {
 
     // extension: create a pre-initialized future object
     template <int DeductionGuard = 0, typename T>
-    PIKA_FORCEINLINE future<pika::detail::decay_unwrap_t<T>> make_ready_future(
-        T&& init)
+    PIKA_FORCEINLINE future<pika::detail::decay_unwrap_t<T>>
+    make_ready_future(T&& init)
     {
         return pika::make_ready_future_alloc<pika::detail::decay_unwrap_t<T>>(
             pika::detail::internal_allocator<>{}, PIKA_FORWARD(T, init));
@@ -1417,8 +1417,8 @@ namespace pika {
     }
 
     template <typename T>
-    std::enable_if_t<std::is_void_v<T>, future<void>> make_ready_future_at(
-        pika::chrono::steady_time_point const& abs_time)
+    std::enable_if_t<std::is_void_v<T>, future<void>>
+    make_ready_future_at(pika::chrono::steady_time_point const& abs_time)
     {
         return pika::make_ready_future_at(abs_time);
     }
@@ -1431,8 +1431,8 @@ namespace pika {
     }
 
     template <typename T>
-    std::enable_if_t<std::is_void_v<T>, future<void>> make_ready_future_after(
-        pika::chrono::steady_duration const& rel_time)
+    std::enable_if_t<std::is_void_v<T>, future<void>>
+    make_ready_future_after(pika::chrono::steady_duration const& rel_time)
     {
         return pika::make_ready_future_at(rel_time.from_now());
     }

--- a/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
@@ -32,8 +32,8 @@
 namespace pika { namespace lcos { namespace detail {
 
     template <typename Future, typename SourceState, typename DestinationState>
-    PIKA_FORCEINLINE void transfer_result(
-        SourceState&& src, DestinationState const& dest)
+    PIKA_FORCEINLINE void
+    transfer_result(SourceState&& src, DestinationState const& dest)
     {
         pika::detail::try_catch_exception_ptr(
             [&]() {
@@ -379,9 +379,9 @@ namespace pika { namespace lcos { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         // TODO: Reduce duplication!
         template <typename Spawner, typename Policy>
-        void attach(Future const& future,
-            std::remove_reference_t<Spawner>& spawner, Policy&& policy,
-            error_code& /*ec*/ = throws)
+        void
+        attach(Future const& future, std::remove_reference_t<Spawner>& spawner,
+            Policy&& policy, error_code& /*ec*/ = throws)
         {
             using shared_state_ptr =
                 traits::detail::shared_state_ptr_for_t<Future>;
@@ -416,9 +416,9 @@ namespace pika { namespace lcos { namespace detail {
         }
 
         template <typename Spawner, typename Policy>
-        void attach(Future const& future,
-            std::remove_reference_t<Spawner>&& spawner, Policy&& policy,
-            error_code& /*ec*/ = throws)
+        void
+        attach(Future const& future, std::remove_reference_t<Spawner>&& spawner,
+            Policy&& policy, error_code& /*ec*/ = throws)
         {
             using shared_state_ptr =
                 traits::detail::shared_state_ptr_for_t<Future>;

--- a/libs/pika/futures/include/pika/futures/traits/detail/future_await_traits.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/detail/future_await_traits.hpp
@@ -58,8 +58,8 @@ namespace pika { namespace lcos { namespace detail {
     }
 
     template <typename T, typename Promise>
-    PIKA_FORCEINLINE void await_suspend(
-        pika::future<T>& f, coroutine_handle<Promise> rh)
+    PIKA_FORCEINLINE void
+    await_suspend(pika::future<T>& f, coroutine_handle<Promise> rh)
     {
         // f.then([=](future<T> result) {});
         auto st = traits::detail::get_shared_state(f);
@@ -100,8 +100,8 @@ namespace pika { namespace lcos { namespace detail {
     }
 
     template <typename T, typename Promise>
-    PIKA_FORCEINLINE void await_suspend(
-        pika::shared_future<T>& f, coroutine_handle<Promise> rh)
+    PIKA_FORCEINLINE void
+    await_suspend(pika::shared_future<T>& f, coroutine_handle<Promise> rh)
     {
         // f.then([=](shared_future<T> result) {})
         auto st = traits::detail::get_shared_state(f);

--- a/libs/pika/futures/include/pika/futures/traits/future_access.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_access.hpp
@@ -137,8 +137,8 @@ namespace pika { namespace traits {
     struct future_access<pika::future<R>>
     {
         template <typename SharedState>
-        static pika::future<R> create(
-            pika::intrusive_ptr<SharedState> const& shared_state)
+        static pika::future<R>
+        create(pika::intrusive_ptr<SharedState> const& shared_state)
         {
             return pika::future<R>(shared_state);
         }
@@ -152,23 +152,23 @@ namespace pika { namespace traits {
         }
 
         template <typename SharedState>
-        static pika::future<R> create(
-            pika::intrusive_ptr<SharedState>&& shared_state)
+        static pika::future<R>
+        create(pika::intrusive_ptr<SharedState>&& shared_state)
         {
             return pika::future<R>(PIKA_MOVE(shared_state));
         }
 
         template <typename T = void>
-        static pika::future<R> create(
-            detail::shared_state_ptr_for_t<pika::future<pika::future<R>>>&&
+        static pika::future<R>
+        create(detail::shared_state_ptr_for_t<pika::future<pika::future<R>>>&&
                 shared_state)
         {
             return pika::future<pika::future<R>>(PIKA_MOVE(shared_state));
         }
 
         template <typename SharedState>
-        static pika::future<R> create(
-            SharedState* shared_state, bool addref = true)
+        static pika::future<R>
+        create(SharedState* shared_state, bool addref = true)
         {
             return pika::future<R>(
                 pika::intrusive_ptr<SharedState>(shared_state, addref));
@@ -205,8 +205,8 @@ namespace pika { namespace traits {
 
     public:
         template <typename Destination>
-        PIKA_FORCEINLINE static void transfer_result(
-            pika::future<R>&& src, Destination& dest)
+        PIKA_FORCEINLINE static void
+        transfer_result(pika::future<R>&& src, Destination& dest)
         {
             transfer_result_impl(PIKA_MOVE(src), dest, std::is_void<R>{});
         }
@@ -216,8 +216,8 @@ namespace pika { namespace traits {
     struct future_access<pika::shared_future<R>>
     {
         template <typename SharedState>
-        static pika::shared_future<R> create(
-            pika::intrusive_ptr<SharedState> const& shared_state)
+        static pika::shared_future<R>
+        create(pika::intrusive_ptr<SharedState> const& shared_state)
         {
             return pika::shared_future<R>(shared_state);
         }
@@ -230,8 +230,8 @@ namespace pika { namespace traits {
         }
 
         template <typename SharedState>
-        static pika::shared_future<R> create(
-            pika::intrusive_ptr<SharedState>&& shared_state)
+        static pika::shared_future<R>
+        create(pika::intrusive_ptr<SharedState>&& shared_state)
         {
             return pika::shared_future<R>(PIKA_MOVE(shared_state));
         }
@@ -245,8 +245,8 @@ namespace pika { namespace traits {
         }
 
         template <typename SharedState>
-        static pika::shared_future<R> create(
-            SharedState* shared_state, bool addref = true)
+        static pika::shared_future<R>
+        create(SharedState* shared_state, bool addref = true)
         {
             return pika::shared_future<R>(
                 pika::intrusive_ptr<SharedState>(shared_state, addref));
@@ -283,8 +283,8 @@ namespace pika { namespace traits {
 
     public:
         template <typename Destination>
-        PIKA_FORCEINLINE static void transfer_result(
-            pika::shared_future<R>&& src, Destination& dest)
+        PIKA_FORCEINLINE static void
+        transfer_result(pika::shared_future<R>&& src, Destination& dest)
         {
             transfer_result_impl(PIKA_MOVE(src), dest, std::is_void<R>{});
         }

--- a/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
@@ -175,9 +175,9 @@ namespace pika { namespace util {
         }
 
         template <typename OtherIncrementable>
-        PIKA_HOST_DEVICE typename base_type::difference_type distance_to(
-            counting_iterator<OtherIncrementable, CategoryOrTraversal,
-                Difference> const& y) const
+        PIKA_HOST_DEVICE typename base_type::difference_type
+        distance_to(counting_iterator<OtherIncrementable, CategoryOrTraversal,
+            Difference> const& y) const
         {
             using difference_type = typename base_type::difference_type;
             return static_cast<difference_type>(y.base()) -

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_facade.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_facade.hpp
@@ -31,8 +31,8 @@ namespace pika { namespace util {
     public:
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename Iterator1, typename Iterator2>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static bool equal(
-            Iterator1 const& lhs, Iterator2 const& rhs)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static bool
+        equal(Iterator1 const& lhs, Iterator2 const& rhs)
         {
             return lhs.equal(rhs);
         }
@@ -53,16 +53,16 @@ namespace pika { namespace util {
 
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename Reference, typename Iterator>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Reference dereference(
-            Iterator const& it)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static Reference
+        dereference(Iterator const& it)
         {
             return it.dereference();
         }
 
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename Iterator, typename Distance>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void advance(
-            Iterator& it, Distance n)
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE static void
+        advance(Iterator& it, Distance n)
         {
             it.advance(n);
         }

--- a/libs/pika/iterator_support/include/pika/iterator_support/range.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/range.hpp
@@ -16,29 +16,29 @@ namespace pika { namespace util {
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename T, std::size_t N>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE T* begin_impl(
-            T (&array)[N], long) noexcept
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE T*
+        begin_impl(T (&array)[N], long) noexcept
         {
             return &array[0];
         }
 
         template <typename T, std::size_t N>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE T* end_impl(
-            T (&array)[N], long) noexcept
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE T*
+        end_impl(T (&array)[N], long) noexcept
         {
             return &array[N];
         }
 
         template <typename T, std::size_t N>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t size_impl(
-            T const (&)[N], long) noexcept
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t
+        size_impl(T const (&)[N], long) noexcept
         {
             return N;
         }
 
         template <typename T, std::size_t N>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool empty_impl(
-            T const (&)[N], long) noexcept
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool
+        empty_impl(T const (&)[N], long) noexcept
         {
             return false;
         }
@@ -109,15 +109,15 @@ namespace pika { namespace util {
         using range_impl::end_impl;
 
         template <typename C>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t size_impl(
-            C const& c, int)
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t
+        size_impl(C const& c, int)
         {
             return std::distance(begin_impl(c, 0L), end_impl(c, 0L));
         }
 
         template <typename C>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool empty_impl(
-            C const& c, int)
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool
+        empty_impl(C const& c, int)
         {
             return begin_impl(c, 0L) == end_impl(c, 0L);
         }
@@ -196,8 +196,8 @@ namespace pika { namespace util {
         template <typename C,
             typename Iterator = typename detail::iterator<C const>::type,
             typename Sentinel = typename detail::sentinel<C const>::type>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t size(
-            C const& c) noexcept(noexcept(detail::size_impl(c, 0L)))
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE std::size_t
+        size(C const& c) noexcept(noexcept(detail::size_impl(c, 0L)))
         {
             return detail::size_impl(c, 0L);
         }
@@ -205,8 +205,8 @@ namespace pika { namespace util {
         template <typename C,
             typename Iterator = typename detail::iterator<C const>::type,
             typename Sentinel = typename detail::sentinel<C const>::type>
-        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool empty(
-            C const& c) noexcept(noexcept(detail::empty_impl(c, 0L)))
+        PIKA_HOST_DEVICE constexpr PIKA_FORCEINLINE bool
+        empty(C const& c) noexcept(noexcept(detail::empty_impl(c, 0L)))
         {
             return detail::empty_impl(c, 0L);
         }

--- a/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
@@ -121,15 +121,15 @@ namespace pika { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Transformer, typename Iterator>
-    inline transform_iterator<Iterator, Transformer> make_transform_iterator(
-        Iterator const& it, Transformer const& f)
+    inline transform_iterator<Iterator, Transformer>
+    make_transform_iterator(Iterator const& it, Transformer const& f)
     {
         return transform_iterator<Iterator, Transformer>(it, f);
     }
 
     template <typename Transformer, typename Iterator>
-    inline transform_iterator<Iterator, Transformer> make_transform_iterator(
-        Iterator const& it)
+    inline transform_iterator<Iterator, Transformer>
+    make_transform_iterator(Iterator const& it)
     {
         return transform_iterator<Iterator, Transformer>(it, Transformer());
     }

--- a/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
@@ -491,8 +491,8 @@ namespace pika { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    PIKA_HOST_DEVICE zip_iterator<std::decay_t<Ts>...> make_zip_iterator(
-        Ts&&... vs)
+    PIKA_HOST_DEVICE zip_iterator<std::decay_t<Ts>...>
+    make_zip_iterator(Ts&&... vs)
     {
         using result_type = zip_iterator<std::decay_t<Ts>...>;
 
@@ -529,8 +529,8 @@ namespace pika { namespace traits {
                 typename F::template apply<Ts>, Ts>::type...>;
 
             template <std::size_t... Is, typename... Ts_>
-            static result_type call(
-                util::detail::index_pack<Is...>, std::tuple<Ts_...> const& t)
+            static result_type
+            call(util::detail::index_pack<Is...>, std::tuple<Ts_...> const& t)
             {
                 return std::make_tuple(
                     typename F::template apply<Ts>()(std::get<Is>(t))...);

--- a/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -89,8 +89,8 @@ namespace pika { namespace experimental {
             }
 
             template <typename Iterator>
-            typename std::iterator_traits<Iterator>::reference operator()(
-                Iterator const& it) const
+            typename std::iterator_traits<Iterator>::reference
+            operator()(Iterator const& it) const
             {
                 if (it == begin_)
                     return *value_;
@@ -126,8 +126,8 @@ namespace pika { namespace experimental {
             }
 
             template <typename Iterator>
-            typename std::iterator_traits<Iterator>::reference operator()(
-                Iterator const& it) const
+            typename std::iterator_traits<Iterator>::reference
+            operator()(Iterator const& it) const
             {
                 if (it == end_)
                     return *value_;
@@ -313,8 +313,8 @@ namespace pika { namespace experimental {
     };
 
     template <typename Iterator>
-    inline stencil3_iterator_v1<Iterator> make_stencil3_iterator_v1(
-        Iterator const& it)
+    inline stencil3_iterator_v1<Iterator>
+    make_stencil3_iterator_v1(Iterator const& it)
     {
         return stencil3_iterator_v1<Iterator>(it);
     }
@@ -422,8 +422,8 @@ namespace pika { namespace experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator>
-    inline stencil3_iterator_v2<Iterator> make_stencil3_iterator_v2(
-        Iterator const& it)
+    inline stencil3_iterator_v2<Iterator>
+    make_stencil3_iterator_v2(Iterator const& it)
     {
         return stencil3_iterator_v2<Iterator>(it);
     }

--- a/libs/pika/iterator_support/tests/unit/stencil3_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/stencil3_iterator.cpp
@@ -77,8 +77,8 @@ namespace test {
     };
 
     template <typename Iterator, typename Transformer>
-    inline stencil3_iterator<Iterator, Transformer> make_stencil3_iterator(
-        Iterator const& it, Transformer const& t)
+    inline stencil3_iterator<Iterator, Transformer>
+    make_stencil3_iterator(Iterator const& it, Transformer const& t)
     {
         return stencil3_iterator<Iterator, Transformer>(it, t);
     }
@@ -95,8 +95,8 @@ namespace test {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator>
-    inline stencil3_iterator<Iterator> make_stencil3_iterator(
-        Iterator const& it)
+    inline stencil3_iterator<Iterator>
+    make_stencil3_iterator(Iterator const& it)
     {
         return stencil3_iterator<Iterator>(it);
     }

--- a/libs/pika/iterator_support/tests/unit/transform_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/transform_iterator.cpp
@@ -44,8 +44,8 @@ namespace test {
         }
 
         template <typename Iterator>
-        typename std::iterator_traits<Iterator>::reference operator()(
-            Iterator const& it) const
+        typename std::iterator_traits<Iterator>::reference
+        operator()(Iterator const& it) const
         {
             if (it == begin_)
                 return *value_;
@@ -79,8 +79,8 @@ namespace test {
         }
 
         template <typename Iterator>
-        typename std::iterator_traits<Iterator>::reference operator()(
-            Iterator const& it) const
+        typename std::iterator_traits<Iterator>::reference
+        operator()(Iterator const& it) const
         {
             if (it == end_)
                 return *value_;
@@ -93,8 +93,8 @@ namespace test {
     };
 
     template <typename IteratorBase, typename IteratorValue>
-    inline next_transformer<IteratorBase, IteratorValue> make_next_transformer(
-        IteratorBase const& base, IteratorValue const& value)
+    inline next_transformer<IteratorBase, IteratorValue>
+    make_next_transformer(IteratorBase const& base, IteratorValue const& value)
     {
         return next_transformer<IteratorBase, IteratorValue>(base, value);
     }

--- a/libs/pika/lcos/include/pika/lcos/and_gate.hpp
+++ b/libs/pika/lcos/include/pika/lcos/and_gate.hpp
@@ -94,8 +94,8 @@ namespace pika { namespace lcos { namespace local {
     protected:
         /// \brief get a future allowing to wait for the gate to fire
         template <typename OuterLock>
-        pika::future<void> get_future(OuterLock& outer_lock,
-            std::size_t count = std::size_t(-1),
+        pika::future<void>
+        get_future(OuterLock& outer_lock, std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = pika::throws)
         {
@@ -184,8 +184,8 @@ namespace pika { namespace lcos { namespace local {
     protected:
         /// \brief Set the data which has to go into the segment \a which.
         template <typename OuterLock>
-        bool set(
-            std::size_t which, OuterLock outer_lock, error_code& ec = throws)
+        bool
+        set(std::size_t which, OuterLock outer_lock, error_code& ec = throws)
         {
             PIKA_ASSERT_OWNS_LOCK(outer_lock);
 
@@ -267,8 +267,8 @@ namespace pika { namespace lcos { namespace local {
             }
 
             template <typename Condition>
-            pika::future<void> get_future(
-                Condition&& func, error_code& ec = pika::throws)
+            pika::future<void>
+            get_future(Condition&& func, error_code& ec = pika::throws)
             {
                 return (*it_)->get_future(PIKA_FORWARD(Condition, func), ec);
             }
@@ -401,8 +401,8 @@ namespace pika { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        pika::future<void> get_future(Lock& l,
-            std::size_t count = std::size_t(-1),
+        pika::future<void>
+        get_future(Lock& l, std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = pika::throws)
         {
@@ -410,8 +410,8 @@ namespace pika { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        pika::shared_future<void> get_shared_future(Lock& l,
-            std::size_t count = std::size_t(-1),
+        pika::shared_future<void>
+        get_shared_future(Lock& l, std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = pika::throws)
         {

--- a/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
@@ -28,8 +28,8 @@ namespace pika { namespace lcos { namespace local {
 
         /// \brief get a future allowing to wait for the trigger to fire
         template <typename Condition>
-        pika::future<void> get_future(
-            Condition&& func, error_code& ec = pika::throws)
+        pika::future<void>
+        get_future(Condition&& func, error_code& ec = pika::throws)
         {
             cond_.assign(PIKA_FORWARD(Condition, func));
 

--- a/libs/pika/lcos/include/pika/lcos/trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/trigger.hpp
@@ -135,8 +135,8 @@ namespace pika { namespace lcos { namespace local {
             }
 
             template <typename Condition>
-            pika::future<void> get_future(
-                Condition&& func, error_code& ec = pika::throws)
+            pika::future<void>
+            get_future(Condition&& func, error_code& ec = pika::throws)
             {
                 return (*it_)->get_future(PIKA_FORWARD(Condition, func), ec);
             }

--- a/libs/pika/logging/include/pika/logging/message.hpp
+++ b/libs/pika/logging/include/pika/logging/message.hpp
@@ -88,8 +88,8 @@ namespace pika { namespace util { namespace logging {
         }
 
         template <typename... Args>
-        message& format(
-            std::string_view format_str, Args const&... args) noexcept
+        message&
+        format(std::string_view format_str, Args const&... args) noexcept
         {
             util::format_to(m_str, format_str, args...);
             m_full_msg_computed = false;

--- a/libs/pika/logging/include/pika/modules/logging.hpp
+++ b/libs/pika/logging/include/pika/modules/logging.hpp
@@ -165,8 +165,8 @@ namespace pika { namespace util {
             }
 
             template <typename... Args>
-            dummy_log_impl const& format(
-                char const*, Args const&...) const noexcept
+            dummy_log_impl const&
+            format(char const*, Args const&...) const noexcept
             {
                 return *this;
             }

--- a/libs/pika/logging/src/format/named_write.cpp
+++ b/libs/pika/logging/src/format/named_write.cpp
@@ -228,8 +228,8 @@ namespace pika { namespace util { namespace logging { namespace detail {
         };
 
         template <typename Named, typename ParserType>
-        void configure(
-            Named& named, std::string const& format, ParserType parser)
+        void
+        configure(Named& named, std::string const& format, ParserType parser)
         {
             // need to parse string
             bool parsing_params = false;

--- a/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
+++ b/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
@@ -193,15 +193,15 @@ namespace pika { namespace memory {
     };
 
     template <typename T, typename U>
-    inline constexpr bool operator==(
-        intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool
+    operator==(intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
     {
         return a.get() == b.get();
     }
 
     template <typename T, typename U>
-    inline constexpr bool operator!=(
-        intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool
+    operator!=(intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
     {
         return a.get() != b.get();
     }
@@ -231,36 +231,36 @@ namespace pika { namespace memory {
     }
 
     template <typename T>
-    inline constexpr bool operator==(
-        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+    inline constexpr bool
+    operator==(intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
-    inline constexpr bool operator==(
-        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+    inline constexpr bool
+    operator==(std::nullptr_t, intrusive_ptr<T> const& p) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
-    inline constexpr bool operator!=(
-        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+    inline constexpr bool
+    operator!=(intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
-    inline constexpr bool operator!=(
-        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+    inline constexpr bool
+    operator!=(std::nullptr_t, intrusive_ptr<T> const& p) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
-    inline constexpr bool operator<(
-        intrusive_ptr<T> const& a, intrusive_ptr<T> const& b) noexcept
+    inline constexpr bool
+    operator<(intrusive_ptr<T> const& a, intrusive_ptr<T> const& b) noexcept
     {
         return std::less<T*>{}(a.get(), b.get());
     }
@@ -298,8 +298,8 @@ namespace pika { namespace memory {
     }
 
     template <typename T, typename U>
-    constexpr intrusive_ptr<T> static_pointer_cast(
-        intrusive_ptr<U>&& p) noexcept
+    constexpr intrusive_ptr<T>
+    static_pointer_cast(intrusive_ptr<U>&& p) noexcept
     {
         return intrusive_ptr<T>(static_cast<T*>(p.detach()), false);
     }

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -287,14 +287,14 @@ namespace pika {
             }
 
             template <std::size_t Position>
-            constexpr static_async_range<Target, Position, End> relocate()
-                const noexcept
+            constexpr static_async_range<Target, Position, End>
+            relocate() const noexcept
             {
                 return static_async_range<Target, Position, End>{target_};
             }
 
-            constexpr static_async_range<Target, Begin + 1, End> next()
-                const noexcept
+            constexpr static_async_range<Target, Begin + 1, End>
+            next() const noexcept
             {
                 return static_async_range<Target, Begin + 1, End>{target_};
             }

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
@@ -137,8 +137,8 @@ namespace pika { namespace util { namespace detail {
             // We overload with one argument here so Clang and GCC don't
             // have any issues with overloading against zero arguments.
             template <typename First, typename... T>
-            constexpr Type<First, T...> operator()(
-                First&& first, T&&... args) const
+            constexpr Type<First, T...>
+            operator()(First&& first, T&&... args) const
             {
                 return Type<First, T...>{
                     PIKA_FORWARD(First, first), PIKA_FORWARD(T, args)...};
@@ -268,8 +268,8 @@ namespace pika { namespace util { namespace detail {
 
         /// Converts an empty tuple to void
         template <typename First, typename... Rest>
-        constexpr std::tuple<First, Rest...> voidify_empty_tuple(
-            std::tuple<First, Rest...> val)
+        constexpr std::tuple<First, Rest...>
+        voidify_empty_tuple(std::tuple<First, Rest...> val)
         {
             return val;
         }

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal.hpp
@@ -64,8 +64,8 @@ namespace pika { namespace util {
     /// if possible. This can be used to create a mapper function used
     /// in map_pack that maps one element to an arbitrary count (1:n).
     template <typename... T>
-    constexpr detail::spreading::spread_box<std::decay_t<T>...> spread_this(
-        T&&... args)
+    constexpr detail::spreading::spread_box<std::decay_t<T>...>
+    spread_this(T&&... args)
     {
         return detail::spreading::spread_box<std::decay_t<T>...>(
             std::make_tuple(PIKA_FORWARD(T, args)...));

--- a/libs/pika/pack_traversal/tests/unit/pack_traversal_async.cpp
+++ b/libs/pika/pack_traversal/tests/unit/pack_traversal_async.cpp
@@ -412,8 +412,8 @@ struct invalidate_visitor : async_counter_base<invalidate_visitor>
     }
 
     template <typename N>
-    void operator()(
-        async_traverse_detach_tag, std::shared_ptr<int>& i, N&& next)
+    void
+    operator()(async_traverse_detach_tag, std::shared_ptr<int>& i, N&& next)
     {
         PIKA_UNUSED(i);
 

--- a/libs/pika/pack_traversal/tests/unit/unwrap.cpp
+++ b/libs/pika/pack_traversal/tests/unit/unwrap.cpp
@@ -164,8 +164,8 @@ struct back_materializer
     }
 
     template <typename First, typename Second, typename... Rest>
-    tuple<First, Second, Rest...> operator()(
-        First&& first, Second&& second, Rest&&... rest) const
+    tuple<First, Second, Rest...>
+    operator()(First&& first, Second&& second, Rest&&... rest) const
     {
         return tuple<First, Second, Rest...>{std::forward<First>(first),
             std::forward<Second>(second), std::forward<Rest>(rest)...};

--- a/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
@@ -36,8 +36,8 @@ namespace pika { namespace program_options {
     }
 
     template <class Char>
-    basic_command_line_parser<Char>& basic_command_line_parser<Char>::options(
-        const options_description& desc)
+    basic_command_line_parser<Char>&
+    basic_command_line_parser<Char>::options(const options_description& desc)
     {
         detail::cmdline::set_options_description(desc);
         m_desc = &desc;
@@ -54,8 +54,8 @@ namespace pika { namespace program_options {
     }
 
     template <class Char>
-    basic_command_line_parser<Char>& basic_command_line_parser<Char>::style(
-        int xstyle)
+    basic_command_line_parser<Char>&
+    basic_command_line_parser<Char>::style(int xstyle)
     {
         detail::cmdline::style(xstyle);
         return *this;
@@ -115,8 +115,8 @@ namespace pika { namespace program_options {
     }
 
     template <class Char>
-    std::vector<std::basic_string<Char>> collect_unrecognized(
-        const std::vector<basic_option<Char>>& options,
+    std::vector<std::basic_string<Char>>
+    collect_unrecognized(const std::vector<basic_option<Char>>& options,
         enum collect_unrecognized_mode mode)
     {
         std::vector<std::basic_string<Char>> result;

--- a/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
@@ -70,8 +70,8 @@ namespace pika { namespace program_options {
            empty string if 'allow_empty' and throws validation_error
            otherwise. */
         template <class Char>
-        const std::basic_string<Char>& get_single_string(
-            const std::vector<std::basic_string<Char>>& v,
+        const std::basic_string<Char>&
+        get_single_string(const std::vector<std::basic_string<Char>>& v,
             bool allow_empty = false)
         {
             static std::basic_string<Char> empty;

--- a/libs/pika/program_options/include/pika/program_options/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/parsers.hpp
@@ -177,8 +177,8 @@ namespace pika { namespace program_options {
         Read from given stream.
     */
     template <class Char>
-    PIKA_EXPORT basic_parsed_options<Char> parse_config_file(
-        std::basic_istream<Char>&, const options_description&,
+    PIKA_EXPORT basic_parsed_options<Char>
+    parse_config_file(std::basic_istream<Char>&, const options_description&,
         bool allow_unregistered = false);
 
     /** Parse a config file.
@@ -187,8 +187,8 @@ namespace pika { namespace program_options {
         passed to the file stream.
     */
     template <class Char = char>
-    PIKA_EXPORT basic_parsed_options<Char> parse_config_file(
-        const char* filename, const options_description&,
+    PIKA_EXPORT basic_parsed_options<Char>
+    parse_config_file(const char* filename, const options_description&,
         bool allow_unregistered = false);
 
     /** Controls if the 'collect_unregistered' function should
@@ -206,8 +206,8 @@ namespace pika { namespace program_options {
         options.
     */
     template <class Char>
-    std::vector<std::basic_string<Char>> collect_unrecognized(
-        const std::vector<basic_option<Char>>& options,
+    std::vector<std::basic_string<Char>>
+    collect_unrecognized(const std::vector<basic_option<Char>>& options,
         enum collect_unrecognized_mode mode);
 
     /** Parse environment.

--- a/libs/pika/program_options/src/convert.cpp
+++ b/libs/pika/program_options/src/convert.cpp
@@ -31,8 +31,8 @@ namespace pika { namespace program_options { namespace detail {
        Experiments show that the performance loss is less than 10%.
     */
     template <class ToChar, class FromChar, class Fun>
-    std::basic_string<ToChar> convert(
-        const std::basic_string<FromChar>& s, Fun fun)
+    std::basic_string<ToChar>
+    convert(const std::basic_string<FromChar>& s, Fun fun)
 
     {
         std::basic_string<ToChar> result;

--- a/libs/pika/program_options/src/split.cpp
+++ b/libs/pika/program_options/src/split.cpp
@@ -15,8 +15,8 @@
 namespace pika { namespace program_options { namespace detail {
 
     template <class Char>
-    std::vector<std::basic_string<Char>> split_unix(
-        const std::basic_string<Char>& cmdline,
+    std::vector<std::basic_string<Char>>
+    split_unix(const std::basic_string<Char>& cmdline,
         const std::basic_string<Char>& separator,
         const std::basic_string<Char>& quote,
         const std::basic_string<Char>& escape)

--- a/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
@@ -85,8 +85,8 @@ struct test_async_executor
     // of a normal async call with arbitrary arguments
     // --------------------------------------------------------------------
     template <typename F, typename... Ts>
-    future<typename util::detail::invoke_result<F, Ts...>::type> async_execute(
-        F&& f, Ts&&... ts)
+    future<typename util::detail::invoke_result<F, Ts...>::type>
+    async_execute(F&& f, Ts&&... ts)
     {
         using result_type =
             typename util::detail::invoke_deferred_result<F, Ts...>::type;

--- a/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
+++ b/libs/pika/runtime/include/pika/runtime/custom_exception_info.hpp
@@ -109,8 +109,8 @@ namespace pika {
             std::string const& state_name, std::string const& auxinfo);
 
         template <typename Exception>
-        PIKA_EXPORT std::exception_ptr construct_exception(
-            Exception const& e, pika::exception_info info);
+        PIKA_EXPORT std::exception_ptr
+        construct_exception(Exception const& e, pika::exception_info info);
 
         PIKA_EXPORT void pre_exception_handler();
 

--- a/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
+++ b/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
@@ -29,8 +29,8 @@ namespace pika { namespace threads {
     namespace detail {
         // This is the overload for running functions which return a value.
         template <typename F, typename... Ts>
-        typename util::detail::invoke_result<F, Ts...>::type run_as_pika_thread(
-            std::false_type, F const& f, Ts&&... ts)
+        typename util::detail::invoke_result<F, Ts...>::type
+        run_as_pika_thread(std::false_type, F const& f, Ts&&... ts)
         {
             // NOTE: The condition variable needs be able to live past the scope
             // of this function. The mutex and boolean are guaranteed to live
@@ -140,8 +140,8 @@ namespace pika { namespace threads {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    typename util::detail::invoke_result<F, Ts...>::type run_as_pika_thread(
-        F const& f, Ts&&... vs)
+    typename util::detail::invoke_result<F, Ts...>::type
+    run_as_pika_thread(F const& f, Ts&&... vs)
     {
         // This shouldn't be used on a pika-thread
         PIKA_ASSERT(pika::threads::detail::get_self_ptr() == nullptr);

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -257,8 +257,8 @@ namespace pika {
         }
 
         template <typename Exception>
-        std::exception_ptr construct_exception(
-            Exception const& e, pika::exception_info info)
+        std::exception_ptr
+        construct_exception(Exception const& e, pika::exception_info info)
         {
             // create a std::exception_ptr object encapsulating the Exception to
             // be thrown and annotate it with all the local information we have

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -494,8 +494,8 @@ namespace pika { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::size_t runtime_configuration::get_spinlock_deadlock_detection_limit()
-        const
+    std::size_t
+    runtime_configuration::get_spinlock_deadlock_detection_limit() const
     {
 #ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION
         if (util::section const* sec = get_section("pika"); nullptr != sec)
@@ -510,8 +510,8 @@ namespace pika { namespace util {
 #endif
     }
 
-    std::size_t runtime_configuration::get_spinlock_deadlock_warning_limit()
-        const
+    std::size_t
+    runtime_configuration::get_spinlock_deadlock_warning_limit() const
     {
 #ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION
         if (util::section const* sec = get_section("pika"); nullptr != sec)

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -56,8 +56,8 @@ namespace pika {
     constexpr int debug_level = 0;
 
     template <int Level>
-    static debug::detail::print_threshold<Level, debug_level> spq_deb(
-        "SPQUEUE");
+    static debug::detail::print_threshold<Level, debug_level>
+        spq_deb("SPQUEUE");
     static debug::detail::print_threshold<1, 1> spq_arr("SPQUEUE");
 #define DEBUG(printer, Expr) PIKA_DP_ONLY(printer, Expr)
 }    // namespace pika

--- a/libs/pika/string_util/include/pika/string_util/classification.hpp
+++ b/libs/pika/string_util/include/pika/string_util/classification.hpp
@@ -24,8 +24,8 @@ namespace pika { namespace string_util {
     }    // namespace detail
 
     template <typename CharT, typename Traits, typename Allocator>
-    detail::is_any_of_pred<CharT, Traits, Allocator> is_any_of(
-        std::basic_string<CharT, Traits, Allocator> const& chars)
+    detail::is_any_of_pred<CharT, Traits, Allocator>
+    is_any_of(std::basic_string<CharT, Traits, Allocator> const& chars)
     {
         return detail::is_any_of_pred<CharT, Traits, Allocator>{chars};
     }

--- a/libs/pika/string_util/include/pika/string_util/split.hpp
+++ b/libs/pika/string_util/include/pika/string_util/split.hpp
@@ -19,8 +19,8 @@ namespace pika { namespace string_util {
     namespace detail {
         template <typename It, typename CharT, typename Traits,
             typename Allocator>
-        std::basic_string<CharT, Traits, Allocator> substr(
-            std::basic_string<CharT, Traits, Allocator> const& s,
+        std::basic_string<CharT, Traits, Allocator>
+        substr(std::basic_string<CharT, Traits, Allocator> const& s,
             It const& first, It const& last)
         {
             std::size_t const pos = std::distance(std::begin(s), first);

--- a/libs/pika/string_util/include/pika/string_util/trim.hpp
+++ b/libs/pika/string_util/include/pika/string_util/trim.hpp
@@ -34,8 +34,8 @@ namespace pika { namespace string_util {
     }
 
     template <typename CharT, class Traits, class Alloc>
-    std::basic_string<CharT, Traits, Alloc> trim_copy(
-        std::basic_string<CharT, Traits, Alloc> const& s)
+    std::basic_string<CharT, Traits, Alloc>
+    trim_copy(std::basic_string<CharT, Traits, Alloc> const& s)
     {
         auto t = s;
         trim(t);

--- a/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp
@@ -256,8 +256,8 @@ namespace pika { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        cv_status wait_until(Lock& lock,
-            pika::chrono::steady_time_point const& abs_time,
+        cv_status
+        wait_until(Lock& lock, pika::chrono::steady_time_point const& abs_time,
             error_code& ec = throws)
         {
             PIKA_ASSERT_OWNS_LOCK(lock);
@@ -290,9 +290,9 @@ namespace pika { namespace lcos { namespace local {
         }
 
         template <typename Lock, typename Predicate>
-        bool wait_until(Lock& lock,
-            pika::chrono::steady_time_point const& abs_time, Predicate pred,
-            error_code& ec = throws)
+        bool
+        wait_until(Lock& lock, pika::chrono::steady_time_point const& abs_time,
+            Predicate pred, error_code& ec = throws)
         {
             PIKA_ASSERT_OWNS_LOCK(lock);
 
@@ -305,8 +305,8 @@ namespace pika { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        cv_status wait_for(Lock& lock,
-            pika::chrono::steady_duration const& rel_time,
+        cv_status
+        wait_for(Lock& lock, pika::chrono::steady_duration const& rel_time,
             error_code& ec = throws)
         {
             return wait_until(lock, rel_time.from_now(), ec);

--- a/libs/pika/synchronization/include/pika/synchronization/stop_token.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/stop_token.hpp
@@ -518,16 +518,16 @@ namespace pika {
     //      template parameter Callback that models both invocable and
     //      destructible.
     template <typename Callback>
-    stop_callback<std::decay_t<Callback>> make_stop_callback(
-        stop_token const& st, Callback&& cb)
+    stop_callback<std::decay_t<Callback>>
+    make_stop_callback(stop_token const& st, Callback&& cb)
     {
         return stop_callback<std::decay_t<Callback>>(
             st, PIKA_FORWARD(Callback, cb));
     }
 
     template <typename Callback>
-    stop_callback<std::decay_t<Callback>> make_stop_callback(
-        stop_token&& st, Callback&& cb)
+    stop_callback<std::decay_t<Callback>>
+    make_stop_callback(stop_token&& st, Callback&& cb)
     {
         return stop_callback<std::decay_t<Callback>>(
             PIKA_MOVE(st), PIKA_FORWARD(Callback, cb));

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
@@ -120,8 +120,8 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Tag tag, Ts&&... ts) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Tag tag, Ts&&... ts) const
                 noexcept(noexcept(tag_fallback_invoke(
                     std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
                     -> decltype(tag_fallback_invoke(
@@ -259,8 +259,8 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable =
                     std::enable_if_t<is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                     -> tag_invoke_result_t<Tag, Args&&...>
             {
@@ -273,8 +273,8 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable =
                     std::enable_if_t<!is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                     -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
@@ -317,8 +317,8 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable = std::enable_if_t<
                     is_nothrow_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> tag_invoke_result_t<Tag, Args&&...>
             {
                 return tag_invoke(static_cast<Tag const&>(*this),
@@ -332,8 +332,8 @@ namespace pika::functional::detail {
                     is_nothrow_tag_fallback_invocable<Tag, Args&&...>,
                 typename Enable = std::enable_if_t<
                     !is_nothrow_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> decltype(tag_fallback_invoke_impl(
                     IsFallbackDispatchable{}, PIKA_FORWARD(Args, args)...))
             {

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
@@ -123,8 +123,8 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Tag tag, Ts&&... ts) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Tag tag, Ts&&... ts) const
                 noexcept(noexcept(tag_override_invoke(
                     std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
                     -> decltype(tag_override_invoke(
@@ -241,8 +241,8 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable = std::enable_if_t<
                     is_tag_override_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_override_invocable_v<Tag, Args...>)
                     -> tag_override_invoke_result_t<Tag, Args&&...>
             {
@@ -256,8 +256,8 @@ namespace pika::functional::detail {
                 typename Enable = std::enable_if_t<
                     !is_tag_override_invocable_v<Tag, Args&&...> &&
                     is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                     -> tag_invoke_result_t<Tag, Args&&...>
             {
@@ -273,8 +273,8 @@ namespace pika::functional::detail {
                     !is_tag_override_invocable_v<Tag, Args&&...> &&
                     !is_tag_invocable_v<Tag, Args&&...> &&
                     is_tag_fallback_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                     -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
@@ -296,8 +296,8 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable = std::enable_if_t<
                     is_nothrow_tag_override_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> tag_override_invoke_result_t<Tag, Args&&...>
             {
                 return tag_override_invoke(static_cast<Tag const&>(*this),
@@ -311,8 +311,8 @@ namespace pika::functional::detail {
                 typename Enable = std::enable_if_t<
                     !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                     is_nothrow_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> tag_invoke_result_t<Tag, Args&&...>
             {
                 return tag_invoke(static_cast<Tag const&>(*this),
@@ -327,8 +327,8 @@ namespace pika::functional::detail {
                     !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                     !is_nothrow_tag_invocable_v<Tag, Args&&...> &&
                     is_nothrow_tag_fallback_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
                 return tag_fallback_invoke(static_cast<Tag const&>(*this),

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -117,12 +117,11 @@ namespace pika { namespace functional {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Tag tag, Ts&&... ts) const
-                noexcept(noexcept(
-                    tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
-                    -> decltype(tag_invoke(
-                        std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Tag tag, Ts&&... ts) const noexcept(noexcept(
+                tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
+                -> decltype(tag_invoke(
+                    std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
             {
                 return tag_invoke(tag, PIKA_FORWARD(Ts, ts)...);
             }
@@ -220,8 +219,8 @@ namespace pika { namespace functional {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const
                 noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                     -> tag_invoke_result_t<Tag, Args...>
             {
@@ -237,8 +236,8 @@ namespace pika { namespace functional {
             template <typename... Args,
                 typename Enable =
                     std::enable_if_t<is_nothrow_tag_invocable_v<Tag, Args...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            operator()(Args&&... args) const noexcept
                 -> tag_invoke_result_t<Tag, decltype(args)...>
             {
                 return tag_invoke(static_cast<Tag const&>(*this),

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -173,8 +173,8 @@ namespace pika::threads::detail {
     }
 
     template <typename Scheduler>
-    pika::runtime_state scheduled_thread_pool<Scheduler>::get_state(
-        std::size_t num_thread) const
+    pika::runtime_state
+    scheduled_thread_pool<Scheduler>::get_state(std::size_t num_thread) const
     {
         PIKA_ASSERT(num_thread != std::size_t(-1));
         return sched_->Scheduler::get_state(num_thread).load();
@@ -651,10 +651,10 @@ namespace pika::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
-    thread_state scheduled_thread_pool<Scheduler>::set_state(
-        thread_id_type const& id, thread_schedule_state new_state,
-        thread_restart_state new_state_ex, execution::thread_priority priority,
-        error_code& ec)
+    thread_state
+    scheduled_thread_pool<Scheduler>::set_state(thread_id_type const& id,
+        thread_schedule_state new_state, thread_restart_state new_state_ex,
+        execution::thread_priority priority, error_code& ec)
     {
         return set_thread_state(id, new_state,    //-V107
             new_state_ex, priority,
@@ -1733,8 +1733,8 @@ namespace pika::threads::detail {
     }
 
     template <typename Scheduler>
-    std::int64_t scheduled_thread_pool<Scheduler>::avg_idle_rate(
-        std::size_t num, bool reset)
+    std::int64_t
+    scheduled_thread_pool<Scheduler>::avg_idle_rate(std::size_t num, bool reset)
     {
         if (num == std::size_t(-1))
             return avg_idle_rate_all(reset);
@@ -1794,8 +1794,8 @@ namespace pika::threads::detail {
     }
 
     template <typename Scheduler>
-    std::int64_t scheduled_thread_pool<Scheduler>::get_scheduler_utilization()
-        const
+    std::int64_t
+    scheduled_thread_pool<Scheduler>::get_scheduler_utilization() const
     {
         return (accumulate_projected(counter_data_.begin(), counter_data_.end(),
                     std::int64_t(0), &scheduling_counter_data::tasks_active_) *
@@ -1820,8 +1820,8 @@ namespace pika::threads::detail {
     }
 
     template <typename Scheduler>
-    void scheduled_thread_pool<Scheduler>::get_idle_core_mask(
-        mask_type& mask) const
+    void
+    scheduled_thread_pool<Scheduler>::get_idle_core_mask(mask_type& mask) const
     {
         std::size_t i = 0;
         for (auto const& data : counter_data_)

--- a/libs/pika/thread_support/include/pika/thread_support/assert_owns_lock.hpp
+++ b/libs/pika/thread_support/include/pika/thread_support/assert_owns_lock.hpp
@@ -28,16 +28,16 @@ namespace pika::util::detail {
     }
 
     template <typename Lock>
-    std::enable_if_t<has_owns_lock<Lock>::value> assert_owns_lock(
-        Lock const& l, long) noexcept
+    std::enable_if_t<has_owns_lock<Lock>::value>
+    assert_owns_lock(Lock const& l, long) noexcept
     {
         PIKA_ASSERT(l.owns_lock());
         PIKA_UNUSED(l);
     }
 
     template <typename Lock>
-    std::enable_if_t<has_owns_lock<Lock>::value> assert_doesnt_own_lock(
-        Lock const& l, long) noexcept
+    std::enable_if_t<has_owns_lock<Lock>::value>
+    assert_doesnt_own_lock(Lock const& l, long) noexcept
     {
         PIKA_ASSERT(!l.owns_lock());
         PIKA_UNUSED(l);

--- a/libs/pika/threading/include/pika/threading/jthread.hpp
+++ b/libs/pika/threading/include/pika/threading/jthread.hpp
@@ -21,8 +21,8 @@ namespace pika {
     {
     private:
         template <typename F, typename... Ts>
-        static void invoke(
-            std::false_type, F&& f, stop_token&& /* st */, Ts&&... ts)
+        static void
+        invoke(std::false_type, F&& f, stop_token&& /* st */, Ts&&... ts)
         {
             // started thread does not expect a stop token:
             PIKA_INVOKE(PIKA_FORWARD(F, f), PIKA_FORWARD(Ts, ts)...);

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -167,8 +167,8 @@ namespace pika {
             thread::id const& x, thread::id const& y) noexcept;
 
         template <typename Char, typename Traits>
-        friend std::basic_ostream<Char, Traits>& operator<<(
-            std::basic_ostream<Char, Traits>&, thread::id const&);
+        friend std::basic_ostream<Char, Traits>&
+        operator<<(std::basic_ostream<Char, Traits>&, thread::id const&);
 
         friend class thread;
 
@@ -230,8 +230,8 @@ namespace pika {
     }
 
     template <typename Char, typename Traits>
-    std::basic_ostream<Char, Traits>& operator<<(
-        std::basic_ostream<Char, Traits>& out, thread::id const& id)
+    std::basic_ostream<Char, Traits>&
+    operator<<(std::basic_ostream<Char, Traits>& out, thread::id const& id)
     {
         out << id.id_;
         return out;

--- a/libs/pika/threading_base/include/pika/threading_base/annotated_function.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/annotated_function.hpp
@@ -57,8 +57,8 @@ namespace pika {
             }
 
             template <typename... Ts>
-            pika::util::detail::invoke_result_t<fun_type, Ts...> operator()(
-                Ts&&... ts)
+            pika::util::detail::invoke_result_t<fun_type, Ts...>
+            operator()(Ts&&... ts)
             {
                 scoped_annotation annotate(get_function_annotation());
                 return PIKA_INVOKE(f_, PIKA_FORWARD(Ts, ts)...);
@@ -99,8 +99,8 @@ namespace pika {
     }    // namespace detail
 
     template <typename F>
-    detail::annotated_function<std::decay_t<F>> annotated_function(
-        F&& f, char const* name = nullptr)
+    detail::annotated_function<std::decay_t<F>>
+    annotated_function(F&& f, char const* name = nullptr)
     {
         using result_type = detail::annotated_function<std::decay_t<F>>;
 
@@ -108,8 +108,8 @@ namespace pika {
     }
 
     template <typename F>
-    detail::annotated_function<std::decay_t<F>> annotated_function(
-        F&& f, std::string name)
+    detail::annotated_function<std::decay_t<F>>
+    annotated_function(F&& f, std::string name)
     {
         using result_type = detail::annotated_function<std::decay_t<F>>;
 

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -114,8 +114,8 @@ namespace pika::threads::detail {
         // return whether all states are at least at the given one
         bool has_reached_state(pika::runtime_state s) const;
         bool is_state(pika::runtime_state s) const;
-        std::pair<pika::runtime_state, pika::runtime_state> get_minmax_state()
-            const;
+        std::pair<pika::runtime_state, pika::runtime_state>
+        get_minmax_state() const;
 
         ///////////////////////////////////////////////////////////////////////
         // get/set scheduler mode

--- a/libs/pika/type_support/include/pika/type_support/unused.hpp
+++ b/libs/pika/type_support/include/pika/type_support/unused.hpp
@@ -48,8 +48,8 @@ namespace pika::util::detail {
             return *this;
         }
         template <typename T>
-        PIKA_HOST_DEVICE PIKA_FORCEINLINE unused_type& operator=(
-            T const&) noexcept
+        PIKA_HOST_DEVICE PIKA_FORCEINLINE unused_type&
+        operator=(T const&) noexcept
         {
             return *this;
         }

--- a/libs/pika/type_support/include/pika/type_support/unwrap_reference.hpp
+++ b/libs/pika/type_support/include/pika/type_support/unwrap_reference.hpp
@@ -30,8 +30,8 @@ namespace pika::detail {
     };
 
     template <typename T>
-    PIKA_FORCEINLINE typename unwrap_reference_impl<T>::type& unwrap_reference(
-        T& t)
+    PIKA_FORCEINLINE typename unwrap_reference_impl<T>::type&
+    unwrap_reference(T& t)
     {
         return t;
     }

--- a/libs/pika/util/include/pika/util/detail/reserve.hpp
+++ b/libs/pika/util/include/pika/util/detail/reserve.hpp
@@ -48,8 +48,8 @@ namespace pika { namespace traits { namespace detail {
     // Reserve sufficient space in the given vector if the underlying
     // iterator type of the given range allow calculating the size in O(1).
     template <typename Container, typename Range>
-    PIKA_FORCEINLINE void reserve_if_random_access_by_range(
-        Container& v, Range const& r)
+    PIKA_FORCEINLINE void
+    reserve_if_random_access_by_range(Container& v, Range const& r)
     {
         using iterator_type = typename range_traits<Range>::iterator_type;
         if constexpr (is_random_access_iterator_v<iterator_type> &&

--- a/testing/testing/include/pika/testing.hpp
+++ b/testing/testing/include/pika/testing.hpp
@@ -94,9 +94,9 @@ namespace pika { namespace util {
             }
 
             template <typename T, typename U>
-            bool check_not_equal(char const* file, int line,
-                char const* function, counter_type c, T const& t, U const& u,
-                char const* msg)
+            bool
+            check_not_equal(char const* file, int line, char const* function,
+                counter_type c, T const& t, U const& u, char const* msg)
             {
                 increment_tests(c);
 
@@ -133,9 +133,9 @@ namespace pika { namespace util {
             }
 
             template <typename T, typename U>
-            bool check_less_equal(char const* file, int line,
-                char const* function, counter_type c, T const& t, U const& u,
-                char const* msg)
+            bool
+            check_less_equal(char const* file, int line, char const* function,
+                counter_type c, T const& t, U const& u, char const* msg)
             {
                 increment_tests(c);
 

--- a/tests/performance/local/htts_v2/htts2.hpp
+++ b/tests/performance/local/htts_v2/htts2.hpp
@@ -58,8 +58,8 @@ namespace htts2 {
     // Performs approximately 'expected_' nanoseconds of artificial work.
     // Returns: nanoseconds of work performed.
     template <typename BaseClock>
-    typename clocksource<BaseClock>::rep payload(
-        typename clocksource<BaseClock>::rep expected)
+    typename clocksource<BaseClock>::rep
+    payload(typename clocksource<BaseClock>::rep expected)
     {
         using rep = typename clocksource<BaseClock>::rep;
 

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -314,9 +314,9 @@ struct triad_step
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Policy>
-std::vector<std::vector<std::chrono::duration<double>>> run_benchmark(
-    std::size_t warmup_iterations, std::size_t iterations, std::size_t size,
-    Policy&& policy)
+std::vector<std::vector<std::chrono::duration<double>>>
+run_benchmark(std::size_t warmup_iterations, std::size_t iterations,
+    std::size_t size, Policy&& policy)
 {
     // Allocate our data
     using vector_type = std::vector<STREAM_TYPE>;


### PR DESCRIPTION
This encourages separating the function name onto a new line which can be more readable in some cases. See https://github.com/pika-org/pika/pull/475#pullrequestreview-1138590510.

This is a draft since I haven't looked through the changes to see if they're sane. @biddisco please also have a quick look to see if you think the changes are better, worse, or no difference.