### PR TITLE
Add tests for reference types to `when_all_vector`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -61,22 +61,14 @@ namespace pika::when_all_vector_detail {
         {
         }
 
-        template <typename Pack>
-        struct element_value_type_helper
-        {
-            using type = pika::util::detail::transform_t<Pack, std::decay>;
-        };
-
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
         // We expect a single value type or nothing from the predecessor
         // sender type
         using element_value_type =
-            pika::execution::experimental::detail::single_result_t<
-                pika::util::detail::transform_t<
-                    pika::execution::experimental::value_types_of_t<Sender,
-                        pika::execution::experimental::detail::empty_env,
-                        pika::util::detail::pack, pika::util::detail::pack>,
-                    element_value_type_helper>>;
+            std::decay_t<pika::execution::experimental::detail::single_result_t<
+                pika::execution::experimental::value_types_of_t<Sender,
+                    pika::execution::experimental::detail::empty_env,
+                    pika::util::detail::pack, pika::util::detail::pack>>>;
 
         static constexpr bool is_void_value_type =
             std::is_void_v<element_value_type>;
@@ -118,12 +110,10 @@ namespace pika::when_all_vector_detail {
         // We expect a single value type or nothing from the predecessor
         // sender type
         using element_value_type =
-            pika::execution::experimental::detail::single_result_t<
-                pika::util::detail::transform_t<
-                    typename pika::execution::experimental::sender_traits<
-                        Sender>::template value_types<pika::util::detail::pack,
-                        pika::util::detail::pack>,
-                    element_value_type_helper>>;
+            std::decay_t<pika::execution::experimental::detail::single_result_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template value_types<pika::util::detail::pack,
+                    pika::util::detail::pack>>>;
 
         static constexpr bool is_void_value_type =
             std::is_void_v<element_value_type>;

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -61,14 +61,22 @@ namespace pika::when_all_vector_detail {
         {
         }
 
+        template <typename Pack>
+        struct element_value_type_helper
+        {
+            using type = pika::util::detail::transform_t<Pack, std::decay>;
+        };
+
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
         // We expect a single value type or nothing from the predecessor
         // sender type
         using element_value_type =
             pika::execution::experimental::detail::single_result_t<
-                pika::execution::experimental::value_types_of_t<Sender,
-                    pika::execution::experimental::detail::empty_env,
-                    pika::util::detail::pack, pika::util::detail::pack>>;
+                pika::util::detail::transform_t<
+                    pika::execution::experimental::value_types_of_t<Sender,
+                        pika::execution::experimental::detail::empty_env,
+                        pika::util::detail::pack, pika::util::detail::pack>,
+                    element_value_type_helper>>;
 
         static constexpr bool is_void_value_type =
             std::is_void_v<element_value_type>;
@@ -109,9 +117,11 @@ namespace pika::when_all_vector_detail {
         // sender type
         using element_value_type =
             pika::execution::experimental::detail::single_result_t<
-                typename pika::execution::experimental::sender_traits<
-                    Sender>::template value_types<pika::util::detail::pack,
-                    pika::util::detail::pack>>;
+                pika::util::detail::transform_t<
+                    typename pika::execution::experimental::sender_traits<
+                        Sender>::template value_types<pika::util::detail::pack,
+                        pika::util::detail::pack>,
+                    element_value_type_helper>>;
 
         static constexpr bool is_void_value_type =
             std::is_void_v<element_value_type>;

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -99,8 +99,10 @@ namespace pika::when_all_vector_detail {
         // or std::exception_ptr
         template <template <typename...> class Variant>
         using error_types = pika::util::detail::unique_concat_t<
-            pika::execution::experimental::error_types_of_t<Sender,
-                pika::execution::experimental::detail::empty_env, Variant>,
+            pika::util::detail::transform_t<
+                pika::execution::experimental::error_types_of_t<Sender,
+                    pika::execution::experimental::detail::empty_env, Variant>,
+                std::decay>,
             Variant<std::exception_ptr>>;
 
         static constexpr bool sends_done = false;
@@ -144,8 +146,10 @@ namespace pika::when_all_vector_detail {
         // or std::exception_ptr
         template <template <typename...> class Variant>
         using error_types = pika::util::detail::unique_concat_t<
-            typename pika::execution::experimental::sender_traits<
-                Sender>::template error_types<Variant>,
+            pika::util::detail::transform_t<
+                typename pika::execution::experimental::sender_traits<
+                    Sender>::template error_types<Variant>,
+                std::decay>,
             Variant<std::exception_ptr>>;
 
         static constexpr bool sends_done = false;

--- a/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -278,6 +278,17 @@ int main()
 
     {
         std::atomic<bool> set_error_called{false};
+        auto s =
+            ex::when_all_vector(std::vector{const_reference_error_sender{}});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
         std::vector<ex::unique_any_sender<double>> senders;
         senders.emplace_back(error_sender<double>{});
         senders.emplace_back(ex::just(42.0));

--- a/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -61,6 +61,21 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
+        int x = 42;
+        auto s =
+            ex::when_all_vector(std::vector{const_reference_sender<int>{x}});
+        auto f = [](std::vector<int> v) {
+            PIKA_TEST_EQ(v.size(), std::size_t(1));
+            PIKA_TEST_EQ(v[0], 42);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
         auto s = ex::when_all_vector(
             std::vector{ex::just(42), ex::just(43), ex::just(44)});
         auto f = [](std::vector<int> v) {


### PR DESCRIPTION
Last part of #284. Fixes #284.