### PR TITLE
More reference type handling fixes to `when_all`, `then_with_stream`, and `transform_mpi`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -498,18 +498,28 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                     std::decay_t<Sender>, then_with_cuda_stream_receiver>;
             operation_state_type op_state;
 
+            template <typename Tuple>
+            struct value_types_helper
+            {
+                using type = pika::util::detail::transform_t<Tuple, std::decay>;
+            };
+
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
             using ts_type = pika::util::detail::prepend_t<
-                pika::execution::experimental::value_types_of_t<
-                    std::decay_t<Sender>,
-                    pika::execution::experimental::detail::empty_env,
-                    std::tuple, pika::detail::variant>,
+                pika::util::detail::transform_t<
+                    pika::execution::experimental::value_types_of_t<
+                        std::decay_t<Sender>,
+                        pika::execution::experimental::detail::empty_env,
+                        std::tuple, pika::detail::variant>,
+                    value_types_helper>,
                 pika::detail::monostate>;
 #else
             using ts_type = pika::util::detail::prepend_t<
-                typename pika::execution::experimental::sender_traits<
-                    std::decay_t<Sender>>::template value_types<std::tuple,
-                    pika::detail::variant>,
+                pika::util::detail::transform_t<
+                    typename pika::execution::experimental::sender_traits<
+                        std::decay_t<Sender>>::template value_types<std::tuple,
+                        pika::detail::variant>,
+                    value_types_helper>,
                 pika::detail::monostate>;
 #endif
             ts_type ts;

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -273,18 +273,30 @@ namespace pika::mpi::experimental {
                         std::decay_t<Sender>, transform_mpi_receiver>;
                 operation_state_type op_state;
 
+                template <typename Tuple>
+                struct value_types_helper
+                {
+                    using type =
+                        pika::util::detail::transform_t<Tuple, std::decay>;
+                };
+
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
                 using ts_type = pika::util::detail::prepend_t<
-                    pika::execution::experimental::value_types_of_t<
-                        std::decay_t<Sender>,
-                        pika::execution::experimental::detail::empty_env,
-                        std::tuple, pika::detail::variant>,
+                    pika::util::detail::transform_t<
+                        pika::execution::experimental::value_types_of_t<
+                            std::decay_t<Sender>,
+                            pika::execution::experimental::detail::empty_env,
+                            std::tuple, pika::detail::variant>,
+                        value_types_helper>,
                     pika::detail::monostate>;
 #else
                 using ts_type = pika::util::detail::prepend_t<
-                    typename pika::execution::experimental::sender_traits<
-                        std::decay_t<Sender>>::template value_types<std::tuple,
-                        pika::detail::variant>,
+                    pika::util::detail::transform_t<
+                        typename pika::execution::experimental::sender_traits<
+                            std::decay_t<Sender>>::
+                            template value_types<std::tuple,
+                                pika::detail::variant>,
+                        value_types_helper>,
                     pika::detail::monostate>;
 #endif
                 ts_type ts;

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -175,27 +175,20 @@ namespace pika::when_all_impl {
         {
         }
 
-        template <typename Sender>
+        template <typename Tuple>
         struct value_types_helper
         {
-            using value_types =
-                typename pika::execution::experimental::sender_traits<
-                    Sender>::template value_types<pika::util::detail::pack,
-                    pika::util::detail::pack>;
-            using type =
-                pika::execution::experimental::detail::single_result_non_void_t<
-                    value_types>;
+            using type = pika::util::detail::transform_t<Tuple, std::decay>;
         };
-
-        template <typename Sender>
-        using value_types_helper_t = typename value_types_helper<Sender>::type;
 
         template <template <typename...> class Tuple,
             template <typename...> class Variant>
-        using value_types = pika::util::detail::concat_inner_packs_t<
-            pika::util::detail::concat_t<
-                typename pika::execution::experimental::sender_traits<
-                    Senders>::template value_types<Tuple, Variant>...>>;
+        using value_types = pika::util::detail::transform_t<
+            pika::util::detail::concat_inner_packs_t<
+                pika::util::detail::concat_t<
+                    typename pika::execution::experimental::sender_traits<
+                        Senders>::template value_types<Tuple, Variant>...>>,
+            value_types_helper>;
 
         template <template <typename...> class Variant>
         using error_types = pika::util::detail::unique_concat_t<

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
@@ -186,17 +186,18 @@ namespace pika::functional::detail {
     // correctly check this condition. We default to the more relaxed
     // noexcept(true) to not falsely exclude correct overloads. However, this
     // may lead to noexcept(false) overloads falsely being candidates.
-#if !defined(PIKA_CUDA_VERSION) || (PIKA_CUDA_VERSION >= 1102)
+#if defined(__NVCC__) && defined(PIKA_CUDA_VERSION) &&                         \
+    (PIKA_CUDA_VERSION < 1102)
+    template <typename Tag, typename... Args>
+    struct is_nothrow_tag_fallback_invocable : std::true_type
+    {
+    };
+#else
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_fallback_invocable
       : is_nothrow_tag_fallback_invocable_impl<
             decltype(tag_fallback_invoke_ns::tag_fallback_invoke)(Tag, Args...),
             is_tag_fallback_invocable_v<Tag, Args...>>
-    {
-    };
-#else
-    template <typename Tag, typename... Args>
-    struct is_nothrow_tag_fallback_invocable : std::true_type
     {
     };
 #endif

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
@@ -189,17 +189,18 @@ namespace pika::functional::detail {
     // correctly check this condition. We default to the more relaxed
     // noexcept(true) to not falsely exclude correct overloads. However, this
     // may lead to noexcept(false) overloads falsely being candidates.
-#if !defined(PIKA_CUDA_VERSION) || (PIKA_CUDA_VERSION >= 1102)
+#if defined(__NVCC__) && defined(PIKA_CUDA_VERSION) &&                         \
+    (PIKA_CUDA_VERSION < 1102)
+    template <typename Tag, typename... Args>
+    struct is_nothrow_tag_override_invocable : std::true_type
+    {
+    };
+#else
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_override_invocable
       : is_nothrow_tag_override_invocable_impl<
             decltype(tag_override_invoke_ns::tag_override_invoke)(Tag, Args...),
             is_tag_override_invocable_v<Tag, Args...>>
-    {
-    };
-#else
-    template <typename Tag, typename... Args>
-    struct is_nothrow_tag_override_invocable : std::true_type
     {
     };
 #endif

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -180,17 +180,18 @@ namespace pika { namespace functional {
     // correctly check this condition. We default to the more relaxed
     // noexcept(true) to not falsely exclude correct overloads. However, this
     // may lead to noexcept(false) overloads falsely being candidates.
-#if !defined(PIKA_CUDA_VERSION) || (PIKA_CUDA_VERSION >= 1102)
+#if defined(__NVCC__) && defined(PIKA_CUDA_VERSION) &&                         \
+    (PIKA_CUDA_VERSION < 1102)
+    template <typename Tag, typename... Args>
+    struct is_nothrow_tag_invocable : is_tag_invocable<Tag, Args...>
+    {
+    };
+#else
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_invocable
       : detail::is_nothrow_tag_invocable_impl<
             decltype(tag_invoke_ns::tag_invoke)(Tag, Args...),
             is_tag_invocable_v<Tag, Args...>>
-    {
-    };
-#else
-    template <typename Tag, typename... Args>
-    struct is_nothrow_tag_invocable : is_tag_invocable<Tag, Args...>
     {
     };
 #endif


### PR DESCRIPTION
This fixes three more reference handling problems that were not included in #284:
1. `when_all` needs to `decay`/`remove_cvref` the types that it sends to successors. Previously it would directly use the value types of predecessors for its own value types. Since it needs to store the values internally before sending them onward to successors (my move) it needs to decay the types.
2. `then_with_stream` and `transform_mpi` did not decay value types before storing them internally.

This adds tests for the above cases as well. This must go into 0.10.0.