### PR TITLE
Add support for Tracy 0.9

### DIFF
--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -25,7 +25,7 @@
 #endif
 
 #if defined(PIKA_HAVE_TRACY)
-#include <Tracy.hpp>
+#include <pika/threading_base/detail/tracy.hpp>
 #include <common/TracyColor.hpp>
 #endif
 

--- a/libs/pika/threading_base/CMakeLists.txt
+++ b/libs/pika/threading_base/CMakeLists.txt
@@ -16,6 +16,7 @@ set(threading_base_headers
     pika/threading_base/detail/get_default_pool.hpp
     pika/threading_base/detail/reset_backtrace.hpp
     pika/threading_base/detail/reset_lco_description.hpp
+    pika/threading_base/detail/tracy.hpp
     pika/threading_base/execution_agent.hpp
     pika/threading_base/external_timer.hpp
     pika/threading_base/network_background_callback.hpp

--- a/libs/pika/threading_base/include/pika/threading_base/detail/tracy.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/detail/tracy.hpp
@@ -1,0 +1,24 @@
+//  Copyright (c) 2022 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+
+#if defined(PIKA_HAVE_TRACY)
+#if defined(__has_include)
+// Newer versions of tracy have Tracy.hpp in the subdirectory tracy
+#if __has_include(<tracy/Tracy.hpp>)
+#include <tracy/Tracy.hpp>
+#else
+#include <Tracy.hpp>
+#endif
+// If we can't detect tracy's includes we assume it is new enough to use the
+// tracy subdirectory
+#else
+#include <tracy/Tracy.hpp>
+#endif
+#endif

--- a/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scoped_annotation.hpp
@@ -17,7 +17,7 @@
 #elif defined(PIKA_HAVE_APEX)
 #include <pika/threading_base/external_timer.hpp>
 #elif defined(PIKA_HAVE_TRACY)
-#include <Tracy.hpp>
+#include <pika/threading_base/detail/tracy.hpp>
 #endif
 #endif
 


### PR DESCRIPTION
Tracy 0.9 moved the Tracy.hpp header to a subdirectory tracy. This adds support for 0.9 and keeps supporting old versions by checking if the `tracy/Tracy.hpp` is available and using it if it is. Otherwise it falls back to the old Tracy.hpp include.

This is a last minute PR for the 0.10.0 release.