### PR TITLE
Remove `add_remove_scheduler_mode`

### DIFF
--- a/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/pika/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -44,8 +44,9 @@ struct disable_stealing_parameter
     template <typename Executor>
     void mark_begin_execution(Executor&&)
     {
-        pika::threads::add_remove_scheduler_mode(
-            ::pika::threads::scheduler_mode::enable_stealing,
+        pika::threads::add_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_stealing);
+        pika::threads::remove_scheduler_mode(
             ::pika::threads::scheduler_mode::enable_idle_backoff);
     }
 
@@ -59,8 +60,9 @@ struct disable_stealing_parameter
     template <typename Executor>
     void mark_end_execution(Executor&&)
     {
-        pika::threads::add_remove_scheduler_mode(
-            ::pika::threads::scheduler_mode::enable_idle_backoff,
+        pika::threads::add_scheduler_mode(
+            ::pika::threads::scheduler_mode::enable_idle_backoff);
+        pika::threads::remove_scheduler_mode(
             ::pika::threads::scheduler_mode::enable_stealing);
     }
 };

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -66,18 +66,12 @@ int pika_main()
         sched->get_description())
     {
         using ::pika::threads::scheduler_mode;
-        sched->add_remove_scheduler_mode(
-            // add these flags
-            scheduler_mode::enable_stealing |
-                scheduler_mode::enable_stealing_numa |
-                scheduler_mode::assign_work_thread_parent |
-                scheduler_mode::steal_after_local,
-            // remove these flags
+        sched->add_scheduler_mode(scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_after_local);
+        sched->remove_scheduler_mode(scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
             scheduler_mode::assign_work_round_robin |
-                scheduler_mode::steal_high_priority_first);
-        sched->update_scheduler_mode(scheduler_mode::enable_stealing, false);
-        sched->update_scheduler_mode(
-            scheduler_mode::enable_stealing_numa, false);
+            scheduler_mode::steal_high_priority_first);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -59,19 +59,16 @@ int pika_main(variables_map& vm)
     {
         using ::pika::threads::scheduler_mode;
         std::cout << "Setting shared-priority mode flags" << std::endl;
-        sched->add_remove_scheduler_mode(
-            // add these flags
-            scheduler_mode::enable_stealing |
-                scheduler_mode::enable_stealing_numa |
-                scheduler_mode::assign_work_round_robin |
-                scheduler_mode::steal_high_priority_first,
-            // remove these flags
-            scheduler_mode::assign_work_thread_parent |
-                scheduler_mode::steal_after_local |
-                scheduler_mode::do_background_work |
-                scheduler_mode::reduce_thread_priority |
-                scheduler_mode::delay_exit | scheduler_mode::fast_idle_mode |
-                scheduler_mode::enable_elasticity);
+        sched->add_scheduler_mode(scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_high_priority_first);
+        sched->remove_scheduler_mode(scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_after_local |
+            scheduler_mode::do_background_work |
+            scheduler_mode::reduce_thread_priority |
+            scheduler_mode::delay_exit | scheduler_mode::fast_idle_mode |
+            scheduler_mode::enable_elasticity);
     }
 
     // setup executors for different task priorities on the pools

--- a/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_fwd.hpp
@@ -163,10 +163,6 @@ namespace pika {
         /// Add the given flags to the scheduler mode
         PIKA_EXPORT void add_scheduler_mode(threads::scheduler_mode to_add);
 
-        /// Add/remove the given flags to the scheduler mode
-        PIKA_EXPORT void add_remove_scheduler_mode(
-            threads::scheduler_mode to_add, threads::scheduler_mode to_remove);
-
         /// Remove the given flags from the scheduler mode
         PIKA_EXPORT void remove_scheduler_mode(
             threads::scheduler_mode to_remove);

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -969,13 +969,6 @@ namespace pika { namespace threads {
         get_runtime().get_thread_manager().add_scheduler_mode(m);
     }
 
-    void add_remove_scheduler_mode(threads::scheduler_mode to_add_mode,
-        threads::scheduler_mode to_remove_mode)
-    {
-        get_runtime().get_thread_manager().add_remove_scheduler_mode(
-            to_add_mode, to_remove_mode);
-    }
-
     void remove_scheduler_mode(threads::scheduler_mode m)
     {
         get_runtime().get_thread_manager().remove_scheduler_mode(m);

--- a/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
+++ b/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
@@ -269,16 +269,6 @@ namespace pika::threads::detail {
             }
         }
 
-        void add_remove_scheduler_mode(threads::scheduler_mode to_add_mode,
-            threads::scheduler_mode to_remove_mode)
-        {
-            for (auto& pool_iter : pools_)
-            {
-                pool_iter->get_scheduler()->add_remove_scheduler_mode(
-                    to_add_mode, to_remove_mode);
-            }
-        }
-
         void remove_scheduler_mode(threads::scheduler_mode mode)
         {
             for (auto& pool_iter : pools_)

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -144,10 +144,6 @@ namespace pika::threads::detail {
         // remove flag from scheduler mode
         void remove_scheduler_mode(scheduler_mode mode);
 
-        // add flag to scheduler mode
-        void add_remove_scheduler_mode(
-            scheduler_mode to_add_mode, scheduler_mode to_remove_mode);
-
         // conditionally add or remove depending on set true/false
         void update_scheduler_mode(scheduler_mode mode, bool set);
 

--- a/libs/pika/threading_base/src/scheduler_base.cpp
+++ b/libs/pika/threading_base/src/scheduler_base.cpp
@@ -336,14 +336,6 @@ namespace pika::threads::detail {
         set_scheduler_mode(mode);
     }
 
-    void scheduler_base::add_remove_scheduler_mode(
-        scheduler_mode to_add_mode, scheduler_mode to_remove_mode)
-    {
-        scheduler_mode mode = scheduler_mode(
-            (get_scheduler_mode() | to_add_mode) & ~to_remove_mode);
-        set_scheduler_mode(mode);
-    }
-
     void scheduler_base::update_scheduler_mode(scheduler_mode mode, bool set)
     {
         if (set)

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -163,15 +163,12 @@ void function_futures_limiting_executor(
         sched->get_description())
     {
         using ::pika::threads::scheduler_mode;
-        sched->add_remove_scheduler_mode(
-            // add these flags
-            scheduler_mode::enable_stealing |
-                scheduler_mode::enable_stealing_numa |
-                scheduler_mode::assign_work_round_robin |
-                scheduler_mode::steal_after_local,
-            // remove these flags
-            scheduler_mode::assign_work_thread_parent |
-                scheduler_mode::steal_high_priority_first);
+        sched->add_scheduler_mode(scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_after_local);
+        sched->remove_scheduler_mode(scheduler_mode::assign_work_thread_parent |
+            scheduler_mode::steal_high_priority_first);
     }
 
     // test a parallel algorithm on custom pool with high priority
@@ -332,15 +329,12 @@ void function_futures_create_thread_hierarchical_placement(
         sched->get_description())
     {
         using ::pika::threads::scheduler_mode;
-        sched->add_remove_scheduler_mode(
-            // add
-            scheduler_mode::assign_work_thread_parent,
-            // remove
-            scheduler_mode::enable_stealing |
-                scheduler_mode::enable_stealing_numa |
-                scheduler_mode::assign_work_round_robin |
-                scheduler_mode::steal_after_local |
-                scheduler_mode::steal_high_priority_first);
+        sched->add_scheduler_mode(scheduler_mode::assign_work_thread_parent);
+        sched->remove_scheduler_mode(scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_after_local |
+            scheduler_mode::steal_high_priority_first);
     }
     auto const func = [&l]() {
         null_function();

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -77,15 +77,12 @@ void measure_function_futures_create_thread_hierarchical_placement(
         sched->get_description())
     {
         using ::pika::threads::scheduler_mode;
-        sched->add_remove_scheduler_mode(
-            // add
-            scheduler_mode::assign_work_thread_parent,
-            // remove
-            scheduler_mode::enable_stealing |
-                scheduler_mode::enable_stealing_numa |
-                scheduler_mode::assign_work_round_robin |
-                scheduler_mode::steal_after_local |
-                scheduler_mode::steal_high_priority_first);
+        sched->add_scheduler_mode(scheduler_mode::assign_work_thread_parent);
+        sched->remove_scheduler_mode(scheduler_mode::enable_stealing |
+            scheduler_mode::enable_stealing_numa |
+            scheduler_mode::assign_work_round_robin |
+            scheduler_mode::steal_after_local |
+            scheduler_mode::steal_high_priority_first);
     }
     auto const desc = pika::detail::thread_description();
     auto prio = pika::execution::thread_priority::normal;


### PR DESCRIPTION
Fixes #455.

The main difference of the combined call compared to two separate calls is that there will be two atomic updates. However, I don't think these are in any way meant to be used in performance critical parts and there are other factors that make relying on this being atomic not a very good assumption (`add_remove_scheduler_mode` was not really atomic either).