### PR TITLE
Update deprecated `std::execution` namespace to `stdexec`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
                 -G "Ninja" \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
-                -DCMAKE_CXX_FLAGS="-fcolor-diagnostics -DSTDEXEC_DISABLE_STD_DEPRECATIONS" \
+                -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" \
                 -DPIKA_WITH_GIT_COMMIT=${CIRCLE_SHA1} \
                 -DPIKA_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
                 -DPIKA_WITH_GIT_TAG="${CIRCLE_TAG}" \

--- a/libs/pika/execution_base/include/pika/execution_base/p2300_forward.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/p2300_forward.hpp
@@ -11,6 +11,6 @@
 #include <stdexec/execution.hpp>
 
 namespace pika::execution::experimental {
-    using namespace std::execution;
+    using namespace stdexec;
 }
 #endif


### PR DESCRIPTION
On top of #487 because it updates the CI image. #487 should go in first.

Fixes #490.

 The only relevant change is https://github.com/pika-org/pika/commit/c72367920a33d7ce9015df0cde1535b5cc8a0045.