### PR TITLE
Check that `MPI_Request` was used in user callback in `transform_mpi`

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -211,7 +211,7 @@ namespace pika::mpi::experimental {
                                 auto& t =
                                     std::get<ts_element_type>(r.op_state.ts);
 
-                                MPI_Request request;
+                                MPI_Request request{MPI_REQUEST_NULL};
 
                                 using invoke_result_type =
                                     mpi_request_invoke_result_t<F, Ts...>;
@@ -226,6 +226,14 @@ namespace pika::mpi::experimental {
                                         [&](auto&... ts) mutable {
                                             PIKA_INVOKE(PIKA_MOVE(r.op_state.f),
                                                 ts..., &request);
+                                            PIKA_ASSERT_MSG(
+                                                request != MPI_REQUEST_NULL,
+                                                "The MPI_Request is still "
+                                                "MPI_REQUEST_NULL after being "
+                                                "passed to the user callback "
+                                                "in transform_mpi. Did you "
+                                                "forget to use the request?");
+
                                             // When the return type is void,
                                             // there is no value to forward to
                                             // the receiver
@@ -242,6 +250,14 @@ namespace pika::mpi::experimental {
                                                 invoke_result_type>(PIKA_INVOKE(
                                                 PIKA_MOVE(r.op_state.f), ts...,
                                                 &request));
+                                            PIKA_ASSERT_MSG(
+                                                request != MPI_REQUEST_NULL,
+                                                "The MPI_Request is still "
+                                                "MPI_REQUEST_NULL after being "
+                                                "passed to the user callback "
+                                                "in transform_mpi. Did you "
+                                                "forget to use the request?");
+
                                             // When the return type is non-void,
                                             // we have to forward the value to
                                             // the receiver


### PR DESCRIPTION
Minor debugging help to catch cases where the request is accidentally unused in the callback.