### PR TITLE
Don't do special linking for some unit tests

### DIFF
--- a/libs/pika/execution_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution_base/tests/unit/CMakeLists.txt
@@ -18,13 +18,9 @@ foreach(test ${tests})
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources}
-    NOLIBS
-    DEPENDENCIES pika ${BOOST_UNDERLYING_THREAD_LIBRARY}
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/ExecutionBase"
   )
 
   pika_add_unit_test("modules.execution_base" ${test} ${${test}_PARAMETERS})
-  target_compile_definitions(${test}_test PRIVATE -DPIKA_MODULE_STATIC_LINKING)
-
 endforeach()

--- a/libs/pika/memory/tests/unit/CMakeLists.txt
+++ b/libs/pika/memory/tests/unit/CMakeLists.txt
@@ -15,12 +15,9 @@ foreach(test ${tests})
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
-    EXCLUDE_FROM_ALL NOLIBS
-    DEPENDENCIES pika
+    EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Memory"
   )
 
   pika_add_unit_test("modules.memory" ${test} ${${test}_PARAMETERS})
-  target_compile_definitions(${test}_test PRIVATE -DPIKA_MODULE_STATIC_LINKING)
-
 endforeach()


### PR DESCRIPTION
It's not necessary (and potentially wrong) since they link to the `pika` target anyway.