### PR TITLE
Temporarily don't require hipcc CI for bors merges

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -40,7 +40,8 @@ status = [
   "ci/circleci: arm64_build",
 
   # Jenkins
-  "jenkins/cscs-ault/hipcc-release",
+  # This is temporary until ault behaves better again
+  # "jenkins/cscs-ault/hipcc-release",
   "jenkins/cscs-daint/cce-debug",
   "jenkins/cscs-daint/cce-release",
   "jenkins/cscs-daint/clang-11-debug",


### PR DESCRIPTION
I'm temporarily disabling this until ault behaves a bit more reliably.