### PR TITLE
Enable `modernize-concat-nested-namespaces` in clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >
     misc-non-copyable-objects,
     misc-use-after-move,
     misc-virtual-near-miss,
+    modernize-concat-nested-namespaces,
     modernize-use-nullptr,
     modernize-use-using,
 # WarningsAsErrors: '*'

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -171,7 +171,7 @@ namespace executor_example {
 
 ///////////////////////////////////////////////////////////////////////////////
 // simple forwarding implementations of executor traits
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
 
     template <typename BaseExecutor>
     struct is_one_way_executor<
@@ -207,7 +207,7 @@ namespace pika { namespace parallel { namespace execution {
       : is_bulk_two_way_executor<std::decay_t<BaseExecutor>>
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 int pika_main()
 {

--- a/libs/pika/async/tests/unit/async_executor_additional_arguments.cpp
+++ b/libs/pika/async/tests/unit/async_executor_additional_arguments.cpp
@@ -41,12 +41,12 @@ struct additional_argument_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<additional_argument_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 std::int32_t increment(additional_argument, std::int32_t i)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
@@ -118,10 +118,10 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
     !defined(__arm64__) && !defined(__aarch64__)
 
 #include <pika/coroutines/detail/context_linux_x86.hpp>
-namespace pika { namespace threads { namespace coroutines { namespace detail {
+namespace pika::threads::coroutines::detail {
     template <typename CoroutineImpl>
     using default_context_impl = lx::x86_linux_context_impl<CoroutineImpl>;
-}}}}    // namespace pika::threads::coroutines::detail
+}    // namespace pika::threads::coroutines::detail
 
 #elif defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||   \
     defined(__s390x__) || defined(__arm__) || defined(arm64) ||                \

--- a/libs/pika/errors/src/exception.cpp
+++ b/libs/pika/errors/src/exception.cpp
@@ -157,7 +157,7 @@ namespace pika {
     }    // namespace detail
 }    // namespace pika
 
-namespace pika { namespace detail {
+namespace pika::detail {
     template <typename Exception>
     PIKA_EXPORT std::exception_ptr
     construct_lightweight_exception(Exception const& e, std::string const& func,
@@ -362,7 +362,7 @@ namespace pika { namespace detail {
         std::out_of_range const&, std::string const&, std::string const&, long);
     template PIKA_EXPORT void throw_exception(std::invalid_argument const&,
         std::string const&, std::string const&, long);
-}}    // namespace pika::detail
+}    // namespace pika::detail
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace pika {

--- a/libs/pika/execution/include/pika/execution/algorithms/execute.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/execute.hpp
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
+namespace pika::execution::experimental {
     inline constexpr struct execute_t final
       : pika::functional::detail::tag_fallback<execute_t>
     {
@@ -32,5 +32,5 @@ namespace pika { namespace execution { namespace experimental {
                     PIKA_FORWARD(F, f)));
         }
     } execute{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
@@ -20,7 +20,7 @@
 
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
+namespace pika::execution::experimental {
     inline constexpr struct transfer_t final
       : pika::functional::detail::tag_priority<transfer_t>
     {
@@ -68,5 +68,5 @@ namespace pika { namespace execution { namespace experimental {
                 PIKA_FORWARD(Scheduler, scheduler)};
         }
     } transfer{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer_just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer_just.hpp
@@ -17,7 +17,7 @@
 
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
+namespace pika::execution::experimental {
     inline constexpr struct transfer_just_t final
       : pika::functional::detail::tag_fallback<transfer_just_t>
     {
@@ -30,5 +30,5 @@ namespace pika { namespace execution { namespace experimental {
                 PIKA_FORWARD(Scheduler, scheduler));
         }
     } transfer_just{};
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution/tests/regressions/future_then_async_executor.cpp
+++ b/libs/pika/execution/tests/regressions/future_then_async_executor.cpp
@@ -26,12 +26,12 @@ struct test_async_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 int pika_main()
 {

--- a/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -41,12 +41,12 @@ struct test_executor_get_chunk_size : pika::execution::parallel_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_executor_get_chunk_size> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_chunk_size
 {
@@ -59,14 +59,14 @@ struct test_chunk_size
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     /// \cond NOINTERNAL
     template <>
     struct is_executor_parameters<test_chunk_size> : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_get_chunk_size()
@@ -116,13 +116,13 @@ struct test_executor_maximal_number_of_chunks
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_executor_maximal_number_of_chunks>
       : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_number_of_chunks
 {
@@ -135,12 +135,12 @@ struct test_number_of_chunks
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_executor_parameters<test_number_of_chunks> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_maximal_number_of_chunks()
@@ -187,13 +187,13 @@ struct test_executor_reset_thread_distribution
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_executor_reset_thread_distribution>
       : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_thread_distribution
 {
@@ -204,12 +204,12 @@ struct test_thread_distribution
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_executor_parameters<test_thread_distribution> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_reset_thread_distribution()
@@ -256,13 +256,13 @@ struct test_executor_processing_units_count : pika::execution::parallel_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_executor_processing_units_count>
       : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_processing_units
 {
@@ -274,12 +274,12 @@ struct test_processing_units
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_executor_parameters<test_processing_units> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_processing_units_count()
@@ -336,12 +336,12 @@ struct test_executor_begin_end : pika::execution::parallel_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_executor_begin_end> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_begin_end
 {
@@ -364,12 +364,12 @@ struct test_begin_end
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_executor_parameters<test_begin_end> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_mark_begin_execution()

--- a/libs/pika/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/pika/execution/tests/unit/minimal_async_executor.cpp
@@ -160,12 +160,12 @@ struct test_async_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor1> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_async_executor2 : test_async_executor1
 {
@@ -182,12 +182,12 @@ struct test_async_executor2 : test_async_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor2> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_async_executor3 : test_async_executor1
 {
@@ -206,12 +206,12 @@ struct test_async_executor3 : test_async_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor3> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_async_executor4 : test_async_executor1
 {
@@ -231,7 +231,7 @@ struct test_async_executor4 : test_async_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor4> : std::true_type
     {
@@ -241,7 +241,7 @@ namespace pika { namespace parallel { namespace execution {
     struct is_bulk_two_way_executor<test_async_executor4> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_async_executor5 : test_async_executor1
 {
@@ -255,12 +255,12 @@ struct test_async_executor5 : test_async_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor5> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 template <typename Executor, typename B1, typename B2, typename B3, typename B4,
     typename B5>

--- a/libs/pika/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/pika/execution/tests/unit/minimal_sync_executor.cpp
@@ -256,12 +256,12 @@ struct test_sync_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_one_way_executor<test_sync_executor1> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 struct test_sync_executor2 : test_sync_executor1
 {
@@ -309,7 +309,7 @@ struct test_sync_executor2 : test_sync_executor1
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_one_way_executor<test_sync_executor2> : std::true_type
     {
@@ -319,7 +319,7 @@ namespace pika { namespace parallel { namespace execution {
     struct is_bulk_one_way_executor<test_sync_executor2> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 template <typename Executor, typename B1, typename B2>
 void static_check_executor(B1, B2)

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -53,7 +53,7 @@ namespace pika::execution::experimental {
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace execution { namespace experimental {
+namespace pika::execution::experimental {
 #if defined(DOXYGEN)
     /// connect is a customization point object.
     /// For some subexpression `s` and `r`, let `S` be the type such that `decltype((s))`
@@ -478,5 +478,5 @@ namespace pika { namespace execution { namespace experimental {
     template <typename S, typename R>
     using connect_result_t =
         typename pika::util::detail::invoke_result<connect_t, S, R>::type;
-}}}    // namespace pika::execution::experimental
+}    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/executors/include/pika/executors/parallel_executor.hpp
+++ b/libs/pika/executors/include/pika/executors/parallel_executor.hpp
@@ -40,7 +40,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace parallel { namespace execution { namespace detail {
+namespace pika::parallel::execution::detail {
     template <typename Policy>
     struct get_default_policy
     {
@@ -69,9 +69,9 @@ namespace pika { namespace parallel { namespace execution { namespace detail {
 
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct then_bulk_function_result;
-}}}}    // namespace pika::parallel::execution::detail
+}    // namespace pika::parallel::execution::detail
 
-namespace pika { namespace execution {
+namespace pika::execution {
     ///////////////////////////////////////////////////////////////////////////
     /// A \a parallel_executor creates groups of parallel execution agents
     /// which execute in threads implicitly created by the executor. This
@@ -342,9 +342,9 @@ namespace pika { namespace execution {
     };
 
     using parallel_executor = parallel_policy_executor<pika::launch>;
-}}    // namespace pika::execution
+}    // namespace pika::execution
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     /// \cond NOINTERNAL
     template <typename Policy>
     struct is_one_way_executor<
@@ -364,4 +364,4 @@ namespace pika { namespace parallel { namespace execution {
     {
     };
     /// \endcond
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution

--- a/libs/pika/executors/tests/unit/created_executor.cpp
+++ b/libs/pika/executors/tests/unit/created_executor.cpp
@@ -52,7 +52,7 @@ struct void_parallel_executor : pika::execution::parallel_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<void_parallel_executor> : std::true_type
     {
@@ -62,7 +62,7 @@ namespace pika { namespace parallel { namespace execution {
     struct is_bulk_two_way_executor<void_parallel_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ////////////////////////////////////////////////////////////////////////////////
 // Tests to void_parallel_executor behavior for the bulk executes

--- a/libs/pika/executors/tests/unit/shared_parallel_executor.cpp
+++ b/libs/pika/executors/tests/unit/shared_parallel_executor.cpp
@@ -30,12 +30,12 @@ struct shared_parallel_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<shared_parallel_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
 pika::thread::id test(int passed_through)

--- a/libs/pika/functional/src/basic_function.cpp
+++ b/libs/pika/functional/src/basic_function.cpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
     ///////////////////////////////////////////////////////////////////////////
     function_base::function_base(
         function_base const& other, vtable const* /* empty_vtable */)
@@ -149,4 +149,4 @@ namespace pika { namespace util { namespace detail {
         return util::itt::string_handle{};
 #endif
     }
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/functional/src/empty_function.cpp
+++ b/libs/pika/functional/src/empty_function.cpp
@@ -10,11 +10,11 @@
 
 #include <pika/modules/errors.hpp>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
     [[noreturn]] void throw_bad_function_call()
     {
         pika::throw_exception(pika::error::bad_function_call,
             "empty function object should not be used",
             "empty_function::operator()");
     }
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/futures/include/pika/futures/detail/future_data.hpp
+++ b/libs/pika/futures/include/pika/futures/detail/future_data.hpp
@@ -49,7 +49,7 @@ namespace pika {
 }    // namespace pika
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
 
     using run_on_completed_error_handler_type =
         util::detail::function<void(std::exception_ptr const& e)>;
@@ -1028,15 +1028,15 @@ namespace pika { namespace lcos { namespace detail {
     protected:
         threads::detail::thread_id_type id_;
     };
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail
 
-namespace pika { namespace traits { namespace detail {
+namespace pika::traits::detail {
 
     template <typename R, typename Allocator>
     struct shared_state_allocator<lcos::detail::future_data<R>, Allocator>
     {
         using type = lcos::detail::future_data_allocator<R, Allocator>;
     };
-}}}    // namespace pika::traits::detail
+}    // namespace pika::traits::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/futures/include/pika/futures/detail/future_transforms.hpp
+++ b/libs/pika/futures/include/pika/futures/detail/future_transforms.hpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
 
     // Returns true when the given future is ready,
     // the future is deferred executed if possible first.
@@ -100,4 +100,4 @@ namespace pika { namespace lcos { namespace detail {
 
         return values;
     }
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail

--- a/libs/pika/futures/include/pika/futures/future.hpp
+++ b/libs/pika/futures/include/pika/futures/future.hpp
@@ -38,7 +38,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
     ///////////////////////////////////////////////////////////////////////////
     enum class future_state
     {
@@ -614,7 +614,7 @@ namespace pika { namespace lcos { namespace detail {
     protected:
         pika::intrusive_ptr<shared_state_type> shared_state_;
     };
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail
 
 namespace pika {
 

--- a/libs/pika/futures/include/pika/futures/future_fwd.hpp
+++ b/libs/pika/futures/include/pika/futures/future_fwd.hpp
@@ -12,12 +12,12 @@
 namespace pika {
 
     /// \namespace lcos
-    namespace lcos { namespace detail {
+    namespace lcos::detail {
         template <typename Result>
         struct future_data;
 
         struct future_data_refcnt_base;
-    }}    // namespace lcos::detail
+    }    // namespace lcos::detail
 
     template <typename R>
     class future;

--- a/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_continuation.hpp
@@ -29,7 +29,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
 
     template <typename Future, typename SourceState, typename DestinationState>
     PIKA_FORCEINLINE void
@@ -573,9 +573,9 @@ namespace pika { namespace lcos { namespace detail {
 
         other_allocator alloc_;
     };
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail
 
-namespace pika { namespace traits { namespace detail {
+namespace pika::traits::detail {
     template <typename Future, typename F, typename ContResult,
         typename Allocator>
     struct shared_state_allocator<
@@ -584,10 +584,10 @@ namespace pika { namespace traits { namespace detail {
         using type = lcos::detail::continuation_allocator<Allocator, Future, F,
             ContResult>;
     };
-}}}    // namespace pika::traits::detail
+}    // namespace pika::traits::detail
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ContResult>
     class unwrap_continuation : public future_data<ContResult>
@@ -722,9 +722,9 @@ namespace pika { namespace lcos { namespace detail {
 
         other_allocator alloc_;
     };
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail
 
-namespace pika { namespace traits { namespace detail {
+namespace pika::traits::detail {
     template <typename ContResult, typename Allocator>
     struct shared_state_allocator<lcos::detail::unwrap_continuation<ContResult>,
         Allocator>
@@ -732,9 +732,9 @@ namespace pika { namespace traits { namespace detail {
         using type =
             lcos::detail::unwrap_continuation_allocator<Allocator, ContResult>;
     };
-}}}    // namespace pika::traits::detail
+}    // namespace pika::traits::detail
 
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
     template <typename Allocator, typename Future>
     inline traits::detail::shared_state_ptr_t<future_unwrap_result_t<Future>>
     unwrap_impl_alloc(Allocator const& a, Future&& future, error_code& /*ec*/)
@@ -789,4 +789,4 @@ namespace pika { namespace lcos { namespace detail {
     {
         return unwrap_impl(PIKA_FORWARD(Future, future), ec);
     }
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail

--- a/libs/pika/futures/include/pika/futures/packaged_task.hpp
+++ b/libs/pika/futures/include/pika/futures/packaged_task.hpp
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
 
     template <typename Sig>
     class packaged_task;
@@ -136,7 +136,7 @@ namespace pika { namespace lcos { namespace local {
         function_type function_;
         local::promise<R> promise_;
     };
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local
 
 namespace std {
     // Requires: Allocator shall be an allocator (17.6.3.5)

--- a/libs/pika/futures/include/pika/futures/promise.hpp
+++ b/libs/pika/futures/include/pika/futures/promise.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     namespace detail {
         template <typename R,
             typename SharedState = lcos::detail::future_data<R>>
@@ -544,7 +544,7 @@ namespace pika { namespace lcos { namespace local {
     {
         x.swap(y);
     }
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local
 
 namespace std {
     // Requires: Allocator shall be an allocator (17.6.3.5)

--- a/libs/pika/futures/include/pika/futures/traits/acquire_future.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/acquire_future.hpp
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     namespace detail {
         template <typename T, typename Enable = void>
         struct acquire_future_impl;
@@ -139,4 +139,4 @@ namespace pika { namespace traits {
             }
         };
     }    // namespace detail
-}}       // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/acquire_shared_state.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/acquire_shared_state.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace traits {
+namespace pika::traits {
 
     namespace detail {
 
@@ -176,4 +176,4 @@ namespace pika { namespace traits {
             }
         };
     }    // namespace detail
-}}       // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/detail/future_await_traits.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/detail/future_await_traits.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
 
     template <typename Promise = void>
     using coroutine_handle = std::coroutine_handle<Promise>;
@@ -191,7 +191,7 @@ namespace pika { namespace lcos { namespace detail {
             traits::deallocate(alloc, static_cast<char*>(p), size);
         }
     };
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace std {

--- a/libs/pika/futures/include/pika/futures/traits/detail/future_traits.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/detail/future_traits.hpp
@@ -13,7 +13,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename Enable = void>
     struct future_iterator_traits
@@ -31,4 +31,4 @@ namespace pika { namespace lcos { namespace detail {
     template <typename Iter>
     using future_iterator_traits_t =
         typename future_iterator_traits<Iter>::type;
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail

--- a/libs/pika/futures/include/pika/futures/traits/future_access.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_access.hpp
@@ -27,7 +27,7 @@ namespace pika {
     }    // namespace lcos::detail
 }    // namespace pika
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         struct future_data_void
@@ -300,4 +300,4 @@ namespace pika { namespace traits {
     template <typename SharedState, typename Allocator>
     using shared_state_allocator_t =
         typename shared_state_allocator<SharedState, Allocator>::type;
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_then_result.hpp
@@ -17,7 +17,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         struct no_executor
@@ -72,4 +72,4 @@ namespace pika { namespace traits {
     template <typename Future, typename F>
     using future_then_result_t = typename future_then_result<Future, F>::type;
 
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/future_traits.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/future_traits.hpp
@@ -18,7 +18,7 @@ namespace pika {
     class shared_future;
 }    // namespace pika
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename Future, typename Enable = void>
@@ -82,4 +82,4 @@ namespace pika { namespace traits {
       : std::is_void<future_traits_t<Future>>
     {
     };
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/is_future.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/is_future.hpp
@@ -19,7 +19,7 @@ namespace pika {
     class shared_future;
 }    // namespace pika
 
-namespace pika { namespace traits {
+namespace pika::traits {
     namespace detail {
         template <typename Future, typename Enable = void>
         struct is_unique_future : std::false_type
@@ -72,4 +72,4 @@ namespace pika { namespace traits {
     template <typename R>
     inline constexpr bool is_ref_wrapped_future_v =
         is_ref_wrapped_future<R>::value;
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/is_future_range.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/is_future_range.hpp
@@ -13,7 +13,7 @@
 #include <functional>
 #include <type_traits>
 
-namespace pika { namespace traits {
+namespace pika::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, typename Enable = void>
@@ -76,4 +76,4 @@ namespace pika { namespace traits {
         inline constexpr bool is_future_or_future_range_v =
             is_future_or_future_range<R>::value;
     }    // namespace detail
-}}       // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/is_future_tuple.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/is_future_tuple.hpp
@@ -12,7 +12,7 @@
 #include <tuple>
 #include <type_traits>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     template <typename Tuple, typename Enable = void>
     struct is_future_tuple : std::false_type
     {
@@ -23,4 +23,4 @@ namespace pika { namespace traits {
       : util::detail::all_of<is_future<Ts>...>
     {
     };
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/include/pika/futures/traits/promise_local_result.hpp
+++ b/libs/pika/futures/include/pika/futures/traits/promise_local_result.hpp
@@ -9,7 +9,7 @@
 #include <pika/config.hpp>
 #include <pika/type_support/unused.hpp>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result, typename Enable = void>
     struct promise_local_result
@@ -26,4 +26,4 @@ namespace pika { namespace traits {
     template <typename Result>
     using promise_local_result_t = typename promise_local_result<Result>::type;
 
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/futures/src/future_data.cpp
+++ b/libs/pika/futures/src/future_data.cpp
@@ -26,7 +26,7 @@
 #include <mutex>
 #include <utility>
 
-namespace pika { namespace lcos { namespace detail {
+namespace pika::lcos::detail {
 
     static run_on_completed_error_handler_type run_on_completed_error_handler;
 
@@ -339,4 +339,4 @@ namespace pika { namespace lcos { namespace detail {
         }
         return pika::future_status::ready;    //-V110
     }
-}}}    // namespace pika::lcos::detail
+}    // namespace pika::lcos::detail

--- a/libs/pika/hardware/include/pika/hardware/bit_manipulation.hpp
+++ b/libs/pika/hardware/include/pika/hardware/bit_manipulation.hpp
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace pika { namespace util { namespace hardware {
+namespace pika::util::hardware {
 
     template <typename T, typename U>
     bool has_bit_set(T value, U bit)
@@ -72,4 +72,4 @@ namespace pika { namespace util { namespace hardware {
         return unbounded_shl<Low, Result>(static_cast<Result>(x));
     }
 
-}}}    // namespace pika::util::hardware
+}    // namespace pika::util::hardware

--- a/libs/pika/hardware/include/pika/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/pika/hardware/include/pika/hardware/timestamp/linux_x86_64.hpp
@@ -16,7 +16,7 @@
 #include <pika/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace pika { namespace util { namespace hardware {
+namespace pika::util::hardware {
 
     // clang-format off
     PIKA_HOST_DEVICE inline std::uint64_t timestamp()
@@ -44,4 +44,4 @@ namespace pika { namespace util { namespace hardware {
     }
     // clang-format on
 
-}}}    // namespace pika::util::hardware
+}    // namespace pika::util::hardware

--- a/libs/pika/hashing/include/pika/hashing/fibhash.hpp
+++ b/libs/pika/hashing/include/pika/hashing/fibhash.hpp
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <cstdlib>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
 
@@ -51,4 +51,4 @@ namespace pika { namespace util {
         return (detail::golden_ratio * (i ^ (i >> helper::shift_amount))) >>
             helper::shift_amount;
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -27,7 +27,7 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////
     class PIKA_EXPORT section
     {
@@ -282,4 +282,4 @@ namespace pika { namespace util {
         }
     };
 
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -38,7 +38,7 @@ extern char** environ;
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     ///////////////////////////////////////////////////////////////////////////////
     // example ini line: line # comment
@@ -986,4 +986,4 @@ namespace pika { namespace util {
         return value;
     }
 
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/init_runtime/include/pika/init_runtime/detail/init_logging.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/detail/init_logging.hpp
@@ -15,7 +15,7 @@
 
 #if defined(PIKA_HAVE_LOGGING)
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     /// \cond NOINTERNAL
 
@@ -79,7 +79,7 @@ namespace pika { namespace util {
 
     /// Disable all logging for the given destination
     PIKA_EXPORT void disable_logging(logging_destination dest);
-}}    // namespace pika::util
+}    // namespace pika::util
 
 #else    // PIKA_HAVE_LOGGING
 

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -29,7 +29,7 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     using logger_writer_type = logging::writer::named_write;
 
@@ -849,7 +849,7 @@ namespace pika { namespace util {
             break;
         }
     }
-}}    // namespace pika::util
+}    // namespace pika::util
 
 #else
 

--- a/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/boost_iterator_categories.hpp
@@ -18,7 +18,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace pika { namespace iterators {
+namespace pika::iterators {
 
     // Traversal Categories
     struct no_traversal_tag
@@ -134,7 +134,7 @@ namespace pika { namespace iterators {
       : pure_traversal_tag<typename iterator_traversal<Iterator>::type>
     {
     };
-}}    // namespace pika::iterators
+}    // namespace pika::iterators
 
 #define PIKA_ITERATOR_TRAVERSAL_TAG_NS pika
 

--- a/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/counting_iterator.hpp
@@ -21,7 +21,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     template <typename Incrementable, typename CategoryOrTraversal = void,
         typename Difference = void, typename Enable = void>
@@ -192,4 +192,4 @@ namespace pika { namespace util {
     {
         return counting_iterator<Incrementable>(x);
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/counting_shape.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/counting_shape.hpp
@@ -12,7 +12,7 @@
 #include <pika/iterator_support/range.hpp>
 #include <pika/iterator_support/traits/is_range.hpp>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Incrementable>
@@ -28,4 +28,4 @@ namespace pika { namespace util { namespace detail {
             pika::util::make_counting_iterator(Incrementable(0)),
             pika::util::make_counting_iterator(n));
     }
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/iterator_support/include/pika/iterator_support/generator_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/generator_iterator.hpp
@@ -15,7 +15,7 @@
 #include <functional>
 #include <iterator>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     template <typename Generator>
     class generator_iterator
@@ -68,4 +68,4 @@ namespace pika { namespace util {
     template <typename Generator>
     generator_iterator(Generator*)->generator_iterator<Generator>;
     // clang-format on
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_adaptor.hpp
@@ -23,7 +23,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
     // Default template argument handling for iterator_adaptor
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
@@ -221,4 +221,4 @@ namespace pika { namespace util {
     private:    // data members
         Base iterator_;
     };
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_facade.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_facade.hpp
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////
     // Helper class to gain access to the implementation functions in the
     // derived (user-defined) iterator classes.
@@ -681,4 +681,4 @@ namespace pika { namespace util {
         Derived tmp(static_cast<Derived const&>(it));
         return tmp += n;
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/iterator_range.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/iterator_range.hpp
@@ -16,7 +16,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
     template <typename Iterator, typename Sentinel = Iterator>
     class iterator_range
     {
@@ -81,9 +81,9 @@ namespace pika { namespace util {
     {
         return iterator_range<Iterator, Sentinel>(iterator, sentinel);
     }
-}}    // namespace pika::util
+}    // namespace pika::util
 
-namespace pika { namespace ranges {
+namespace pika::ranges {
     template <typename I, typename S = I>
     using subrange_t = pika::util::iterator_range<I, S>;
-}}    // namespace pika::ranges
+}    // namespace pika::ranges

--- a/libs/pika/iterator_support/include/pika/iterator_support/range.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/range.hpp
@@ -12,7 +12,7 @@
 #include <iterator>
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename T, std::size_t N>
@@ -213,4 +213,4 @@ namespace pika { namespace util {
     }    // namespace range_adl
 
     using namespace range_adl;
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/traits/is_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/traits/is_iterator.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         // This implementation of is_iterator seems to work fine even for
@@ -544,4 +544,4 @@ namespace pika { namespace traits {
     template <typename Iter>
     using iter_ref_t = typename std::iterator_traits<Iter>::reference;
 
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/iterator_support/include/pika/iterator_support/traits/is_range.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/traits/is_range.hpp
@@ -14,7 +14,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
     struct is_range : std::false_type
@@ -66,4 +66,4 @@ namespace pika { namespace traits {
 
     template <typename T>
     using range_iterator_t = typename range_iterator<T>::type;
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/iterator_support/include/pika/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/traits/is_sentinel_for.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace traits {
+namespace pika::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // The trait checks whether sentinel Sent is proper for iterator I.
@@ -66,4 +66,4 @@ namespace pika { namespace traits {
     inline constexpr bool is_sized_sentinel_for_v =
         is_sized_sentinel_for<Sent, Iter>::value;
 
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/transform_iterator.hpp
@@ -15,7 +15,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator, typename Transformer,
@@ -133,4 +133,4 @@ namespace pika { namespace util {
     {
         return transform_iterator<Iterator, Transformer>(it, Transformer());
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
 
@@ -505,12 +505,10 @@ namespace pika { namespace util {
       : detail::zip_iterator_category<typename ZipIter::iterator_tuple_type>
     {
     };
-}}    // namespace pika::util
+}    // namespace pika::util
 
-namespace pika { namespace traits {
-
+namespace pika::traits {
     namespace functional {
-
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename T>
         struct element_result_of : util::detail::invoke_result<F, T>
@@ -551,4 +549,4 @@ namespace pika { namespace traits {
     struct is_zip_iterator<pika::util::zip_iterator<Iter...>> : std::true_type
     {
     };
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -25,7 +25,7 @@ int test_count = 100;
 int partition_size = 10000;
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace experimental { namespace detail {
+namespace pika::experimental::detail {
     template <typename Iterator>
     PIKA_FORCEINLINE Iterator previous(Iterator it, std::false_type)
     {
@@ -62,11 +62,11 @@ namespace pika { namespace experimental { namespace detail {
     {
         return next(it, pika::traits::is_random_access_iterator<Iterator>());
     }
-}}}    // namespace pika::experimental::detail
+}    // namespace pika::experimental::detail
 
 ///////////////////////////////////////////////////////////////////////////////
 // Version of stencil3_iterator which handles boundary elements internally
-namespace pika { namespace experimental {
+namespace pika::experimental {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator, typename IterBegin = Iterator,
         typename IterValueBegin = Iterator, typename IterEnd = IterBegin,
@@ -255,7 +255,7 @@ namespace pika { namespace experimental {
             begin, begin, begin_val, detail::previous(end), end_val);
         return std::make_pair(b, make_stencil3_full_iterator<decltype(b)>(end));
     }
-}}    // namespace pika::experimental
+}    // namespace pika::experimental
 
 std::chrono::duration<double> bench_stencil3_iterator_full()
 {
@@ -281,7 +281,7 @@ std::chrono::duration<double> bench_stencil3_iterator_full()
 
 ///////////////////////////////////////////////////////////////////////////////
 // compare with unchecked stencil3_iterator (version 1)
-namespace pika { namespace experimental {
+namespace pika::experimental {
     template <typename Iterator>
     class stencil3_iterator_v1
       : public util::detail::zip_iterator_base<
@@ -327,7 +327,7 @@ namespace pika { namespace experimental {
         return std::make_pair(
             make_stencil3_iterator_v1(begin), make_stencil3_iterator_v1(end));
     }
-}}    // namespace pika::experimental
+}    // namespace pika::experimental
 
 std::chrono::duration<double> bench_stencil3_iterator_v1()
 {
@@ -357,7 +357,7 @@ std::chrono::duration<double> bench_stencil3_iterator_v1()
 
 ///////////////////////////////////////////////////////////////////////////////
 // compare with unchecked stencil3_iterator (version 2)
-namespace pika { namespace experimental {
+namespace pika::experimental {
     namespace detail {
         struct stencil_transformer_v2
         {
@@ -436,7 +436,7 @@ namespace pika { namespace experimental {
         return std::make_pair(
             make_stencil3_iterator_v2(begin), make_stencil3_iterator_v2(end));
     }
-}}    // namespace pika::experimental
+}    // namespace pika::experimental
 
 std::chrono::duration<double> bench_stencil3_iterator_v2()
 {

--- a/libs/pika/itt_notify/include/pika/itt_notify/thread_name.hpp
+++ b/libs/pika/itt_notify/include/pika/itt_notify/thread_name.hpp
@@ -10,8 +10,8 @@
 
 #include <string>
 
-namespace pika { namespace detail {
+namespace pika::detail {
     /// Helper utility to set and store a name for the current operating system
     /// thread. Returns a reference to the name for the current thread.
     PIKA_EXPORT std::string& thread_name();
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
+++ b/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
@@ -652,7 +652,7 @@ namespace pika::detail {
 
 }    // namespace pika::detail
 
-namespace pika { namespace util { namespace itt {
+namespace pika::util::itt {
 
     struct stack_context
     {
@@ -781,6 +781,6 @@ namespace pika { namespace util { namespace itt {
     };
 
     inline constexpr void event_tick(event const&) noexcept {}
-}}}    // namespace pika::util::itt
+}    // namespace pika::util::itt
 
 #endif    // PIKA_HAVE_ITTNOTIFY

--- a/libs/pika/itt_notify/src/thread_name.cpp
+++ b/libs/pika/itt_notify/src/thread_name.cpp
@@ -9,10 +9,10 @@
 
 #include <string>
 
-namespace pika { namespace detail {
+namespace pika::detail {
     std::string& thread_name()
     {
         static thread_local std::string thread_name_;
         return thread_name_;
     }
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/lcos/include/pika/lcos/and_gate.hpp
+++ b/libs/pika/lcos/include/pika/lcos/and_gate.hpp
@@ -23,7 +23,7 @@
 #include <mutex>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Mutex = pika::spinlock>
     struct base_and_gate
@@ -434,4 +434,4 @@ namespace pika { namespace lcos { namespace local {
                 generation_value, l, function_name, ec);
         }
     };
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/include/pika/lcos/channel.hpp
+++ b/libs/pika/lcos/include/pika/lcos/channel.hpp
@@ -30,7 +30,7 @@
 #include <mutex>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
@@ -1187,4 +1187,4 @@ namespace pika { namespace lcos { namespace local {
       , data_(c ? get_checked() : false)
     {
     }
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
+++ b/libs/pika/lcos/include/pika/lcos/composable_guard.hpp
@@ -92,7 +92,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     namespace detail {
         struct debug_object
         {
@@ -205,4 +205,4 @@ namespace pika { namespace lcos { namespace local {
             detail::guard_function(util::detail::deferred_call(
                 PIKA_FORWARD(F, f), PIKA_FORWARD(Args, args)...)));
     }
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/conditional_trigger.hpp
@@ -14,7 +14,7 @@
 
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     ///////////////////////////////////////////////////////////////////////////
     struct conditional_trigger
     {
@@ -66,4 +66,4 @@ namespace pika { namespace lcos { namespace local {
         lcos::local::promise<void> promise_;
         util::detail::function<bool()> cond_;
     };
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
+++ b/libs/pika/lcos/include/pika/lcos/receive_buffer.hpp
@@ -21,7 +21,7 @@
 #include <mutex>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Mutex = pika::spinlock>
     struct receive_buffer
@@ -468,4 +468,4 @@ namespace pika { namespace lcos { namespace local {
         mutable mutex_type mtx_;
         buffer_map_type buffer_map_;
     };
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/include/pika/lcos/trigger.hpp
+++ b/libs/pika/lcos/include/pika/lcos/trigger.hpp
@@ -22,7 +22,7 @@
 #include <mutex>
 #include <utility>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Mutex = pika::spinlock>
     struct base_trigger
@@ -248,4 +248,4 @@ namespace pika { namespace lcos { namespace local {
                 generation_value, l, function_name, ec);
         }
     };
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/src/composable_guard.cpp
+++ b/libs/pika/lcos/src/composable_guard.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace lcos { namespace local {
+namespace pika::lcos::local {
     static void run_composable(detail::guard_task* task);
 
     static void nothing() {}
@@ -280,4 +280,4 @@ namespace pika { namespace lcos { namespace local {
             free(zero);
         }
     }
-}}}    // namespace pika::lcos::local
+}    // namespace pika::lcos::local

--- a/libs/pika/lcos/tests/unit/dataflow_executor_additional_arguments.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_executor_additional_arguments.cpp
@@ -64,7 +64,7 @@ struct additional_argument_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_one_way_executor<additional_argument_executor> : std::true_type
     {
@@ -74,7 +74,7 @@ namespace pika { namespace parallel { namespace execution {
     struct is_two_way_executor<additional_argument_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 std::atomic<std::uint32_t> void_f_count;
 std::atomic<std::uint32_t> int_f_count;

--- a/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
@@ -223,7 +223,7 @@ struct external_future_additional_argument_executor
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<external_future_executor> : std::true_type
     {
@@ -234,7 +234,7 @@ namespace pika { namespace parallel { namespace execution {
       : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 int pika_main()
 {

--- a/libs/pika/lcos/tests/unit/dataflow_small_vector.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_small_vector.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace traits {
+namespace pika::traits {
 
     // support unwrapping of pika::detail::small_vector
     template <typename NewType, typename OldType, std::size_t Size,
@@ -41,7 +41,7 @@ namespace pika { namespace traits {
             return pika::detail::small_vector<NewType, Size, NewAllocator>();
         }
     };
-}}    // namespace pika::traits
+}    // namespace pika::traits
 
 template <typename T>
 using small_vector =

--- a/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
+++ b/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     struct register_lock_data
     {
@@ -202,4 +202,4 @@ namespace pika { namespace util {
     }
 
 #endif
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/lock_registration/src/register_locks.cpp
+++ b/libs/pika/lock_registration/src/register_locks.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
 #ifdef PIKA_HAVE_VERIFY_LOCKS
     ///////////////////////////////////////////////////////////////////////////
@@ -402,4 +402,4 @@ namespace pika { namespace util {
 
     void set_held_locks_data(std::unique_ptr<held_locks_data>&& /* data */) {}
 #endif
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/logging/include/pika/logging/detail/logger.hpp
+++ b/libs/pika/logging/include/pika/logging/detail/logger.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     /**
     @brief The logger class. Every log from your application is an instance of
@@ -182,4 +182,4 @@ namespace pika { namespace util { namespace logging {
         writer::named_write m_writer;
         level m_level;
     };
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging

--- a/libs/pika/logging/include/pika/logging/detail/macros.hpp
+++ b/libs/pika/logging/include/pika/logging/detail/macros.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     /**
 @page macros Macros - how, what for?
@@ -155,4 +155,4 @@ PIKA_DEFINE_LOG(g_l, logger_type)
 #define PIKA_LOG_FORMAT(NAME, LEVEL, FORMAT, ...)                              \
     PIKA_LOG_USE_LOG(NAME, LEVEL).format(FORMAT, __VA_ARGS__)
 
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging

--- a/libs/pika/logging/include/pika/logging/format/destinations.hpp
+++ b/libs/pika/logging/include/pika/logging/format/destinations.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-namespace pika { namespace util { namespace logging { namespace destination {
+namespace pika::util::logging::destination {
 
     /**
     @brief Writes the string to console
@@ -159,4 +159,4 @@ namespace pika { namespace util { namespace logging { namespace destination {
         file_settings settings;
     };
 
-}}}}    // namespace pika::util::logging::destination
+}    // namespace pika::util::logging::destination

--- a/libs/pika/logging/include/pika/logging/format/formatters.hpp
+++ b/libs/pika/logging/include/pika/logging/format/formatters.hpp
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 
-namespace pika { namespace util { namespace logging { namespace formatter {
+namespace pika::util::logging::formatter {
 
     /**
 @brief prefixes each message with an index.
@@ -113,4 +113,4 @@ std::(w)string and the string that holds your logged message. See convert_format
         thread_id() = default;
     };
 
-}}}}    // namespace pika::util::logging::formatter
+}    // namespace pika::util::logging::formatter

--- a/libs/pika/logging/include/pika/logging/format/named_write.hpp
+++ b/libs/pika/logging/include/pika/logging/format/named_write.hpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace util { namespace logging { namespace detail {
+namespace pika::util::logging::detail {
 
     template <typename T>
     struct named
@@ -267,9 +267,9 @@ namespace pika { namespace util { namespace logging { namespace detail {
         std::string format_string;
     };
 
-}}}}    // namespace pika::util::logging::detail
+}    // namespace pika::util::logging::detail
 
-namespace pika { namespace util { namespace logging { namespace writer {
+namespace pika::util::logging::writer {
 
     /// @brief Composed of a named formatter and a named destinations.
     /// Thus, you can specify the formatting and destinations as strings
@@ -447,4 +447,4 @@ namespace pika { namespace util { namespace logging { namespace writer {
         std::string m_destination_str;
     };
 
-}}}}    // namespace pika::util::logging::writer
+}    // namespace pika::util::logging::writer

--- a/libs/pika/logging/include/pika/logging/level.hpp
+++ b/libs/pika/logging/include/pika/logging/level.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     /**
     @brief Handling levels - classes that can hold and/or deal with levels
@@ -56,7 +56,7 @@ namespace pika { namespace util { namespace logging {
     };
 
     PIKA_EXPORT std::string levelname(level value);
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging
 
 template <>
 struct fmt::formatter<pika::util::logging::level> : fmt::formatter<std::string>

--- a/libs/pika/logging/include/pika/logging/logging.hpp
+++ b/libs/pika/logging/include/pika/logging/logging.hpp
@@ -20,20 +20,13 @@
 #include <pika/logging/detail/macros.hpp>
 #include <pika/logging/level.hpp>
 
-namespace pika { namespace util { namespace logging {
-
-    /**
-@file pika/logging/logging.hpp
-
-Include this file when you're using the logging lib, but don't necessarily want to
-use @ref manipulator "formatters and destinations".
-If you want to use @ref manipulator "formatters and destinations",
-then you can include this one instead:
-
-@code
-#include <pika/logging/format.hpp>
-@endcode
-
-*/
-
-}}}    // namespace pika::util::logging
+/// @file pika/logging/logging.hpp
+///
+/// Include this file when you're using the logging lib, but don't necessarily want to
+/// use @ref manipulator "formatters and destinations".
+/// If you want to use @ref manipulator "formatters and destinations",
+/// then you can include this one instead:
+///
+/// @code
+/// #include <pika/logging/format.hpp>
+/// @endcode

--- a/libs/pika/logging/include/pika/logging/manipulator.hpp
+++ b/libs/pika/logging/include/pika/logging/manipulator.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <string_view>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     /// @brief Formatter is a manipulator.
     /// It allows you to format the message before writing it to the destination(s)
@@ -87,4 +87,4 @@ namespace pika { namespace util { namespace logging {
 
     }    // namespace destination
 
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging

--- a/libs/pika/logging/include/pika/logging/message.hpp
+++ b/libs/pika/logging/include/pika/logging/message.hpp
@@ -30,7 +30,7 @@
 #include <string_view>
 #include <utility>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     /**
         @brief Optimizes the formatting for prepending and/or appending strings to
@@ -134,4 +134,4 @@ namespace pika { namespace util { namespace logging {
         mutable bool m_full_msg_computed;
         mutable std::string m_full_msg;
     };
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging

--- a/libs/pika/logging/include/pika/modules/logging.hpp
+++ b/libs/pika/logging/include/pika/modules/logging.hpp
@@ -35,7 +35,7 @@ namespace pika {
 #define LBT_(lvl) LPIKA_(lvl, "  [BT] ")  /* bootstrap */
 
 ////////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -108,7 +108,7 @@ namespace pika { namespace util {
         PIKA_EXPORT PIKA_DECLARE_LOG(app_console)
         // special debug logging channel
         PIKA_EXPORT PIKA_DECLARE_LOG(debuglog_console)
-}}    // namespace pika::util
+}    // namespace pika::util
 
 ///////////////////////////////////////////////////////////////////////////////
 #define LTIM_CONSOLE_(lvl)                                                     \

--- a/libs/pika/logging/src/format/destination/defaults_destination.cpp
+++ b/libs/pika/logging/src/format/destination/defaults_destination.cpp
@@ -26,7 +26,7 @@
 #include <windows.h>
 #endif
 
-namespace pika { namespace util { namespace logging { namespace destination {
+namespace pika::util::logging::destination {
 
     cout::~cout() = default;
 
@@ -99,4 +99,4 @@ namespace pika { namespace util { namespace logging { namespace destination {
         return std::unique_ptr<dbg_window>(new dbg_window_impl());
     }
 
-}}}}    // namespace pika::util::logging::destination
+}    // namespace pika::util::logging::destination

--- a/libs/pika/logging/src/format/destination/file.cpp
+++ b/libs/pika/logging/src/format/destination/file.cpp
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <string>
 
-namespace pika { namespace util { namespace logging { namespace destination {
+namespace pika::util::logging::destination {
 
     file::~file() = default;
 
@@ -91,4 +91,4 @@ namespace pika { namespace util { namespace logging { namespace destination {
         return std::unique_ptr<file>(new file_impl(file_name, set));
     }
 
-}}}}    // namespace pika::util::logging::destination
+}    // namespace pika::util::logging::destination

--- a/libs/pika/logging/src/format/formatter/defaults_formatter.cpp
+++ b/libs/pika/logging/src/format/formatter/defaults_formatter.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <ostream>
 
-namespace pika { namespace util { namespace logging { namespace formatter {
+namespace pika::util::logging::formatter {
 
     idx::~idx() = default;
 
@@ -49,4 +49,4 @@ namespace pika { namespace util { namespace logging { namespace formatter {
         return std::unique_ptr<idx>(new idx_impl());
     }
 
-}}}}    // namespace pika::util::logging::formatter
+}    // namespace pika::util::logging::formatter

--- a/libs/pika/logging/src/format/formatter/high_precision_time.cpp
+++ b/libs/pika/logging/src/format/formatter/high_precision_time.cpp
@@ -35,7 +35,7 @@
 #include <mutex>
 #endif
 
-namespace pika { namespace util { namespace logging { namespace formatter {
+namespace pika::util::logging::formatter {
 
     high_precision_time::~high_precision_time() = default;
 
@@ -127,4 +127,4 @@ namespace pika { namespace util { namespace logging { namespace formatter {
             new high_precision_time_impl(format));
     }
 
-}}}}    // namespace pika::util::logging::formatter
+}    // namespace pika::util::logging::formatter

--- a/libs/pika/logging/src/format/formatter/thread_id.cpp
+++ b/libs/pika/logging/src/format/formatter/thread_id.cpp
@@ -33,7 +33,7 @@
 #include <pthread.h>
 #endif
 
-namespace pika { namespace util { namespace logging { namespace formatter {
+namespace pika::util::logging::formatter {
 
     thread_id::~thread_id() = default;
 
@@ -63,4 +63,4 @@ namespace pika { namespace util { namespace logging { namespace formatter {
         return std::unique_ptr<thread_id>(new thread_id_impl());
     }
 
-}}}}    // namespace pika::util::logging::formatter
+}    // namespace pika::util::logging::formatter

--- a/libs/pika/logging/src/format/named_write.cpp
+++ b/libs/pika/logging/src/format/named_write.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <string>
 
-namespace pika { namespace util { namespace logging { namespace detail {
+namespace pika::util::logging::detail {
 
     static std::string unescape(std::string escaped)
     {
@@ -272,9 +272,9 @@ namespace pika { namespace util { namespace logging { namespace detail {
         }
     }    // namespace
 
-}}}}    // namespace pika::util::logging::detail
+}    // namespace pika::util::logging::detail
 
-namespace pika { namespace util { namespace logging { namespace writer {
+namespace pika::util::logging::writer {
 
     named_write::named_write()
     {
@@ -298,4 +298,4 @@ namespace pika { namespace util { namespace logging { namespace writer {
         detail::configure(m_destination, format, detail::parse_destination{});
     }
 
-}}}}    // namespace pika::util::logging::writer
+}    // namespace pika::util::logging::writer

--- a/libs/pika/logging/src/level.cpp
+++ b/libs/pika/logging/src/level.cpp
@@ -17,7 +17,7 @@
 #include <string_view>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
     std::string levelname(level value)
     {
         switch (value)
@@ -42,6 +42,6 @@ namespace pika { namespace util { namespace logging {
 
         return '<' + std::to_string(static_cast<int>(value)) + '>';
     }
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging
 
 #endif    // PIKA_HAVE_LOGGING

--- a/libs/pika/logging/src/logging.cpp
+++ b/libs/pika/logging/src/logging.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     PIKA_DEFINE_LOG(app, disable_all)
     PIKA_DEFINE_LOG(app_console, disable_all)
     PIKA_DEFINE_LOG(app_error, fatal)
@@ -68,12 +68,12 @@ namespace pika { namespace util {
             }
         }
     }    // namespace detail
-}}       // namespace pika::util
+}    // namespace pika::util
 
 ///////////////////////////////////////////////////////////////////////////////
 #include <pika/logging/detail/logger.hpp>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     void logger::turn_cache_off()
     {
@@ -90,6 +90,6 @@ namespace pika { namespace util { namespace logging {
             m_writer(msg);
     }
 
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging
 
 #endif    // PIKA_HAVE_LOGGING

--- a/libs/pika/logging/src/manipulator.cpp
+++ b/libs/pika/logging/src/manipulator.cpp
@@ -16,7 +16,7 @@
 
 #include <pika/logging/manipulator.hpp>
 
-namespace pika { namespace util { namespace logging {
+namespace pika::util::logging {
 
     namespace formatter {
 
@@ -30,4 +30,4 @@ namespace pika { namespace util { namespace logging {
 
     }    // namespace destination
 
-}}}    // namespace pika::util::logging
+}    // namespace pika::util::logging

--- a/libs/pika/memory/include/pika/memory/detail/sp_convertible.hpp
+++ b/libs/pika/memory/include/pika/memory/detail/sp_convertible.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace pika { namespace memory { namespace detail {
+namespace pika::memory::detail {
 
     template <typename Y, typename T>
     struct sp_convertible
@@ -49,4 +49,4 @@ namespace pika { namespace memory { namespace detail {
     template <typename Y, typename T>
     inline constexpr bool sp_convertible_v = sp_convertible<Y, T>::value;
 
-}}}    // namespace pika::memory::detail
+}    // namespace pika::memory::detail

--- a/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
+++ b/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
@@ -23,7 +23,7 @@
 #include <iosfwd>
 #include <type_traits>
 
-namespace pika { namespace memory {
+namespace pika::memory {
 
     //
     //  intrusive_ptr
@@ -332,7 +332,7 @@ namespace pika { namespace memory {
         os << p.get();
         return os;
     }
-}}    // namespace pika::memory
+}    // namespace pika::memory
 
 namespace pika {
 

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/container_category.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/container_category.hpp
@@ -10,7 +10,7 @@
 #include <pika/datastructures/traits/is_tuple_like.hpp>
 #include <pika/iterator_support/traits/is_range.hpp>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
     /// A tag for dispatching based on the tuple like
     /// or container properties of a type.
     template <bool IsContainer, bool IsTupleLike>
@@ -23,4 +23,4 @@ namespace pika { namespace util { namespace detail {
     using container_category_of_t =
         container_category_tag<traits::is_range<T>::value,
             traits::detail::is_tuple_like_v<T>>;
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -29,7 +29,7 @@
 #include <utility>
 
 namespace pika {
-    namespace util { namespace detail {
+    namespace util::detail {
         /// A tag which is passed to the `operator()` of the visitor
         /// if an element is visited synchronously.
         struct async_traverse_visit_tag
@@ -237,9 +237,9 @@ namespace pika {
 
             other_allocator alloc_;
         };
-    }}    // namespace util::detail
+    }    // namespace util::detail
 
-    namespace traits { namespace detail {
+    namespace traits::detail {
         template <typename Visitor, typename... Args, typename Allocator>
         struct shared_state_allocator<
             util::detail::async_traversal_frame<Visitor, Args...>, Allocator>
@@ -248,9 +248,9 @@ namespace pika {
                 util::detail::async_traversal_frame_allocator<Allocator,
                     Visitor, Args...>;
         };
-    }}    // namespace traits::detail
+    }    // namespace traits::detail
 
-    namespace util { namespace detail {
+    namespace util::detail {
         template <typename Target, std::size_t Begin, std::size_t End>
         struct static_async_range
         {
@@ -727,5 +727,5 @@ namespace pika {
             resumer();
             return frame;
         }
-    }}    // namespace util::detail
+    }    // namespace util::detail
 }    // end namespace pika

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/pack_traversal_impl.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
     /// Exposes useful facilities for dealing with 1:n mappings
     namespace spreading {
         /// A struct to mark a tuple to be unpacked into the parent context
@@ -933,4 +933,4 @@ namespace pika { namespace util { namespace detail {
             PIKA_FORWARD(Mapper, mapper));
         return helper.init_traverse(strategy, PIKA_FORWARD(T, pack)...);
     }
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/detail/unwrap_impl.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/detail/unwrap_impl.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace util { namespace detail {
+namespace pika::util::detail {
     /// Deduces to a true_type if the given future is instantiated with
     /// a non void type.
     template <typename T>
@@ -299,4 +299,4 @@ namespace pika { namespace util { namespace detail {
         return functional_unwrap_impl<std::decay_t<T>, Depth>(
             PIKA_FORWARD(T, callable));
     }
-}}}    // namespace pika::util::detail
+}    // namespace pika::util::detail

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal.hpp
@@ -50,7 +50,7 @@ namespace pika { namespace util {
 }}       // namespace pika::util
 #else    // DOXYGEN
 
-namespace pika { namespace util {
+namespace pika::util {
     template <typename Mapper, typename... T>
     auto map_pack(Mapper&& mapper, T&&... pack)
         -> decltype(detail::apply_pack_transform(detail::strategy_remap_tag{},
@@ -83,6 +83,6 @@ namespace pika { namespace util {
         detail::apply_pack_transform(detail::strategy_traverse_tag{},
             PIKA_FORWARD(Mapper, mapper), PIKA_FORWARD(T, pack)...);
     }
-}}    // namespace pika::util
+}    // namespace pika::util
 
 #endif    // DOXYGEN

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal_async.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/pack_traversal_async.hpp
@@ -10,7 +10,7 @@
 
 #include <utility>
 
-namespace pika { namespace util {
+namespace pika::util {
     /// A tag which is passed to the `operator()` of the visitor
     /// if an element is visited synchronously.
     using detail::async_traverse_visit_tag;
@@ -159,4 +159,4 @@ namespace pika { namespace util {
         return detail::apply_pack_transform_async_allocator(
             alloc, PIKA_FORWARD(Visitor, visitor), PIKA_FORWARD(T, pack)...);
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/pack_traversal/include/pika/pack_traversal/traits/pack_traversal_rebind_container.hpp
+++ b/libs/pika/pack_traversal/include/pika/pack_traversal/traits/pack_traversal_rebind_container.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace pika { namespace traits {
+namespace pika::traits {
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
         ////////////////////////////////////////////////////////////////////////
@@ -116,4 +116,4 @@ namespace pika { namespace traits {
             return std::array<NewType, N>();
         }
     };
-}}    // namespace pika::traits
+}    // namespace pika::traits

--- a/libs/pika/prefix/include/pika/prefix/find_prefix.hpp
+++ b/libs/pika/prefix/include/pika/prefix/find_prefix.hpp
@@ -13,9 +13,9 @@
 
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::util {
     // return the full path of the current executable
     PIKA_EXPORT std::string get_executable_filename(
         char const* argv0 = nullptr);
     PIKA_EXPORT std::string get_executable_prefix(char const* argv0 = nullptr);
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/prefix/src/find_prefix.cpp
+++ b/libs/pika/prefix/src/find_prefix.cpp
@@ -38,7 +38,7 @@
 #include <filesystem>
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////////
     std::string get_executable_prefix(char const* argv0)
     {
@@ -170,4 +170,4 @@ namespace pika { namespace util {
 
         return r;
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/program_options/include/pika/program_options/cmdline.hpp
+++ b/libs/pika/program_options/include/pika/program_options/cmdline.hpp
@@ -8,7 +8,7 @@
 
 #include <pika/program_options/config.hpp>
 
-namespace pika { namespace program_options { namespace command_line_style {
+namespace pika::program_options::command_line_style {
 
     /** Various possible styles of options.
 
@@ -86,6 +86,6 @@ namespace pika { namespace program_options { namespace command_line_style {
         /** The default style. */
         default_style = unix_style
     };
-}}}    // namespace pika::program_options::command_line_style
+}    // namespace pika::program_options::command_line_style
 
 #include <pika/program_options/detail/cmdline.hpp>

--- a/libs/pika/program_options/include/pika/program_options/detail/cmdline.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/cmdline.hpp
@@ -20,7 +20,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     /** Command line parser class. Main requirements were:
         - Powerful enough to support all common uses.
@@ -138,6 +138,6 @@ namespace pika { namespace program_options { namespace detail {
 
     void test_cmdline_detail();
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
@@ -19,7 +19,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     /** Standalone parser for config files in ini-line format.
         The parser is a model of single-pass lvalue iterator, and
@@ -164,6 +164,6 @@ namespace pika { namespace program_options { namespace detail {
         }
     }
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/include/pika/program_options/detail/convert.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/convert.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** Converts from local 8 bit encoding into wchar_t string using
         the specified locale facet. */
@@ -59,4 +59,4 @@ namespace pika { namespace program_options {
         return result;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     template <class Char>
     basic_command_line_parser<Char>::basic_command_line_parser(
@@ -133,4 +133,4 @@ namespace pika { namespace program_options {
         return result;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/detail/utf8_codecvt_facet.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/utf8_codecvt_facet.hpp
@@ -95,7 +95,7 @@
 //            See utf8_codecvt_facet.cpp for the implementation.              //
 //----------------------------------------------------------------------------//
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     struct PIKA_EXPORT utf8_codecvt_facet
       : public std::codecvt<wchar_t, char, std::mbstate_t>
@@ -175,4 +175,4 @@ namespace pika { namespace program_options { namespace detail {
         }
     };
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail

--- a/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     extern PIKA_EXPORT std::string arg;
 
@@ -215,4 +215,4 @@ namespace pika { namespace program_options {
         return r;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/environment_iterator.hpp
+++ b/libs/pika/program_options/include/pika/program_options/environment_iterator.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <utility>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     class environment_iterator
       : public eof_iterator<environment_iterator,
@@ -51,4 +51,4 @@ namespace pika { namespace program_options {
     private:
         char** m_environment;
     };
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/eof_iterator.hpp
+++ b/libs/pika/program_options/include/pika/program_options/eof_iterator.hpp
@@ -12,7 +12,7 @@
 
 #include <iterator>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** The 'eof_iterator' class is useful for constructing forward iterators
         in cases where iterator extract data from some source and it's easy
@@ -95,4 +95,4 @@ namespace pika { namespace program_options {
         bool m_at_eof;
         ValueType m_value;
     };
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/errors.hpp
+++ b/libs/pika/program_options/include/pika/program_options/errors.hpp
@@ -16,7 +16,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     inline std::string strip_prefixes(const std::string& text)
     {
@@ -445,6 +445,6 @@ namespace pika { namespace program_options {
         invalid_bool_value(const std::string& value);
     };
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/include/pika/program_options/option.hpp
+++ b/libs/pika/program_options/include/pika/program_options/option.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** Option found in input source.
         Contains a key and a value. The key, in turn, can be a string (name of
@@ -70,4 +70,4 @@ namespace pika { namespace program_options {
     using option = basic_option<char>;
     using woption = basic_option<wchar_t>;
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/options_description.hpp
+++ b/libs/pika/program_options/include/pika/program_options/options_description.hpp
@@ -23,7 +23,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** Describes one possible command line/config file option. There are two
         kinds of properties of an option. First describe it syntactically and
@@ -276,6 +276,6 @@ namespace pika { namespace program_options {
         }
     };
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/include/pika/program_options/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/parsers.hpp
@@ -18,7 +18,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     class options_description;
     class positional_options_description;
@@ -270,7 +270,7 @@ namespace pika { namespace program_options {
         const std::wstring& cmdline);
 #endif
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/config/warnings_suffix.hpp>
 

--- a/libs/pika/program_options/include/pika/program_options/positional_options.hpp
+++ b/libs/pika/program_options/include/pika/program_options/positional_options.hpp
@@ -13,7 +13,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** Describes positional options.
 
@@ -61,6 +61,6 @@ namespace pika { namespace program_options {
         std::string m_trailing;
     };
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
@@ -18,7 +18,7 @@
 #include <typeinfo>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     /** Class which specifies how the option's value is to be parsed
         and converted into C++ types.
@@ -432,6 +432,6 @@ namespace pika { namespace program_options {
     */
     PIKA_EXPORT typed_value<bool>* bool_switch(bool* v);
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/program_options/detail/value_semantic.hpp>

--- a/libs/pika/program_options/include/pika/program_options/variables_map.hpp
+++ b/libs/pika/program_options/include/pika/program_options/variables_map.hpp
@@ -17,7 +17,7 @@
 
 #include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     template <class Char>
     class basic_parsed_options;
@@ -208,6 +208,6 @@ namespace pika { namespace program_options {
         return v;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/program_options/src/cmdline.cpp
+++ b/libs/pika/program_options/src/cmdline.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     using namespace std;
     using namespace pika::program_options::command_line_style;
@@ -67,9 +67,9 @@ namespace pika { namespace program_options {
         return msg;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     using namespace std;
     using namespace program_options;
@@ -695,4 +695,4 @@ namespace pika { namespace program_options { namespace detail {
         m_style_parser = s;
     }
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail

--- a/libs/pika/program_options/src/config_file.cpp
+++ b/libs/pika/program_options/src/config_file.cpp
@@ -14,7 +14,7 @@
 #include <set>
 #include <string>
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     using namespace std;
 
@@ -164,4 +164,4 @@ namespace pika { namespace program_options { namespace detail {
     }
 #endif
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail

--- a/libs/pika/program_options/src/convert.cpp
+++ b/libs/pika/program_options/src/convert.cpp
@@ -15,7 +15,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     using namespace std;
 
@@ -72,9 +72,9 @@ namespace pika { namespace program_options { namespace detail {
 
         return result;
     }
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     std::wstring from_8_bit(const std::string& s,
         const std::codecvt<wchar_t, char, std::mbstate_t>& cvt)
@@ -129,4 +129,4 @@ namespace pika { namespace program_options {
     {
         return to_utf8(s);
     }
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/options_description.cpp
+++ b/libs/pika/program_options/src/options_description.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     namespace {
 
@@ -688,4 +688,4 @@ namespace pika { namespace program_options {
         }
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/parsers.cpp
+++ b/libs/pika/program_options/src/parsers.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     namespace {
 
@@ -196,4 +196,4 @@ namespace pika { namespace program_options {
         return parse_environment(desc, string(prefix));
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/positional_options.cpp
+++ b/libs/pika/program_options/src/positional_options.cpp
@@ -12,7 +12,7 @@
 #include <limits>
 #include <string>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     positional_options_description::positional_options_description() {}
 
@@ -48,4 +48,4 @@ namespace pika { namespace program_options {
         return m_trailing;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/split.cpp
+++ b/libs/pika/program_options/src/split.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     template <class Char>
     std::vector<std::basic_string<Char>>
@@ -39,9 +39,9 @@ namespace pika { namespace program_options { namespace detail {
         return result;
     }
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     // Take a command line string and splits in into tokens, according
     // to the given collection of separators chars.
@@ -59,4 +59,4 @@ namespace pika { namespace program_options {
         return detail::split_unix<wchar_t>(cmdline, separator, quote, escape);
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/utf8_codecvt_facet.cpp
+++ b/libs/pika/program_options/src/utf8_codecvt_facet.cpp
@@ -24,7 +24,7 @@
 // compile this file.
 
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-namespace pika { namespace program_options { namespace detail {
+namespace pika::program_options::detail {
 
     // implementation for wchar_t
 
@@ -291,4 +291,4 @@ namespace pika { namespace program_options { namespace detail {
         return detail::get_cont_octet_out_count_impl<sizeof(wchar_t)>(word);
     }
 
-}}}    // namespace pika::program_options::detail
+}    // namespace pika::program_options::detail

--- a/libs/pika/program_options/src/value_semantic.cpp
+++ b/libs/pika/program_options/src/value_semantic.cpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     using namespace std;
 
@@ -400,4 +400,4 @@ namespace pika { namespace program_options {
         return msg;
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/program_options/src/variables_map.cpp
+++ b/libs/pika/program_options/src/variables_map.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-namespace pika { namespace program_options {
+namespace pika::program_options {
 
     using namespace std;
 
@@ -246,4 +246,4 @@ namespace pika { namespace program_options {
         }
     }
 
-}}    // namespace pika::program_options
+}    // namespace pika::program_options

--- a/libs/pika/properties/include/pika/properties/property.hpp
+++ b/libs/pika/properties/include/pika/properties/property.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace experimental {
+namespace pika::experimental {
 
     inline constexpr struct prefer_t
       : pika::functional::detail::tag_fallback<prefer_t>
@@ -44,4 +44,4 @@ namespace pika { namespace experimental {
             return PIKA_FORWARD(T0, t0);
         }
     } prefer{};
-}}    // namespace pika::experimental
+}    // namespace pika::experimental

--- a/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
@@ -70,7 +70,7 @@ std::string a_function(pika::future<double>&& df)
     return "The number 2";
 }
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
 
     struct guided_test_tag
     {
@@ -117,7 +117,7 @@ namespace pika { namespace parallel { namespace execution {
             return 56;
         }
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 using namespace pika::parallel::execution;
 

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -28,7 +28,7 @@
 // NB
 // this test needs to be updated as it no longer does what it is supposed to do
 
-namespace resource { namespace pools {
+namespace resource::pools {
     enum ids
     {
         DEFAULT = 0,
@@ -36,7 +36,7 @@ namespace resource { namespace pools {
         GPU = 2,
         MATRIX = 3,
     };
-}}    // namespace resource::pools
+}    // namespace resource::pools
 
 static bool use_pools = false;
 static int pool_threads = 1;

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/create_partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/create_partitioner.hpp
@@ -19,9 +19,9 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace resource { namespace detail {
+namespace pika::resource::detail {
     PIKA_EXPORT partitioner& create_partitioner(
         resource::partitioner_mode rpmode, pika::util::section rtcfg,
         pika::detail::affinity_data affinity_data);
 
-}}}    // namespace pika::resource::detail
+}    // namespace pika::resource::detail

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -24,7 +24,7 @@
 #include <tuple>
 #include <vector>
 
-namespace pika { namespace resource { namespace detail {
+namespace pika::resource::detail {
     ///////////////////////////////////////////////////////////////////////////
     // structure used to encapsulate all characteristics of thread_pools
     // as specified by the user in int main()
@@ -242,4 +242,4 @@ namespace pika { namespace resource { namespace detail {
 
         threads::scheduler_mode default_scheduler_mode_;
     };
-}}}    // namespace pika::resource::detail
+}    // namespace pika::resource::detail

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace resource {
+namespace pika::resource {
     ///////////////////////////////////////////////////////////////////////////
     class pu
     {
@@ -211,4 +211,4 @@ namespace pika { namespace resource {
             return ::pika::resource::partitioner(rpmode, rtcfg, affinity_data);
         }
     }    // namespace detail
-}}       // namespace pika::resource
+}    // namespace pika::resource

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <string>
 
-namespace pika { namespace resource {
+namespace pika::resource {
     class numa_domain;
     class core;
     class pu;
@@ -72,4 +72,4 @@ namespace pika { namespace resource {
         abp_priority_lifo = 6,
         shared_priority = 7,
     };
-}}    // namespace pika::resource
+}    // namespace pika::resource

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -31,7 +31,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace resource { namespace detail {
+namespace pika::resource::detail {
     ///////////////////////////////////////////////////////////////////////////
     [[noreturn]] void throw_runtime_error(
         std::string const& func, std::string const& message)
@@ -1088,4 +1088,4 @@ namespace pika { namespace resource { namespace detail {
 
     ////////////////////////////////////////////////////////////////////////
     std::atomic<int> partitioner::instance_number_counter_(-1);
-}}}    // namespace pika::resource::detail
+}    // namespace pika::resource::detail

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace resource {
+namespace pika::resource {
     ///////////////////////////////////////////////////////////////////////////
     std::vector<pu> pu::pus_sharing_core()
     {
@@ -218,4 +218,4 @@ namespace pika { namespace resource {
     {
         partitioner_.configure_pools();
     }
-}}    // namespace pika::resource
+}    // namespace pika::resource

--- a/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
@@ -253,12 +253,12 @@ private:
 // --------------------------------------------------------------------
 // set traits for executor to say it is an async executor
 // --------------------------------------------------------------------
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_two_way_executor<test_async_executor> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 template <typename T>
 T dummy_task(T val)
@@ -442,7 +442,7 @@ struct dummy_tag
 {
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct pool_numa_hint<dummy_tag>
     {
@@ -484,7 +484,7 @@ namespace pika { namespace parallel { namespace execution {
             return 4;
         }
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 int pika_main()
 {

--- a/libs/pika/runtime/include/pika/runtime/debugging.hpp
+++ b/libs/pika/runtime/include/pika/runtime/debugging.hpp
@@ -10,8 +10,8 @@
 #include <pika/config.hpp>
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::util {
     /// Attaches a debugger if \c category is equal to the configuration entry
     /// pika.attach-debugger.
     void PIKA_EXPORT may_attach_debugger(std::string const& category);
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
+++ b/libs/pika/runtime/include/pika/runtime/run_as_pika_thread.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace threads {
+namespace pika::threads {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         // This is the overload for running functions which return a value.
@@ -150,4 +150,4 @@ namespace pika { namespace threads {
         return detail::run_as_pika_thread(
             result_is_void(), f, PIKA_FORWARD(Ts, vs)...);
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads

--- a/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <string>
 
-namespace pika { namespace detail {
+namespace pika::detail {
     [[noreturn]] PIKA_EXPORT void assertion_handler(
         pika::detail::source_location const& loc, const char* expr,
         std::string const& msg);
@@ -30,4 +30,4 @@ namespace pika { namespace detail {
     PIKA_EXPORT threads::detail::thread_pool_base* get_default_pool();
     PIKA_EXPORT threads::detail::mask_cref_type get_pu_mask(
         threads::detail::topology& topo, std::size_t thread_num);
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/runtime/include/pika/runtime/state.hpp
+++ b/libs/pika/runtime/include/pika/runtime/state.hpp
@@ -12,9 +12,9 @@
 #include <pika/runtime/state.hpp>
 #include <pika/threading_base/scheduler_state.hpp>
 
-namespace pika { namespace threads {
+namespace pika::threads {
 
     // return whether thread manager is in the state described by 'mask'
     PIKA_EXPORT bool thread_manager_is(runtime_state st);
     PIKA_EXPORT bool thread_manager_is_at_least(runtime_state st);
-}}    // namespace pika::threads
+}    // namespace pika::threads

--- a/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_mapper.hpp
@@ -26,7 +26,7 @@
 #include <sys/syscall.h>
 #endif
 
-namespace pika { namespace util {
+namespace pika::util {
 
     ///////////////////////////////////////////////////////////////////////////
     // enumerates active OS threads and maintains their metadata
@@ -154,6 +154,6 @@ namespace pika { namespace util {
         // mapping between pika thread labels and thread indices
         label_map_type label_map_;
     };
-}}    // namespace pika::util
+}    // namespace pika::util
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_pool_helpers.hpp
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include <string>
 
-namespace pika { namespace resource {
+namespace pika::resource {
     ///////////////////////////////////////////////////////////////////////////
     /// Return the number of thread pools currently managed by the
     /// \a resource_partitioner
@@ -53,9 +53,9 @@ namespace pika { namespace resource {
 
     /// Return true if the pool with the given index exists
     PIKA_EXPORT bool pool_exists(std::size_t pool_index);
-}}    // namespace pika::resource
+}    // namespace pika::resource
 
-namespace pika { namespace threads {
+namespace pika::threads {
     ///    The function \a get_thread_count returns the number of currently
     /// known threads.
     ///
@@ -107,4 +107,4 @@ namespace pika { namespace threads {
         util::detail::function<bool(detail::thread_id_type)> const& f,
         detail::thread_schedule_state state =
             detail::thread_schedule_state::unknown);
-}}    // namespace pika::threads
+}    // namespace pika::threads

--- a/libs/pika/runtime/include/pika/runtime/thread_stacktrace.hpp
+++ b/libs/pika/runtime/include/pika/runtime/thread_stacktrace.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace util { namespace debug {
+namespace pika::util::debug {
 
     // ------------------------------------------------------------------------
     // return a vector of suspended/other task Ids
@@ -31,4 +31,4 @@ namespace pika { namespace util { namespace debug {
     // return string containing the stack backtrace for suspended tasks
     PIKA_EXPORT std::string suspended_task_backtraces();
 
-}}}    // namespace pika::util::debug
+}    // namespace pika::util::debug

--- a/libs/pika/runtime/src/debugging.cpp
+++ b/libs/pika/runtime/src/debugging.cpp
@@ -12,7 +12,7 @@
 
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::util {
     void may_attach_debugger(std::string const& category)
     {
         if (get_config_entry("pika.attach_debugger", "") == category)
@@ -20,4 +20,4 @@ namespace pika { namespace util {
             debug::detail::attach_debugger();
         }
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime/src/get_locality_name.cpp
+++ b/libs/pika/runtime/src/get_locality_name.cpp
@@ -11,7 +11,7 @@
 
 #include <string>
 
-namespace pika { namespace detail {
+namespace pika::detail {
 
     std::string get_locality_base_name()
     {
@@ -31,7 +31,7 @@ namespace pika { namespace detail {
         std::string basename = get_locality_base_name();
         return basename + '#' + std::to_string(get_locality_id());
     }
-}}    // namespace pika::detail
+}    // namespace pika::detail
 
 namespace pika {
 

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -922,7 +922,7 @@ namespace pika {
 }    // namespace pika
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     std::string expand(std::string const& in)
     {
         return get_runtime().get_config().expand(in);
@@ -932,10 +932,10 @@ namespace pika { namespace util {
     {
         get_runtime().get_config().expand(in, std::string::size_type(-1));
     }
-}}    // namespace pika::util
+}    // namespace pika::util
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace threads {
+namespace pika::threads {
     detail::thread_manager& get_thread_manager()
     {
         return get_runtime().get_thread_manager();
@@ -987,7 +987,7 @@ namespace pika { namespace threads {
         }
         return rt->get_topology();
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace pika {

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <string>
 
-namespace pika { namespace detail {
+namespace pika::detail {
 
     [[noreturn]] void assertion_handler(
         pika::detail::source_location const& loc, const char* expr,
@@ -148,4 +148,4 @@ namespace pika { namespace detail {
         auto& rp = pika::resource::get_partitioner();
         return rp.get_pu_mask(thread_num);
     }
-}}    // namespace pika::detail
+}    // namespace pika::detail

--- a/libs/pika/runtime/src/state.cpp
+++ b/libs/pika/runtime/src/state.cpp
@@ -12,7 +12,7 @@
 #include <pika/runtime/state.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace threads {
+namespace pika::threads {
     // return whether thread manager is in the runtime_state described by st
     bool thread_manager_is(runtime_state st)
     {
@@ -35,4 +35,4 @@ namespace pika { namespace threads {
         }
         return (rt->get_thread_manager().status() >= st);
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads

--- a/libs/pika/runtime/src/thread_mapper.cpp
+++ b/libs/pika/runtime/src/thread_mapper.cpp
@@ -26,7 +26,7 @@
 #include <unistd.h>
 #endif
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
 
@@ -293,4 +293,4 @@ namespace pika { namespace util {
         return true;
     }
 
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime/src/thread_pool_helpers.cpp
+++ b/libs/pika/runtime/src/thread_pool_helpers.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace pika { namespace resource {
+namespace pika::resource {
     std::size_t get_num_thread_pools()
     {
         return get_partitioner().get_num_pools();
@@ -71,9 +71,9 @@ namespace pika { namespace resource {
     {
         return get_runtime().get_thread_manager().pool_exists(pool_index);
     }
-}}    // namespace pika::resource
+}    // namespace pika::resource
 
-namespace pika { namespace threads {
+namespace pika::threads {
     std::int64_t get_thread_count(detail::thread_schedule_state state)
     {
         return get_thread_manager().get_thread_count(state);
@@ -101,4 +101,4 @@ namespace pika { namespace threads {
     {
         return get_thread_manager().enumerate_threads(f, state);
     }
-}}    // namespace pika::threads
+}    // namespace pika::threads

--- a/libs/pika/runtime/src/thread_stacktrace.cpp
+++ b/libs/pika/runtime/src/thread_stacktrace.cpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace pika { namespace util { namespace debug {
+namespace pika::util::debug {
 
     // ------------------------------------------------------------------------
     // return a vector of suspended/other task Ids
@@ -80,4 +80,4 @@ namespace pika { namespace util { namespace debug {
         }
         return tmp.str();
     }
-}}}    // namespace pika::util::debug
+}    // namespace pika::util::debug

--- a/libs/pika/runtime_configuration/include/pika/runtime_configuration/init_ini_data.hpp
+++ b/libs/pika/runtime_configuration/include/pika/runtime_configuration/init_ini_data.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////
     bool handle_ini_file(section& ini, std::string const& loc);
     bool handle_ini_file_env(
@@ -32,4 +32,4 @@ namespace pika { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     // global function to read component ini information
     void merge_component_inis(section& ini);
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
+++ b/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////
     // The runtime_configuration class is a wrapper for the runtime
     // configuration data allowing to extract configuration information in a
@@ -125,4 +125,4 @@ namespace pika { namespace util {
         char const* argv0;
 #endif
     };
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration_fwd.hpp
+++ b/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration_fwd.hpp
@@ -9,8 +9,8 @@
 #include <pika/config.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     // forward declaration only
     class PIKA_EXPORT runtime_configuration;
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/pika/runtime_configuration/src/init_ini_data.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
     ///////////////////////////////////////////////////////////////////////////
     bool handle_ini_file(section& ini, std::string const& loc)
     {
@@ -237,4 +237,4 @@ namespace pika { namespace util {
             return lhs.first == rhs.first;
         }
     }    // namespace detail
-}}       // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -44,7 +44,7 @@
 #include <limits>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
 
@@ -673,4 +673,4 @@ namespace pika { namespace util {
         }
         return small_stacksize;
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
@@ -24,126 +24,116 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika::threads {
+namespace pika::threads::detail {
+    ///////////////////////////////////////////////////////////////////////////
+    // debug helper function, logs all suspended threads
+    // this returns true if all threads in the map are currently suspended
+    template <typename Map>
+    bool dump_suspended_threads(std::size_t num_thread, Map& tm,
+        std::int64_t& idle_loop_count, bool running) PIKA_COLD;
 
-    ///////////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        ///////////////////////////////////////////////////////////////////////////
-        // debug helper function, logs all suspended threads
-        // this returns true if all threads in the map are currently suspended
-        template <typename Map>
-        bool dump_suspended_threads(std::size_t num_thread, Map& tm,
-            std::int64_t& idle_loop_count, bool running) PIKA_COLD;
-
-        template <typename Map>
-        bool dump_suspended_threads(std::size_t num_thread, Map& tm,
-            std::int64_t& idle_loop_count, bool running)
-        {
+    template <typename Map>
+    bool dump_suspended_threads(std::size_t num_thread, Map& tm,
+        std::int64_t& idle_loop_count, bool running)
+    {
 #if !defined(PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION)
-            PIKA_UNUSED(num_thread);
-            PIKA_UNUSED(tm);
-            PIKA_UNUSED(idle_loop_count);
-            PIKA_UNUSED(running);    //-V601
-            return false;
+        PIKA_UNUSED(num_thread);
+        PIKA_UNUSED(tm);
+        PIKA_UNUSED(idle_loop_count);
+        PIKA_UNUSED(running);    //-V601
+        return false;
 #else
-            if (!get_minimal_deadlock_detection_enabled())
-                return false;
+        if (!get_minimal_deadlock_detection_enabled())
+            return false;
 
-            // attempt to output possibly deadlocked threads occasionally only
-            if (PIKA_LIKELY(
-                    (idle_loop_count++ % PIKA_IDLE_LOOP_COUNT_MAX) != 0))
-                return false;
+        // attempt to output possibly deadlocked threads occasionally only
+        if (PIKA_LIKELY((idle_loop_count++ % PIKA_IDLE_LOOP_COUNT_MAX) != 0))
+            return false;
 
-            bool result = false;
-            bool collect_suspended = true;
+        bool result = false;
+        bool collect_suspended = true;
 
-            bool logged_headline = false;
-            typename Map::const_iterator end = tm.end();
-            for (typename Map::const_iterator it = tm.begin(); it != end; ++it)
+        bool logged_headline = false;
+        typename Map::const_iterator end = tm.end();
+        for (typename Map::const_iterator it = tm.begin(); it != end; ++it)
+        {
+            threads::detail::thread_data const* thrd = get_thread_id_data(*it);
+            threads::detail::thread_schedule_state state =
+                thrd->get_state().state();
+            threads::detail::thread_schedule_state marked_state =
+                thrd->get_marked_state();
+
+            if (state != marked_state)
             {
-                threads::detail::thread_data const* thrd =
-                    get_thread_id_data(*it);
-                threads::detail::thread_schedule_state state =
-                    thrd->get_state().state();
-                threads::detail::thread_schedule_state marked_state =
-                    thrd->get_marked_state();
-
-                if (state != marked_state)
+                // log each thread only once
+                if (!logged_headline)
                 {
-                    // log each thread only once
-                    if (!logged_headline)
-                    {
-                        if (running)
-                        {
-                            LTM_(warning).format("Listing suspended threads "
-                                                 "while queue ({}) is empty:",
-                                num_thread);
-                        }
-                        else
-                        {
-                            LPIKA_CONSOLE_(pika::util::logging::level::warning)
-                                .format("  [TM] Listing suspended threads "
-                                        "while queue ({}) is empty:\n",
-                                    num_thread);
-                        }
-                        logged_headline = true;
-                    }
-
                     if (running)
                     {
-                        LTM_(warning)
-                            .format("queue({}): {}({:08x}.{:02x}/{:08x})",
-                                num_thread, get_thread_state_name(state), *it,
-                                thrd->get_thread_phase(),
-                                thrd->get_component_id())
-#ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
-                            .format(" P{:08x}", thrd->get_parent_thread_id())
-#endif
-                            .format(": {}: {}", thrd->get_description(),
-                                thrd->get_lco_description());
+                        LTM_(warning).format("Listing suspended threads "
+                                             "while queue ({}) is empty:",
+                            num_thread);
                     }
                     else
                     {
                         LPIKA_CONSOLE_(pika::util::logging::level::warning)
-                            .format("queue({}): {}({:08x}.{:02x}/{:08x})",
-                                num_thread, get_thread_state_name(state), *it,
-                                thrd->get_thread_phase(),
-                                thrd->get_component_id())
-#ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
-                            .format(" P{:08x}", thrd->get_parent_thread_id())
-#endif
-                            .format(": {}: {}", thrd->get_description(),
-                                thrd->get_lco_description());
+                            .format("  [TM] Listing suspended threads "
+                                    "while queue ({}) is empty:\n",
+                                num_thread);
                     }
-                    thrd->set_marked_state(state);
+                    logged_headline = true;
+                }
 
-                    // result should be true if we found only suspended threads
-                    if (collect_suspended)
+                if (running)
+                {
+                    LTM_(warning)
+                        .format("queue({}): {}({:08x}.{:02x}/{:08x})",
+                            num_thread, get_thread_state_name(state), *it,
+                            thrd->get_thread_phase(), thrd->get_component_id())
+#ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
+                        .format(" P{:08x}", thrd->get_parent_thread_id())
+#endif
+                        .format(": {}: {}", thrd->get_description(),
+                            thrd->get_lco_description());
+                }
+                else
+                {
+                    LPIKA_CONSOLE_(pika::util::logging::level::warning)
+                        .format("queue({}): {}({:08x}.{:02x}/{:08x})",
+                            num_thread, get_thread_state_name(state), *it,
+                            thrd->get_thread_phase(), thrd->get_component_id())
+#ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
+                        .format(" P{:08x}", thrd->get_parent_thread_id())
+#endif
+                        .format(": {}: {}", thrd->get_description(),
+                            thrd->get_lco_description());
+                }
+                thrd->set_marked_state(state);
+
+                // result should be true if we found only suspended threads
+                if (collect_suspended)
+                {
+                    switch (state)
                     {
-                        switch (state)
-                        {
-                        case threads::detail::thread_schedule_state::suspended:
-                            result = true;    // at least one is suspended
-                            break;
+                    case threads::detail::thread_schedule_state::suspended:
+                        result = true;    // at least one is suspended
+                        break;
 
-                        case threads::detail::thread_schedule_state::pending:
-                        case threads::detail::thread_schedule_state::active:
-                            result =
-                                false;    // one is active, no deadlock (yet)
-                            collect_suspended = false;
-                            break;
+                    case threads::detail::thread_schedule_state::pending:
+                    case threads::detail::thread_schedule_state::active:
+                        result = false;    // one is active, no deadlock (yet)
+                        collect_suspended = false;
+                        break;
 
-                        default:
-                            // If the thread is terminated we don't care too much
-                            // anymore.
-                            break;
-                        }
+                    default:
+                        // If the thread is terminated we don't care too much
+                        // anymore.
+                        break;
                     }
                 }
             }
-            return result;
-#endif
         }
-    }    // namespace detail
-
-}    // namespace pika::threads
+        return result;
+#endif
+    }
+}    // namespace pika::threads::detail

--- a/libs/pika/string_util/include/pika/string_util/case_conv.hpp
+++ b/libs/pika/string_util/include/pika/string_util/case_conv.hpp
@@ -10,11 +10,11 @@
 #include <cctype>
 #include <string>
 
-namespace pika { namespace string_util {
+namespace pika::string_util {
     template <typename CharT, class Traits, class Alloc>
     void to_lower(std::basic_string<CharT, Traits, Alloc>& s)
     {
         std::transform(std::begin(s), std::end(s), std::begin(s),
             [](int c) { return std::tolower(c); });
     }
-}}    // namespace pika::string_util
+}    // namespace pika::string_util

--- a/libs/pika/string_util/include/pika/string_util/classification.hpp
+++ b/libs/pika/string_util/include/pika/string_util/classification.hpp
@@ -9,7 +9,7 @@
 #include <cctype>
 #include <string>
 
-namespace pika { namespace string_util {
+namespace pika::string_util {
     namespace detail {
         template <typename CharT, typename Traits, typename Allocator>
         struct is_any_of_pred
@@ -43,4 +43,4 @@ namespace pika { namespace string_util {
             return std::isspace(c);
         }
     };
-}}    // namespace pika::string_util
+}    // namespace pika::string_util

--- a/libs/pika/string_util/include/pika/string_util/split.hpp
+++ b/libs/pika/string_util/include/pika/string_util/split.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <utility>
 
-namespace pika { namespace string_util {
+namespace pika::string_util {
     namespace detail {
         template <typename It, typename CharT, typename Traits,
             typename Allocator>
@@ -76,4 +76,4 @@ namespace pika { namespace string_util {
         split(container, std::string{str}, PIKA_FORWARD(Predicate, pred),
             compress_mode);
     }
-}}    // namespace pika::string_util
+}    // namespace pika::string_util

--- a/libs/pika/string_util/include/pika/string_util/to_string.hpp
+++ b/libs/pika/string_util/include/pika/string_util/to_string.hpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <type_traits>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
         template <typename T, typename Enable = void>
@@ -51,4 +51,4 @@ namespace pika { namespace util {
         }
     }
 
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/libs/pika/string_util/include/pika/string_util/trim.hpp
+++ b/libs/pika/string_util/include/pika/string_util/trim.hpp
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <string>
 
-namespace pika { namespace string_util {
+namespace pika::string_util {
     template <typename CharT, class Traits, class Alloc>
     void trim(std::basic_string<CharT, Traits, Alloc>& s)
     {
@@ -42,4 +42,4 @@ namespace pika { namespace string_util {
 
         return t;
     }
-}}    // namespace pika::string_util
+}    // namespace pika::string_util

--- a/libs/pika/synchronization/include/pika/synchronization/shared_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/shared_mutex.hpp
@@ -13,226 +13,226 @@
 
 #include <mutex>
 
-namespace pika {
-    namespace detail {
-        template <typename Mutex = pika::mutex>
-        class shared_mutex
+namespace pika::detail {
+    template <typename Mutex = pika::mutex>
+    class shared_mutex
+    {
+    private:
+        using mutex_type = Mutex;
+
+        struct state_data
         {
-        private:
-            using mutex_type = Mutex;
+            unsigned shared_count;
+            bool exclusive;
+            bool upgrade;
+            bool exclusive_waiting_blocked;
+        };
 
-            struct state_data
+        state_data state;
+        mutex_type state_change;
+        pika::condition_variable shared_cond;
+        pika::condition_variable exclusive_cond;
+        pika::condition_variable upgrade_cond;
+
+        void release_waiters()
+        {
+            exclusive_cond.notify_one();
+            shared_cond.notify_all();
+        }
+
+    public:
+        shared_mutex()
+          : state{0u, false, false, false}
+          , shared_cond()
+          , exclusive_cond()
+          , upgrade_cond()
+        {
+        }
+
+        void lock_shared()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            while (state.exclusive || state.exclusive_waiting_blocked)
             {
-                unsigned shared_count;
-                bool exclusive;
-                bool upgrade;
-                bool exclusive_waiting_blocked;
-            };
-
-            state_data state;
-            mutex_type state_change;
-            pika::condition_variable shared_cond;
-            pika::condition_variable exclusive_cond;
-            pika::condition_variable upgrade_cond;
-
-            void release_waiters()
-            {
-                exclusive_cond.notify_one();
-                shared_cond.notify_all();
+                shared_cond.wait(lk);
             }
 
-        public:
-            shared_mutex()
-              : state{0u, false, false, false}
-              , shared_cond()
-              , exclusive_cond()
-              , upgrade_cond()
+            ++state.shared_count;
+        }
+
+        bool try_lock_shared()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            if (state.exclusive || state.exclusive_waiting_blocked)
+                return false;
+
+            else
             {
-            }
-
-            void lock_shared()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                while (state.exclusive || state.exclusive_waiting_blocked)
-                {
-                    shared_cond.wait(lk);
-                }
-
                 ++state.shared_count;
+                return true;
             }
+        }
 
-            bool try_lock_shared()
+        void unlock_shared()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            bool const last_reader = !--state.shared_count;
+
+            if (last_reader)
             {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                if (state.exclusive || state.exclusive_waiting_blocked)
-                    return false;
-
-                else
+                if (state.upgrade)
                 {
-                    ++state.shared_count;
-                    return true;
-                }
-            }
-
-            void unlock_shared()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                bool const last_reader = !--state.shared_count;
-
-                if (last_reader)
-                {
-                    if (state.upgrade)
-                    {
-                        state.upgrade = false;
-                        state.exclusive = true;
-
-                        upgrade_cond.notify_one();
-                    }
-                    else
-                    {
-                        state.exclusive_waiting_blocked = false;
-                    }
-
-                    release_waiters();
-                }
-            }
-
-            void lock()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                while (state.shared_count || state.exclusive)
-                {
-                    state.exclusive_waiting_blocked = true;
-                    exclusive_cond.wait(lk);
-                }
-
-                state.exclusive = true;
-            }
-
-            bool try_lock()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                if (state.shared_count || state.exclusive)
-                    return false;
-
-                else
-                {
+                    state.upgrade = false;
                     state.exclusive = true;
-                    return true;
+
+                    upgrade_cond.notify_one();
                 }
-            }
-
-            void unlock()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-                state.exclusive = false;
-                state.exclusive_waiting_blocked = false;
-                release_waiters();
-            }
-
-            void lock_upgrade()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                while (state.exclusive || state.exclusive_waiting_blocked ||
-                    state.upgrade)
-                {
-                    shared_cond.wait(lk);
-                }
-
-                ++state.shared_count;
-                state.upgrade = true;
-            }
-
-            bool try_lock_upgrade()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-
-                if (state.exclusive || state.exclusive_waiting_blocked ||
-                    state.upgrade)
-                    return false;
-
                 else
-                {
-                    ++state.shared_count;
-                    state.upgrade = true;
-                    return true;
-                }
-            }
-
-            void unlock_upgrade()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-                state.upgrade = false;
-                bool const last_reader = !--state.shared_count;
-
-                if (last_reader)
                 {
                     state.exclusive_waiting_blocked = false;
-                    release_waiters();
-                }
-            }
-
-            void unlock_upgrade_and_lock()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-                --state.shared_count;
-
-                while (state.shared_count)
-                {
-                    upgrade_cond.wait(lk);
                 }
 
-                state.upgrade = false;
-                state.exclusive = true;
-            }
-
-            void unlock_and_lock_upgrade()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-                state.exclusive = false;
-                state.upgrade = true;
-                ++state.shared_count;
-                state.exclusive_waiting_blocked = false;
                 release_waiters();
             }
+        }
 
-            void unlock_and_lock_shared()
+        void lock()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            while (state.shared_count || state.exclusive)
             {
-                std::unique_lock<mutex_type> lk(state_change);
-                state.exclusive = false;
-                ++state.shared_count;
-                state.exclusive_waiting_blocked = false;
-                release_waiters();
+                state.exclusive_waiting_blocked = true;
+                exclusive_cond.wait(lk);
             }
 
-            bool try_unlock_shared_and_lock()
-            {
-                std::unique_lock<mutex_type> lk(state_change);
-                if (!state.exclusive && !state.exclusive_waiting_blocked &&
-                    !state.upgrade && state.shared_count == 1)
-                {
-                    state.shared_count = 0;
-                    state.exclusive = true;
-                    return true;
-                }
+            state.exclusive = true;
+        }
+
+        bool try_lock()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            if (state.shared_count || state.exclusive)
                 return false;
+
+            else
+            {
+                state.exclusive = true;
+                return true;
+            }
+        }
+
+        void unlock()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            state.exclusive = false;
+            state.exclusive_waiting_blocked = false;
+            release_waiters();
+        }
+
+        void lock_upgrade()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            while (state.exclusive || state.exclusive_waiting_blocked ||
+                state.upgrade)
+            {
+                shared_cond.wait(lk);
             }
 
-            void unlock_upgrade_and_lock_shared()
+            ++state.shared_count;
+            state.upgrade = true;
+        }
+
+        bool try_lock_upgrade()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+
+            if (state.exclusive || state.exclusive_waiting_blocked ||
+                state.upgrade)
+                return false;
+
+            else
             {
-                std::unique_lock<mutex_type> lk(state_change);
-                state.upgrade = false;
+                ++state.shared_count;
+                state.upgrade = true;
+                return true;
+            }
+        }
+
+        void unlock_upgrade()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            state.upgrade = false;
+            bool const last_reader = !--state.shared_count;
+
+            if (last_reader)
+            {
                 state.exclusive_waiting_blocked = false;
                 release_waiters();
             }
-        };
-    }    // namespace detail
+        }
 
+        void unlock_upgrade_and_lock()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            --state.shared_count;
+
+            while (state.shared_count)
+            {
+                upgrade_cond.wait(lk);
+            }
+
+            state.upgrade = false;
+            state.exclusive = true;
+        }
+
+        void unlock_and_lock_upgrade()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            state.exclusive = false;
+            state.upgrade = true;
+            ++state.shared_count;
+            state.exclusive_waiting_blocked = false;
+            release_waiters();
+        }
+
+        void unlock_and_lock_shared()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            state.exclusive = false;
+            ++state.shared_count;
+            state.exclusive_waiting_blocked = false;
+            release_waiters();
+        }
+
+        bool try_unlock_shared_and_lock()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            if (!state.exclusive && !state.exclusive_waiting_blocked &&
+                !state.upgrade && state.shared_count == 1)
+            {
+                state.shared_count = 0;
+                state.exclusive = true;
+                return true;
+            }
+            return false;
+        }
+
+        void unlock_upgrade_and_lock_shared()
+        {
+            std::unique_lock<mutex_type> lk(state_change);
+            state.upgrade = false;
+            state.exclusive_waiting_blocked = false;
+            release_waiters();
+        }
+    };
+}    // namespace pika::detail
+
+namespace pika {
     using shared_mutex = detail::shared_mutex<>;
-}    // namespace pika
+}

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -105,7 +105,7 @@ namespace pika { namespace functional {
 #include <type_traits>
 #include <utility>
 
-namespace pika { namespace functional {
+namespace pika::functional {
     template <auto& Tag>
     using tag_t = std::decay_t<decltype(Tag)>;
 
@@ -258,6 +258,6 @@ namespace pika { namespace functional {
     inline namespace tag_invoke_f_ns {
         using tag_invoke_ns::tag_invoke;
     }    // namespace tag_invoke_f_ns
-}}       // namespace pika::functional
+}    // namespace pika::functional
 
 #endif

--- a/libs/pika/util/include/pika/util/detail/reserve.hpp
+++ b/libs/pika/util/include/pika/util/detail/reserve.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace pika { namespace traits { namespace detail {
+namespace pika::traits::detail {
 
     ///////////////////////////////////////////////////////////////////////
     // not every random access sequence is reservable
@@ -69,4 +69,4 @@ namespace pika { namespace traits { namespace detail {
             v.reserve(std::distance(begin, end));
         }
     }
-}}}    // namespace pika::traits::detail
+}    // namespace pika::traits::detail

--- a/testing/performance_testing/include/pika/testing/performance.hpp
+++ b/testing/performance_testing/include/pika/testing/performance.hpp
@@ -18,7 +18,7 @@
 #include <tuple>
 #include <vector>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
         // Json output for performance reports
@@ -88,4 +88,4 @@ namespace pika { namespace util {
 
     PIKA_EXPORT void print_cdash_timing(const char* name, double time);
     PIKA_EXPORT void print_cdash_timing(const char* name, std::uint64_t time);
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/testing/performance_testing/src/performance.cpp
+++ b/testing/performance_testing/src/performance.cpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <type_traits>
 
-namespace pika { namespace util {
+namespace pika::util {
 
     namespace detail {
 
@@ -73,4 +73,4 @@ namespace pika { namespace util {
     {
         print_cdash_timing(name, static_cast<double>(time) / 1e9);
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/testing/testing/include/pika/testing.hpp
+++ b/testing/testing/include/pika/testing.hpp
@@ -29,7 +29,7 @@
 #include <mutex>
 #include <ostream>
 
-namespace pika { namespace util {
+namespace pika::util {
     enum counter_type
     {
         counter_sanity,
@@ -206,7 +206,7 @@ namespace pika { namespace util {
     ////////////////////////////////////////////////////////////////////////////
     PIKA_EXPORT int report_errors();
     PIKA_EXPORT int report_errors(std::ostream& stream);
-}}    // namespace pika::util
+}    // namespace pika::util
 
 ////////////////////////////////////////////////////////////////////////////////
 #define PIKA_TEST(...)                                                         \

--- a/testing/testing/src/testing.cpp
+++ b/testing/testing/src/testing.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <string>
 
-namespace pika { namespace util {
+namespace pika::util {
     namespace detail {
 
         std::atomic<std::size_t> fixture::sanity_tests_(0);
@@ -148,4 +148,4 @@ namespace pika { namespace util {
             return 1;
         }
     }
-}}    // namespace pika::util
+}    // namespace pika::util

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -182,12 +182,12 @@ struct unlimited_number_of_chunks
     }
 };
 
-namespace pika { namespace parallel { namespace execution {
+namespace pika::parallel::execution {
     template <>
     struct is_executor_parameters<unlimited_number_of_chunks> : std::true_type
     {
     };
-}}}    // namespace pika::parallel::execution
+}    // namespace pika::parallel::execution
 
 void function_futures_register_work(std::uint64_t count, bool csv)
 {


### PR DESCRIPTION
Fixes #533.