### PR TITLE
Use C++20 in macos CI workflows

### DIFF
--- a/.github/workflows/macos_arm64_debug.yml
+++ b/.github/workflows/macos_arm64_debug.yml
@@ -43,6 +43,7 @@ jobs:
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_CXX_STANDARD=20 \
               -DPIKA_WITH_MALLOC=system \
               -DPIKA_WITH_EXAMPLES=ON \
               -DPIKA_WITH_TESTS=ON \

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -42,6 +42,7 @@ jobs:
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_CXX_STANDARD=20 \
               -DPIKA_WITH_UNITY_BUILD=ON \
               -DPIKA_WITH_EXAMPLES=ON \
               -DPIKA_WITH_TESTS=ON \


### PR DESCRIPTION
Trying to trigger the failure in #540.