### PR TITLE
`async_rw_mutex` enhancements

### DIFF
--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -718,6 +718,22 @@ namespace pika::execution::experimental {
                 return operation_state<R>{PIKA_FORWARD(R, r),
                     PIKA_MOVE(s.prev_state), PIKA_MOVE(s.state)};
             }
+
+            template <typename R>
+            friend auto tag_invoke(pika::execution::experimental::connect_t,
+                sender const& s, R&& r)
+            {
+                if constexpr (AccessType ==
+                    detail::async_rw_mutex_access_type::readwrite)
+                {
+                    static_assert(sizeof(R) == 0,
+                        "senders returned from async_rw_mutex::readwrite are "
+                        "not l-lvalue connectable");
+                }
+
+                return operation_state<R>{
+                    PIKA_FORWARD(R, r), s.prev_state, s.state};
+            }
         };
 
         PIKA_NO_UNIQUE_ADDRESS value_type value;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -516,7 +516,7 @@ namespace pika::execution::experimental {
             }
         };
 
-        allocator_type alloc;
+        PIKA_NO_UNIQUE_ADDRESS allocator_type alloc;
 
         detail::async_rw_mutex_access_type prev_access =
             detail::async_rw_mutex_access_type::readwrite;
@@ -720,8 +720,8 @@ namespace pika::execution::experimental {
             }
         };
 
-        value_type value;
-        allocator_type alloc;
+        PIKA_NO_UNIQUE_ADDRESS value_type value;
+        PIKA_NO_UNIQUE_ADDRESS allocator_type alloc;
 
         detail::async_rw_mutex_access_type prev_access =
             detail::async_rw_mutex_access_type::readwrite;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -194,12 +194,6 @@ namespace pika::execution::experimental {
                 PIKA_ASSERT(state);
                 return state->get_value();
             }
-
-            operator ReadT&() const
-            {
-                PIKA_ASSERT(state);
-                return state->get_value();
-            }
         };
 
         template <typename ReadWriteT, typename ReadT>
@@ -236,12 +230,6 @@ namespace pika::execution::experimental {
                 async_rw_mutex_access_wrapper const&) = delete;
 
             ReadWriteT& get()
-            {
-                PIKA_ASSERT(state);
-                return state->get_value();
-            }
-
-            operator ReadWriteT&()
             {
                 PIKA_ASSERT(state);
                 return state->get_value();

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -99,28 +99,19 @@ struct checker
     using size_t_readwrite_access_type =
         typename async_rw_mutex<std::size_t>::readwrite_access_type;
 
-    static_assert(
-        std::is_convertible<size_t_read_access_type, std::size_t const&>::value,
-        "The given access type must be convertible to a const reference of "
-        "given template type");
-    static_assert(
-        std::is_convertible<size_t_readwrite_access_type, std::size_t&>::value,
-        "The given access type must be convertible to a reference of given "
-        "template type");
-
-    void operator()(std::size_t const& x)
+    void operator()(size_t_read_access_type x)
     {
         PIKA_TEST(expect_readonly);
-        PIKA_TEST_EQ(x, expected_predecessor_value);
+        PIKA_TEST_EQ(x.get(), expected_predecessor_value);
         PIKA_TEST_RANGE(++count, count_min, count_max);
     }
 
-    void operator()(std::size_t& x)
+    void operator()(size_t_readwrite_access_type x)
     {
         PIKA_ASSERT(!expect_readonly);
-        PIKA_TEST_EQ(x, expected_predecessor_value);
+        PIKA_TEST_EQ(x.get(), expected_predecessor_value);
         PIKA_TEST_RANGE(++count, count_min, count_max);
-        ++x;
+        ++x.get();
     }
 
     // Non-void access types must be convertible to (const) references of the
@@ -130,28 +121,19 @@ struct checker
     using mytype_readwrite_access_type =
         typename async_rw_mutex<mytype, mytype_base>::readwrite_access_type;
 
-    static_assert(
-        std::is_convertible<mytype_read_access_type, mytype_base const&>::value,
-        "The given access type must be convertible to a const reference of "
-        "given template type");
-    static_assert(
-        std::is_convertible<mytype_readwrite_access_type, mytype&>::value,
-        "The given access type must be convertible to a reference of given "
-        "template type");
-
-    void operator()(mytype_base const& x)
+    void operator()(mytype_read_access_type x)
     {
         PIKA_TEST(expect_readonly);
-        PIKA_TEST_EQ(x.read(), expected_predecessor_value);
+        PIKA_TEST_EQ(x.get().read(), expected_predecessor_value);
         PIKA_TEST_RANGE(++count, count_min, count_max);
     }
 
-    void operator()(mytype& x)
+    void operator()(mytype_readwrite_access_type x)
     {
         PIKA_ASSERT(!expect_readonly);
-        PIKA_TEST_EQ(x.read(), expected_predecessor_value);
+        PIKA_TEST_EQ(x.get().read(), expected_predecessor_value);
         PIKA_TEST_RANGE(++count, count_min, count_max);
-        ++(x.readwrite());
+        ++(x.get().readwrite());
     }
 };
 

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -296,6 +296,10 @@ int pika_main(pika::program_options::variables_map& vm)
     test_shared_state_deadlock(async_rw_mutex<std::size_t>{0});
     test_shared_state_deadlock(async_rw_mutex<mytype, mytype_base>{mytype{}});
 
+    test_read_sender_copyable(async_rw_mutex<void>{});
+    test_read_sender_copyable(async_rw_mutex<std::size_t>{0});
+    test_read_sender_copyable(async_rw_mutex<mytype, mytype_base>{mytype{}});
+
     return pika::finalize();
 }
 

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -68,11 +68,11 @@ public:
 // from the async_rw_mutex senders.
 struct checker
 {
-    bool expect_readonly;
-    std::size_t expected_predecessor_value;
+    const bool expect_readonly;
+    const std::size_t expected_predecessor_value;
     std::atomic<std::size_t>& count;
-    std::size_t count_min;
-    std::size_t count_max = count_min;
+    const std::size_t count_min;
+    const std::size_t count_max = count_min;
 
     // Access types are differently tagged for read-only and read-write access.
     using void_read_access_type =
@@ -286,7 +286,7 @@ int pika_main(pika::program_options::variables_map& vm)
     test_moved(async_rw_mutex<std::size_t>{0});
     test_moved(async_rw_mutex<mytype, mytype_base>{mytype{}});
 
-    std::size_t iterations = 100;
+    constexpr std::size_t iterations = 1000;
     test_multiple_accesses(async_rw_mutex<void>{}, iterations);
     test_multiple_accesses(async_rw_mutex<std::size_t>{0}, iterations);
     test_multiple_accesses(


### PR DESCRIPTION
Changes a few essential and less essential things in `async_rw_mutex` for use in DLA-Future.
- The most important fix is in https://github.com/pika-org/pika/commit/ead0444d4ec1f41f40b2474e67436bb1e09d8ca7. It fixes deadlocks which happen if one tries to do a read-only access after a read-write access, and the read-only access is eagerly waited for with e.g. `sync_wait` in the same scope as the `async_rw_mutex` itself. This was caused by the `async_rw_mutex` holding on to shared states too long. I'm not 100% happy with the current fix (especially the `yield_while`), but it will do for now.
- This also makes read-only access senders connectable with l-value references.
- Removes the conversion operators from the wrapper types. They're gone because they cause problems when used in DLA-Future (specifically, they seem to require complete types which is a problem in DLA-Future where `async_rw_mutex`es of `Tile`s can be stored in `Tile`s).
- Minor changes are use of `no_unique_address` and more const/constexpr in various places.