### PR TITLE
Make `thread_pool_scheduler` bulk sender be correctly l-value connectable

### DIFF
--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -538,8 +538,7 @@ namespace pika::thread_pool_bulk_detail {
             template <typename Sender_, typename Shape_, typename F_,
                 typename Receiver_>
             operation_state(
-                pika::execution::experimental::thread_pool_scheduler&&
-                    scheduler,
+                pika::execution::experimental::thread_pool_scheduler scheduler,
                 Sender_&& sender, Shape_&& shape, F_&& f, Receiver_&& receiver)
               : scheduler(PIKA_MOVE(scheduler))
               , op_state(pika::execution::experimental::connect(
@@ -568,7 +567,7 @@ namespace pika::thread_pool_bulk_detail {
         }
 
         template <typename Receiver>
-        auto tag_invoke(pika::execution::experimental::connect_t,
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
             thread_pool_bulk_sender& s, Receiver&& receiver)
         {
             return operation_state<std::decay_t<Receiver>>{s.scheduler,

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1774,6 +1774,25 @@ void test_bulk()
         }
     }
 
+    // l-value reference sender
+    for (int n : ns)
+    {
+        std::vector<int> v(n, 0);
+        pika::thread::id parent_id = pika::this_thread::get_id();
+
+        auto s =
+            ex::schedule(ex::thread_pool_scheduler{}) | ex::bulk(n, [&](int i) {
+                ++v[i];
+                PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
+            });
+        tt::sync_wait(s);
+
+        for (int i = 0; i < n; ++i)
+        {
+            PIKA_TEST_EQ(v[i], 1);
+        }
+    }
+
     // The specification only allows integral shapes
 #if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
     {


### PR DESCRIPTION
Porting fix from https://github.com/STEllAR-GROUP/hpx/pull/6125.