### PR TITLE
Fix ault CI by adding `amdgpu_target` explicitly to the spack spec

### DIFF
--- a/.jenkins/cscs-ault/env-hipcc.sh
+++ b/.jenkins/cscs-ault/env-hipcc.sh
@@ -13,7 +13,7 @@ hwloc_version="2.6.0"
 spack_compiler="gcc@${gcc_version}"
 spack_arch="linux-centos8-zen"
 
-spack_spec="pika@main+rocm arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version}"
+spack_spec="pika@main+rocm amdgpu_target='gfx900,gfx906' arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version} ^whip amdgpu_target='gfx900,gfx906'"
 
 configure_extra_options+=" -DCMAKE_BUILD_RPATH=$(spack location -i ${spack_compiler})/lib64"
 configure_extra_options+=" -DCMAKE_HIP_ARCHITECTURES=gfx900;gfx906"


### PR DESCRIPTION
Add amdgpu_target for pika and whip (now required after spack update)