### PR TITLE
Require whip 0.1.0

### DIFF
--- a/cmake/pika_setup_whip.cmake
+++ b/cmake/pika_setup_whip.cmake
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(PIKA_WITH_GPU_SUPPORT)
-  pika_find_package(whip REQUIRED)
+  pika_find_package(whip 0.1.0 REQUIRED)
   if(NOT PIKA_FIND_PACKAGE)
     target_link_libraries(pika_base_libraries INTERFACE whip::whip)
   endif()


### PR DESCRIPTION
Since whip `main` already had 0.1.0 as the version I think this will keep working in CI without changes.