### PR TITLE
Bump CI image versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
     docker:
-      - image: pikaorg/pika-ci-base:13
+      - image: pikaorg/pika-ci-base:14
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:13
+    container: pikaorg/pika-ci-base:14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:13
+    container: pikaorg/pika-ci-base:14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/hip/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-hip:6
+    container: pikaorg/pika-ci-hip:7
     steps:
     - uses: actions/checkout@v3
     - name: Update apt repositories for ccache

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/fetchcontent/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:13
+    container: pikaorg/pika-ci-base:14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/sanitizers/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:13
+    container: pikaorg/pika-ci-base:14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: github/linux/tracy/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:13
+    container: pikaorg/pika-ci-base:14
 
     steps:
     - name: Check out Tracy


### PR DESCRIPTION
Use pinned version of `stdexec` (from https://github.com/pika-org/pika-ci-image/pull/27).