### PR TITLE
Disable Jenkins HIP configuration in bors configuration

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -37,7 +37,7 @@ status = [
   "ci/circleci: arm64_build",
 
   # Jenkins
-  "jenkins/cscs-ault/hipcc-release",
+  # "jenkins/cscs-ault/hipcc-release",
   "jenkins/cscs-daint/cce-debug",
   "jenkins/cscs-daint/cce-release",
   "jenkins/cscs-daint/clang-11-debug",


### PR DESCRIPTION
The Jenkins ault agent is currently down and blocking other PRs from merging.