### PR TITLE
compiler_fence: fix PPC assembler for Darwin, unbreak the build

### DIFF
--- a/libs/pika/config/include/pika/config/compiler_fence.hpp
+++ b/libs/pika/config/include/pika/config/compiler_fence.hpp
@@ -41,9 +41,13 @@ extern "C" void _mm_pause();
 
 #if defined(__i386__) || defined(__x86_64__)
 #define PIKA_SMT_PAUSE __asm__ __volatile__("rep; nop" : : : "memory")
-#elif defined(__ppc__)
+#elif defined(__ppc__) || defined(__ppc64__)
 // According to: https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc
+#ifdef __APPLE__
+#define PIKA_SMT_PAUSE __asm__ volatile("or r27,r27,r27")
+#else
 #define PIKA_SMT_PAUSE __asm__ __volatile__("or 27,27,27")
+#endif
 #elif defined(__arm__)
 #define PIKA_SMT_PAUSE __asm__ __volatile__("yield")
 #else


### PR DESCRIPTION
Fixes: https://github.com/pika-org/pika/issues/577

Existing one-size-fits-all PPC code breaks the build on Darwin. PR fixes it.
Also, ppc64 case should be accommodated.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
- [ ] I have changed the CI configurations and made a corresponding change to bors.toml.
