### PR TITLE
Disable `std_thread_scheduler_test` on macOS CI

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -74,6 +74,7 @@ jobs:
             --timeout 120 \
             --exclude-regex \
           "tests.unit.modules.execution.standalone_thread_pool_executor|\
+          tests.unit.modules.executors.std_thread_scheduler|\
           tests.unit.modules.resource_partitioner.used_pus"
     - name: Install
       shell: bash


### PR DESCRIPTION
It fails frequently and is listed on https://github.com/pika-org/pika/issues/191.