### PR TITLE
Change gfx906 arch to xnack- to avoid conflict in rocblas

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -36,7 +36,7 @@ status = [
   "ci/circleci: arm64_build",
 
   # Jenkins
-  # "jenkins/cscs-ault/hipcc-release",
+  "jenkins/cscs-ault/hipcc-release",
   "jenkins/cscs-daint/cce-debug",
   "jenkins/cscs-daint/cce-release",
   "jenkins/cscs-daint/clang-11-debug",

--- a/.jenkins/cscs-ault/env-hipcc.sh
+++ b/.jenkins/cscs-ault/env-hipcc.sh
@@ -15,10 +15,10 @@ spack_arch="linux-centos8-zen"
 stdexec_version="c0fe16f451137b00ceb85d912ec3a288990ce766"
 
 # The xnack- architectures are not supported by rocblas@5.3.3
-spack_spec="pika@main+rocm+p2300 amdgpu_target='gfx900,gfx906:xnack-' arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version} ^whip amdgpu_target='gfx900,gfx906:xnack-' ^stdexec@${stdexec_version}"
+spack_spec="pika@main+rocm+p2300 amdgpu_target='gfx906:xnack-' arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version} ^whip amdgpu_target='gfx906:xnack-' ^stdexec@${stdexec_version}"
 
 configure_extra_options+=" -DCMAKE_BUILD_RPATH=$(spack location -i ${spack_compiler})/lib64"
-configure_extra_options+=" -DCMAKE_HIP_ARCHITECTURES=gfx900;gfx906:xnack-"
+configure_extra_options+=" -DCMAKE_HIP_ARCHITECTURES=gfx906:xnack-"
 configure_extra_options+=" -DPIKA_WITH_HIP=ON"
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"

--- a/.jenkins/cscs-ault/env-hipcc.sh
+++ b/.jenkins/cscs-ault/env-hipcc.sh
@@ -15,10 +15,10 @@ spack_arch="linux-centos8-zen"
 stdexec_version="c0fe16f451137b00ceb85d912ec3a288990ce766"
 
 # The xnack- architectures are not supported by rocblas@5.3.3
-spack_spec="pika@main+rocm+p2300 amdgpu_target='gfx900,gfx906' arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version} ^whip amdgpu_target='gfx900,gfx906' ^stdexec@${stdexec_version}"
+spack_spec="pika@main+rocm+p2300 amdgpu_target='gfx900,gfx906:xnack-' arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^hip@${hip_version} ^whip amdgpu_target='gfx900,gfx906:xnack-' ^stdexec@${stdexec_version}"
 
 configure_extra_options+=" -DCMAKE_BUILD_RPATH=$(spack location -i ${spack_compiler})/lib64"
-configure_extra_options+=" -DCMAKE_HIP_ARCHITECTURES=gfx900;gfx906"
+configure_extra_options+=" -DCMAKE_HIP_ARCHITECTURES=gfx900;gfx906:xnack-"
 configure_extra_options+=" -DPIKA_WITH_HIP=ON"
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"

--- a/libs/pika/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_cuda/tests/unit/CMakeLists.txt
@@ -10,16 +10,11 @@ set(tests
     cuda_bulk
     cuda_pool
     cuda_scheduler
+    cuda_sender
     cuda_stream
     cusolver_handle
     then_with_stream
 )
-
-if(PIKA_WITH_CUDA)
-  list(APPEND tests cuda_sender)
-elseif(PIKA_WITH_HIP)
-  set(compile_tests cuda_sender)
-endif()
 
 set(cublas_matmul_PARAMETERS THREADS 4)
 set(cuda_sender_PARAMETERS THREADS 4)

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -45,7 +45,6 @@ auto launch_saxpy_kernel(pika::cuda::experimental::cuda_scheduler& cuda_sched,
 template <typename T>
 __global__ void trivial_kernel(T val)
 {
-    // TODO: Fingers crossed that printf now works with HIP?
     printf("hello from gpu with value %f\n", static_cast<double>(val));
 }
 

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -126,8 +126,16 @@ int pika_main(pika::program_options::variables_map& vm)
     std::size_t device = vm["device"].as<std::size_t>();
     //
     unsigned int seed = (unsigned int) std::time(nullptr);
+#if !defined(PIKA_HAVE_HIP)
+    // ROCm Clang-15 (HIP 5.3.3) fails to compile this with an internal compiler
+    // error. See https://github.com/pika-org/pika/issues/585 for more details.
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
+#else
+    std::cout << "The --seed command line argument is ignored because HIP is ";
+    std::cout << "enabled. See https://github.com/pika-org/pika/issues/585 ";
+    std::cout << "for more details." << std::endl;
+#endif
 
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);


### PR DESCRIPTION
Also removes gfx900, as all Vega10 have been removed from ault.

Fixes #384.