### PR TITLE
Move nested `done_type` helper structs into common definition

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -143,9 +143,6 @@ namespace pika::ensure_started_detail {
             // the predecessor work is released as soon as possible.
             std::optional<operation_state_type> os;
 
-            struct done_type
-            {
-            };
             template <typename Tuple>
             struct value_types_helper
             {
@@ -161,8 +158,8 @@ namespace pika::ensure_started_detail {
             using error_type =
                 pika::util::detail::unique_t<pika::util::detail::prepend_t<
                     error_types<pika::detail::variant>, std::exception_ptr>>;
-            pika::detail::variant<pika::detail::monostate, done_type,
-                error_type, value_type>
+            pika::detail::variant<pika::detail::monostate,
+                pika::execution::detail::stopped_type, error_type, value_type>
                 v;
 
             using continuation_type =
@@ -252,7 +249,7 @@ namespace pika::ensure_started_detail {
                     PIKA_UNREACHABLE;
                 }
 
-                void operator()(done_type)
+                void operator()(pika::execution::detail::stopped_type)
                 {
                     pika::execution::experimental::set_stopped(
                         PIKA_MOVE(receiver));

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -236,7 +236,7 @@ namespace pika::ensure_started_detail {
             }
 
             template <typename Receiver>
-            struct done_error_value_visitor
+            struct stopped_error_value_visitor
             {
                 PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
@@ -344,7 +344,7 @@ namespace pika::ensure_started_detail {
                     // TODO: Should this preserve the scheduler? It does not
                     // if we call set_* inline.
                     pika::detail::visit(
-                        done_error_value_visitor<Receiver>{
+                        stopped_error_value_visitor<Receiver>{
                             PIKA_FORWARD(Receiver, receiver)},
                         PIKA_MOVE(v));
                 }
@@ -362,7 +362,7 @@ namespace pika::ensure_started_detail {
                         // directly again.
                         l.unlock();
                         pika::detail::visit(
-                            done_error_value_visitor<Receiver>{
+                            stopped_error_value_visitor<Receiver>{
                                 PIKA_FORWARD(Receiver, receiver)},
                             PIKA_MOVE(v));
                     }
@@ -377,7 +377,7 @@ namespace pika::ensure_started_detail {
                                 receiver = PIKA_FORWARD(
                                     Receiver, receiver)]() mutable {
                                 pika::detail::visit(
-                                    done_error_value_visitor<Receiver>{
+                                    stopped_error_value_visitor<Receiver>{
                                         PIKA_MOVE(receiver)},
                                     PIKA_MOVE(v));
                             });

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -151,9 +151,6 @@ namespace pika::split_detail {
                 using type = pika::util::detail::transform_t<Tuple, std::decay>;
             };
 
-            struct done_type
-            {
-            };
             using value_type = pika::util::detail::transform_t<
                 typename pika::execution::experimental::sender_traits<Sender>::
                     template value_types<std::tuple, pika::detail::variant>,
@@ -166,8 +163,8 @@ namespace pika::split_detail {
                                 pika::detail::variant>,
                         std::decay>,
                     std::exception_ptr>>;
-            pika::detail::variant<pika::detail::monostate, done_type,
-                error_type, value_type>
+            pika::detail::variant<pika::detail::monostate,
+                pika::execution::detail::stopped_type, error_type, value_type>
                 v;
 
             using continuation_type =
@@ -258,7 +255,7 @@ namespace pika::split_detail {
                     PIKA_UNREACHABLE;
                 }
 
-                void operator()(done_type)
+                void operator()(pika::execution::detail::stopped_type)
                 {
                     pika::execution::experimental::set_stopped(
                         PIKA_MOVE(receiver));

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -246,7 +246,7 @@ namespace pika::split_detail {
             }
 
             template <typename Receiver>
-            struct done_error_value_visitor
+            struct stopped_error_value_visitor
             {
                 PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
@@ -352,7 +352,7 @@ namespace pika::split_detail {
                     // TODO: Should this preserve the scheduler? It does not
                     // if we call set_* inline.
                     pika::detail::visit(
-                        done_error_value_visitor<Receiver>{
+                        stopped_error_value_visitor<Receiver>{
                             PIKA_FORWARD(Receiver, receiver)},
                         v);
                 }
@@ -371,7 +371,7 @@ namespace pika::split_detail {
                         // directly again.
                         l.unlock();
                         pika::detail::visit(
-                            done_error_value_visitor<Receiver>{
+                            stopped_error_value_visitor<Receiver>{
                                 PIKA_FORWARD(Receiver, receiver)},
                             v);
                     }
@@ -389,7 +389,7 @@ namespace pika::split_detail {
                                 receiver = PIKA_FORWARD(
                                     Receiver, receiver)]() mutable {
                                 pika::detail::visit(
-                                    done_error_value_visitor<Receiver>{
+                                    stopped_error_value_visitor<Receiver>{
                                         PIKA_MOVE(receiver)},
                                     v);
                             });

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -199,7 +199,7 @@ namespace pika::split_tuple_detail {
         }
 
         template <std::size_t Index, typename Receiver>
-        struct done_error_value_visitor
+        struct stopped_error_value_visitor
         {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
@@ -321,7 +321,7 @@ namespace pika::split_tuple_detail {
                 // values/errors have been stored into the shared state.
                 // We can trigger the continuation directly.
                 pika::detail::visit(
-                    done_error_value_visitor<Index, Receiver>{
+                    stopped_error_value_visitor<Index, Receiver>{
                         PIKA_FORWARD(Receiver, receiver)},
                     v);
             }
@@ -340,7 +340,7 @@ namespace pika::split_tuple_detail {
                     // directly again.
                     l.unlock();
                     pika::detail::visit(
-                        done_error_value_visitor<Index, Receiver>{
+                        stopped_error_value_visitor<Index, Receiver>{
                             PIKA_FORWARD(Receiver, receiver)},
                         v);
                 }
@@ -357,7 +357,7 @@ namespace pika::split_tuple_detail {
                                                receiver = PIKA_FORWARD(Receiver,
                                                    receiver)]() mutable {
                         pika::detail::visit(
-                            done_error_value_visitor<Index, Receiver>{
+                            stopped_error_value_visitor<Index, Receiver>{
                                 PIKA_MOVE(receiver)},
                             v);
                     };

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -90,9 +90,6 @@ namespace pika::split_tuple_detail {
                     pika::util::detail::pack>>>::type;
 #endif
 
-        struct done_type
-        {
-        };
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
         using error_type =
             pika::util::detail::unique_t<pika::util::detail::prepend_t<
@@ -112,8 +109,8 @@ namespace pika::split_tuple_detail {
                     std::decay>,
                 std::exception_ptr>>;
 #endif
-        pika::detail::variant<pika::detail::monostate, done_type, error_type,
-            value_type>
+        pika::detail::variant<pika::detail::monostate,
+            pika::execution::detail::stopped_type, error_type, value_type>
             v;
 
         using continuation_type = pika::util::detail::unique_function<void()>;
@@ -211,7 +208,7 @@ namespace pika::split_tuple_detail {
                 PIKA_UNREACHABLE;
             }
 
-            void operator()(done_type)
+            void operator()(pika::execution::detail::stopped_type)
             {
                 constexpr bool sends_stopped =
 #if defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -469,3 +469,10 @@ namespace pika::execution::experimental {
         typename pika::util::detail::invoke_result<connect_t, S, R>::type;
 }    // namespace pika::execution::experimental
 #endif
+
+namespace pika::execution::detail {
+    /// Helper type for storing set_stopped signals in variants.
+    struct stopped_type
+    {
+    };
+}    // namespace pika::execution::detail


### PR DESCRIPTION
A lot of sender adaptors use a `struct done_type {}` in variants to mark that `set_stopped` has been called. This:
- renames them to `struct stopped_type {}`, and
- moves them out of the sender definitions into a single, common definition (nesting them inside the senders increases debug bloat)

I've also renamed the helper visitors `done_error_value_visitor` to `stopped_error_value_visitor` to match the `done` to `stopped` change.