### PR TITLE
Add static asserts for senders that are not l-value connectable

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -475,6 +475,17 @@ namespace pika::ensure_started_detail {
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
         }
+
+        template <typename Receiver>
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
+            ensure_started_sender_type const&, Receiver&&)
+        {
+            static_assert(sizeof(Receiver) == 0,
+                "Are you missing a std::move? The ensure_started sender is not "
+                "copyable and thus not l-value connectable. Make sure you are "
+                "passing an r-value reference of the sender.");
+        }
     };
 
     template <typename Sender, typename Enable = void>

--- a/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
@@ -111,6 +111,18 @@ namespace pika::keep_future_detail {
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.future)};
         }
+
+        template <typename Receiver>
+        friend operation_state<Receiver, future_type>
+        tag_invoke(pika::execution::experimental::connect_t,
+            keep_future_sender const&, Receiver&&)
+        {
+            static_assert(sizeof(Receiver) == 0,
+                "Are you missing a std::move? The keep_future sender of a "
+                "future is not copyable (because future is not copyable) and "
+                "thus not l-value connectable. Make sure you are passing an "
+                "r-value reference of the sender.");
+        }
     };
 
     template <typename T>

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -310,6 +310,16 @@ namespace pika::let_error_detail {
             return operation_state<Receiver>(PIKA_MOVE(s.predecessor_sender),
                 PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
         }
+
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            let_error_sender_type const&, Receiver&&)
+        {
+            static_assert(sizeof(Receiver) == 0,
+                "Are you missing a std::move? The let_error sender is not "
+                "copyable and thus not l-value connectable. Make sure you are "
+                "passing an r-value reference of the sender.");
+        }
     };
 }    // namespace pika::let_error_detail
 

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -338,6 +338,16 @@ namespace pika::let_value_detail {
             return operation_state<Receiver>(PIKA_MOVE(s.predecessor_sender),
                 PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f));
         }
+
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            let_value_sender_type const&, Receiver&&)
+        {
+            static_assert(sizeof(Receiver) == 0,
+                "Are you missing a std::move? The let_value sender is not "
+                "copyable and thus not l-value connectable. Make sure you are "
+                "passing an r-value reference of the sender.");
+        }
     };
 }    // namespace pika::let_value_detail
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -521,6 +521,17 @@ namespace pika::split_tuple_detail {
         {
             return {PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.state)};
         }
+
+        template <typename Receiver>
+        friend operation_state<Receiver>
+        tag_invoke(pika::execution::experimental::connect_t,
+            split_tuple_sender_type const&, Receiver&&)
+        {
+            static_assert(sizeof(Receiver) == 0,
+                "Are you missing a std::move? The split_tuple sender is not "
+                "copyable and thus not l-value connectable. Make sure you are "
+                "passing an r-value reference of the sender.");
+        }
     };
 
     template <typename Sender, typename Allocator, std::size_t... Is>

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -800,6 +800,17 @@ namespace pika::execution::experimental {
                 .connect(detail::any_receiver<Ts...>{PIKA_FORWARD(R, r)});
         }
 
+        template <typename R>
+        friend detail::any_operation_state
+        tag_invoke(pika::execution::experimental::connect_t,
+            unique_any_sender const&, R&&)
+        {
+            static_assert(sizeof(R) == 0,
+                "Are you missing a std::move? unique_any_sender is not "
+                "copyable and thus not l-value connectable. Make sure you are "
+                "passing an r-value reference of the sender.");
+        }
+
         bool empty() const noexcept
         {
             return storage.empty();


### PR DESCRIPTION
This is an attempt to improve diagnostics when senders that should be moved aren't being moved in the right places. This PR adds static asserts that always fail in the l-value case with a hopefully useful error message to help understand what's gone wrong. With these changes GCC prints this:
```
/home/mjs/src/pika/libs/pika/execution/tests/unit/algorithm_split_tuple.cpp:170:51:   required from here
/home/mjs/src/pika/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp:530:44: error: static assertion failed: Are you missing a std::move? The split_tuple sender is not copyable and thus not l-value connectable. Make sure you are passing an r-value reference of the sender.
  530 |             static_assert(sizeof(Receiver) == 0,
      |                           ~~~~~~~~~~~~~~~~~^~~~
/home/mjs/src/pika/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp:530:44: note: ‘(sizeof (pika::sync_wait_detail::sync_wait_receiver_impl<pika::split_tuple_detail::split_tuple_sender_impl<const_reference_error_sender<std::tuple<int> >, std::allocator<int>, 0>::split_tuple_sender_type&>::sync_wait_receiver_type) == 0)’ evaluates to false
```

clang prints this:
```
/home/mjs/src/pika/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp:530:13: error: static_assert failed due to requirement 'sizeof(pika::sync_wait_detail::sync_wait_receiver_impl<pika::split_tuple_detail::split_tuple_sender_impl<const_reference_error_sender<std::tuple<int>>, std::allocator<int>, 0>::split_tuple_sender_type &>::sync_wait_receiver_type) == 0' "Are you missing a std::move? The split_tuple sender is not copyable and thus not l-value connectable. Make sure you are passing an r-value reference of the sender."
            static_assert(sizeof(Receiver) == 0,
            ^             ~~~~~~~~~~~~~~~~~~~~~
/home/mjs/src/pika/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp:226:24: note: in instantiation of function template specialization 'pika::split_tuple_detail::tag_invoke<pika::sync_wait_detail::sync_wait_receiver_impl<pika::split_tuple_detail::split_tuple_sender_impl<const_reference_error_sender<std::tuple<int>>, std::allocator<int>, 0>::split_tuple_sender_type &>::sync_wait_receiver_type>' requested here
                return tag_invoke(static_cast<Tag const&>(*this),
```

It's not perfect, since clang doesn't seem to print the original line that fails to move a sender, but it seems like an improvement. Previously the error message would be of the type `no match for call to connect...`.