### PR TITLE
Add `const` to l-value reference connect overloads

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -219,7 +219,7 @@ namespace pika::cuda::experimental {
 
             template <typename Receiver>
             friend auto tag_invoke(pika::execution::experimental::connect_t,
-                then_on_host_sender_type& s, Receiver&& receiver)
+                then_on_host_sender_type const& s, Receiver&& receiver)
             {
                 return pika::execution::experimental::connect(s.sender,
                     then_on_host_receiver<Receiver, F>{

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -597,7 +597,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            then_with_cuda_stream_sender_type& s, Receiver&& receiver)
+            then_with_cuda_stream_sender_type const& s, Receiver&& receiver)
         {
             return operation_state<Receiver>(
                 PIKA_FORWARD(Receiver, receiver), s.f, s.sched, s.sender);

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -384,7 +384,7 @@ namespace pika::mpi::experimental {
             template <typename Receiver>
             friend constexpr auto
             tag_invoke(pika::execution::experimental::connect_t,
-                transform_mpi_sender_type& s, Receiver&& receiver)
+                transform_mpi_sender_type const& s, Receiver&& receiver)
             {
                 return operation_state<Receiver>(
                     PIKA_FORWARD(Receiver, receiver), s.f, s.sender, s.stream);

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -155,7 +155,7 @@ namespace pika::bulk_detail {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            bulk_sender_type& s, Receiver&& receiver)
+            bulk_sender_type const& s, Receiver&& receiver)
         {
             return pika::execution::experimental::connect(s.sender,
                 bulk_receiver<Receiver>(

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -133,7 +133,7 @@ namespace pika::drop_value_detail {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            drop_value_sender_type& r, Receiver&& receiver)
+            drop_value_sender_type const& r, Receiver&& receiver)
         {
             return pika::execution::experimental::connect(r.sender,
                 drop_value_receiver<Receiver>{

--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -109,7 +109,7 @@ namespace pika::just_detail {
 
             template <typename Receiver>
             friend auto tag_invoke(pika::execution::experimental::connect_t,
-                just_sender_type& s, Receiver&& receiver)
+                just_sender_type const& s, Receiver&& receiver)
             {
                 return operation_state<Receiver>{
                     PIKA_FORWARD(Receiver, receiver), s.ts};

--- a/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/keep_future.hpp
@@ -145,7 +145,7 @@ namespace pika::keep_future_detail {
         template <typename Receiver>
         friend operation_state<Receiver, future_type>
         tag_invoke(pika::execution::experimental::connect_t,
-            keep_future_sender& s, Receiver&& receiver)
+            keep_future_sender const& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), s.future};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -346,7 +346,7 @@ namespace pika::schedule_from_detail {
         template <typename Receiver>
         friend operation_state<Receiver>
         tag_invoke(pika::execution::experimental::connect_t,
-            schedule_from_sender_type& s, Receiver&& receiver)
+            schedule_from_sender_type const& s, Receiver&& receiver)
         {
             return {s.predecessor_sender, s.scheduler,
                 PIKA_FORWARD(Receiver, receiver)};

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -488,7 +488,7 @@ namespace pika::split_detail {
         template <typename Receiver>
         friend operation_state<Receiver>
         tag_invoke(pika::execution::experimental::connect_t,
-            split_sender_type& s, Receiver&& receiver)
+            split_sender_type const& s, Receiver&& receiver)
         {
             return {PIKA_FORWARD(Receiver, receiver), s.state};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -175,7 +175,7 @@ namespace pika::then_detail {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            then_sender_type& r, Receiver&& receiver)
+            then_sender_type const& r, Receiver&& receiver)
         {
             return pika::execution::experimental::connect(r.sender,
                 then_receiver<Receiver, F>{

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -398,7 +398,7 @@ namespace pika::when_all_impl {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            when_all_sender_type& s, Receiver&& receiver)
+            when_all_sender_type const& s, Receiver&& receiver)
         {
             return operation_state<Receiver, senders_type&,
                 num_predecessors - 1>(

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -375,7 +375,7 @@ namespace pika::when_all_vector_detail {
 
         template <typename Receiver>
         friend auto tag_invoke(pika::execution::experimental::connect_t,
-            when_all_vector_sender_type& s, Receiver&& receiver)
+            when_all_vector_sender_type const& s, Receiver&& receiver)
         {
             return operation_state<Receiver>(receiver, s.senders);
         }

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -580,7 +580,7 @@ namespace pika::execution::experimental::detail {
         virtual void clone_into(void* p) const = 0;
         using unique_any_sender_base<Ts...>::connect;
         virtual any_operation_state connect(
-            any_receiver<Ts...>&& receiver) & = 0;
+            any_receiver<Ts...>&& receiver) const& = 0;
     };
 
     template <typename... Ts>
@@ -626,8 +626,8 @@ namespace pika::execution::experimental::detail {
             return true;
         }
 
-        [[noreturn]] any_operation_state connect(any_receiver<Ts...>&&) &
-            override
+        [[noreturn]] any_operation_state connect(
+            any_receiver<Ts...>&&) const& override
         {
             throw_bad_any_call("any_sender", "connect");
         }
@@ -691,7 +691,8 @@ namespace pika::execution::experimental::detail {
             new (p) any_sender_impl(sender);
         }
 
-        any_operation_state connect(any_receiver<Ts...>&& receiver) & override
+        any_operation_state connect(
+            any_receiver<Ts...>&& receiver) const& override
         {
             return any_operation_state{sender, PIKA_MOVE(receiver)};
         }
@@ -879,8 +880,9 @@ namespace pika::execution::experimental {
                 pika::execution::experimental::set_stopped_t()>;
 
         template <typename R>
-        friend detail::any_operation_state tag_invoke(
-            pika::execution::experimental::connect_t, any_sender& s, R&& r)
+        friend detail::any_operation_state
+        tag_invoke(pika::execution::experimental::connect_t,
+            any_sender const& s, R&& r)
         {
             return s.storage.get().connect(
                 detail::any_receiver<Ts...>{PIKA_FORWARD(R, r)});

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -160,7 +160,7 @@ struct sender
 
     template <typename R>
     friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, sender& s, R&& r)
+    tag_invoke(pika::execution::experimental::connect_t, sender const& s, R&& r)
     {
         return {std::forward<R>(r), s.ts};
     }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -231,7 +231,7 @@ namespace pika::execution::experimental {
 
             template <typename Receiver>
             friend operation_state<Scheduler, Receiver>
-            tag_invoke(connect_t, sender& s, Receiver&& receiver)
+            tag_invoke(connect_t, sender const& s, Receiver&& receiver)
             {
                 return {s.scheduler, PIKA_FORWARD(Receiver, receiver),
                     s.fallback_annotation};


### PR DESCRIPTION
This makes no practical difference, but may prevent accidental moves from the reference in the future.