### PR TITLE
Minor fix in `cuda_sender` test

### DIFF
--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -172,7 +172,7 @@ int pika_main(pika::program_options::variables_map& vm)
     // and adding a continuation with a copy of a copy
     std::cout << "Copying executor : " << testd2 + 1 << std::endl;
     auto cuda_sched_copy = cuda_sched;
-    tt::sync_wait(ex::transfer_just(cuda_sched, testd2 + 1) |
+    tt::sync_wait(ex::transfer_just(cuda_sched_copy, testd2 + 1) |
         cu::then_with_stream(&cuda_trivial_kernel<double>) |
         cu::then_on_host([] { std::cout << "copy continuation triggered\n"; }));
 


### PR DESCRIPTION
The `cuda_sched_copy` variable was unused, `cuda_sched` was used instead. This simply uses the copy instead of the original scheduler. This shouldn't fix any bug or change the behaviour, but at least uses the variable.