### PR TITLE
Improve MPI polling

### DIFF
--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -35,6 +35,7 @@ pika_add_module(
     pika_execution_base
     pika_executors
     pika_memory
+    pika_resource_partitioner
     pika_threading_base
     pika_mpi_base
     pika_runtime

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -29,8 +29,10 @@ pika_add_module(
   DEPENDENCIES MPI::MPI_CXX
   MODULE_DEPENDENCIES
     pika_concurrency
+    pika_debugging
     pika_errors
     pika_execution_base
+    pika_executors
     pika_memory
     pika_threading_base
     pika_mpi_base

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -13,8 +13,9 @@ endif()
 
 # Default location is $PIKA_ROOT/libs/mpi/include
 set(async_mpi_headers
-    pika/async_mpi/mpi_exception.hpp pika/async_mpi/mpi_polling.hpp
-    pika/async_mpi/transform_mpi.hpp
+    pika/async_mpi/mpi_exception.hpp pika/async_mpi/mpi_helpers.hpp
+    pika/async_mpi/mpi_polling.hpp pika/async_mpi/dispatch_mpi.hpp
+    pika/async_mpi/trigger_mpi.hpp pika/async_mpi/transform_mpi.hpp
 )
 
 # Default location is $PIKA_ROOT/libs/mpi/src

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -199,8 +199,6 @@ namespace pika::mpi::experimental::detail {
                 using type = util::detail::transform_t<Tuple, std::decay>;
             };
 
-            // note that result_type = pika::detail::variant<std::tuple<MPI_Request>>;
-
             template <typename Receiver_, typename F_, typename Sender_>
             operation_state(Receiver_&& receiver, F_&& f, Sender_&& sender, stream_type s)
               : receiver(PIKA_FORWARD(Receiver_, receiver))

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -1,0 +1,230 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/transform_xxx.hpp
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+#include <pika/async_mpi/mpi_helpers.hpp>
+#include <pika/async_mpi/mpi_polling.hpp>
+#include <pika/concepts/concepts.hpp>
+#include <pika/datastructures/variant.hpp>
+#include <pika/debugging/demangle_helper.hpp>
+#include <pika/debugging/print.hpp>
+#include <pika/execution/algorithms/detail/helpers.hpp>
+#include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution/algorithms/transfer.hpp>
+#include <pika/execution_base/any_sender.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/executors/inline_scheduler.hpp>
+#include <pika/executors/limiting_scheduler.hpp>
+#include <pika/executors/thread_pool_scheduler.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/functional/invoke.hpp>
+#include <pika/functional/invoke_fused.hpp>
+#include <pika/mpi_base/mpi.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace pika::mpi::experimental::transform_mpi_detail {
+
+    // -----------------------------------------------------------------
+    // route calls through an impl layer for ADL resolution
+    template <typename Sender, typename F>
+    struct dispatch_mpi_impl
+    {
+        struct dispatch_mpi_type;
+    };
+
+    template <typename Sender, typename F>
+    using dispatch_mpi = typename dispatch_mpi_impl<Sender, F>::dispatch_mpi_type;
+
+    // -----------------------------------------------------------------
+    // transform MPI adapter - sender type
+    template <typename Sender, typename F>
+    struct dispatch_mpi_impl<Sender, F>::dispatch_mpi_type
+    {
+        using is_sender = void;
+
+        std::decay_t<Sender> sender;
+        std::decay_t<F> f;
+        stream_type stream;
+
+        // -----------------------------------------------------------------
+        // completion signatures
+        template <template <typename...> class Tuple, template <typename...> class Variant>
+        using value_types = Variant<Tuple<MPI_Request>>;
+
+        template <template <typename...> class Variant>
+        using error_types = pud::unique_t<
+            pud::prepend_t<typename exp::sender_traits<Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
+
+        static constexpr bool sends_done = false;
+
+        // -----------------------------------------------------------------
+        // operation state for a internal receiver
+        template <typename Receiver>
+        struct operation_state
+        {
+            std::decay_t<Receiver> receiver;
+            std::decay_t<F> f;
+            stream_type stream_;
+
+            // -----------------------------------------------------------------
+            // The mpi_receiver receives inputs from the previous sender,
+            // invokes the mpi call, and sets a callback on the polling handler
+            struct dispatch_mpi_receiver
+            {
+                using is_receiver = void;
+
+                operation_state& op_state;
+
+                template <typename Error>
+                friend constexpr void
+                tag_invoke(exp::set_error_t, dispatch_mpi_receiver&& r, Error&& error) noexcept
+                {
+                    exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_FORWARD(Error, error));
+                }
+
+                friend constexpr void tag_invoke(
+                    exp::set_stopped_t, dispatch_mpi_receiver&& r) noexcept
+                {
+                    exp::set_stopped(PIKA_MOVE(r.op_state.receiver));
+                }
+
+                // receive the MPI function invocable + arguments and add a request,
+                // then invoke the mpi function with the added request
+                // if the invocation gives an error, set_error
+                // otherwise return the request by passing it to set_value
+                template <typename... Ts,
+                    typename = std::enable_if_t<is_mpi_request_invocable_v<F, Ts...>>>
+                friend constexpr void
+                tag_invoke(exp::set_value_t, dispatch_mpi_receiver&& r, Ts&&... ts) noexcept
+                {
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() mutable {
+                            using namespace pika::debug::detail;
+                            using ts_element_type = std::tuple<std::decay_t<Ts>...>;
+                            using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
+
+                            // move/copy the received params into our local opstate
+                            r.op_state.ts.template emplace<ts_element_type>(
+                                PIKA_FORWARD(Ts, ts)...);
+                            // and get a reference to the tuple of local params
+                            auto& t = std::get<ts_element_type>(r.op_state.ts);
+                            // init a request
+                            MPI_Request request{MPI_REQUEST_NULL};
+                            int status = MPI_SUCCESS;
+                            // invoke the function, with the contents of the param tuple as args
+                            pud::invoke_fused(
+                                [&](auto&... ts) mutable {
+                                    // execute the mpi function call, passing in the request object
+                                    if constexpr (std::is_void_v<invoke_result_type>)
+                                    {
+                                        PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts..., &request);
+                                        PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                            "MPI_REQUEST_NULL returned from mpi "
+                                            "invocation");
+                                    }
+                                    else
+                                    {
+                                        status =
+                                            PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts..., &request);
+                                        PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                            "MPI_REQUEST_NULL returned from mpi "
+                                            "invocation");
+                                    }
+                                },
+                                t);
+                            // function called, Ts... can now be released (if refs hold lifetime)
+                            r.op_state.ts = {};
+                            // calls set_value(request), or set_error(mpi_exception(status))
+                            set_value_error_helper(status, PIKA_MOVE(r.op_state.receiver), request);
+                        },
+                        [&](std::exception_ptr ep) {
+                            exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));
+                        });
+                }
+
+                friend constexpr exp::empty_env tag_invoke(
+                    exp::get_env_t, dispatch_mpi_receiver const&) noexcept
+                {
+                    return {};
+                }
+            };
+
+            using operation_state_type =
+                exp::connect_result_t<std::decay_t<Sender>, dispatch_mpi_receiver>;
+            operation_state_type op_state;
+
+            template <typename Tuple>
+            struct value_types_helper
+            {
+                using type = pud::transform_t<Tuple, std::decay>;
+            };
+
+#if defined(PIKA_HAVE_STDEXEC)
+            using ts_type = pika::util::detail::prepend_t<
+                pika::util::detail::transform_t<
+                    execution::experimental::value_types_of_t<std::decay_t<Sender>,
+                        execution::experimental::empty_env, std::tuple, pika::detail::variant>,
+                    value_types_helper>,
+                pika::detail::monostate>;
+#else
+            using ts_type = pika::util::detail::prepend_t<
+                pika::util::detail::transform_t<
+                    typename execution::experimental::sender_traits<std::decay_t<Sender>>::
+                        template value_types<std::tuple, pika::detail::variant>,
+                    value_types_helper>,
+                pika::detail::monostate>;
+#endif
+            ts_type ts;
+
+            using result_type = pika::detail::variant<std::tuple<MPI_Request>>;
+            result_type result;
+
+            template <typename Receiver_, typename F_, typename Sender_>
+            operation_state(Receiver_&& receiver, F_&& f, Sender_&& sender, stream_type s)
+              : receiver(PIKA_FORWARD(Receiver_, receiver))
+              , f(PIKA_FORWARD(F_, f))
+              , stream_{s}
+              , op_state(exp::connect(PIKA_FORWARD(Sender_, sender), dispatch_mpi_receiver{*this}))
+            {
+                PIKA_DETAIL_DP(mpi_tran,
+                    debug(
+                        debug::detail::str<>("operation_state"), "stream", detail::stream_name(s)));
+            }
+
+            friend constexpr auto tag_invoke(exp::start_t, operation_state& os) noexcept
+            {
+                return exp::start(os.op_state);
+            }
+        };
+
+        template <typename Receiver>
+        friend constexpr auto
+        tag_invoke(exp::connect_t, dispatch_mpi_type const& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(
+                PIKA_FORWARD(Receiver, receiver), s.f, s.sender, s.stream);
+        }
+
+        template <typename Receiver>
+        friend constexpr auto tag_invoke(exp::connect_t, dispatch_mpi_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(
+                PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f), PIKA_MOVE(s.sender), s.stream);
+        }
+    };
+
+}    // namespace pika::mpi::experimental::transform_mpi_detail

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -22,8 +22,6 @@
 #include <pika/execution_base/any_sender.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
-#include <pika/executors/inline_scheduler.hpp>
-#include <pika/executors/limiting_scheduler.hpp>
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -61,6 +61,12 @@ namespace pika::mpi::experimental::detail {
         std::decay_t<F> f;
         stream_type stream;
 
+#if defined(PIKA_HAVE_STDEXEC)
+
+        using completion_signatures = pika::execution::experimental::completion_signatures<
+            pika::execution::experimental::set_value_t(MPI_Request)>;
+
+#else
         // -----------------------------------------------------------------
         // completion signatures
         template <template <typename...> class Tuple, template <typename...> class Variant>
@@ -70,6 +76,8 @@ namespace pika::mpi::experimental::detail {
         using error_types = pud::unique_t<
             pud::prepend_t<typename exp::sender_traits<Sender>::template error_types<Variant>,
                 std::exception_ptr>>;
+
+#endif
 
         static constexpr bool sends_done = false;
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -150,10 +150,20 @@ namespace pika::mpi::experimental::detail {
                                     }
                                 },
                                 t);
+
                             // function called, Ts... can now be released (if refs hold lifetime)
                             r.op_state.ts = {};
-                            // calls set_value(request), or set_error(mpi_exception(status))
-                            set_value_error_helper(status, PIKA_MOVE(r.op_state.receiver), request);
+                            if (poll_request(request))
+                            {
+                                // calls set_value(request), or set_error(mpi_exception(status))
+                                set_value_error_helper(
+                                    status, PIKA_MOVE(r.op_state.receiver), MPI_REQUEST_NULL);
+                            }
+                            else
+                            {
+                                set_value_error_helper(
+                                    status, PIKA_MOVE(r.op_state.receiver), request);
+                            }
                         },
                         [&](std::exception_ptr ep) {
                             exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -146,7 +146,7 @@ namespace pika::mpi::experimental::detail {
                                     }
                                     PIKA_DETAIL_DP(mpi_tran<7>,
                                         debug(str<>("dispatch_mpi_recv"), "invoke mpi",
-                                            detail::stream_name(r.op_state.stream_), request));
+                                            detail::stream_name(r.op_state.stream_), ptr(request)));
 
                                     PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
                                         "MPI_REQUEST_NULL returned from mpi invocation");
@@ -158,7 +158,7 @@ namespace pika::mpi::experimental::detail {
                             {
                                 PIKA_DETAIL_DP(mpi_tran<7>,
                                     debug(str<>("dispatch_mpi_recv"), "eager poll ok",
-                                        detail::stream_name(r.op_state.stream_), request));
+                                        detail::stream_name(r.op_state.stream_), ptr(request)));
                                 // calls set_value(request), or set_error(mpi_exception(status))
                                 set_value_error_helper(
                                     status, PIKA_MOVE(r.op_state.receiver), MPI_REQUEST_NULL);

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -34,10 +34,7 @@
 #include <utility>
 
 namespace pika::mpi::experimental::detail {
-
-    namespace {
-        namespace ex = execution::experimental;
-    }
+    namespace ex = execution::experimental;
 
     // -----------------------------------------------------------------
     // route calls through an impl layer for ADL isolation
@@ -240,28 +237,27 @@ namespace pika::mpi::experimental::detail {
 }    // namespace pika::mpi::experimental::detail
 
 namespace pika::mpi::experimental {
-
-    namespace ex = pika::execution::experimental;
-
     inline constexpr struct dispatch_mpi_t final
       : pika::functional::detail::tag_fallback<dispatch_mpi_t>
     {
     private:
         template <typename Sender, typename F,
-            PIKA_CONCEPT_REQUIRES_(ex::is_sender_v<std::decay_t<Sender>>)>
+            PIKA_CONCEPT_REQUIRES_(
+                pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
         friend constexpr PIKA_FORCEINLINE auto
         tag_fallback_invoke(dispatch_mpi_t, Sender&& sender, F&& f, stream_type s)
         {
             auto snd1 = detail::dispatch_mpi_sender<Sender, F>{
                 PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
-            return ex::make_unique_any_sender(std::move(snd1));
+            return pika::execution::experimental::make_unique_any_sender(std::move(snd1));
         }
 
         template <typename F>
         friend constexpr PIKA_FORCEINLINE auto
         tag_fallback_invoke(dispatch_mpi_t, F&& f, stream_type s)
         {
-            return ex::detail::partial_algorithm<dispatch_mpi_t, F>{PIKA_FORWARD(F, f), s};
+            return pika::execution::experimental::detail::partial_algorithm<dispatch_mpi_t, F>{
+                PIKA_FORWARD(F, f), s};
         }
 
     } dispatch_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -127,11 +127,12 @@ namespace pika::mpi::experimental::detail {
                             using ts_element_type = std::tuple<std::decay_t<Ts>...>;
                             using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
 
-                            using namespace pika::debug::detail;
                             PIKA_DETAIL_DP(mpi_tran<5>,
                                 debug(str<>("dispatch_mpi_recv"), "set_value_t", "stream",
                                     detail::stream_name(r.op_state.stream_)));
-
+#ifdef PIKA_HAVE_APEX
+                            apex::scoped_timer apex_post("pika::mpi::post");
+#endif
                             // init a request
                             MPI_Request request;
                             int status = MPI_SUCCESS;
@@ -164,6 +165,9 @@ namespace pika::mpi::experimental::detail {
 
                             if (poll_request(request))
                             {
+#ifdef PIKA_HAVE_APEX
+                                apex::scoped_timer apex_invoke("pika::mpi::trigger");
+#endif
                                 PIKA_DETAIL_DP(mpi_tran<7>,
                                     debug(str<>("dispatch_mpi_recv"), "eager poll ok",
                                         detail::stream_name(r.op_state.stream_), ptr(request)));

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -124,7 +124,6 @@ namespace pika::mpi::experimental::detail {
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
                             using namespace pika::debug::detail;
-                            using ts_element_type = std::tuple<std::decay_t<Ts>...>;
                             using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
 
                             PIKA_DETAIL_DP(mpi_tran<5>,

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -152,6 +152,15 @@ namespace pika::mpi::experimental::detail {
                                         "MPI_REQUEST_NULL returned from mpi invocation");
                                 },
                                 t);
+                            if (status != MPI_SUCCESS)
+                            {
+                                PIKA_DETAIL_DP(mpi_tran<5>,
+                                    debug(str<>("set_error"), "status != MPI_SUCCESS",
+                                        detail::error_message(status)));
+                                exp::set_error(PIKA_MOVE(r.op_state.receiver),
+                                    std::make_exception_ptr(mpi_exception(status)));
+                                return;
+                            }
                             // function called, Ts... can now be released (if refs hold lifetime)
                             r.op_state.ts = {};
                             if (poll_request(request))

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -34,7 +34,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::mpi::experimental::transform_mpi_detail {
+namespace pika::mpi::experimental::detail {
 
     // -----------------------------------------------------------------
     // by convention the title is 7 chars (for alignment)
@@ -178,4 +178,4 @@ namespace pika::mpi::experimental::transform_mpi_detail {
             request, detail::check_request_eager::no);
     }
 
-}    // namespace pika::mpi::experimental::transform_mpi_detail
+}    // namespace pika::mpi::experimental::detail

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -39,9 +39,7 @@ namespace pika::mpi::experimental::detail {
     template <int Level>
     inline constexpr print_threshold<Level, 0> mpi_tran("MPITRAN");
 
-    namespace {
-        namespace ex = pika::execution::experimental;
-    }
+    namespace ex = pika::execution::experimental;
 
     // -----------------------------------------------------------------
     template <typename T>

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -37,7 +37,7 @@ namespace pika::mpi::experimental::detail {
     // by convention the title is 7 chars (for alignment)
     using namespace pika::debug::detail;
     template <int Level>
-    inline print_threshold<Level, 0> mpi_tran("MPITRAN");
+    inline constexpr print_threshold<Level, 0> mpi_tran("MPITRAN");
 
     namespace {
         namespace ex = pika::execution::experimental;

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -1,0 +1,181 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/transform_xxx.hpp
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+#include <pika/async_mpi/mpi_polling.hpp>
+#include <pika/concepts/concepts.hpp>
+#include <pika/datastructures/variant.hpp>
+#include <pika/debugging/demangle_helper.hpp>
+#include <pika/debugging/print.hpp>
+#include <pika/execution/algorithms/detail/helpers.hpp>
+#include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution/algorithms/transfer.hpp>
+#include <pika/execution_base/any_sender.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/executors/inline_scheduler.hpp>
+#include <pika/executors/limiting_scheduler.hpp>
+#include <pika/executors/thread_pool_scheduler.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/functional/invoke.hpp>
+#include <pika/functional/invoke_fused.hpp>
+#include <pika/mpi_base/mpi.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace pika::mpi::experimental::transform_mpi_detail {
+
+    // -----------------------------------------------------------------
+    // by convention the title is 7 chars (for alignment)
+    using print_on = pika::debug::detail::enable_print<false>;
+    inline constexpr print_on mpi_tran("MPITRAN");
+
+    namespace pud = pika::util::detail;
+    namespace exp = execution::experimental;
+
+    // -----------------------------------------------------------------
+    template <typename T>
+    struct any_sender_helper
+    {
+        using type = exp::unique_any_sender<T>;
+    };
+
+    template <>
+    struct any_sender_helper<void>
+    {
+        using type = exp::unique_any_sender<>;
+    };
+
+    // -----------------------------------------------------------------
+    // is func(Ts..., MPI_Request) invokable
+    template <typename F, typename... Ts>
+    inline constexpr bool is_mpi_request_invocable_v =
+        std::is_invocable_v<F, std::add_lvalue_reference_t<std::decay_t<Ts>>..., MPI_Request*>;
+
+    // -----------------------------------------------------------------
+    // get return type of func(Ts..., MPI_Request)
+    template <typename F, typename... Ts>
+    using mpi_request_invoke_result_t = std::decay_t<
+        std::invoke_result_t<F, std::add_lvalue_reference_t<std::decay_t<Ts>>..., MPI_Request*>>;
+
+    // -----------------------------------------------------------------
+    // return a scheduler on the mpi pool, with or without stack
+    inline auto mpi_pool_scheduler(bool stack = true)
+    {
+        if (stack)
+        {
+            return exp::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())};
+        }
+        else
+        {
+            return exp::with_stacksize(
+                exp::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())},
+                execution::thread_stacksize::nostack);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // return a scheduler on the default pool with added priority if requested
+    inline auto default_pool_scheduler(
+        execution::thread_priority p = execution::thread_priority::normal)
+    {
+        if (p == execution::thread_priority::normal)
+        {
+            return exp::thread_pool_scheduler{&resource::get_thread_pool("default")};
+        }
+        return exp::with_priority(
+            exp::thread_pool_scheduler{&resource::get_thread_pool("default")}, p);
+    }
+
+    // -----------------------------------------------------------------
+    // depending on mpi_status : calls set_value (with Ts...) or set_error on the receiver
+    template <typename Receiver, typename... Ts>
+    void set_value_error_helper(int mpi_status, Receiver&& receiver, Ts&&... ts)
+    {
+        static_assert(sizeof...(Ts) <= 1, "Expecting at most one value");
+        if (mpi_status == MPI_SUCCESS)
+        {
+            exp::set_value(PIKA_FORWARD(Receiver, receiver), PIKA_FORWARD(Ts, ts)...);
+        }
+        else
+        {
+            exp::set_error(PIKA_FORWARD(Receiver, receiver),
+                std::make_exception_ptr(mpi_exception(mpi_status)));
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // adds a request callback to the mpi polling code which will call
+    // the set_value/set_error helper using the void return signature
+    template <typename OperationState>
+    void set_value_request_callback_void(MPI_Request request, OperationState& op_state)
+    {
+        detail::add_request_callback(
+            [&op_state](int status) mutable {
+                using namespace pika::debug::detail;
+                PIKA_DETAIL_DP(mpi_tran,
+                    debug(str<>("callback_void"), "stream", detail::stream_name(op_state.stream)));
+                op_state.ts = {};
+                set_value_error_helper(status, PIKA_MOVE(op_state.receiver));
+            },
+            request, detail::check_request_eager::yes);
+    }
+
+    // -----------------------------------------------------------------
+    // adds a request callback to the mpi polling code which will call
+    // the set_value/set_error helper with a valid return value
+    template <typename Result, typename OperationState>
+    void set_value_request_callback_non_void(MPI_Request request, OperationState& op_state)
+    {
+        detail::add_request_callback(
+            [&op_state](int status) mutable {
+                using namespace pika::debug::detail;
+                PIKA_DETAIL_DP(mpi_tran,
+                    debug(
+                        str<>("callback_nonvoid"), "stream", detail::stream_name(op_state.stream)));
+                op_state.ts = {};
+                PIKA_ASSERT(std::holds_alternative<Result>(op_state.result));
+                set_value_error_helper(status, PIKA_MOVE(op_state.receiver),
+                    PIKA_MOVE(std::get<Result>(op_state.result)));
+            },
+            request, detail::check_request_eager::yes);
+    }
+
+    // -----------------------------------------------------------------
+    // adds a request callback to the mpi polling code which will call
+    // notify_one to wake up a suspended task
+    template <typename OperationState>
+    void resume_request_callback(MPI_Request request, OperationState& op_state)
+    {
+        detail::add_request_callback(
+            [&op_state](int status) mutable {
+                using namespace pika::debug::detail;
+                PIKA_DETAIL_DP(mpi_tran,
+                    debug(str<>("callback_void_suspend_resume"), "stream",
+                        detail::stream_name(op_state.stream)));
+                op_state.ts = {};
+                op_state.status = status;
+
+                // wake up the suspended thread
+                {
+                    std::lock_guard lk(op_state.mutex_);
+                    op_state.completed = true;
+                }
+                op_state.cond_var_.notify_one();
+            },
+            // we do not need to eagerly check, because it was done earlier
+            request, detail::check_request_eager::no);
+    }
+
+}    // namespace pika::mpi::experimental::transform_mpi_detail

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -162,11 +162,11 @@ namespace pika::mpi::experimental::detail {
                         /*, "stream", detail::stream_name(op_state.stream)*/));
                 // wake up the suspended thread
                 {
-                    std::lock_guard lk(op_state.mutex_);
+                    std::lock_guard lk(op_state.mutex);
                     op_state.status = status;
                     op_state.completed = true;
                 }
-                op_state.cond_var_.notify_one();
+                op_state.cond_var.notify_one();
             },
             request);
     }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -162,8 +162,8 @@ namespace pika::mpi::experimental::detail {
             [&op_state](int status) mutable {
                 using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(mpi_tran<5>,
-                    debug(str<>("callback_void_suspend_resume"), "stream",
-                        detail::stream_name(op_state.stream)));
+                    debug(str<>("callback_void_suspend_resume")/*, "stream",
+                        detail::stream_name(op_state.stream)*/));
                 // wake up the suspended thread
                 {
                     std::lock_guard lk(op_state.mutex_);

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -84,7 +84,7 @@ namespace pika::mpi::experimental {
         // utility function to avoid duplication in eager check locations
         PIKA_EXPORT bool poll_request(MPI_Request& /*req*/);
 
-        inline constexpr bool throttling_enabled = true;
+        inline constexpr bool throttling_enabled = false;
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -13,6 +13,7 @@
 #include <pika/modules/concurrency.hpp>
 #include <pika/modules/execution_base.hpp>
 #include <pika/modules/memory.hpp>
+#include <pika/modules/resource_partitioner.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi.hpp>
 #include <pika/runtime/thread_pool_helpers.hpp>
@@ -30,10 +31,17 @@
 
 namespace pika::mpi::experimental {
 
-    enum progress_mode
+    //    enum progress_mode
+    //    {
+    //        can_block,
+    //        cannot_block
+    //    };
+
+    enum pool_create_mode
     {
-        can_block,
-        cannot_block
+        pika_decides = 0,
+        force_create,
+        force_no_create,
     };
 
     enum class stream_type : std::uint32_t
@@ -58,6 +66,8 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT bool add_request_callback(request_callback_function_type&&, MPI_Request);
         PIKA_EXPORT void register_polling(pika::threads::detail::thread_pool_base&);
         PIKA_EXPORT void unregister_polling(pika::threads::detail::thread_pool_base&);
+
+        PIKA_EXPORT std::size_t get_completion_mode_default();
 
         // -----------------------------------------------------------------
         // an MPI error handling type that we can use to intercept
@@ -133,6 +143,9 @@ namespace pika::mpi::experimental {
     /// mode 3 - the continuation is wrapped into a task but run inline on
     /// whichever pool is doing the polling, bypassing queues altogether
     PIKA_EXPORT std::size_t get_completion_mode();
+
+    PIKA_EXPORT bool setup_pool(
+        pika::resource::partitioner&, pool_create_mode mode = pool_create_mode::pika_decides);
 
     PIKA_EXPORT const std::string& get_pool_name();
     PIKA_EXPORT void set_pool_name(const std::string&);

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -31,16 +31,10 @@
 
 namespace pika::mpi::experimental {
 
-    //    enum progress_mode
-    //    {
-    //        can_block,
-    //        cannot_block
-    //    };
-
     template <typename E>
-    constexpr typename std::underlying_type<E>::type to_underlying(E e) noexcept
+    constexpr std::underlying_type_t<E> to_underlying(E e) noexcept
     {
-        return static_cast<typename std::underlying_type<E>::type>(e);
+        return static_cast<std::underlying_type_t<E>>(e);
     }
 
     enum pool_create_mode
@@ -122,7 +116,7 @@ namespace pika::mpi::experimental {
 
             /// this bit enables the use of a high priority task flag when a
             /// completion is handled so that the continuation is executed quickly
-            /// if transfered to a new task, or resumed from sleep.
+            /// if transferred to a new task, or resumed from sleep.
             high_priority = 0x08,
 
             /// 3 bits control the handler method,
@@ -145,20 +139,20 @@ namespace pika::mpi::experimental {
             return static_cast<handler_mode>(flags & to_underlying(handler_mode::method_mask));
         }
 
-        // 1 bit defines pool or no pool
-        inline bool use_HP_com(int mode)
+        // 1 bit defines high priority mode for completion
+        inline bool use_HP_completion(int mode)
         {
             return static_cast<bool>((mode & to_underlying(handler_mode::high_priority)) ==
                 to_underlying(handler_mode::high_priority));
         }
         // 1 bit defines inline or transfer completion
-        inline bool use_inline_com(int mode)
+        inline bool use_inline_completion(int mode)
         {
             return static_cast<bool>((mode & to_underlying(handler_mode::completion_inline)) ==
                 to_underlying(handler_mode::completion_inline));
         }
         // 1 bit defines inline or transfer mpi invocation
-        inline bool use_inline_req(int mode)
+        inline bool use_inline_request(int mode)
         {
             return static_cast<bool>((mode & to_underlying(handler_mode::request_inline)) ==
                 to_underlying(handler_mode::request_inline));

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -96,6 +96,21 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT std::shared_ptr<semaphore_type> get_semaphore(stream_type s);
 
         inline constexpr bool throttling_enabled = false;
+
+        enum handler_mode
+        {
+            yield_while = 0,
+            suspend_resume = 1,
+            new_task = 2,
+            continuation = 3,
+        };
+
+        // 0x30 : 2 bits define continuation mode
+        inline handler_mode get_handler_mode(int mode)
+        {
+            return static_cast<handler_mode>((mode & 0b11 << 4) >> 4);
+        }
+
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -111,6 +111,9 @@ namespace pika::mpi::experimental {
             return static_cast<handler_mode>((mode & 0b11 << 4) >> 4);
         }
 
+        // needed by static checks when debugging
+        PIKA_EXPORT int comm_world_size();
+
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -135,6 +135,9 @@ namespace pika::mpi::experimental {
     PIKA_EXPORT const std::string& get_pool_name();
     PIKA_EXPORT void set_pool_name(const std::string&);
 
+    // returns false if no custom mpi pool has been created
+    PIKA_EXPORT bool pool_exists();
+
     // initialize the pika::mpi background request handler
     // All ranks should call this function,
     // but only one thread per rank needs to do so

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -29,13 +29,15 @@
 #include <utility>
 #include <vector>
 
-namespace pika::mpi::experimental {
-
+namespace pika::mpi::experimental::detail {
     template <typename E>
     constexpr std::underlying_type_t<E> to_underlying(E e) noexcept
     {
         return static_cast<std::underlying_type_t<E>>(e);
     }
+}    // namespace pika::mpi::experimental::detail
+
+namespace pika::mpi::experimental {
 
     enum pool_create_mode
     {
@@ -119,15 +121,14 @@ namespace pika::mpi::experimental {
             /// if transferred to a new task, or resumed from sleep.
             high_priority = 0x08,
 
-            /// 3 bits control the handler method,
-            method_mask = 0x70,
+            /// 2 bits control the handler method,
+            method_mask = 0x30,
 
             /// the individual methods that are supported for dispatching continuations
             yield_while = 0x00,
             suspend_resume = 0x10,
             new_task = 0x20,
             continuation = 0x30,
-            original = 0x40,
 
             /// Default flags are to invoke inline, but transfer completion using a dedicated pool
             default_mode = use_pool | request_inline | high_priority | new_task,
@@ -136,32 +137,34 @@ namespace pika::mpi::experimental {
         // 2 bits define continuation mode
         inline handler_mode get_handler_mode(int flags)
         {
-            return static_cast<handler_mode>(flags & to_underlying(handler_mode::method_mask));
+            return static_cast<handler_mode>(
+                flags & detail::to_underlying(handler_mode::method_mask));
         }
 
         // 1 bit defines high priority mode for completion
         inline bool use_HP_completion(int mode)
         {
-            return static_cast<bool>((mode & to_underlying(handler_mode::high_priority)) ==
-                to_underlying(handler_mode::high_priority));
+            return static_cast<bool>((mode & detail::to_underlying(handler_mode::high_priority)) ==
+                detail::to_underlying(handler_mode::high_priority));
         }
         // 1 bit defines inline or transfer completion
         inline bool use_inline_completion(int mode)
         {
-            return static_cast<bool>((mode & to_underlying(handler_mode::completion_inline)) ==
-                to_underlying(handler_mode::completion_inline));
+            return static_cast<bool>(
+                (mode & detail::to_underlying(handler_mode::completion_inline)) ==
+                detail::to_underlying(handler_mode::completion_inline));
         }
         // 1 bit defines inline or transfer mpi invocation
         inline bool use_inline_request(int mode)
         {
-            return static_cast<bool>((mode & to_underlying(handler_mode::request_inline)) ==
-                to_underlying(handler_mode::request_inline));
+            return static_cast<bool>((mode & detail::to_underlying(handler_mode::request_inline)) ==
+                detail::to_underlying(handler_mode::request_inline));
         }
         // 1 bit defines whether we use a pool or not
         inline bool use_pool(int mode)
         {
-            return static_cast<bool>((mode & to_underlying(handler_mode::use_pool)) ==
-                to_underlying(handler_mode::use_pool));
+            return static_cast<bool>((mode & detail::to_underlying(handler_mode::use_pool)) ==
+                detail::to_underlying(handler_mode::use_pool));
         }
 
         inline const char* mode_string(int flags)
@@ -181,7 +184,7 @@ namespace pika::mpi::experimental {
                 return "suspend_resume";
                 break;
             default:
-                return "default";
+                return "invalid";
             }
         }
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -69,7 +69,7 @@ namespace pika::mpi::experimental {
         // -----------------------------------------------------------------
         /// Called by the mpi senders/executors to initiate throttling
         /// when necessary
-        PIKA_EXPORT void wait_for_throttling(stream_type);
+        //        PIKA_EXPORT void wait_for_throttling(stream_type);
 
         // -----------------------------------------------------------------
         // set an error handler for communicators that will be called
@@ -84,7 +84,7 @@ namespace pika::mpi::experimental {
         // utility function to avoid duplication in eager check locations
         PIKA_EXPORT bool poll_request(MPI_Request& /*req*/);
 
-        inline constexpr bool throttling_enabled = false;
+        //        inline constexpr bool throttling_enabled = false;
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -220,8 +220,8 @@ namespace pika::mpi::experimental {
     PIKA_EXPORT size_t get_work_count();
 
     // -----------------------------------------------------------------
-    /// set the maximume number of MPI_Request completions to
-    /// handle at each polling event
+    /// set the maximum number of MPI_Request completions to handle at each
+    /// polling event
     PIKA_EXPORT void set_max_polling_size(std::size_t);
     PIKA_EXPORT std::size_t get_max_polling_size();
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -111,6 +111,27 @@ namespace pika::mpi::experimental {
             return static_cast<handler_mode>((flags & (0b11 << 4)) >> 4);
         }
 
+        // 0x08: 1 bit defines pool or no pool
+        inline bool use_HP_com(int mode)
+        {
+            return static_cast<bool>((mode & (0b01 << 3)) >> 3);
+        }
+        // 0x04: 1 bit defines inline or transfer completion
+        inline bool use_inline_com(int mode)
+        {
+            return static_cast<bool>((mode & (0b01 << 2)) >> 2);
+        }
+        // 0x02: 1 bit defines inline or transfer mpi invocation
+        inline bool use_inline_req(int mode)
+        {
+            return static_cast<bool>((mode & (0b01 << 1)) >> 1);
+        }
+        // 0x01 : 1 bit defines whether we use a pool or not
+        inline bool use_pool(int mode)
+        {
+            return static_cast<bool>(mode & 0b01);
+        }
+
         inline const char* mode_string(int flags)
         {
             switch (get_handler_mode(flags))

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -53,16 +53,9 @@ namespace pika::mpi::experimental {
     namespace detail {
         using request_callback_function_type = pika::util::detail::unique_function<void(int)>;
 
-        enum struct check_request_eager : bool
-        {
-            no = false,
-            yes = true
-        };
-
         const char* stream_name(stream_type s);
 
-        PIKA_EXPORT bool add_request_callback(
-            request_callback_function_type&&, MPI_Request, check_request_eager);
+        PIKA_EXPORT bool add_request_callback(request_callback_function_type&&, MPI_Request);
         PIKA_EXPORT void register_polling(pika::threads::detail::thread_pool_base&);
         PIKA_EXPORT void unregister_polling(pika::threads::detail::thread_pool_base&);
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -84,7 +84,7 @@ namespace pika::mpi::experimental {
         // utility function to avoid duplication in eager check locations
         PIKA_EXPORT bool poll_request(MPI_Request& /*req*/);
 
-        inline constexpr bool throttling_enabled = false;
+        inline constexpr bool throttling_enabled = true;
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -85,7 +85,7 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT pika::threads::detail::polling_status poll();
 
         // utility function to avoid duplication in eager check locations
-        PIKA_EXPORT bool poll_request(MPI_Request& /*req*/);
+        PIKA_EXPORT bool poll_request(MPI_Request /*req*/);
 
         // -----------------------------------------------------------------
         using semaphore_type = pika::counting_semaphore<>;

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -26,8 +26,6 @@
 #include <utility>
 #include <vector>
 
-//#define DISALLOW_EAGER_POLLING_CHECK 1
-
 namespace pika::mpi::experimental {
 
     enum class stream_type : std::uint32_t
@@ -47,10 +45,16 @@ namespace pika::mpi::experimental {
     namespace detail {
         using request_callback_function_type = pika::util::detail::unique_function<void(int)>;
 
+        enum struct check_request_eager : bool
+        {
+            no = false,
+            yes = true
+        };
+
         const char* stream_name(stream_type s);
 
         PIKA_EXPORT bool add_request_callback(
-            request_callback_function_type&&, MPI_Request, bool, stream_type);
+            request_callback_function_type&&, MPI_Request, check_request_eager, stream_type);
         PIKA_EXPORT void register_polling(pika::threads::detail::thread_pool_base&);
         PIKA_EXPORT void unregister_polling(pika::threads::detail::thread_pool_base&);
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -30,6 +30,12 @@
 
 namespace pika::mpi::experimental {
 
+    enum progress_mode
+    {
+        can_block,
+        cannot_block
+    };
+
     enum class stream_type : std::uint32_t
     {
         automatic = 0,

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -81,7 +81,6 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT bool poll_request(MPI_Request& /*req*/);
 
         inline constexpr bool throttling_enabled = false;
-
     }    // namespace detail
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -318,6 +318,7 @@ namespace pika::mpi::experimental {
                                             r.op_state.resume = false;
                                             set_value_request_callback_suspend_resume<
                                                 invoke_result_type>(request, r.op_state);
+                                            PIKA_ASSERT(pika::threads::detail::get_self_id());
                                             priority_set_restore set_restore(
                                                 pika::execution::thread_priority::high);
                                             std::unique_lock l{r.op_state.mutex_};

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -70,7 +70,7 @@ namespace pika::mpi::experimental {
             detail::add_request_callback(
                 [&op_state](int status) mutable {
                     using namespace pika::debug::detail;
-                    PIKA_DP(mpi_tran,
+                    PIKA_DETAIL_DP(mpi_tran,
                         debug(str<>("callback_void"), "stream",
                             detail::stream_name(op_state.stream)));
                     op_state.ts = {};
@@ -85,7 +85,7 @@ namespace pika::mpi::experimental {
             detail::add_request_callback(
                 [&op_state](int status) mutable {
                     using namespace pika::debug::detail;
-                    PIKA_DP(mpi_tran,
+                    PIKA_DETAIL_DP(mpi_tran,
                         debug(str<>("callback_nonvoid"), "stream",
                             detail::stream_name(op_state.stream)));
                     op_state.ts = {};
@@ -103,7 +103,7 @@ namespace pika::mpi::experimental {
             detail::add_request_callback(
                 [&op_state](int status) mutable {
                     using namespace pika::debug::detail;
-                    PIKA_DP(mpi_tran,
+                    PIKA_DETAIL_DP(mpi_tran,
                         debug(str<>("callback_void_suspend_resume"), "stream",
                             detail::stream_name(op_state.stream)));
                     op_state.ts = {};
@@ -263,7 +263,7 @@ namespace pika::mpi::experimental {
                                 {
                                     pika::util::detail::invoke_fused(
                                         [&](auto&... ts) mutable {
-                                            PIKA_DP(mpi_tran,
+                                            PIKA_DETAIL_DP(mpi_tran,
                                                 debug(str<>("mpi invoke"), dec<2>(mode),
                                                     print_type<invoke_result_type>()));
                                             // execute the mpi function call, passing in the request object
@@ -327,12 +327,12 @@ namespace pika::mpi::experimental {
                                 // modes 3,4,5,6,7,8 ....
                                 else
                                 {
-                                    PIKA_DP(mpi_tran,
+                                    PIKA_DETAIL_DP(mpi_tran,
                                         debug(str<>("throttle?"), "stream",
                                             detail::stream_name(r.op_state.stream)));
                                     // throttle if too many "in flight"
                                     detail::wait_for_throttling(r.op_state.stream);
-                                    PIKA_DP(mpi_tran,
+                                    PIKA_DETAIL_DP(mpi_tran,
                                         debug(str<>("mpi invoke"), dec<2>(mode),
                                             print_type<invoke_result_type>()));
                                     if constexpr (std::is_void_v<invoke_result_type>)
@@ -471,7 +471,7 @@ namespace pika::mpi::experimental {
                   , op_state(pika::execution::experimental::connect(
                         PIKA_FORWARD(Sender_, sender), transform_mpi_receiver{*this}))
                 {
-                    PIKA_DP(mpi_tran,
+                    PIKA_DETAIL_DP(mpi_tran,
                         debug(debug::detail::str<>("operation_state"), "stream",
                             detail::stream_name(s)));
                 }
@@ -531,11 +531,11 @@ namespace pika::mpi::experimental {
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(
                 pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(transform_mpi_t, Sender&& sender,
-            F&& f, stream_type s = stream_type::automatic)
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
+            transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
         {
             using namespace transform_mpi_detail;
-            PIKA_DP(mpi_tran,
+            PIKA_DETAIL_DP(mpi_tran,
                 debug(
                     debug::detail::str<>("tag_fallback_invoke"), "stream", detail::stream_name(s)));
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -34,18 +34,19 @@
 
 namespace pika::mpi::experimental {
 
-    namespace pud = pika::util::detail;
-    namespace exp = execution::experimental;
+    namespace {
+        namespace pud = pika::util::detail;
+        namespace ex = execution::experimental;
+    }    // namespace
 
     inline constexpr struct transform_mpi_t final
       : pika::functional::detail::tag_fallback<transform_mpi_t>
     {
     private:
         template <typename Sender, typename F,
-            PIKA_CONCEPT_REQUIRES_(exp::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE exp::unique_any_sender<>
-        tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f,
-            /*progress_mode p, */ stream_type s = stream_type::automatic)
+            PIKA_CONCEPT_REQUIRES_(ex::is_sender_v<std::decay_t<Sender>>)>
+        friend constexpr PIKA_FORCEINLINE ex::unique_any_sender<> tag_fallback_invoke(
+            transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
         {
             using namespace pika::mpi::experimental::detail;
             using namespace pika::debug::detail;
@@ -53,16 +54,16 @@ namespace pika::mpi::experimental {
                 debug(str<>("transform_mpi_t"), "tag_fallback_invoke", "stream",
                     detail::stream_name(s)));
 
+            using ex::make_unique_any_sender;
+            using ex::then;
+            using ex::transfer;
             using execution::thread_priority;
-            using exp::make_unique_any_sender;
-            using exp::then;
-            using exp::transfer;
 
             // get the mpi completion mode
             auto mode = get_completion_mode();
 
-            bool inline_com = use_inline_com(mode);
-            bool inline_req = use_inline_req(mode);
+            bool inline_com = use_inline_completion(mode);
+            bool inline_req = use_inline_request(mode);
 
 #ifdef PIKA_DEBUG
             // ----------------------------------------------------------
@@ -72,33 +73,35 @@ namespace pika::mpi::experimental {
 
             if (pool_exists() != need_pool)
             {
-                std::cerr << "mode " << mode << " pool_exists() " << pool_exists() << " need_pool "
-                          << need_pool << std::endl;
+                PIKA_DETAIL_DP(mpi_tran<1>,
+                    error(str<>("transform_mpi"), "mode", mode, "pool_exists()", pool_exists(),
+                        "need_pool", need_pool));
             }
             PIKA_ASSERT(pool_exists() == need_pool);
 #endif
 
             using execution::thread_priority;
-            thread_priority p = use_HP_com(mode) ? thread_priority::high : thread_priority::normal;
+            thread_priority p =
+                use_HP_completion(mode) ? thread_priority::high : thread_priority::normal;
             if (inline_req)
             {
                 return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f), s} |
                     pika::execution::experimental::let_value(
-                        [=](MPI_Request request) -> exp::unique_any_sender<> {
+                        [=](MPI_Request request) -> ex::unique_any_sender<> {
                             if (inline_com)
                             {
                                 if (request == MPI_REQUEST_NULL)
-                                    return exp::just();
+                                    return ex::just();
                                 else
-                                    return exp::just(request) | trigger_mpi(mode);
+                                    return ex::just(request) | trigger_mpi(mode);
                             }
                             else
                             {
                                 if (request == MPI_REQUEST_NULL)
-                                    return exp::just() | transfer(default_pool_scheduler(p));
+                                    return ex::just() | transfer(default_pool_scheduler(p));
                                 else
-                                    return exp::just(request) |
-                                        transfer(default_pool_scheduler(p)) | trigger_mpi(mode);
+                                    return ex::just(request) | transfer(default_pool_scheduler(p)) |
+                                        trigger_mpi(mode);
                             }
                         });
             }
@@ -107,20 +110,20 @@ namespace pika::mpi::experimental {
                 auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
                 return dispatch_mpi_sender<decltype(snd0), F>{
                            PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s} |
-                    exp::let_value([=](MPI_Request request) -> exp::unique_any_sender<> {
+                    ex::let_value([=](MPI_Request request) -> ex::unique_any_sender<> {
                         if (inline_com)
                         {
                             if (request == MPI_REQUEST_NULL)
-                                return exp::just();
+                                return ex::just();
                             else
-                                return exp::just(request) | trigger_mpi(mode);
+                                return ex::just(request) | trigger_mpi(mode);
                         }
                         else
                         {
                             if (request == MPI_REQUEST_NULL)
-                                return exp::just() | transfer(default_pool_scheduler(p));
+                                return ex::just() | transfer(default_pool_scheduler(p));
                             else
-                                return exp::just(request) | transfer(default_pool_scheduler(p)) |
+                                return ex::just(request) | transfer(default_pool_scheduler(p)) |
                                     trigger_mpi(mode);
                         }
                     });
@@ -131,11 +134,11 @@ namespace pika::mpi::experimental {
         // tag invoke overload for mpi_transform
         //
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transform_mpi_t, F&& f, /*progress_mode p, */ stream_type s = stream_type::automatic)
+        friend constexpr PIKA_FORCEINLINE auto
+        tag_fallback_invoke(transform_mpi_t, F&& f, stream_type s = stream_type::automatic)
         {
-            return exp::detail::partial_algorithm<transform_mpi_t, F,
-                /*progress_mode, */ stream_type>{PIKA_FORWARD(F, f), /*p, */ s};
+            return ex::detail::partial_algorithm<transform_mpi_t, F, stream_type>{
+                PIKA_FORWARD(F, f), /*p, */ s};
         }
 
     } transform_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -383,7 +383,7 @@ namespace pika::mpi::experimental {
     private:
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(exp::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE exp::unique_any_sender<>
+        friend constexpr PIKA_FORCEINLINE /*exp::unique_any_sender<>*/ auto
         tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f,
             /*progress_mode p, */ stream_type s = stream_type::automatic)
         {
@@ -471,7 +471,8 @@ namespace pika::mpi::experimental {
                                             trigger_mpi(mode) | drop_value();
                                 }
                             });
-                    return snd1;
+                    return make_unique_any_sender(std::move(snd1));
+                    //return snd1;
                 }
                 else
                 {
@@ -497,7 +498,8 @@ namespace pika::mpi::experimental {
                                         drop_value();
                             }
                         });
-                    return snd1;
+                    return make_unique_any_sender(std::move(snd1));
+                    //return snd1;
                 }
             }
         }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -35,11 +35,6 @@
 
 namespace pika::mpi::experimental {
 
-    namespace {
-        namespace pud = pika::util::detail;
-        namespace ex = execution::experimental;
-    }    // namespace
-
     inline constexpr struct transform_mpi_t final
       : pika::functional::detail::tag_fallback<transform_mpi_t>
     {

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -487,6 +487,8 @@ namespace pika::mpi::experimental {
                   , stream{s}
                   , op_state(pika::execution::experimental::connect(
                         PIKA_FORWARD(Sender_, sender), transform_mpi_receiver{*this}))
+                  , resume{false}
+                  , status{MPI_SUCCESS}
                 {
                     PIKA_DP(mpi_tran,
                         debug(debug::detail::str<>("operation_state"), "stream",

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -19,12 +19,11 @@
 #include <pika/debugging/print.hpp>
 #include <pika/execution/algorithms/detail/helpers.hpp>
 #include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution/algorithms/let_value.hpp>
 #include <pika/execution/algorithms/transfer.hpp>
 #include <pika/execution_base/any_sender.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
-#include <pika/executors/inline_scheduler.hpp>
-#include <pika/executors/limiting_scheduler.hpp>
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
@@ -157,38 +156,34 @@ namespace pika::mpi::experimental::detail {
                                 PIKA_FORWARD(Ts, ts)...);
                             auto& t = std::get<ts_element_type>(r.op_state.ts);
                             //
-                            MPI_Request request{MPI_REQUEST_NULL};
+                            MPI_Request request;
                             // modes 0 uses the task yield_while method of callback
                             // modes 1,2 use the task resume method of callback
                             auto mode = get_completion_mode();
-                            if (mode < 3)
+                            if (mode == 100 || mode < 3)
                             {
                                 pud::invoke_fused(
                                     [&](auto&... ts) mutable {
-                                        PIKA_DETAIL_DP(mpi_tran,
-                                            debug(str<>("mpi invoke"), dec<2>(mode),
-                                                print_type<invoke_result_type>()));
                                         // execute the mpi function call, passing in the request object
                                         if constexpr (std::is_void_v<invoke_result_type>)
                                         {
                                             PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts..., &request);
-                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                "MPI_REQUEST_NULL returned from mpi "
-                                                "invocation");
                                         }
                                         else
                                         {
                                             r.op_state.result.template emplace<invoke_result_type>(
                                                 PIKA_INVOKE(
                                                     PIKA_MOVE(r.op_state.f), ts..., &request));
-                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                "MPI_REQUEST_NULL returned from mpi "
-                                                "invocation");
                                         }
+                                        PIKA_DETAIL_DP(
+                                            mpi_tran<5>, debug(str<>("mpi invoke"), request));
+                                        PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                            "MPI_REQUEST_NULL returned from mpi "
+                                            "invocation");
                                     },
                                     t);
                                 //
-                                if (mode == 0)
+                                if (mode == 100 || mode == 0)
                                 {
                                     pika::util::yield_while(
                                         [&request]() { return !detail::poll_request(request); });
@@ -225,7 +220,7 @@ namespace pika::mpi::experimental::detail {
                             // modes 3,4,5,6,7,8 ....
                             else
                             {
-                                PIKA_DETAIL_DP(mpi_tran,
+                                PIKA_DETAIL_DP(mpi_tran<5>,
                                     debug(str<>("mpi invoke"), dec<2>(mode),
                                         print_type<invoke_result_type>()));
                                 if constexpr (std::is_void_v<invoke_result_type>)
@@ -350,9 +345,6 @@ namespace pika::mpi::experimental::detail {
               , status{MPI_SUCCESS}
               , op_state(exp::connect(PIKA_FORWARD(Sender_, sender), transform_mpi_receiver{*this}))
             {
-                PIKA_DETAIL_DP(mpi_tran,
-                    debug(
-                        debug::detail::str<>("operation_state"), "stream", detail::stream_name(s)));
             }
 
             friend constexpr auto tag_invoke(exp::start_t, operation_state& os) noexcept
@@ -377,6 +369,7 @@ namespace pika::mpi::experimental::detail {
                 PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f), PIKA_MOVE(s.sender), s.stream);
         }
     };
+
 }    // namespace pika::mpi::experimental::detail
 
 namespace pika::mpi::experimental {
@@ -390,15 +383,18 @@ namespace pika::mpi::experimental {
     private:
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(exp::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(transform_mpi_t, Sender&& sender,
-            F&& f, progress_mode p, stream_type s = stream_type::automatic)
+        friend constexpr PIKA_FORCEINLINE exp::unique_any_sender<>
+        tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f,
+            /*progress_mode p, */ stream_type s = stream_type::automatic)
         {
             using namespace pika::mpi::experimental::detail;
-            PIKA_DETAIL_DP(mpi_tran,
-                debug(
-                    debug::detail::str<>("tag_fallback_invoke"), "stream", detail::stream_name(s)));
+            using namespace pika::debug::detail;
+            PIKA_DETAIL_DP(mpi_tran<5>,
+                debug(str<>("transform_mpi_t"), "tag_fallback_invoke", "stream",
+                    detail::stream_name(s)));
 
             using execution::thread_priority;
+            using exp::drop_value;
             using exp::make_unique_any_sender;
             using exp::schedule;
             using exp::then;
@@ -406,239 +402,104 @@ namespace pika::mpi::experimental {
             using exp::transfer;
             using exp::with_priority;
             using exp::with_stacksize;
-
-            // what is the output of set_value for this transform_mpi sender
-            using our_type = transform_mpi_sender<Sender, F>;
-            using value_type =
-                typename std::decay<exp::detail::single_result_t<typename exp::sender_traits<
-                    our_type>::template value_types<pud::pack, pud::pack>>>::type;
-            // this is the final sender type unique_any_sender<?>
-            typename any_sender_helper<value_type>::type result;
+            exp::unique_any_sender<> result;
 
             // does a custom mpi pool exist?
             auto mpi_exist = pool_exists();
+
             // get the mpi completion mode
             auto mode = get_completion_mode();
+
+            bool HP_com = use_HP_com(mode);
+            bool inline_com = use_inline_com(mode);
+            bool inline_req = use_inline_req(mode);
+            bool mpi_pool = use_pool(mode);
+
+            // ----------------------------------------------------------
+            // the pool should exist if the completion mode needs it
+            std::cout << "mpi_exist " << mpi_exist << " mpi_pool " << mpi_pool << std::endl;
+            PIKA_ASSERT(mpi_exist == mpi_pool);
+
             // ----------------------------------------------------------
             // DLAF default : use yield_while (transfer to mpi pool if cannot_block)
-            if (mode == 0)
+            if (mode == 100)
             {
-                if (p == progress_mode::can_block)
+                //
+                //                if (p == progress_mode::can_block)
+                //                {
+                //                    auto snd1 = transform_mpi_sender<Sender, F>{
+                //                        PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
+                //                    result = make_unique_any_sender(std::move(snd1));
+                //                }
+                //                else
                 {
-                    auto snd1 = transform_mpi_sender<Sender, F>{
-                        PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
-                    result = make_unique_any_sender(std::move(snd1));
+                    auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
+                    auto snd1 = transform_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0),
+                                    PIKA_FORWARD(F, f), s} |
+                        drop_value();
+                    return make_unique_any_sender(std::move(snd1));
+                }
+            }
+            // ----------------------------------------------------------
+            else
+            {
+                using execution::thread_priority;
+                thread_priority p =
+                    use_HP_com(mode) ? thread_priority::high : thread_priority::normal;
+                if (inline_req)
+                {
+                    auto snd1 =
+                        dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f), s} |
+                        pika::execution::experimental::let_value(
+                            [=](MPI_Request request) -> exp::unique_any_sender</*int*/> {
+                                if (inline_com)
+                                {
+                                    if (request == MPI_REQUEST_NULL)
+                                        return {};    //exp::just(/*MPI_SUCCESS*/);
+                                    else
+                                        return exp::just(request) | trigger_mpi(mode) |
+                                            drop_value();
+                                }
+                                else
+                                {
+                                    if (request == MPI_REQUEST_NULL)
+                                        return exp::just(MPI_SUCCESS) |
+                                            transfer(default_pool_scheduler(p)) | drop_value();
+                                    else
+                                        return exp::just(request) |
+                                            transfer(default_pool_scheduler(p)) |
+                                            trigger_mpi(mode) | drop_value();
+                                }
+                            });
+                    return snd1;
                 }
                 else
                 {
                     auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
-                    auto snd1 = transform_mpi_sender<decltype(snd0), F>{
-                        PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s};
-                    result = make_unique_any_sender(std::move(snd1));
+                    auto snd1 = dispatch_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0),
+                                    PIKA_FORWARD(F, f), s} |
+                        exp::let_value([=](MPI_Request request) -> exp::unique_any_sender</*int*/> {
+                            if (inline_com)
+                            {
+                                if (request == MPI_REQUEST_NULL)
+                                    return exp::just(/*MPI_SUCCESS*/);
+                                else
+                                    return exp::just(request) | trigger_mpi(mode) | drop_value();
+                            }
+                            else
+                            {
+                                if (request == MPI_REQUEST_NULL)
+                                    return exp::just(MPI_SUCCESS) |
+                                        transfer(default_pool_scheduler(p)) | drop_value();
+                                else
+                                    return exp::just(request) |
+                                        transfer(default_pool_scheduler(p)) | trigger_mpi(mode) |
+                                        drop_value();
+                            }
+                        });
+                    return snd1;
                 }
             }
-            // ----------------------------------------------------------
-            // suspend resume : run mpi inline - transfer completion if necessary
-            else if (mode == 1)
-            {
-                auto snd0 = dispatch_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
-                                PIKA_FORWARD(F, f), s} |
-                    exp::let_value([](MPI_Request request) -> exp::unique_any_sender<int> {
-                        if (request == MPI_REQUEST_NULL)
-                            return exp::just(MPI_SUCCESS);
-                        else
-                        {
-                            return exp::just(request) | trigger_mpi();
-                        }
-                    });
-                result = snd0;
-            }
-            // ----------------------------------------------------------
-            // suspend resume : transfer to mpi - run completion on mpi pool
-            else if (mode == 2)
-            {
-                auto snd0 = dispatch_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
-                                PIKA_FORWARD(F, f), s} |
-                    exp::let_value([](MPI_Request r) -> exp::unique_any_sender<int> {
-                        return (r == MPI_REQUEST_NULL) ?
-                            exp::just(MPI_SUCCESS) :
-
-                            exp::just(r) | transfer(default_pool_scheduler()) | trigger_mpi();
-                    });
-                result = snd0;
-            }
-            // ----------------------------------------------------------
-            // suspend resume : transfer to mpi - transfer completion back
-            else if (mode == 3)
-            {
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(default_pool_scheduler(thread_priority::high));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            // ----------------------------------------------------------
-            // polling mode : run mpi inline - HP transfer completion if necessary
-            else if (mode == 4)
-            {
-                auto snd0 = transform_mpi_sender<Sender, F>{
-                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
-                if (p == progress_mode::can_block)
-                {
-                    result = make_unique_any_sender(std::move(snd0));
-                }
-                else
-                {
-                    auto snd1 =
-                        std::move(snd0) | transfer(default_pool_scheduler(thread_priority::high));
-                    result = make_unique_any_sender(std::move(snd1));
-                }
-            }
-            // ----------------------------------------------------------
-            // polling mode : run mpi inline - NP transfer completion if necessary
-            else if (mode == 5)
-            {
-                auto snd0 = transform_mpi_sender<Sender, F>{
-                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
-                if (p == progress_mode::can_block)
-                {
-                    result = make_unique_any_sender(std::move(snd0));
-                }
-                else
-                {
-                    auto snd1 = std::move(snd0) | transfer(default_pool_scheduler());
-                    result = make_unique_any_sender(std::move(snd1));
-                }
-            }
-            // ----------------------------------------------------------
-            // polling mode : transfer mpi - HP transfer completion
-            else if (mode == 6)
-            {
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(default_pool_scheduler(thread_priority::high));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 7)
-            {
-                // transfer mpi to mpi pool,
-                // run completion explicitly on default pool without priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(default_pool_scheduler());
-                result = make_unique_any_sender(std::move(snd1));
-            }
-
-            // ----------------------------
-            // Modes need checking before use
-            // ----------------------------
-            else if (mode == 8)
-            {
-                // transfer mpi to mpi pool,
-                // run completion on polling thread (mpi or default pool)
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 =
-                    transform_mpi_sender<decltype(snd0), F>{std::move(snd0), PIKA_FORWARD(F, f), s};
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 9)
-            {
-                // transfer mpi to mpi pool
-                // run completion explicitly on mpi pool as high priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(mpi_pool_scheduler(true), thread_priority::high));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 10)
-            {
-                // transfer mpi to mpi pool
-                // run completion explicitly on default pool using high priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(default_pool_scheduler(thread_priority::high));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 11)
-            {
-                // transfer mpi to mpi pool
-                // run completion explicitly on default pool using default priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
-                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(default_pool_scheduler(), thread_priority::normal));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            /*
- *     Temporarily disabled until bypass scheduler available
- *
-                else if (mode == 11)
-                {
-                    // run mpi inline on current pool
-                    // run completion with bypass on mpi pool
-                    auto snd1 =
-                        transform_mpi_sender<Sender, F>{
-                            PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f),
-                            s} |
-                        transfer(thread_pool_scheduler_queue_bypass{
-                            &pika::resource::get_thread_pool(
-                                get_pool_name())});
-                    return make_unique_any_sender(std::move(snd1));
-                }
-                else if (mode == 12)
-                {
-                    // transfer mpi to mpi pool,
-                    // run completion with bypass on mpi pool
-                    auto snd0 = PIKA_FORWARD(Sender, sender) |
-                        transfer(with_stacksize(
-                            mpi_pool_scheduler(),
-                            execution::thread_stacksize::nostack));
-                    auto snd1 =
-                        transform_mpi_sender<decltype(snd0), F>{
-                            std::move(snd0), PIKA_FORWARD(F, f), s} |
-                        transfer(thread_pool_scheduler_queue_bypass{
-                            &pika::resource::get_thread_pool(
-                                get_pool_name())});
-                    return make_unique_any_sender(std::move(snd1));
-                }
-                else if (mode == 13)
-                {
-                    // transfer mpi to mpi pool
-                    // run completion inline with bypass on default pool
-                    // only effective if default pool is polling pool (mpi=default)
-                    auto snd0 = PIKA_FORWARD(Sender, sender) |
-                        transfer(with_stacksize(
-                            mpi_pool_scheduler(),
-                            execution::thread_stacksize::nostack));
-                    auto snd1 =
-                        transform_mpi_sender<decltype(snd0), F>{
-                            std::move(snd0), PIKA_FORWARD(F, f), s} |
-                        transfer(thread_pool_scheduler_queue_bypass{
-                            &pika::resource::get_thread_pool("default")});
-                    return make_unique_any_sender(std::move(snd1));
-                }
-*/
-            else
-            {
-                PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "transform_mpi",
-                    "Unsupported transfer mode: {} (valid options are between {} and {} and "
-                    "can be set with env{PIKA_MPI_COMPLETION_MODE}",
-                    mode, 0, 10);
-            }
-
-            //            if constexpr (exp::detail::has_completion_scheduler_v<
-            //                              exp::set_value_t, std::decay_t<Sender>>)
-            //            {
-            //                auto cs = exp::get_completion_scheduler<
-            //                    exp::set_value_t>(PIKA_FORWARD(Sender, sender));
-            //                result = make_unique_any_sender(transfer(cs, std::move(result)));
-            //                throw std::runtime_error("This is never called!");
-            //            }
-            return result;
         }
 
         //
@@ -646,10 +507,10 @@ namespace pika::mpi::experimental {
         //
         template <typename F>
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transform_mpi_t, F&& f, progress_mode p, stream_type s = stream_type::automatic)
+            transform_mpi_t, F&& f, /*progress_mode p, */ stream_type s = stream_type::automatic)
         {
-            return exp::detail::partial_algorithm<transform_mpi_t, F, progress_mode, stream_type>{
-                PIKA_FORWARD(F, f), p, s};
+            return exp::detail::partial_algorithm<transform_mpi_t, F,
+                /*progress_mode, */ stream_type>{PIKA_FORWARD(F, f), /*p, */ s};
         }
 
     } transform_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -518,6 +518,7 @@ namespace pika::mpi::experimental {
             if constexpr (pika::execution::experimental::detail::has_completion_scheduler_v<
                               pika::execution::experimental::set_value_t, std::decay_t<Sender>>)
             {
+                throw std::runtime_error("This should be fixed");
                 return pika::execution::experimental::transfer(
                     transform_mpi_sender<Sender, F>{
                         PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s},
@@ -733,7 +734,10 @@ namespace pika::mpi::experimental {
 */
                 else
                 {
-                    throw std::runtime_error("Unsupported transfer mode " + std::to_string(mode));
+                    PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "transform_mpi",
+                        "Unsupported transfer mode: {} (valid options are between {} and {} and "
+                        "can be set with env{PIKA_MPI_COMPLETION_MODE}",
+                        mode, 0, 10);
                     auto snd1 = transform_mpi_sender<Sender, F>{
                         PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
                     return make_unique_any_sender(std::move(snd1));

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -42,7 +42,7 @@ namespace pika::mpi::experimental {
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(
                 pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE pika::execution::experimental::unique_any_sender<>
+        friend PIKA_FORCEINLINE pika::execution::experimental::unique_any_sender<>
         tag_fallback_invoke(
             transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
         {

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -112,7 +112,7 @@ namespace pika::mpi::experimental::detail {
             std::decay_t<Receiver> receiver;
             std::decay_t<F> f;
             stream_type stream;
-            pika::spinlock mutex_;
+            pika::detail::spinlock mutex_;
             pika::condition_variable cond_var_;
             bool completed;
             int status;

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -19,6 +19,7 @@
 #include <pika/execution/algorithms/detail/partial_algorithm.hpp>
 #include <pika/execution/algorithms/let_value.hpp>
 #include <pika/execution/algorithms/transfer.hpp>
+#include <pika/execution/algorithms/transfer_just.hpp>
 #include <pika/execution_base/any_sender.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
@@ -54,9 +55,10 @@ namespace pika::mpi::experimental {
                 debug(str<>("transform_mpi_t"), "tag_fallback_invoke", "stream",
                     detail::stream_name(s)));
 
-            using ex::make_unique_any_sender;
+            using ex::just;
             using ex::then;
             using ex::transfer;
+            using ex::transfer_just;
             using execution::thread_priority;
 
             // get the mpi completion mode
@@ -91,16 +93,16 @@ namespace pika::mpi::experimental {
                             if (inline_com)
                             {
                                 if (request == MPI_REQUEST_NULL)
-                                    return ex::just();
+                                    return just();
                                 else
-                                    return ex::just(request) | trigger_mpi(mode);
+                                    return just(request) | trigger_mpi(mode);
                             }
                             else
                             {
                                 if (request == MPI_REQUEST_NULL)
-                                    return ex::just() | transfer(default_pool_scheduler(p));
+                                    return transfer_just(default_pool_scheduler(p));
                                 else
-                                    return ex::just(request) | transfer(default_pool_scheduler(p)) |
+                                    return transfer_just(default_pool_scheduler(p), request) |
                                         trigger_mpi(mode);
                             }
                         });
@@ -114,16 +116,16 @@ namespace pika::mpi::experimental {
                         if (inline_com)
                         {
                             if (request == MPI_REQUEST_NULL)
-                                return ex::just();
+                                return just();
                             else
-                                return ex::just(request) | trigger_mpi(mode);
+                                return just(request) | trigger_mpi(mode);
                         }
                         else
                         {
                             if (request == MPI_REQUEST_NULL)
-                                return ex::just() | transfer(default_pool_scheduler(p));
+                                return transfer_just(default_pool_scheduler(p));
                             else
-                                return ex::just(request) | transfer(default_pool_scheduler(p)) |
+                                return transfer_just(default_pool_scheduler(p), request) |
                                     trigger_mpi(mode);
                         }
                     });

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -501,7 +501,7 @@ namespace pika::mpi::experimental {
         };
     }    // namespace transform_mpi_detail
 
-    inline auto mpi_pool_scheduler()
+    inline auto mpi_pool_scheduler(stream_type s)
     {
         using pika::execution::experimental::thread_pool_scheduler;
         return thread_pool_scheduler{&pika::resource::get_thread_pool(get_pool_name())};
@@ -563,7 +563,7 @@ namespace pika::mpi::experimental {
             if (mode == 0)
             {
                 // use yield_while on the mpi pool
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(s));
                 auto snd1 =
                     transform_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s};
                 result = make_unique_any_sender(std::move(snd1));
@@ -588,7 +588,7 @@ namespace pika::mpi::experimental {
                 else
                 {
                     // transfer to mpi pool and use suspend/resume there
-                    auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
+                    auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(s));
                     auto snd1 = transform_mpi_sender<decltype(snd0), F>{
                         std::move(snd0), PIKA_FORWARD(F, f), s};
                     result = make_unique_any_sender(std::move(snd1));
@@ -620,7 +620,7 @@ namespace pika::mpi::experimental {
                     // transfer mpi to mpi pool,
                     auto snd0 = PIKA_FORWARD(Sender, sender) |
                         transfer(with_stacksize(
-                            mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                            mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                     // run completion explicitly on default pool with High priority
                     auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                     PIKA_FORWARD(F, f), s} |
@@ -642,7 +642,7 @@ namespace pika::mpi::experimental {
                 // run completion explicitly on default pool without priority
                 auto snd0 = PIKA_FORWARD(Sender, sender) |
                     transfer(with_stacksize(
-                        mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                        mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     transfer(default_pool_scheduler());
@@ -658,7 +658,7 @@ namespace pika::mpi::experimental {
                 // run completion on polling thread (mpi or default pool)
                 auto snd0 = PIKA_FORWARD(Sender, sender) |
                     transfer(with_stacksize(
-                        mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                        mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                 auto snd1 =
                     transform_mpi_sender<decltype(snd0), F>{std::move(snd0), PIKA_FORWARD(F, f), s};
                 result = make_unique_any_sender(std::move(snd1));
@@ -669,10 +669,10 @@ namespace pika::mpi::experimental {
                 // run completion explicitly on mpi pool as high priority
                 auto snd0 = PIKA_FORWARD(Sender, sender) |
                     transfer(with_stacksize(
-                        mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                        mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(mpi_pool_scheduler(), thread_priority::high));
+                    transfer(with_priority(mpi_pool_scheduler(s), thread_priority::high));
                 result = make_unique_any_sender(std::move(snd1));
             }
             else if (mode == 9)
@@ -681,7 +681,7 @@ namespace pika::mpi::experimental {
                 // run completion explicitly on default pool using high priority
                 auto snd0 = PIKA_FORWARD(Sender, sender) |
                     transfer(with_stacksize(
-                        mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                        mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     transfer(with_priority(default_pool_scheduler(), thread_priority::high));
@@ -693,7 +693,7 @@ namespace pika::mpi::experimental {
                 // run completion explicitly on default pool using default priority
                 auto snd0 = PIKA_FORWARD(Sender, sender) |
                     transfer(with_stacksize(
-                        mpi_pool_scheduler(), pika::execution::thread_stacksize::nostack));
+                        mpi_pool_scheduler(s), pika::execution::thread_stacksize::nostack));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     transfer(with_priority(default_pool_scheduler(), thread_priority::normal));

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -334,7 +334,7 @@ namespace pika::mpi::experimental {
     private:
         template <typename Sender, typename F,
             PIKA_CONCEPT_REQUIRES_(exp::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE /*exp::unique_any_sender<>*/ auto
+        friend constexpr PIKA_FORCEINLINE exp::unique_any_sender<>
         tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f,
             /*progress_mode p, */ stream_type s = stream_type::automatic)
         {
@@ -381,7 +381,7 @@ namespace pika::mpi::experimental {
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     drop_value();
-                return make_unique_any_sender(std::move(snd1));
+                return make_unique_any_sender<>(std::move(snd1));
             }
             // ----------------------------------------------------------
             else
@@ -398,7 +398,7 @@ namespace pika::mpi::experimental {
                                 if (inline_com)
                                 {
                                     if (request == MPI_REQUEST_NULL)
-                                        return {};    //exp::just(/*MPI_SUCCESS*/);
+                                        return exp::just(/*MPI_SUCCESS*/);
                                     else
                                         return exp::just(request) | trigger_mpi(mode) |
                                             drop_value();
@@ -414,8 +414,7 @@ namespace pika::mpi::experimental {
                                             trigger_mpi(mode) | drop_value();
                                 }
                             });
-                    return make_unique_any_sender(std::move(snd1));
-                    //return snd1;
+                    return make_unique_any_sender<>(std::move(snd1));
                 }
                 else
                 {
@@ -441,8 +440,7 @@ namespace pika::mpi::experimental {
                                         drop_value();
                             }
                         });
-                    return make_unique_any_sender(std::move(snd1));
-                    //return snd1;
+                    return make_unique_any_sender<>(std::move(snd1));
                 }
             }
         }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -10,7 +10,9 @@
 
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
+#include <pika/async_mpi/dispatch_mpi.hpp>
 #include <pika/async_mpi/mpi_polling.hpp>
+#include <pika/async_mpi/trigger_mpi.hpp>
 #include <pika/concepts/concepts.hpp>
 #include <pika/datastructures/variant.hpp>
 #include <pika/debugging/demangle_helper.hpp>
@@ -34,546 +36,381 @@
 #include <type_traits>
 #include <utility>
 
-namespace pika::mpi::experimental {
-    namespace transform_mpi_detail {
-        // -----------------------------------------------------------------
-        // by convention the title is 7 chars (for alignment)
-        using print_on = pika::debug::detail::enable_print<false>;
-        inline constexpr print_on mpi_tran("MPITRAN");
+namespace pika::mpi::experimental::detail {
 
+    namespace pud = pika::util::detail;
+    namespace exp = execution::experimental;
+
+    // -----------------------------------------------------------------
+    // route calls through an impl layer for ADL resolution
+    template <typename Sender, typename F>
+    struct transform_mpi_sender_impl
+    {
+        struct transform_mpi_sender_type;
+    };
+
+    template <typename Sender, typename F>
+    using transform_mpi_sender =
+        typename transform_mpi_sender_impl<Sender, F>::transform_mpi_sender_type;
+
+    // -----------------------------------------------------------------
+    // transform MPI adapter - sender type
+    template <typename Sender, typename F>
+    struct transform_mpi_sender_impl<Sender, F>::transform_mpi_sender_type
+    {
+        using is_sender = void;
+
+        std::decay_t<Sender> sender;
+        std::decay_t<F> f;
+        stream_type stream;
+
+#if defined(PIKA_HAVE_STDEXEC)
+        template <typename... Ts>
+        requires is_mpi_request_invocable_v<F, Ts...>
+        using invoke_result_helper = exp::completion_signatures<
+            exp::detail::result_type_signature_helper_t<mpi_request_invoke_result_t<F, Ts...>>>;
+
+        using completion_signatures = exp::make_completion_signatures<std::decay_t<Sender>,
+            exp::empty_env, exp::completion_signatures<exp::set_error_t(std::exception_ptr)>,
+            invoke_result_helper>;
+#else
         // -----------------------------------------------------------------
-        // calls set_value or set_error on the receiver
-        template <typename Receiver, typename... Ts>
-        void set_value_request_callback_helper(int mpi_status, Receiver&& receiver, Ts&&... ts)
+        // get the return tuple<type> of func (tuple<args> + MPI_Request)
+        template <typename Tuple>
+        struct invoke_result_helper;
+
+        template <template <typename...> class Tuple, typename... Ts>
+        struct invoke_result_helper<Tuple<Ts...>>
         {
-            static_assert(sizeof...(Ts) <= 1, "Expecting at most one value");
-            if (mpi_status == MPI_SUCCESS)
-            {
-                pika::execution::experimental::set_value(
-                    PIKA_FORWARD(Receiver, receiver), PIKA_FORWARD(Ts, ts)...);
-            }
-            else
-            {
-                pika::execution::experimental::set_error(PIKA_FORWARD(Receiver, receiver),
-                    std::make_exception_ptr(mpi_exception(mpi_status)));
-            }
-        }
-
-        // -----------------------------------------------------------------
-        // After an MPI call is made, a callback must be given to the polling
-        // code to allow the result of the mpi call to be set when the request
-        // has completed. This function sets the callback to invoke
-        // the callback helper with or without a passed result.
-        // (mpi calls nearly always return an int, so the void one is not used much)
-        template <typename OperationState>
-        void set_value_request_callback_void(MPI_Request request, OperationState& op_state)
-        {
-            detail::add_request_callback(
-                [&op_state](int status) mutable {
-                    using namespace pika::debug::detail;
-                    PIKA_DETAIL_DP(mpi_tran,
-                        debug(str<>("callback_void"), "stream",
-                            detail::stream_name(op_state.stream)));
-                    op_state.ts = {};
-                    set_value_request_callback_helper(status, PIKA_MOVE(op_state.receiver));
-                },
-                request, detail::check_request_eager::yes);
-        }
-
-        template <typename Result, typename OperationState>
-        void set_value_request_callback_non_void(MPI_Request request, OperationState& op_state)
-        {
-            detail::add_request_callback(
-                [&op_state](int status) mutable {
-                    using namespace pika::debug::detail;
-                    PIKA_DETAIL_DP(mpi_tran,
-                        debug(str<>("callback_nonvoid"), "stream",
-                            detail::stream_name(op_state.stream)));
-                    op_state.ts = {};
-                    PIKA_ASSERT(std::holds_alternative<Result>(op_state.result));
-                    set_value_request_callback_helper(status, PIKA_MOVE(op_state.receiver),
-                        PIKA_MOVE(std::get<Result>(op_state.result)));
-                },
-                request, detail::check_request_eager::yes);
-        }
-
-        template <typename Result, typename OperationState>
-        void
-        set_value_request_callback_suspend_resume(MPI_Request request, OperationState& op_state)
-        {
-            detail::add_request_callback(
-                [&op_state](int status) mutable {
-                    using namespace pika::debug::detail;
-                    PIKA_DETAIL_DP(mpi_tran,
-                        debug(str<>("callback_void_suspend_resume"), "stream",
-                            detail::stream_name(op_state.stream)));
-                    op_state.ts = {};
-                    op_state.status = status;
-
-                    // wake up the suspended thread
-                    {
-                        std::lock_guard lk(op_state.mutex_);
-                        op_state.completed = true;
-                    }
-                    op_state.cond_var_.notify_one();
-                },
-                // we do not need to eagerly check, because it was done earlier
-                request, detail::check_request_eager::no);
-        }
-
-        // -----------------------------------------------------------------
-        // can function be invoked with param types + MPI_Request
-        template <typename F, typename... Ts>
-        inline constexpr bool is_mpi_request_invocable_v =
-            std::is_invocable_v<F, std::add_lvalue_reference_t<std::decay_t<Ts>>..., MPI_Request*>;
-
-        // -----------------------------------------------------------------
-        // get return type of func(Ts..., MPI_Request)
-        template <typename F, typename... Ts>
-        using mpi_request_invoke_result_t = std::decay_t<std::invoke_result_t<F,
-            std::add_lvalue_reference_t<std::decay_t<Ts>>..., MPI_Request*>>;
-
-        // -----------------------------------------------------------------
-        // route calls through an impl layer for ADL resolution
-        template <typename Sender, typename F>
-        struct transform_mpi_sender_impl
-        {
-            struct transform_mpi_sender_type;
+            static_assert(is_mpi_request_invocable_v<F, Ts...>,
+                "F not invocable with the value_types specified.");
+            using result_type = mpi_request_invoke_result_t<F, Ts...>;
+            using type =
+                std::conditional_t<std::is_void<result_type>::value, Tuple<>, Tuple<result_type>>;
         };
 
-        template <typename Sender, typename F>
-        using transform_mpi_sender =
-            typename transform_mpi_sender_impl<Sender, F>::transform_mpi_sender_type;
+        // -----------------------------------------------------------------
+        // get pack of unique types from combined tuple and variant
+        template <template <typename...> class Tuple, template <typename...> class Variant>
+        using value_types = pud::unique_t<pud::transform_t<
+            typename exp::sender_traits<Sender>::template value_types<Tuple, Variant>,
+            invoke_result_helper>>;
+
+        template <template <typename...> class Variant>
+        using error_types = pud::unique_t<
+            pud::prepend_t<typename exp::sender_traits<Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
+
+        static constexpr bool sends_done = false;
+#endif
 
         // -----------------------------------------------------------------
-        // transform MPI adapter - sender type
-        template <typename Sender, typename F>
-        struct transform_mpi_sender_impl<Sender, F>::transform_mpi_sender_type
+        // operation state for a given receiver
+        template <typename Receiver>
+        struct operation_state
         {
-            using is_sender = void;
-
-            std::decay_t<Sender> sender;
+            std::decay_t<Receiver> receiver;
             std::decay_t<F> f;
             stream_type stream;
+            pika::spinlock mutex_;
+            pika::condition_variable cond_var_;
+            bool completed;
+            int status;
 
-#if defined(PIKA_HAVE_STDEXEC)
-            template <typename... Ts>
-            requires is_mpi_request_invocable_v<F, Ts...>
-            using invoke_result_helper = pika::execution::experimental::completion_signatures<
-                pika::execution::experimental::detail::result_type_signature_helper_t<
-                    mpi_request_invoke_result_t<F, Ts...>>>;
-
-            using completion_signatures =
-                pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
-                    pika::execution::experimental::empty_env,
-                    pika::execution::experimental::completion_signatures<
-                        pika::execution::experimental::set_error_t(std::exception_ptr)>,
-                    invoke_result_helper>;
-#else
             // -----------------------------------------------------------------
-            // get the return tuple<type> of func (tuple<args> + MPI_Request)
-            template <typename Tuple>
-            struct invoke_result_helper;
-
-            template <template <typename...> class Tuple, typename... Ts>
-            struct invoke_result_helper<Tuple<Ts...>>
+            // The mpi_receiver receives inputs from the previous sender,
+            // invokes the mpi call, and sets a callback on the polling handler
+            struct transform_mpi_receiver
             {
-                static_assert(is_mpi_request_invocable_v<F, Ts...>,
-                    "F not invocable with the value_types specified.");
-                using result_type = mpi_request_invoke_result_t<F, Ts...>;
-                using type = std::conditional_t<std::is_void<result_type>::value, Tuple<>,
-                    Tuple<result_type>>;
-            };
+                using is_receiver = void;
 
-            // -----------------------------------------------------------------
-            // get pack of unique types from combined tuple and variant
-            template <template <typename...> class Tuple, template <typename...> class Variant>
-            using value_types = pika::util::detail::unique_t<pika::util::detail::transform_t<
-                typename pika::execution::experimental::sender_traits<Sender>::template value_types<
-                    Tuple, Variant>,
-                invoke_result_helper>>;
+                operation_state& op_state;
 
-            template <template <typename...> class Variant>
-            using error_types = pika::util::detail::unique_t<
-                pika::util::detail::prepend_t<typename pika::execution::experimental::sender_traits<
-                                                  Sender>::template error_types<Variant>,
-                    std::exception_ptr>>;
-
-            static constexpr bool sends_done = false;
-#endif
-
-            // -----------------------------------------------------------------
-            // operation state for a given receiver
-            template <typename Receiver>
-            struct operation_state
-            {
-                std::decay_t<Receiver> receiver;
-                std::decay_t<F> f;
-                stream_type stream;
-                pika::spinlock mutex_;
-                pika::condition_variable cond_var_;
-                bool completed;
-                int status;
-
-                // -----------------------------------------------------------------
-                // The mpi_receiver receives inputs from the previous sender,
-                // invokes the mpi call, and sets a callback on the polling handler
-                struct transform_mpi_receiver
+                template <typename Error>
+                friend constexpr void
+                tag_invoke(exp::set_error_t, transform_mpi_receiver&& r, Error&& error) noexcept
                 {
-                    using is_receiver = void;
+                    exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_FORWARD(Error, error));
+                }
 
-                    operation_state& op_state;
+                friend constexpr void tag_invoke(
+                    exp::set_stopped_t, transform_mpi_receiver&& r) noexcept
+                {
+                    exp::set_stopped(PIKA_MOVE(r.op_state.receiver));
+                }
 
-                    template <typename Error>
-                    friend constexpr void tag_invoke(pika::execution::experimental::set_error_t,
-                        transform_mpi_receiver&& r, Error&& error) noexcept
-                    {
-                        pika::execution::experimental::set_error(
-                            PIKA_MOVE(r.op_state.receiver), PIKA_FORWARD(Error, error));
-                    }
-
-                    friend constexpr void tag_invoke(pika::execution::experimental::set_stopped_t,
-                        transform_mpi_receiver&& r) noexcept
-                    {
-                        pika::execution::experimental::set_stopped(PIKA_MOVE(r.op_state.receiver));
-                    };
-
-                    // receive the MPI function and arguments and add a request,
-                    // then invoke the mpi function and set a callback to be
-                    // triggered when the mpi request completes
-                    template <typename... Ts,
-                        typename = std::enable_if_t<is_mpi_request_invocable_v<F, Ts...>>>
-                    friend constexpr void tag_invoke(pika::execution::experimental::set_value_t,
-                        transform_mpi_receiver&& r, Ts&&... ts) noexcept
-                    {
-                        pika::detail::try_catch_exception_ptr(
-                            [&]() mutable {
-                                using namespace pika::debug::detail;
-                                using ts_element_type = std::tuple<std::decay_t<Ts>...>;
-                                using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
-                                //
-                                r.op_state.ts.template emplace<ts_element_type>(
-                                    PIKA_FORWARD(Ts, ts)...);
-                                auto& t = std::get<ts_element_type>(r.op_state.ts);
-                                //
-                                MPI_Request request{MPI_REQUEST_NULL};
-                                // modes 0 uses the task yield_while method of callback
-                                // modes 1,2 use the task resume method of callback
-                                auto mode = experimental::get_completion_mode();
-                                if (mode < 3)
-                                {
-                                    pika::util::detail::invoke_fused(
-                                        [&](auto&... ts) mutable {
-                                            PIKA_DETAIL_DP(mpi_tran,
-                                                debug(str<>("mpi invoke"), dec<2>(mode),
-                                                    print_type<invoke_result_type>()));
-                                            // execute the mpi function call, passing in the request object
-                                            if constexpr (std::is_void_v<invoke_result_type>)
-                                            {
-                                                PIKA_INVOKE(
-                                                    PIKA_MOVE(r.op_state.f), ts..., &request);
-                                                PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                    "MPI_REQUEST_NULL returned from mpi "
-                                                    "invocation");
-                                            }
-                                            else
-                                            {
-                                                r.op_state.result
-                                                    .template emplace<invoke_result_type>(
-                                                        PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts...,
-                                                            &request));
-                                                PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                    "MPI_REQUEST_NULL returned from mpi "
-                                                    "invocation");
-                                            }
-                                        },
-                                        t);
-                                    //
-                                    if (mode == 0)
-                                    {
-                                        pika::util::yield_while([&request]() {
-                                            return !detail::poll_request(request);
-                                        });
-                                    }
-                                    else
-                                    {
-                                        // don't suspend if request completed already
-                                        if (!detail::poll_request(request))
+                // receive the MPI function and arguments and add a request,
+                // then invoke the mpi function and set a callback to be
+                // triggered when the mpi request completes
+                template <typename... Ts,
+                    typename = std::enable_if_t<is_mpi_request_invocable_v<F, Ts...>>>
+                friend constexpr void
+                tag_invoke(exp::set_value_t, transform_mpi_receiver&& r, Ts&&... ts) noexcept
+                {
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() mutable {
+                            using namespace pika::debug::detail;
+                            using ts_element_type = std::tuple<std::decay_t<Ts>...>;
+                            using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
+                            //
+                            r.op_state.ts.template emplace<ts_element_type>(
+                                PIKA_FORWARD(Ts, ts)...);
+                            auto& t = std::get<ts_element_type>(r.op_state.ts);
+                            //
+                            MPI_Request request{MPI_REQUEST_NULL};
+                            // modes 0 uses the task yield_while method of callback
+                            // modes 1,2 use the task resume method of callback
+                            auto mode = get_completion_mode();
+                            if (mode < 3)
+                            {
+                                pud::invoke_fused(
+                                    [&](auto&... ts) mutable {
+                                        PIKA_DETAIL_DP(mpi_tran,
+                                            debug(str<>("mpi invoke"), dec<2>(mode),
+                                                print_type<invoke_result_type>()));
+                                        // execute the mpi function call, passing in the request object
+                                        if constexpr (std::is_void_v<invoke_result_type>)
                                         {
-                                            set_value_request_callback_suspend_resume<
-                                                invoke_result_type>(request, r.op_state);
-                                            PIKA_ASSERT(pika::threads::detail::get_self_id());
-                                            threads::detail::thread_data::scoped_thread_priority
-                                                set_restore(pika::execution::thread_priority::high);
-                                            std::unique_lock l{r.op_state.mutex_};
-                                            r.op_state.cond_var_.wait(
-                                                l, [&]() { return r.op_state.completed; });
+                                            PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts..., &request);
+                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                                "MPI_REQUEST_NULL returned from mpi "
+                                                "invocation");
                                         }
-                                    }
-                                    r.op_state.ts = {};
-                                    r.op_state.status = MPI_SUCCESS;
-                                    if constexpr (!std::is_void_v<invoke_result_type>)
-                                    {
-                                        set_value_request_callback_helper(r.op_state.status,
-                                            PIKA_MOVE(r.op_state.receiver),
-                                            PIKA_MOVE(
-                                                std::get<invoke_result_type>(r.op_state.result)));
-                                    }
-                                    else
-                                    {
-                                        set_value_request_callback_helper(
-                                            r.op_state.status, PIKA_MOVE(r.op_state.receiver));
-                                    }
+                                        else
+                                        {
+                                            r.op_state.result.template emplace<invoke_result_type>(
+                                                PIKA_INVOKE(
+                                                    PIKA_MOVE(r.op_state.f), ts..., &request));
+                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                                "MPI_REQUEST_NULL returned from mpi "
+                                                "invocation");
+                                        }
+                                    },
+                                    t);
+                                //
+                                if (mode == 0)
+                                {
+                                    pika::util::yield_while(
+                                        [&request]() { return !detail::poll_request(request); });
                                 }
-                                // modes 3,4,5,6,7,8 ....
                                 else
                                 {
-                                    //                                    PIKA_DETAIL_DP(mpi_tran,
-                                    //                                        debug(str<>("throttle?"), "stream",
-                                    //                                            detail::stream_name(r.op_state.stream)));
-                                    // throttle if too many "in flight"
-                                    //                                    detail::wait_for_throttling(r.op_state.stream);
-                                    PIKA_DETAIL_DP(mpi_tran,
-                                        debug(str<>("mpi invoke"), dec<2>(mode),
-                                            print_type<invoke_result_type>()));
-                                    if constexpr (std::is_void_v<invoke_result_type>)
+                                    // don't suspend if request completed already
+                                    if (!detail::poll_request(request))
                                     {
-                                        pika::util::detail::invoke_fused(
-                                            [&](auto&... ts) mutable {
-                                                PIKA_INVOKE(
-                                                    PIKA_MOVE(r.op_state.f), ts..., &request);
-                                                PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                    "MPI_REQUEST_NULL returned from mpi "
-                                                    "invocation");
-                                                // return type void, no value to forward to receiver
-                                                set_value_request_callback_void(
-                                                    request, r.op_state);
-                                            },
-                                            t);
-                                    }
-                                    else
-                                    {
-                                        pika::util::detail::invoke_fused(
-                                            [&](auto&... ts) mutable {
-                                                r.op_state.result
-                                                    .template emplace<invoke_result_type>(
-                                                        PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts...,
-                                                            &request));
-                                                PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
-                                                    "MPI_REQUEST_NULL returned from mpi "
-                                                    "invocation");
-                                                // forward value to receiver
-                                                set_value_request_callback_non_void<
-                                                    invoke_result_type>(request, r.op_state);
-                                            },
-                                            t);
+                                        resume_request_callback(request, r.op_state);
+                                        PIKA_ASSERT(pika::threads::detail::get_self_id());
+                                        threads::detail::thread_data::scoped_thread_priority
+                                            set_restore(execution::thread_priority::high);
+                                        std::unique_lock l{r.op_state.mutex_};
+                                        r.op_state.cond_var_.wait(
+                                            l, [&]() { return r.op_state.completed; });
                                     }
                                 }
-                            },
-                            [&](std::exception_ptr ep) {
-                                pika::execution::experimental::set_error(
-                                    PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));
-                            });
-                    }
-
-                    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                        pika::execution::experimental::get_env_t,
-                        transform_mpi_receiver const&) noexcept
-                    {
-                        return {};
-                    }
-                };
-
-                using operation_state_type =
-                    pika::execution::experimental::connect_result_t<std::decay_t<Sender>,
-                        transform_mpi_receiver>;
-                operation_state_type op_state;
-
-                template <typename Tuple>
-                struct value_types_helper
-                {
-                    using type = pika::util::detail::transform_t<Tuple, std::decay>;
-                };
-
-#if defined(PIKA_HAVE_STDEXEC)
-                using ts_type = pika::util::detail::prepend_t<
-                    pika::util::detail::transform_t<
-                        pika::execution::experimental::value_types_of_t<std::decay_t<Sender>,
-                            pika::execution::experimental::empty_env, std::tuple,
-                            pika::detail::variant>,
-                        value_types_helper>,
-                    pika::detail::monostate>;
-#else
-                using ts_type = pika::util::detail::prepend_t<
-                    pika::util::detail::transform_t<
-                        typename pika::execution::experimental::sender_traits<std::decay_t<
-                            Sender>>::template value_types<std::tuple, pika::detail::variant>,
-                        value_types_helper>,
-                    pika::detail::monostate>;
-#endif
-                ts_type ts;
-
-                // We store the return value of f in a variant. We know that
-                // value_types of the transform_mpi_sender contains packs of at
-                // most one element (the return value of f), so we only
-                // specialize result_types_helper for zero or one value. For
-                // empty packs we use pika::detail::monostate since we don't
-                // need to store anything in that case.
-                //
-                // All in all, we:
-                // - transform one-element packs to the single element, and
-                //   empty packs to pika::detail::monostate
-                // - add pika::detail::monostate to the pack in case it wasn't
-                //   there already
-                // - remove duplicates in case pika::detail::monostate has been
-                //   added twice
-                // - change the outer pack to a pika::detail::variant
-                template <typename Tuple>
-                struct result_types_helper;
-
-                template <template <typename...> class Tuple, typename T>
-                struct result_types_helper<Tuple<T>>
-                {
-                    using type = std::decay_t<T>;
-                };
-
-                template <template <typename...> class Tuple>
-                struct result_types_helper<Tuple<>>
-                {
-                    using type = pika::detail::monostate;
-                };
-#if defined(PIKA_HAVE_STDEXEC)
-                using result_type = pika::util::detail::change_pack_t<pika::detail::variant,
-                    pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                        pika::util::detail::transform_t<
-                            pika::execution::experimental::value_types_of_t<
-                                transform_mpi_sender_type, pika::execution::experimental::empty_env,
-                                pika::util::detail::pack, pika::util::detail::pack>,
-                            result_types_helper>,
-                        pika::detail::monostate>>>;
-#else
-                using result_type = pika::util::detail::change_pack_t<pika::detail::variant,
-                    pika::util::detail::unique_t<pika::util::detail::prepend_t<
-                        pika::util::detail::transform_t<
-                            transform_mpi_sender_type::value_types<pika::util::detail::pack,
-                                pika::util::detail::pack>,
-                            result_types_helper>,
-                        pika::detail::monostate>>>;
-#endif
-                result_type result;
-
-                template <typename Receiver_, typename F_, typename Sender_>
-                operation_state(Receiver_&& receiver, F_&& f, Sender_&& sender, stream_type s)
-                  : receiver(PIKA_FORWARD(Receiver_, receiver))
-                  , f(PIKA_FORWARD(F_, f))
-                  , stream{s}
-                  , completed{false}
-                  , status{MPI_SUCCESS}
-                  , op_state(pika::execution::experimental::connect(
-                        PIKA_FORWARD(Sender_, sender), transform_mpi_receiver{*this}))
-                {
-                    PIKA_DETAIL_DP(mpi_tran,
-                        debug(debug::detail::str<>("operation_state"), "stream",
-                            detail::stream_name(s)));
+                                r.op_state.ts = {};
+                                r.op_state.status = MPI_SUCCESS;
+                                if constexpr (!std::is_void_v<invoke_result_type>)
+                                {
+                                    set_value_error_helper(r.op_state.status,
+                                        PIKA_MOVE(r.op_state.receiver),
+                                        PIKA_MOVE(std::get<invoke_result_type>(r.op_state.result)));
+                                }
+                                else
+                                {
+                                    set_value_error_helper(
+                                        r.op_state.status, PIKA_MOVE(r.op_state.receiver));
+                                }
+                            }
+                            // modes 3,4,5,6,7,8 ....
+                            else
+                            {
+                                PIKA_DETAIL_DP(mpi_tran,
+                                    debug(str<>("mpi invoke"), dec<2>(mode),
+                                        print_type<invoke_result_type>()));
+                                if constexpr (std::is_void_v<invoke_result_type>)
+                                {
+                                    pud::invoke_fused(
+                                        [&](auto&... ts) mutable {
+                                            PIKA_INVOKE(PIKA_MOVE(r.op_state.f), ts..., &request);
+                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                                "MPI_REQUEST_NULL returned from mpi "
+                                                "invocation");
+                                            // return type void, no value to forward to receiver
+                                            set_value_request_callback_void(request, r.op_state);
+                                        },
+                                        t);
+                                }
+                                else
+                                {
+                                    pud::invoke_fused(
+                                        [&](auto&... ts) mutable {
+                                            r.op_state.result.template emplace<invoke_result_type>(
+                                                PIKA_INVOKE(
+                                                    PIKA_MOVE(r.op_state.f), ts..., &request));
+                                            PIKA_ASSERT_MSG(request != MPI_REQUEST_NULL,
+                                                "MPI_REQUEST_NULL returned from mpi "
+                                                "invocation");
+                                            // forward value to receiver
+                                            detail::set_value_request_callback_non_void<
+                                                invoke_result_type>(request, r.op_state);
+                                        },
+                                        t);
+                                }
+                            }
+                        },
+                        [&](std::exception_ptr ep) {
+                            exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));
+                        });
                 }
 
-                friend constexpr auto tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
+                friend constexpr exp::empty_env tag_invoke(
+                    exp::get_env_t, transform_mpi_receiver const&) noexcept
                 {
-                    return pika::execution::experimental::start(os.op_state);
+                    return {};
                 }
             };
 
-            template <typename Receiver>
-            friend constexpr auto tag_invoke(pika::execution::experimental::connect_t,
-                transform_mpi_sender_type const& s, Receiver&& receiver)
+            using operation_state_type =
+                exp::connect_result_t<std::decay_t<Sender>, transform_mpi_receiver>;
+            operation_state_type op_state;
+
+            template <typename Tuple>
+            struct value_types_helper
             {
-                return operation_state<Receiver>(
-                    PIKA_FORWARD(Receiver, receiver), s.f, s.sender, s.stream);
+                using type = pud::transform_t<Tuple, std::decay>;
+            };
+
+#if defined(PIKA_HAVE_STDEXEC)
+            using ts_type = pud::prepend_t<
+                pud::transform_t<exp::value_types_of_t<std::decay_t<Sender>, exp::empty_env,
+                                     std::tuple, pika::detail::variant>,
+                    value_types_helper>,
+                pika::detail::monostate>;
+#else
+            using ts_type = pud::prepend_t<
+                pud::transform_t<typename exp::sender_traits<std::decay_t<Sender>>::
+                                     template value_types<std::tuple, pika::detail::variant>,
+                    value_types_helper>,
+                pika::detail::monostate>;
+#endif
+            ts_type ts;
+
+            // We store the return value of f in a variant. We know that
+            // value_types of the transform_mpi_sender contains packs of at
+            // most one element (the return value of f), so we only
+            // specialize result_types_helper for zero or one value. For
+            // empty packs we use pika::detail::monostate since we don't
+            // need to store anything in that case.
+            //
+            // All in all, we:
+            // - transform one-element packs to the single element, and
+            //   empty packs to pika::detail::monostate
+            // - add pika::detail::monostate to the pack in case it wasn't
+            //   there already
+            // - remove duplicates in case pika::detail::monostate has been
+            //   added twice
+            // - change the outer pack to a pika::detail::variant
+            template <typename Tuple>
+            struct result_types_helper;
+
+            template <template <typename...> class Tuple, typename T>
+            struct result_types_helper<Tuple<T>>
+            {
+                using type = std::decay_t<T>;
+            };
+
+            template <template <typename...> class Tuple>
+            struct result_types_helper<Tuple<>>
+            {
+                using type = pika::detail::monostate;
+            };
+#if defined(PIKA_HAVE_STDEXEC)
+            using result_type = pud::change_pack_t<pika::detail::variant,
+                pud::unique_t<
+                    pud::prepend_t<pud::transform_t<exp::value_types_of_t<transform_mpi_sender_type,
+                                                        exp::empty_env, pud::pack, pud::pack>,
+                                       result_types_helper>,
+                        pika::detail::monostate>>>;
+#else
+            using result_type = pud::change_pack_t<pika::detail::variant,
+                pud::unique_t<pud::prepend_t<
+                    pud::transform_t<transform_mpi_sender_type::value_types<pud::pack, pud::pack>,
+                        result_types_helper>,
+                    pika::detail::monostate>>>;
+#endif
+            result_type result;
+
+            template <typename Receiver_, typename F_, typename Sender_>
+            operation_state(Receiver_&& receiver, F_&& f, Sender_&& sender, stream_type s)
+              : receiver(PIKA_FORWARD(Receiver_, receiver))
+              , f(PIKA_FORWARD(F_, f))
+              , stream{s}
+              , completed{false}
+              , status{MPI_SUCCESS}
+              , op_state(exp::connect(PIKA_FORWARD(Sender_, sender), transform_mpi_receiver{*this}))
+            {
+                PIKA_DETAIL_DP(mpi_tran,
+                    debug(
+                        debug::detail::str<>("operation_state"), "stream", detail::stream_name(s)));
             }
 
-            template <typename Receiver>
-            friend constexpr auto tag_invoke(pika::execution::experimental::connect_t,
-                transform_mpi_sender_type&& s, Receiver&& receiver)
+            friend constexpr auto tag_invoke(exp::start_t, operation_state& os) noexcept
             {
-                return operation_state<Receiver>(PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f),
-                    PIKA_MOVE(s.sender), s.stream);
+                return exp::start(os.op_state);
             }
         };
-    }    // namespace transform_mpi_detail
 
-    inline auto mpi_pool_scheduler()
-    {
-        using pika::execution::experimental::thread_pool_scheduler;
-        return thread_pool_scheduler{&pika::resource::get_thread_pool(get_pool_name())};
-    }
+        template <typename Receiver>
+        friend constexpr auto
+        tag_invoke(exp::connect_t, transform_mpi_sender_type const& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(
+                PIKA_FORWARD(Receiver, receiver), s.f, s.sender, s.stream);
+        }
 
-    template <typename Scheduler = pika::execution::experimental::thread_pool_scheduler>
-    inline auto mpi_limiting_scheduler(stream_type s)
-    {
-        using pika::execution::experimental::limiting_scheduler;
-        using pika::execution::experimental::thread_pool_scheduler;
-        return limiting_scheduler<thread_pool_scheduler>(
-            mpi::experimental::detail::get_semaphore(s), mpi_pool_scheduler());
-    }
-
-    template <>
-    inline auto
-    mpi_limiting_scheduler<pika::execution::experimental::inline_scheduler>(stream_type s)
-    {
-        using pika::execution::experimental::inline_scheduler;
-        using pika::execution::experimental::limiting_scheduler;
-        return limiting_scheduler<inline_scheduler>(
-            mpi::experimental::detail::get_semaphore(s), inline_scheduler{});
-    }
-
-    inline auto default_pool_scheduler()
-    {
-        using pika::execution::experimental::thread_pool_scheduler;
-        return thread_pool_scheduler{&pika::resource::get_thread_pool("default")};
-    }
-
-    template <typename T>
-    struct any_sender_helper
-    {
-        using type = pika::execution::experimental::unique_any_sender<T>;
+        template <typename Receiver>
+        friend constexpr auto
+        tag_invoke(exp::connect_t, transform_mpi_sender_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(
+                PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.f), PIKA_MOVE(s.sender), s.stream);
+        }
     };
+}    // namespace pika::mpi::experimental::detail
 
-    template <>
-    struct any_sender_helper<void>
-    {
-        using type = pika::execution::experimental::unique_any_sender<>;
-    };
+namespace pika::mpi::experimental {
+
+    namespace pud = pika::util::detail;
+    namespace exp = execution::experimental;
 
     inline constexpr struct transform_mpi_t final
       : pika::functional::detail::tag_fallback<transform_mpi_t>
     {
     private:
         template <typename Sender, typename F,
-            PIKA_CONCEPT_REQUIRES_(
-                pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
-        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
-            transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
+            PIKA_CONCEPT_REQUIRES_(exp::is_sender_v<std::decay_t<Sender>>)>
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(transform_mpi_t, Sender&& sender,
+            F&& f, progress_mode p, stream_type s = stream_type::automatic)
         {
-            using namespace transform_mpi_detail;
+            using namespace pika::mpi::experimental::detail;
             PIKA_DETAIL_DP(mpi_tran,
                 debug(
                     debug::detail::str<>("tag_fallback_invoke"), "stream", detail::stream_name(s)));
 
-            using pika::execution::thread_priority;
-            using pika::execution::experimental::make_unique_any_sender;
-            using pika::execution::experimental::thread_pool_scheduler;
-            using pika::execution::experimental::transfer;
-            using pika::execution::experimental::with_priority;
-            using pika::execution::experimental::with_stacksize;
+            using execution::thread_priority;
+            using exp::make_unique_any_sender;
+            using exp::schedule;
+            using exp::then;
+            using exp::thread_pool_scheduler;
+            using exp::transfer;
+            using exp::with_priority;
+            using exp::with_stacksize;
 
             // what is the output of set_value for this transform_mpi sender
             using our_type = transform_mpi_sender<Sender, F>;
             using value_type =
-                typename std::decay<pika::execution::experimental::detail::single_result_t<
-                    typename pika::execution::experimental::sender_traits<our_type>::
-                        template value_types<pika::util::detail::pack, pika::util::detail::pack>>>::
-                    type;
+                typename std::decay<exp::detail::single_result_t<typename exp::sender_traits<
+                    our_type>::template value_types<pud::pack, pud::pack>>>::type;
             // this is the final sender type unique_any_sender<?>
             typename any_sender_helper<value_type>::type result;
 
@@ -581,90 +418,134 @@ namespace pika::mpi::experimental {
             auto mpi_exist = pool_exists();
             // get the mpi completion mode
             auto mode = get_completion_mode();
+            // ----------------------------------------------------------
+            // DLAF default : use yield_while (transfer to mpi pool if cannot_block)
             if (mode == 0)
             {
-                // use yield_while on the mpi pool
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_limiting_scheduler<>(s));
-                auto snd1 =
-                    transform_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s};
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 1)
-            {
-                // run mpi inline
-                // use suspend/resume without transfer of completion
-                auto snd1 = transform_mpi_sender<Sender, F>{
-                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 2)
-            {
-                if (!mpi_exist)
+                if (p == progress_mode::can_block)
                 {
-                    // same as mode 1
                     auto snd1 = transform_mpi_sender<Sender, F>{
                         PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
                     result = make_unique_any_sender(std::move(snd1));
                 }
                 else
                 {
-                    // transfer to mpi pool and use suspend/resume there
-                    auto snd0 =
-                        PIKA_FORWARD(Sender, sender) | transfer(mpi_limiting_scheduler<>(s));
+                    auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
                     auto snd1 = transform_mpi_sender<decltype(snd0), F>{
-                        std::move(snd0), PIKA_FORWARD(F, f), s};
+                        PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s};
                     result = make_unique_any_sender(std::move(snd1));
                 }
             }
             // ----------------------------------------------------------
-            else if (mode == 3)
+            // suspend resume : run mpi inline - transfer completion if necessary
+            else if (mode == 1)
             {
-                // run mpi inline
-                // run completion explicitly on default pool with High priority
-                auto snd1 = transform_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
+                //                auto snd0 =
+                //                    dispatch_mpi<Sender, F>{PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s} |
+                //                    exp::then([](MPI_Request r) {
+                //                        if (r != MPI_REQUEST_NULL)
+                //                        {
+                //                            auto snd0 = exp::just(r) |
+                //                                transfer(default_pool_scheduler(thread_priority::high));
+                //                            auto snd1 = trigger_mpi<decltype(snd0)>{PIKA_MOVE(snd0)};
+                //                            return this_thread::experimental::sync_wait(snd1);
+                //                        }
+                //                        return MPI_SUCCESS;
+                //                    });
+                //                result = make_unique_any_sender(std::move(snd0));
+
+                auto snd0 = dispatch_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
                                 PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(default_pool_scheduler(), thread_priority::high));
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 4)
-            {
-                // run mpi inline
-                // run completion explicitly on default pool without priority
-                auto snd1 = transform_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
-                                PIKA_FORWARD(F, f), s} |
-                    transfer(default_pool_scheduler());
-                result = make_unique_any_sender(std::move(snd1));
-            }
-            else if (mode == 5)
-            {
-                if (mpi_exist)
+                    exp::let_value([](MPI_Request r) -> exp::unique_any_sender<int> {
+                        return (r == MPI_REQUEST_NULL) ?
+                            exp::just(MPI_SUCCESS) :
+                            exp::just(r) | transfer(default_pool_scheduler(thread_priority::high)) |
+                                trigger_mpi();
+                    });
+                result = make_unique_any_sender(std::move(snd0));
+
+                /*
+                auto snd0 = transform_mpi_sender<Sender, F>{
+                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
+                if (p == progress_mode::can_block)
                 {
-                    // transfer mpi to mpi pool,
-                    auto snd0 = PIKA_FORWARD(Sender, sender) |
-                        transfer(with_stacksize(mpi_limiting_scheduler<>(s),
-                            pika::execution::thread_stacksize::nostack));
-                    // run completion explicitly on default pool with High priority
-                    auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
-                                    PIKA_FORWARD(F, f), s} |
-                        transfer(with_priority(default_pool_scheduler(), thread_priority::high));
-                    result = make_unique_any_sender(std::move(snd1));
+                    result = make_unique_any_sender(std::move(snd0));
                 }
                 else
                 {
-                    // mpi inline - same as mode
-                    auto snd1 = transform_mpi_sender<Sender, F>{PIKA_FORWARD(Sender, sender),
-                                    PIKA_FORWARD(F, f), s} |
-                        transfer(with_priority(default_pool_scheduler(), thread_priority::high));
+                    auto snd1 =
+                        std::move(snd0) | transfer(default_pool_scheduler(thread_priority::high));
                     result = make_unique_any_sender(std::move(snd1));
                 }
+*/
+            }
+            // ----------------------------------------------------------
+            // suspend resume : transfer to mpi - run completion on mpi pool
+            else if (mode == 2)
+            {
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
+                auto snd1 =
+                    transform_mpi_sender<decltype(snd0), F>{std::move(snd0), PIKA_FORWARD(F, f), s};
+                result = make_unique_any_sender(std::move(snd1));
+            }
+            // ----------------------------------------------------------
+            // suspend resume : transfer to mpi - transfer completion back
+            else if (mode == 3)
+            {
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
+                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
+                                PIKA_FORWARD(F, f), s} |
+                    transfer(default_pool_scheduler(thread_priority::high));
+                result = make_unique_any_sender(std::move(snd1));
+            }
+            // ----------------------------------------------------------
+            // polling mode : run mpi inline - HP transfer completion if necessary
+            else if (mode == 3)
+            {
+                auto snd0 = transform_mpi_sender<Sender, F>{
+                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
+                if (p == progress_mode::can_block)
+                {
+                    result = make_unique_any_sender(std::move(snd0));
+                }
+                else
+                {
+                    auto snd1 =
+                        std::move(snd0) | transfer(default_pool_scheduler(thread_priority::high));
+                    result = make_unique_any_sender(std::move(snd1));
+                }
+            }
+            // ----------------------------------------------------------
+            // polling mode : run mpi inline - NP transfer completion if necessary
+            else if (mode == 4)
+            {
+                auto snd0 = transform_mpi_sender<Sender, F>{
+                    PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f), s};
+                if (p == progress_mode::can_block)
+                {
+                    result = make_unique_any_sender(std::move(snd0));
+                }
+                else
+                {
+                    auto snd1 = std::move(snd0) | transfer(default_pool_scheduler());
+                    result = make_unique_any_sender(std::move(snd1));
+                }
+            }
+            // ----------------------------------------------------------
+            // polling mode : transfer mpi - HP transfer completion
+            else if (mode == 5)
+            {
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
+                auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
+                                PIKA_FORWARD(F, f), s} |
+                    transfer(default_pool_scheduler(thread_priority::high));
+                result = make_unique_any_sender(std::move(snd1));
             }
             else if (mode == 6)
             {
                 // transfer mpi to mpi pool,
                 // run completion explicitly on default pool without priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) |
-                    transfer(with_stacksize(
-                        mpi_limiting_scheduler<>(s), pika::execution::thread_stacksize::nostack));
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     transfer(default_pool_scheduler());
@@ -678,9 +559,7 @@ namespace pika::mpi::experimental {
             {
                 // transfer mpi to mpi pool,
                 // run completion on polling thread (mpi or default pool)
-                auto snd0 = PIKA_FORWARD(Sender, sender) |
-                    transfer(with_stacksize(
-                        mpi_limiting_scheduler<>(s), pika::execution::thread_stacksize::nostack));
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
                 auto snd1 =
                     transform_mpi_sender<decltype(snd0), F>{std::move(snd0), PIKA_FORWARD(F, f), s};
                 result = make_unique_any_sender(std::move(snd1));
@@ -689,33 +568,27 @@ namespace pika::mpi::experimental {
             {
                 // transfer mpi to mpi pool
                 // run completion explicitly on mpi pool as high priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) |
-                    transfer(with_stacksize(
-                        mpi_limiting_scheduler<>(s), pika::execution::thread_stacksize::nostack));
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(mpi_limiting_scheduler<>(s), thread_priority::high));
+                    transfer(with_priority(mpi_pool_scheduler(true), thread_priority::high));
                 result = make_unique_any_sender(std::move(snd1));
             }
             else if (mode == 9)
             {
                 // transfer mpi to mpi pool
                 // run completion explicitly on default pool using high priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) |
-                    transfer(with_stacksize(
-                        mpi_limiting_scheduler<>(s), pika::execution::thread_stacksize::nostack));
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
-                    transfer(with_priority(default_pool_scheduler(), thread_priority::high));
+                    transfer(default_pool_scheduler(thread_priority::high));
                 result = make_unique_any_sender(std::move(snd1));
             }
             else if (mode == 10)
             {
                 // transfer mpi to mpi pool
                 // run completion explicitly on default pool using default priority
-                auto snd0 = PIKA_FORWARD(Sender, sender) |
-                    transfer(with_stacksize(
-                        mpi_limiting_scheduler<>(s), pika::execution::thread_stacksize::nostack));
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(false));
                 auto snd1 = transform_mpi_sender<decltype(snd0), F>{std::move(snd0),
                                 PIKA_FORWARD(F, f), s} |
                     transfer(with_priority(default_pool_scheduler(), thread_priority::normal));
@@ -744,7 +617,7 @@ namespace pika::mpi::experimental {
                     auto snd0 = PIKA_FORWARD(Sender, sender) |
                         transfer(with_stacksize(
                             mpi_pool_scheduler(),
-                            pika::execution::thread_stacksize::nostack));
+                            execution::thread_stacksize::nostack));
                     auto snd1 =
                         transform_mpi_sender<decltype(snd0), F>{
                             std::move(snd0), PIKA_FORWARD(F, f), s} |
@@ -761,7 +634,7 @@ namespace pika::mpi::experimental {
                     auto snd0 = PIKA_FORWARD(Sender, sender) |
                         transfer(with_stacksize(
                             mpi_pool_scheduler(),
-                            pika::execution::thread_stacksize::nostack));
+                            execution::thread_stacksize::nostack));
                     auto snd1 =
                         transform_mpi_sender<decltype(snd0), F>{
                             std::move(snd0), PIKA_FORWARD(F, f), s} |
@@ -778,14 +651,14 @@ namespace pika::mpi::experimental {
                     mode, 0, 10);
             }
 
-            if constexpr (pika::execution::experimental::detail::has_completion_scheduler_v<
-                              pika::execution::experimental::set_value_t, std::decay_t<Sender>>)
-            {
-                auto cs = pika::execution::experimental::get_completion_scheduler<
-                    pika::execution::experimental::set_value_t>(PIKA_FORWARD(Sender, sender));
-                result = make_unique_any_sender(transfer(cs, std::move(result)));
-                throw std::runtime_error("This is never called!");
-            }
+            //            if constexpr (exp::detail::has_completion_scheduler_v<
+            //                              exp::set_value_t, std::decay_t<Sender>>)
+            //            {
+            //                auto cs = exp::get_completion_scheduler<
+            //                    exp::set_value_t>(PIKA_FORWARD(Sender, sender));
+            //                result = make_unique_any_sender(transfer(cs, std::move(result)));
+            //                throw std::runtime_error("This is never called!");
+            //            }
             return result;
         }
 
@@ -793,11 +666,11 @@ namespace pika::mpi::experimental {
         // tag invoke overload for mpi_transform
         //
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto
-        tag_fallback_invoke(transform_mpi_t, F&& f, stream_type s = stream_type::automatic)
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(
+            transform_mpi_t, F&& f, progress_mode p, stream_type s = stream_type::automatic)
         {
-            return ::pika::execution::experimental::detail::partial_algorithm<transform_mpi_t, F,
-                stream_type>{PIKA_FORWARD(F, f), s};
+            return exp::detail::partial_algorithm<transform_mpi_t, F, progress_mode, stream_type>{
+                PIKA_FORWARD(F, f), p, s};
         }
 
     } transform_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -360,9 +360,18 @@ namespace pika::mpi::experimental {
 
             bool inline_com = use_inline_com(mode);
             bool inline_req = use_inline_req(mode);
+
             // ----------------------------------------------------------
             // the pool should exist if the completion mode needs it
-            PIKA_ASSERT(pool_exists() == use_pool(mode));
+            int cwsize = detail::comm_world_size();
+            bool need_pool = (cwsize > 1 && use_pool(mode));
+
+            if (pool_exists() != need_pool)
+            {
+                std::cerr << "mode " << mode << " pool_exists() " << pool_exists() << " need_pool "
+                          << need_pool << std::endl;
+            }
+            PIKA_ASSERT(pool_exists() == need_pool);
 
             // ----------------------------------------------------------
             // DLAF default : use yield_while

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -38,19 +38,6 @@ namespace pika::mpi::experimental::detail {
     namespace pud = pika::util::detail;
     namespace exp = execution::experimental;
 
-    enum handler_mode
-    {
-        yield_while = 0,
-        suspend_resume = 1,
-        new_task = 2,
-        continuation = 3,
-    };
-
-    // 0x30 : 2 bits define continuation mode
-    inline handler_mode get_handler_mode(int mode)
-    {
-        return static_cast<handler_mode>((mode & 0b11 << 4) >> 4);
-    }
     // 0x08: 1 bit defines pool or no pool
     inline bool use_HP_com(int mode)
     {

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -136,6 +136,9 @@ namespace pika::mpi::experimental::detail {
                             {
                                 pika::util::yield_while(
                                     [&request]() { return !detail::poll_request(request); });
+#ifdef PIKA_HAVE_APEX
+                                apex::scoped_timer apex_invoke("pika::mpi::trigger");
+#endif
                                 // we just assume the return from mpi_test is always MPI_SUCCESS
                                 ex::set_value(PIKA_MOVE(r.op_state.receiver));
                                 break;
@@ -174,6 +177,9 @@ namespace pika::mpi::experimental::detail {
                                     r.op_state.cond_var_.wait(
                                         l, [&]() { return r.op_state.completed; });
                                 }
+#ifdef PIKA_HAVE_APEX
+                                apex::scoped_timer apex_invoke("pika::mpi::trigger");
+#endif
                                 // call set_value/set_error depending on mpi return status
                                 set_value_error_helper(
                                     r.op_state.status, PIKA_MOVE(r.op_state.receiver));

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -80,7 +80,7 @@ namespace pika::mpi::experimental::detail {
             int status;
             // these vars are needed by suspend/resume mode
             bool completed;
-            pika::spinlock mutex_;
+            pika::detail::spinlock mutex_;
             pika::condition_variable cond_var_;
 
             // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -37,7 +37,6 @@
 namespace pika::mpi::experimental::detail {
 
     namespace pud = pika::util::detail;
-    namespace exp = execution::experimental;
 
     // -----------------------------------------------------------------
     // route calls through an impl layer for ADL resolution

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -58,6 +58,10 @@ namespace pika::mpi::experimental::detail {
         std::decay_t<Sender> sender;
         int completion_mode_flags_;
 
+#if defined(PIKA_HAVE_STDEXEC)
+        using completion_signatures = pika::execution::experimental::completion_signatures<
+            pika::execution::experimental::set_value_t()>;
+#else
         // -----------------------------------------------------------------
         // completion signatures
         template <template <typename...> class Tuple, template <typename...> class Variant>
@@ -67,6 +71,7 @@ namespace pika::mpi::experimental::detail {
         using error_types = pud::unique_t<
             pud::prepend_t<typename exp::sender_traits<Sender>::template error_types<Variant>,
                 std::exception_ptr>>;
+#endif
 
         static constexpr bool sends_done = false;
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -1,0 +1,220 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/transform_xxx.hpp
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+#include <pika/async_mpi/dispatch_mpi.hpp>
+#include <pika/async_mpi/mpi_polling.hpp>
+#include <pika/concepts/concepts.hpp>
+#include <pika/datastructures/variant.hpp>
+#include <pika/debugging/demangle_helper.hpp>
+#include <pika/debugging/print.hpp>
+#include <pika/execution/algorithms/detail/helpers.hpp>
+#include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution/algorithms/transfer.hpp>
+#include <pika/execution_base/any_sender.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/executors/inline_scheduler.hpp>
+#include <pika/executors/limiting_scheduler.hpp>
+#include <pika/executors/thread_pool_scheduler.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/functional/invoke.hpp>
+#include <pika/functional/invoke_fused.hpp>
+#include <pika/mpi_base/mpi.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace pika::mpi::experimental::transform_mpi_detail {
+
+    // -----------------------------------------------------------------
+    // route calls through an impl layer for ADL resolution
+    template <typename Sender>
+    struct trigger_mpi_impl
+    {
+        struct trigger_mpi_type;
+    };
+
+    template <typename Sender>
+    using trigger_mpi = typename trigger_mpi_impl<Sender>::trigger_mpi_type;
+
+    // -----------------------------------------------------------------
+    // transform MPI adapter - sender type
+    template <typename Sender>
+    struct trigger_mpi_impl<Sender>::trigger_mpi_type
+    {
+        using is_sender = void;
+        std::decay_t<Sender> sender;
+
+        // -----------------------------------------------------------------
+        // completion signatures
+        template <template <typename...> class Tuple, template <typename...> class Variant>
+        using value_types = Variant<Tuple<int>>;
+
+        template <template <typename...> class Variant>
+        using error_types = pud::unique_t<
+            pud::prepend_t<typename exp::sender_traits<Sender>::template error_types<Variant>,
+                std::exception_ptr>>;
+
+        static constexpr bool sends_done = false;
+
+        // -----------------------------------------------------------------
+        // operation state for a given receiver
+        template <typename Receiver>
+        struct operation_state
+        {
+            std::decay_t<Receiver> receiver;
+            pika::spinlock mutex_;
+            pika::condition_variable cond_var_;
+            bool completed;
+            int status;
+
+            // -----------------------------------------------------------------
+            // The mpi_receiver receives inputs from the previous sender,
+            // invokes the mpi call, and sets a callback on the polling handler
+            struct trigger_mpi_receiver
+            {
+                using is_receiver = void;
+                operation_state& op_state;
+                int result;
+
+                template <typename Error>
+                friend constexpr void
+                tag_invoke(exp::set_error_t, trigger_mpi_receiver&& r, Error&& error) noexcept
+                {
+                    exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_FORWARD(Error, error));
+                }
+
+                friend constexpr void tag_invoke(
+                    exp::set_stopped_t, trigger_mpi_receiver&& r) noexcept
+                {
+                    exp::set_stopped(PIKA_MOVE(r.op_state.receiver));
+                }
+
+                // receive the MPI Request and set a callback to be
+                // triggered when the mpi request completes
+                friend constexpr void tag_invoke(
+                    exp::set_value_t, trigger_mpi_receiver&& r, MPI_Request request) noexcept
+                {
+                    PIKA_ASSERT_MSG(
+                        request != MPI_REQUEST_NULL, "MPI_REQUEST_NULL passed to mpi trigger");
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() mutable {
+                            // modes 0 uses the task yield_while method of callback
+                            // modes 1,2 use the task resume method of callback
+                            auto mode = get_completion_mode();
+                            if (mode < 3)
+                            {
+                                if (mode == 0)
+                                {
+                                    pika::util::yield_while(
+                                        [&request]() { return !detail::poll_request(request); });
+                                }
+                                else
+                                {
+                                    // don't suspend if request completed already
+                                    if (!detail::poll_request(request))
+                                    {
+                                        resume_request_callback(request, r.op_state);
+                                        PIKA_ASSERT(pika::threads::detail::get_self_id());
+                                        // RAII priority boost
+                                        threads::detail::thread_data::scoped_thread_priority
+                                            set_restore(execution::thread_priority::high);
+                                        // suspend task until callback notifies
+                                        std::unique_lock l{r.op_state.mutex_};
+                                        r.op_state.cond_var_.wait(
+                                            l, [&]() { return r.op_state.completed; });
+                                    }
+                                }
+                                r.op_state.status = MPI_SUCCESS;
+                                set_value_error_helper(r.op_state.status,
+                                    PIKA_MOVE(r.op_state.receiver), r.op_state.status);
+                            }
+                            // modes 3,4,5,6,7,8 ....
+                            else
+                            {
+                                // forward value to receiver
+                                r.op_state.result = MPI_SUCCESS;
+                                set_value_request_callback_non_void<int>(request, r.op_state);
+                            }
+                        },
+                        [&](std::exception_ptr ep) {
+                            exp::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));
+                        });
+                }
+
+                friend constexpr exp::empty_env tag_invoke(
+                    exp::get_env_t, trigger_mpi_receiver const&) noexcept
+                {
+                    return {};
+                }
+            };
+
+            using operation_state_type =
+                exp::connect_result_t<std::decay_t<Sender>, trigger_mpi_receiver>;
+            operation_state_type op_state;
+
+            template <typename Tuple>
+            struct value_types_helper
+            {
+                using type = pud::transform_t<Tuple, std::decay>;
+            };
+
+            template <typename Tuple>
+            struct result_types_helper;
+
+            template <template <typename...> class Tuple, typename T>
+            struct result_types_helper<Tuple<T>>
+            {
+                using type = std::decay_t<T>;
+            };
+
+            template <template <typename...> class Tuple>
+            struct result_types_helper<Tuple<>>
+            {
+                using type = pika::detail::monostate;
+            };
+
+            using result_type = pika::detail::variant<int>;
+            result_type result;
+            int ts;
+
+            template <typename Receiver_, typename Sender_>
+            operation_state(Receiver_&& receiver, Sender_&& sender)
+              : receiver(PIKA_FORWARD(Receiver_, receiver))
+              , completed{false}
+              , op_state(exp::connect(PIKA_FORWARD(Sender_, sender), trigger_mpi_receiver{*this}))
+            {
+            }
+
+            friend constexpr auto tag_invoke(exp::start_t, operation_state& os) noexcept
+            {
+                return exp::start(os.op_state);
+            }
+        };
+
+        template <typename Receiver>
+        friend constexpr auto
+        tag_invoke(exp::connect_t, trigger_mpi_type const& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(PIKA_FORWARD(Receiver, receiver), s.sender);
+        }
+
+        template <typename Receiver>
+        friend constexpr auto tag_invoke(exp::connect_t, trigger_mpi_type&& s, Receiver&& receiver)
+        {
+            return operation_state<Receiver>(PIKA_FORWARD(Receiver, receiver), PIKA_MOVE(s.sender));
+        }
+    };
+
+}    // namespace pika::mpi::experimental::transform_mpi_detail

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -35,10 +35,8 @@
 #include <utility>
 
 namespace pika::mpi::experimental::detail {
+    namespace ex = pika::execution::experimental;
 
-    namespace {
-        namespace ex = pika::execution::experimental;
-    }
     // -----------------------------------------------------------------
     // route calls through an impl layer for ADL isolation
     template <typename Sender>
@@ -240,13 +238,13 @@ namespace pika::mpi::experimental::detail {
 
 namespace pika::mpi::experimental {
 
-    namespace exp = pika::execution::experimental;
-
     inline constexpr struct trigger_mpi_t final
       : pika::functional::detail::tag_fallback<trigger_mpi_t>
     {
     private:
-        template <typename Sender, PIKA_CONCEPT_REQUIRES_(ex::is_sender_v<std::decay_t<Sender>>)>
+        template <typename Sender,
+            PIKA_CONCEPT_REQUIRES_(
+                pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
         friend constexpr PIKA_FORCEINLINE auto
         tag_fallback_invoke(trigger_mpi_t, Sender&& sender, int flags)
         {
@@ -258,7 +256,8 @@ namespace pika::mpi::experimental {
         //
         friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(trigger_mpi_t, int flags)
         {
-            return ex::detail::partial_algorithm<trigger_mpi_t, int>{flags};
+            return pika::execution::experimental::detail::partial_algorithm<trigger_mpi_t, int>{
+                flags};
         }
 
     } trigger_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -128,10 +128,6 @@ namespace pika::mpi::experimental::detail {
                 friend constexpr void tag_invoke(
                     exp::set_value_t, trigger_mpi_receiver&& r, MPI_Request request) noexcept
                 {
-                    PIKA_DETAIL_DP(mpi_tran<5>,
-                        debug(str<>("trigger_mpi_recv"), "set_value_t", request,
-                            r.op_state.handler_mode_));
-
                     // early exit check
                     if (request == MPI_REQUEST_NULL)
                     {
@@ -141,6 +137,11 @@ namespace pika::mpi::experimental::detail {
                     }
 
                     handler_mode mode = get_handler_mode(r.op_state.mode_flags_);
+
+                    PIKA_DETAIL_DP(mpi_tran<5>,
+                        debug(str<>("trigger_mpi_recv"), "set_value_t", "req", request, "flags",
+                            bin<8>(r.op_state.mode_flags_), mode_string(r.op_state.mode_flags_)));
+
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
                             // modes 0 uses the task yield_while method of callback
@@ -150,7 +151,7 @@ namespace pika::mpi::experimental::detail {
                             case handler_mode::yield_while:
                             {
                                 pika::util::yield_while(
-                                    [request]() { return !detail::poll_request(request); });
+                                    [&request]() { return !detail::poll_request(request); });
                                 // we just assume the status is always MPI_SUCCESS
                                 set_value_error_helper(
                                     MPI_SUCCESS, PIKA_MOVE(r.op_state.receiver), MPI_SUCCESS);

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -81,12 +81,12 @@ namespace pika::mpi::experimental::detail {
         struct operation_state
         {
             std::decay_t<Receiver> receiver;
-            int mode_flags_;
+            int mode_flags;
             int status;
             // these vars are needed by suspend/resume mode
             bool completed;
-            pika::detail::spinlock mutex_;
-            pika::condition_variable cond_var_;
+            pika::detail::spinlock mutex;
+            pika::condition_variable cond_var;
 
             // -----------------------------------------------------------------
             // The mpi_receiver receives inputs from the previous sender,
@@ -121,12 +121,12 @@ namespace pika::mpi::experimental::detail {
                     }
 
                     // which polling/testing mode are we using
-                    handler_mode mode = get_handler_mode(r.op_state.mode_flags_);
+                    handler_mode mode = get_handler_mode(r.op_state.mode_flags);
 
                     PIKA_DETAIL_DP(mpi_tran<5>,
                         debug(str<>("trigger_mpi_recv"), "set_value_t", "req", ptr(request),
-                            "flags", bin<8>(r.op_state.mode_flags_),
-                            mode_string(r.op_state.mode_flags_)));
+                            "flags", bin<8>(r.op_state.mode_flags),
+                            mode_string(r.op_state.mode_flags)));
 
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
@@ -163,18 +163,18 @@ namespace pika::mpi::experimental::detail {
                                 // suspend is invalid except on a pika thread
                                 PIKA_ASSERT(pika::threads::detail::get_self_id());
                                 // the callback will resume _this_ thread
-                                std::unique_lock l{r.op_state.mutex_};
+                                std::unique_lock l{r.op_state.mutex};
                                 resume_request_callback(request, r.op_state);
-                                if (use_HP_completion(r.op_state.mode_flags_))
+                                if (use_HP_completion(r.op_state.mode_flags))
                                 {
                                     threads::detail::thread_data::scoped_thread_priority
                                         set_restore(execution::thread_priority::high);
-                                    r.op_state.cond_var_.wait(
+                                    r.op_state.cond_var.wait(
                                         l, [&]() { return r.op_state.completed; });
                                 }
                                 else
                                 {
-                                    r.op_state.cond_var_.wait(
+                                    r.op_state.cond_var.wait(
                                         l, [&]() { return r.op_state.completed; });
                                 }
 #ifdef PIKA_HAVE_APEX
@@ -208,7 +208,7 @@ namespace pika::mpi::experimental::detail {
             template <typename Receiver_, typename Sender_>
             operation_state(Receiver_&& receiver, Sender_&& sender, int flags)
               : receiver(PIKA_FORWARD(Receiver_, receiver))
-              , mode_flags_{flags}
+              , mode_flags{flags}
               , status{MPI_SUCCESS}
               , op_state(ex::connect(PIKA_FORWARD(Sender_, sender), trigger_mpi_receiver{*this}))
             {

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -285,15 +285,15 @@ namespace pika::mpi::experimental {
             //            }
         }
 
-        // -----------------------------------------------------------------
-        void wait_for_throttling(stream_type stream)
-        {
-            // if throttling is disabled, then do nothing
-            if constexpr (detail::throttling_enabled)
-            {
-                wait_for_throttling_impl(get_stream_ref(stream));
-            }
-        }
+        //        // -----------------------------------------------------------------
+        //        void wait_for_throttling(stream_type stream)
+        //        {
+        //            // if throttling is disabled, then do nothing
+        //            if constexpr (detail::throttling_enabled)
+        //            {
+        //                wait_for_throttling_impl(get_stream_ref(stream));
+        //            }
+        //        }
 
         // -----------------------------------------------------------------
         std::uint32_t get_throttling_default()
@@ -589,14 +589,14 @@ namespace pika::mpi::experimental {
                                 --mpi_data_.all_in_flight_;
                                 --mpi_data_.active_request_vector_size_;
 
-                                // wake any thread that is waiting for throttling
-                                if constexpr (detail::throttling_enabled)
-                                {
-                                    mpi_stream& stream =
-                                        *detail::mpi_data_.callback_vector_[index].stream_;
-                                    --stream.active_requests_;
-                                    stream.semaphore_.release();
-                                }
+                                //                                // wake any thread that is waiting for throttling
+                                //                                if constexpr (detail::throttling_enabled)
+                                //                                {
+                                //                                    mpi_stream& stream =
+                                //                                        *detail::mpi_data_.callback_vector_[index].stream_;
+                                //                                    --stream.active_requests_;
+                                //                                    stream.semaphore_.release();
+                                //                                }
                             }
                         }
                     }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -15,6 +15,7 @@
 #include <pika/modules/errors.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi_environment.hpp>
+#include <pika/string_util/case_conv.hpp>
 #include <pika/synchronization/condition_variable.hpp>
 #include <pika/synchronization/mutex.hpp>
 //
@@ -285,8 +286,7 @@ namespace pika::mpi::experimental {
             {
                 std::string str =
                     "PIKA_MPI_MSG_THROTTLE_" + std::string(stream_name(stream_type(i)));
-                std::transform(str.begin(), str.end(), str.begin(),
-                    [](unsigned char c) { return std::toupper(c); });
+                pika::detail::to_upper(str);
                 val = pika::detail::get_env_var_as<std::uint32_t>(str.c_str(), def);
                 if (val != def)
                 {

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -521,7 +521,7 @@ namespace pika::mpi::experimental {
                         int req_init = 0;
                         while (vsize > 0)
                         {
-                            int req_size = std::min(vsize, max_poll_requests);
+                            int req_size = (std::min)(vsize, max_poll_requests);
                             /* @TODO: if we use MPI_STATUSES_IGNORE - how do we report failures? */
                             int status = MPI_Testsome(req_size, &mpi_data_.requests_[req_init],
                                 &num_completed, indices_vector_.data(),

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -8,7 +8,7 @@
 #include <pika/assert.hpp>
 #include <pika/async_mpi/mpi_exception.hpp>
 #include <pika/async_mpi/mpi_polling.hpp>
-#include <pika/command_line_handling/get_env_var.hpp>
+#include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/concurrency/spinlock.hpp>
 #include <pika/datastructures/detail/small_vector.hpp>
 #include <pika/debugging/print.hpp>
@@ -110,7 +110,7 @@ namespace pika::mpi::experimental {
 
         // -----------------------------------------------------------------
         /// Spinlock is used as it can be called by OS threads or pika tasks
-        using mutex_type = pika::spinlock;
+        using mutex_type = pika::detail::spinlock;
 
         PIKA_EXPORT const char* stream_name(stream_type s)
         {
@@ -287,7 +287,8 @@ namespace pika::mpi::experimental {
         {
             // if the global throttling var is set, set all streams
             std::uint32_t def = std::uint32_t(-1);    // unlimited
-            std::uint32_t val = pika::get_env_value("PIKA_MPI_MSG_THROTTLE", def);
+            std::uint32_t val =
+                pika::detail::get_env_var_as<std::uint32_t>("PIKA_MPI_MSG_THROTTLE", def);
             for (size_t i = 0; i < mpi_data_.default_queues_.size(); ++i)
             {
                 detail::init_stream(stream_type(i), val);
@@ -299,7 +300,7 @@ namespace pika::mpi::experimental {
                     "PIKA_MPI_MSG_THROTTLE_" + std::string(stream_name(stream_type(i)));
                 std::transform(str.begin(), str.end(), str.begin(),
                     [](unsigned char c) { return std::toupper(c); });
-                val = pika::get_env_value(str.c_str(), def);
+                val = pika::detail::get_env_var_as<std::uint32_t>(str.c_str(), def);
                 if (val != def)
                 {
                     detail::init_stream(stream_type(i), val);
@@ -312,7 +313,8 @@ namespace pika::mpi::experimental {
         // -----------------------------------------------------------------
         std::size_t get_polling_default()
         {
-            std::uint32_t val = pika::get_env_value("PIKA_MPI_POLLING_SIZE", 8);
+            std::uint32_t val =
+                pika::detail::get_env_var_as<std::uint32_t>("PIKA_MPI_POLLING_SIZE", 8);
             PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("Poll size"), dec<3>(val)));
             mpi_data_.max_polling_requests = val;
             return val;
@@ -322,7 +324,8 @@ namespace pika::mpi::experimental {
         std::size_t get_completion_mode_default()
         {
             // inline continuations are default
-            task_completion_flags_ = pika::get_env_value("PIKA_MPI_COMPLETION_MODE", 1);
+            task_completion_flags_ =
+                pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE", 1);
             return task_completion_flags_;
         }
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -552,8 +552,8 @@ namespace pika::mpi::experimental {
                                     --mpi_data_.active_requests_size_;
                                 }
                             }
-                            vsize -= 32;
-                            req_init += 32;
+                            vsize -= req_size;
+                            req_init += req_size;
                         }
                     }
                     else

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -414,7 +414,7 @@ namespace pika::mpi::experimental {
             MPI_Comm_set_errhandler(MPI_COMM_WORLD, detail::pika_mpi_errhandler);
         }
 
-        bool poll_request(MPI_Request& req)
+        bool poll_request(MPI_Request req)
         {
             int flag;
             MPI_Test(&req, &flag, MPI_STATUS_IGNORE);

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -315,8 +315,6 @@ namespace pika::mpi::experimental {
                 }
             }
             // return default val for automatic (unspecified) stream
-            std::cout << "get_throttling_default " << get_stream_ref(stream_type::automatic).limit_
-                      << std::endl;
             return get_stream_ref(stream_type::automatic).limit_;
         }
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -293,8 +293,6 @@ namespace pika::mpi::experimental {
                     detail::init_stream(stream_type(i), val);
                 }
             }
-            // return default val for automatic (unspecified) stream
-            //            return get_stream_ref(stream_type::automatic).limit_;
         }
 
         // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -187,7 +187,7 @@ namespace pika::mpi::experimental {
         // default transfer mode for mpi continuations
         static std::size_t task_completion_mode_ = get_completion_mode_default();
 
-        static std::string default_pool_name = "pika:mpi";
+        static std::string default_pool_name = "pika:polling";
 
         inline mpi_stream& get_stream_ref(stream_type stream)
         {

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -841,7 +841,14 @@ namespace pika::mpi::experimental {
             }
             // override mpi pool name with whatever we decided on
             set_pool_name(name);
-            detail::register_polling(pika::resource::get_thread_pool(name));
+            auto mode = mpi::experimental::get_completion_mode();
+            if (mode > 0 && mode < 100)
+            {
+                PIKA_DETAIL_DP(detail::mpi_debug<0>,
+                    debug(str<>("register_polling"), name, "mode",
+                        mpi::experimental::get_completion_mode()));
+                detail::register_polling(pika::resource::get_thread_pool(name));
+            }
             detail::pool_exists_ = (name != resource::get_pool_name(0));
         }
         else
@@ -850,7 +857,14 @@ namespace pika::mpi::experimental {
             // make sure the mpi pool name matches what the user passed in
             detail::pool_exists_ = true;
             set_pool_name(pool_name);
-            detail::register_polling(pika::resource::get_thread_pool(pool_name));
+            auto mode = mpi::experimental::get_completion_mode();
+            if (mode > 0 && mode < 100)
+            {
+                PIKA_DETAIL_DP(detail::mpi_debug<0>,
+                    debug(str<>("register_polling"), pool_name, "mode",
+                        mpi::experimental::get_completion_mode()));
+                detail::register_polling(pika::resource::get_thread_pool(pool_name));
+            }
             detail::pool_exists_ = (pool_name != resource::get_pool_name(0));
         }
     }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -803,11 +803,21 @@ namespace pika::mpi::experimental {
         // install polling loop on requested thread pool
         if (pool_name.empty() || !pika::resource::pool_exists(pool_name))
         {
-            set_pool_name(resource::get_pool_name(0));
-            detail::register_polling(pika::resource::get_thread_pool(0));
+            // does mpi pool exist with mpi pool name
+            std::string name = mpi::experimental::get_pool_name();
+            if (!pika::resource::pool_exists(name))
+            {
+                // drop back to default pika pool name
+                name = resource::get_pool_name(0);
+            }
+            // override mpi pool name with whatever we decided on
+            set_pool_name(name);
+            detail::register_polling(pika::resource::get_thread_pool(name));
         }
         else
         {
+            PIKA_ASSERT_MSG(pool_name == get_pool_name(), "MPI pool name mismatch");
+            // make sure the mpi pool name matches what the user passed in
             set_pool_name(pool_name);
             detail::register_polling(pika::resource::get_thread_pool(pool_name));
         }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -469,7 +469,7 @@ namespace pika::mpi::experimental {
             // start a scoped block where the polling lock is held
             {
 #ifdef PIKA_HAVE_APEX
-                apex::scoped_timer apex_poll("pika::mpi::poll");
+                //apex::scoped_timer apex_poll("pika::mpi::poll");
 #endif
                 std::unique_lock<mutex_type> lk(mpi_data_.polling_vector_mtx_, std::try_to_lock);
                 if (!lk.owns_lock())

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -21,12 +21,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iostream>
 #include <memory>
 #include <mpi.h>
 #include <optional>
 #include <ostream>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -354,7 +354,7 @@ namespace pika::mpi::experimental {
             ++mpi_data_.request_queue_size_;
             ++get_stream_ref(stream).active_requests_;
             ++mpi_data_.all_in_flight_;
-            PIKA_DP(mpi_debug<5>,
+            PIKA_DETAIL_DP(mpi_debug<5>,
                 debug(
                     str<>("CB queued"), req_callback.request_, get_stream_ref(stream), mpi_data_));
         }
@@ -372,7 +372,7 @@ namespace pika::mpi::experimental {
             ++(mpi_data_.active_request_vector_size_);
 
             // clang-format off
-            PIKA_DP(mpi_debug<5>, debug(str<>("CB queue => vector"),
+            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("CB queue => vector"),
                 mpi_data_, req_callback.request_, get_stream_ref(req_callback.index_),
                 "nulls", dec<3>(get_num_null_requests_in_vector())
                 ));
@@ -399,7 +399,8 @@ namespace pika::mpi::experimental {
 #ifndef DISALLOW_EAGER_POLLING_CHECK
             if (eager == check_request_eager::yes && detail::poll_request(request))
             {
-                PIKA_DP(mpi_debug<5>, debug(str<>("eager poll"), request, get_stream_ref(s)));
+                PIKA_DETAIL_DP(
+                    mpi_debug<5>, debug(str<>("eager poll"), request, get_stream_ref(s)));
                 // invoke the callback now since request has completed eagerly
                 PIKA_INVOKE(PIKA_MOVE(callback), MPI_SUCCESS);
                 // didn't increment 'in flight' counter, don't notify condition
@@ -419,7 +420,7 @@ namespace pika::mpi::experimental {
         // function that converts an MPI error into an exception
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
-            PIKA_DP(mpi_debug<5>, debug(str<>("pika_MPI_Handler")));
+            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("pika_MPI_Handler")));
             throw mpi_exception(*errorcode, error_message(*errorcode));
         }
 
@@ -428,7 +429,7 @@ namespace pika::mpi::experimental {
         // on any error instead of the default behavior of program termination
         void set_error_handler()
         {
-            PIKA_DP(mpi_debug<5>, debug(str<>("set_error_handler")));
+            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("set_error_handler")));
 
             MPI_Comm_create_errhandler(detail::pika_MPI_Handler, &detail::pika_mpi_errhandler);
             MPI_Comm_set_errhandler(MPI_COMM_WORLD, detail::pika_mpi_errhandler);
@@ -440,7 +441,7 @@ namespace pika::mpi::experimental {
             MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
             if (flag)
             {
-                PIKA_DP(mpi_debug<5>, debug(str<>("eager poll ok"), req));
+                PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("eager poll ok"), req));
             }
             return flag;
         };
@@ -495,7 +496,7 @@ namespace pika::mpi::experimental {
             detail::ready_callback ready_callback_;
             while (detail::mpi_data_.ready_requests_.try_dequeue(ready_callback_))
             {
-                PIKA_DP(mpi_debug<5>,
+                PIKA_DETAIL_DP(mpi_debug<5>,
                     debug(str<>("CB invoke"), ready_callback_.request_, ready_callback_.err_));
 
                 // Invoke callback (PIKA_MOVE doesn't compile here)
@@ -516,7 +517,7 @@ namespace pika::mpi::experimental {
                         // for debugging, create a timer : debug info every N seconds
                         static auto poll_deb =
                             mpi_debug<5>.make_timer(1, str<>("Poll - lock failed"));
-                        PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
+                        PIKA_DETAIL_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                     }
                     return polling_status::idle;
                 }
@@ -525,7 +526,7 @@ namespace pika::mpi::experimental {
                 {
                     // for debugging, create a timer : debug info every N seconds
                     static auto poll_deb = mpi_debug<5>.make_timer(1, str<>("Poll - lock success"));
-                    PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
+                    PIKA_DETAIL_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                 }
 
                 bool event_handled;
@@ -568,7 +569,7 @@ namespace pika::mpi::experimental {
                         if (outcount != MPI_UNDEFINED && outcount != 0)
                         {
                             event_handled = true;
-                            PIKA_DP(mpi_debug<5>,
+                            PIKA_DETAIL_DP(mpi_debug<5>,
                                 debug(str<>("Polling loop"), detail::mpi_data_, "outcount",
                                     dec<3>(outcount)));
 
@@ -643,13 +644,13 @@ namespace pika::mpi::experimental {
             if constexpr (mpi_debug<5>.is_enabled())
             {
                 static auto poll_deb = mpi_debug<5>.make_timer(1, str<>("Poll - success"));
-                PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
+                PIKA_DETAIL_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
             }
 
             // invoke (new) ready callbacks without being under lock
             while (detail::mpi_data_.ready_requests_.try_dequeue(ready_callback_))
             {
-                PIKA_DP(mpi_debug<5>,
+                PIKA_DETAIL_DP(mpi_debug<5>,
                     debug(str<>("CB invoke"), ready_callback_.request_, ready_callback_.err_));
 
                 // Invoke callback (PIKA_MOVE doesn't compile here)
@@ -673,7 +674,7 @@ namespace pika::mpi::experimental {
 #if defined(PIKA_DEBUG)
             ++get_register_polling_count();
 #endif
-            PIKA_DP(mpi_debug<5>, debug(str<>("enable polling")));
+            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("enable polling")));
             auto* sched = pool.get_scheduler();
             sched->set_mpi_polling_functions(
                 &pika::mpi::experimental::detail::poll, &get_work_count);
@@ -698,7 +699,7 @@ namespace pika::mpi::experimental {
                     "sure MPI request polling is not disabled too early.");
             }
 #endif
-            PIKA_DP(mpi_debug<5>, debug(str<>("disable polling")));
+            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("disable polling")));
             auto* sched = pool.get_scheduler();
             sched->clear_mpi_polling_function();
         }
@@ -793,7 +794,7 @@ namespace pika::mpi::experimental {
             pika::util::mpi_environment::init(nullptr, nullptr, required, minimal, provided);
             if (provided < MPI_THREAD_FUNNELED)
             {
-                PIKA_DP(detail::mpi_debug<5>,
+                PIKA_DETAIL_DP(detail::mpi_debug<5>,
                     error(str<>("pika::mpi::experimental::init"), "init failed"));
                 PIKA_THROW_EXCEPTION(pika::error::invalid_status, "pika::mpi::experimental::init",
                     "the MPI installation doesn't allow multiple threads");
@@ -816,7 +817,7 @@ namespace pika::mpi::experimental {
             }
         }
 
-        PIKA_DP(
+        PIKA_DETAIL_DP(
             detail::mpi_debug<5>, debug(str<>("pika::mpi::experimental::init"), detail::mpi_data_));
 
         if (init_errorhandler)
@@ -825,7 +826,7 @@ namespace pika::mpi::experimental {
             detail::mpi_data_.error_handler_initialized_ = true;
         }
 
-        PIKA_DP(detail::mpi_debug<1>,
+        PIKA_DETAIL_DP(detail::mpi_debug<1>,
             debug(str<>("pika::mpi::experimental::init"), "pool name", pool_name));
 
         // install polling loop on requested thread pool
@@ -869,7 +870,7 @@ namespace pika::mpi::experimental {
         // clean up if we initialized mpi
         pika::util::mpi_environment::finalize();
 
-        PIKA_DP(detail::mpi_debug<5>,
+        PIKA_DETAIL_DP(detail::mpi_debug<5>,
             debug(str<>("Clearing mode"), detail::mpi_data_, "disable_user_polling"));
 
         if (pool_name.empty())

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -14,6 +14,7 @@
 #include <pika/modules/errors.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi_environment.hpp>
+#include <pika/resource_partitioner/detail/partitioner.hpp>
 #include <pika/synchronization/condition_variable.hpp>
 
 #include <array>
@@ -187,7 +188,7 @@ namespace pika::mpi::experimental {
         // default transfer mode for mpi continuations
         static std::size_t task_completion_mode_ = get_completion_mode_default();
 
-        static std::string default_pool_name = "pika:polling";
+        static std::string polling_pool_name = "pika:polling";
 
         inline mpi_stream& get_stream_ref(stream_type stream)
         {
@@ -749,13 +750,13 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     const std::string& get_pool_name()
     {
-        return detail::default_pool_name;
+        return detail::polling_pool_name;
     }
 
     // -----------------------------------------------------------------
     void set_pool_name(const std::string& name)
     {
-        detail::default_pool_name = name;
+        detail::polling_pool_name = name;
     }
 
     // -------------------------------------------------------------
@@ -810,7 +811,7 @@ namespace pika::mpi::experimental {
         // install polling loop on requested thread pool
         if (pool_name.empty() || !pika::resource::pool_exists(pool_name))
         {
-            set_pool_name("default");
+            set_pool_name(resource::get_partitioner().get_default_pool_name());
             detail::register_polling(pika::resource::get_thread_pool(0));
         }
         else

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -820,7 +820,8 @@ namespace pika::mpi::experimental {
             // override mpi pool name with whatever we decided on
             set_pool_name(name);
             auto mode = mpi::experimental::get_completion_mode();
-            if (mode > 0 && mode < 100)
+            if (pika::mpi::experimental::detail::get_handler_mode(mode) !=
+                detail::handler_mode::yield_while)
             {
                 PIKA_DETAIL_DP(detail::mpi_debug<0>,
                     debug(str<>("register_polling"), name, "mode",
@@ -836,7 +837,7 @@ namespace pika::mpi::experimental {
             detail::pool_exists_ = true;
             set_pool_name(pool_name);
             auto mode = mpi::experimental::get_completion_mode();
-            if (mode > 0 && mode < 100)
+            if (detail::get_handler_mode(mode) != detail::handler_mode::yield_while)
             {
                 PIKA_DETAIL_DP(detail::mpi_debug<0>,
                     debug(str<>("register_polling"), pool_name, "mode",

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -508,141 +508,156 @@ namespace pika::mpi::experimental {
 
             // completed requests will be moved into this temp array
             // so that we can release the lock before triggering continuations
-            pika::detail::small_vector<mpi_callback_tuple, 64> callbacks_;
+            pika::detail::small_vector<mpi_callback_tuple, 8> callbacks_;
 
-            // start a scope block where the polling lock is held
+            bool event_handled;
+            do
             {
-                std::unique_lock<detail::mutex_type> lk(
-                    detail::mpi_data_.polling_vector_mtx_, std::try_to_lock);
-                if (!lk.owns_lock())
+                event_handled = false;
+                // start a scope block where the polling lock is held
                 {
+                    std::unique_lock<detail::mutex_type> lk(
+                        detail::mpi_data_.polling_vector_mtx_, std::try_to_lock);
+                    if (!lk.owns_lock())
+                    {
+                        if constexpr (mpi_debug<5>.is_enabled())
+                        {
+                            // for debugging, create a timer : debug info every N seconds
+                            static auto poll_deb =
+                                mpi_debug<5>.make_timer(1, str<>("Poll - lock failed"));
+                            PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
+                        }
+                        return polling_status::idle;
+                    }
+
                     if constexpr (mpi_debug<5>.is_enabled())
                     {
                         // for debugging, create a timer : debug info every N seconds
                         static auto poll_deb =
-                            mpi_debug<5>.make_timer(1, str<>("Poll - lock failed"));
+                            mpi_debug<5>.make_timer(1, str<>("Poll - lock success"));
                         PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                     }
-                    return polling_status::idle;
-                }
 
-                if constexpr (mpi_debug<5>.is_enabled())
-                {
-                    // for debugging, create a timer : debug info every N seconds
-                    static auto poll_deb = mpi_debug<5>.make_timer(1, str<>("Poll - lock success"));
-                    PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
-                }
+                    // Move requests in the queue (that have not yet been polled for)
+                    // into the polling vector ...
+                    // Number in_flight does not change during this section as one
+                    // is moved off the queue and into the vector
 
-                // Move requests in the queue (that have not yet been polled for)
-                // into the polling vector ...
-                // Number in_flight does not change during this section as one
-                // is moved off the queue and into the vector
-
-                detail::request_callback req_callback;
-                while (detail::mpi_data_.request_callback_queue_.try_dequeue(req_callback))
-                {
-                    --detail::mpi_data_.request_queue_size_;
-                    add_to_request_callback_vector(PIKA_MOVE(req_callback));
-                }
-
-                const std::size_t max_test_vector_size = 512;
-                std::size_t vsize =
-                    std::min(detail::mpi_data_.request_vector_.size(), max_test_vector_size);
-                int outcount = 0;
-
-                // do we poll for N requests at a time, or just 1
-                if (detail::mpi_data_.max_polling_requests > 1)
-                {
-                    std::size_t req_size = std::min(vsize, detail::mpi_data_.max_polling_requests);
-                    detail::mpi_data_.indices_vector_.resize(req_size);
-                    detail::mpi_data_.status_vector_.resize(req_size);
-
-                    int result = MPI_Testsome(req_size, detail::mpi_data_.request_vector_.data(),
-                        &outcount, detail::mpi_data_.indices_vector_.data(),
-                        detail::mpi_data_.status_vector_.data());
-                    /*use MPI_STATUSES_IGNORE ?*/
-
-                    if (result != MPI_SUCCESS)
-                        throw mpi_exception(result, "MPI_Testsome error");
-                    if (outcount != MPI_UNDEFINED && outcount != 0)
+                    detail::request_callback req_callback;
+                    while (detail::mpi_data_.request_callback_queue_.try_dequeue(req_callback))
                     {
-                        PIKA_DP(mpi_debug<5>,
-                            debug(str<>("Polling loop"), detail::mpi_data_, "outcount",
-                                dec<3>(outcount)));
-                        // for each completed request
-                        for (int i = 0; i < outcount; ++i)
+                        --detail::mpi_data_.request_queue_size_;
+                        add_to_request_callback_vector(PIKA_MOVE(req_callback));
+                    }
+
+                    const std::size_t max_test_vector_size = 512;
+                    std::size_t vsize =
+                        std::min(detail::mpi_data_.request_vector_.size(), max_test_vector_size);
+                    int outcount = 0;
+
+                    // do we poll for N requests at a time, or just 1
+                    if (detail::mpi_data_.max_polling_requests > 1)
+                    {
+                        std::size_t req_size =
+                            std::min(vsize, detail::mpi_data_.max_polling_requests);
+                        detail::mpi_data_.indices_vector_.resize(req_size);
+                        detail::mpi_data_.status_vector_.resize(req_size);
+
+                        int result =
+                            MPI_Testsome(req_size, detail::mpi_data_.request_vector_.data(),
+                                &outcount, detail::mpi_data_.indices_vector_.data(),
+                                detail::mpi_data_.status_vector_.data());
+                        /*use MPI_STATUSES_IGNORE ?*/
+
+                        if (result != MPI_SUCCESS)
+                            throw mpi_exception(result, "MPI_Testsome error");
+                        if (outcount != MPI_UNDEFINED && outcount != 0)
                         {
-                            size_t index = detail::mpi_data_.indices_vector_[i];
+                            PIKA_DP(mpi_debug<5>,
+                                debug(str<>("Polling loop"), detail::mpi_data_, "outcount",
+                                    dec<3>(outcount)));
+                            // for each completed request
+                            for (int i = 0; i < outcount; ++i)
+                            {
+                                size_t index = detail::mpi_data_.indices_vector_[i];
+                                event_handled = true;
+                                callbacks_.emplace_back(
+                                    PIKA_MOVE(detail::mpi_data_.callback_vector_[index]));
+                                std::get<error_type>(callbacks_[i]) =
+                                    detail::mpi_data_.status_vector_[i].MPI_ERROR;
+                                // Remove the request from our vector to prevent retesting
+                                detail::mpi_data_.request_vector_[index] = MPI_REQUEST_NULL;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        int rindex, flag;
+                        int result = MPI_Testany(detail::mpi_data_.request_vector_.size(),
+                            detail::mpi_data_.request_vector_.data(), &rindex, &flag,
+                            MPI_STATUS_IGNORE);
+                        if (result != MPI_SUCCESS)
+                            throw mpi_exception(result, "MPI_Testany error");
+                        if (rindex != MPI_UNDEFINED)
+                        {
+                            outcount = 1;
+                            size_t index = static_cast<size_t>(rindex);
+                            event_handled = true;
                             callbacks_.emplace_back(
                                 PIKA_MOVE(detail::mpi_data_.callback_vector_[index]));
-                            std::get<error_type>(callbacks_[i]) =
-                                detail::mpi_data_.status_vector_[i].MPI_ERROR;
                             // Remove the request from our vector to prevent retesting
                             detail::mpi_data_.request_vector_[index] = MPI_REQUEST_NULL;
                         }
                     }
-                }
-                else
+
+                    // still under lock : remove wasted space caused by completed requests
+                    compact_vectors();
+                }    // end lock scope block
+
+                // output a debug heartbeat every N seconds
+                if constexpr (mpi_debug<5>.is_enabled())
                 {
-                    int rindex, flag;
-                    int result = MPI_Testany(detail::mpi_data_.request_vector_.size(),
-                        detail::mpi_data_.request_vector_.data(), &rindex, &flag,
-                        MPI_STATUS_IGNORE);
-                    if (result != MPI_SUCCESS)
-                        throw mpi_exception(result, "MPI_Testany error");
-                    if (rindex != MPI_UNDEFINED)
-                    {
-                        outcount = 1;
-                        size_t index = static_cast<size_t>(rindex);
-                        callbacks_.emplace_back(
-                            PIKA_MOVE(detail::mpi_data_.callback_vector_[index]));
-                        // Remove the request from our vector to prevent retesting
-                        detail::mpi_data_.request_vector_[index] = MPI_REQUEST_NULL;
-                    }
+                    static auto poll_deb = mpi_debug<5>.make_timer(1, str<>("Poll - success"));
+                    PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                 }
 
-                // still under lock : remove wasted space caused by completed requests
-                compact_vectors();
-            }    // end lock scope block
-
-            // output a debug heartbeat every N seconds
-            if constexpr (mpi_debug<5>.is_enabled())
-            {
-                static auto poll_deb = mpi_debug<5>.make_timer(1, str<>("Poll - success"));
-                PIKA_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
-            }
-
-            // we can now invoke callbacks without holding the lock
-            for (const auto& c : callbacks_)
-            {
-                // decrement before invoking callback to avoid race
-                // if invoked code checks in_flight value
-                mpi_stream& stream = *std::get<mpi_stream*>(c);
-                --stream.in_stream_;
-                --mpi_data_.all_in_flight_;
-                --mpi_data_.active_request_vector_size_;
-
-                // wake any thread that is waiting for throttling
-                // if throttling is disabled, then do nothing
-                if constexpr (detail::throttling_enabled)
+                // we can now invoke callbacks without holding the lock
+                for (const auto& c : callbacks_)
                 {
-                    if (stream.in_stream_ < stream.limit_)
+                    // decrement before invoking callback to avoid race
+                    // if invoked code checks in_flight value
+                    mpi_stream& stream = *std::get<mpi_stream*>(c);
+                    --stream.in_stream_;
+                    --mpi_data_.all_in_flight_;
+                    --mpi_data_.active_request_vector_size_;
+
+                    // wake any thread that is waiting for throttling
+                    // if throttling is disabled, then do nothing
+                    if constexpr (detail::throttling_enabled)
                     {
-                        std::unique_lock lk(stream.throttling_mtx_);
-                        PIKA_DP(mpi_debug<5>,
-                            debug(
-                                str<>("notify_one"), std::get<MPI_Request>(c), stream, mpi_data_));
-                        stream.throttling_cond_.notify_one();
+                        if (stream.in_stream_ < stream.limit_)
+                        {
+                            std::unique_lock lk(stream.throttling_mtx_);
+                            PIKA_DP(mpi_debug<5>,
+                                debug(str<>("notify_one"), std::get<MPI_Request>(c), stream,
+                                    mpi_data_));
+                            stream.throttling_cond_.notify_one();
+                        }
                     }
+
+                    PIKA_DP(mpi_debug<5>,
+                        debug(str<>("CB invoke"), std::get<MPI_Request>(c), stream, mpi_data_));
+
+                    // Invoke the callback with the result status
+                    PIKA_INVOKE(PIKA_MOVE(std::get<request_callback_function_type>(c)),
+                        std::get<error_type>(c));
                 }
 
-                PIKA_DP(mpi_debug<5>,
-                    debug(str<>("CB invoke"), std::get<MPI_Request>(c), stream, mpi_data_));
+                // wipe any we have triggered before testing again
+                callbacks_.clear();
 
-                // Invoke the callback with the result status
-                PIKA_INVOKE(PIKA_MOVE(std::get<request_callback_function_type>(c)),
-                    std::get<error_type>(c));
-            }
+            } while (event_handled == true);
+
             return detail::mpi_data_.all_in_flight_.load(std::memory_order_relaxed) == 0 ?
                 polling_status::idle :
                 polling_status::busy;

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -43,11 +43,6 @@
 #include <vector>
 
 namespace pika::mpi::experimental {
-    template <typename E>
-    constexpr typename std::underlying_type<E>::type to_underlying(E e) noexcept
-    {
-        return static_cast<typename std::underlying_type<E>::type>(e);
-    }
 
     namespace detail {
         // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -451,6 +451,9 @@ namespace pika::mpi::experimental {
             ready_callback ready_callback_;
             while (mpi_data_.ready_requests_.try_dequeue(ready_callback_))
             {
+#ifdef PIKA_HAVE_APEX
+                apex::scoped_timer apex_invoke("pika::mpi::trigger");
+#endif
                 PIKA_DETAIL_DP(mpi_debug<4>,
                     debug(str<>("Ready CB invoke"), ptr(ready_callback_.request_),
                         ready_callback_.err_));
@@ -465,6 +468,9 @@ namespace pika::mpi::experimental {
 
             // start a scoped block where the polling lock is held
             {
+#ifdef PIKA_HAVE_APEX
+                apex::scoped_timer apex_poll("pika::mpi::poll");
+#endif
                 std::unique_lock<mutex_type> lk(mpi_data_.polling_vector_mtx_, std::try_to_lock);
                 if (!lk.owns_lock())
                 {
@@ -589,6 +595,9 @@ namespace pika::mpi::experimental {
             // invoke (new) ready callbacks without being under lock
             while (mpi_data_.ready_requests_.try_dequeue(ready_callback_))
             {
+#ifdef PIKA_HAVE_APEX
+                apex::scoped_timer apex_invoke("pika::mpi::trigger");
+#endif
                 PIKA_DETAIL_DP(mpi_debug<5>,
                     debug(str<>("CB invoke"), ptr(ready_callback_.request_), ready_callback_.err_));
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -444,7 +444,6 @@ namespace pika::mpi::experimental {
             MPI_Comm_set_errhandler(MPI_COMM_WORLD, detail::pika_mpi_errhandler);
         }
 
-#ifndef DISALLOW_EAGER_POLLING_CHECK
         bool poll_request(MPI_Request& req)
         {
             int flag;
@@ -455,7 +454,6 @@ namespace pika::mpi::experimental {
             }
             return flag;
         };
-#endif
 
         // -------------------------------------------------------------
         /// Remove all entries in request and callback vectors that are invalid

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -402,7 +402,7 @@ namespace pika::mpi::experimental {
                 "MPI event polling has not been enabled on any pool. Make sure that MPI event "
                 "polling is enabled on at least one thread pool.");
 
-            // if already complete, kip callback
+            // if already complete, skip callback
 #ifndef DISALLOW_EAGER_POLLING_CHECK
             if (eager_check && detail::poll_request(request))
             {

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -190,7 +190,8 @@ namespace pika::mpi::experimental {
         // default transfer mode for mpi continuations
         static std::size_t task_completion_mode_ = get_completion_mode_default();
 
-        static std::string polling_pool_name = "pika:polling";
+        static std::string polling_pool_name_ = "pika:polling";
+        static bool pool_exists_ = false;
 
         inline mpi_stream& get_stream_ref(stream_type stream)
         {
@@ -741,13 +742,18 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     const std::string& get_pool_name()
     {
-        return detail::polling_pool_name;
+        return detail::polling_pool_name_;
     }
 
     // -----------------------------------------------------------------
     void set_pool_name(const std::string& name)
     {
-        detail::polling_pool_name = name;
+        detail::polling_pool_name_ = name;
+    }
+
+    // -----------------------------------------------------------------
+    bool pool_exists() {
+        return detail::pool_exists_;
     }
 
     // -------------------------------------------------------------
@@ -813,13 +819,16 @@ namespace pika::mpi::experimental {
             // override mpi pool name with whatever we decided on
             set_pool_name(name);
             detail::register_polling(pika::resource::get_thread_pool(name));
+            detail::pool_exists_ = (name!=resource::get_pool_name(0));
         }
         else
         {
             PIKA_ASSERT_MSG(pool_name == get_pool_name(), "MPI pool name mismatch");
             // make sure the mpi pool name matches what the user passed in
+            detail::pool_exists_ = true;
             set_pool_name(pool_name);
             detail::register_polling(pika::resource::get_thread_pool(pool_name));
+            detail::pool_exists_ = (pool_name!=resource::get_pool_name(0));
         }
     }
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -368,24 +368,11 @@ namespace pika::mpi::experimental {
 #endif
 
         // -------------------------------------------------------------
-        bool add_request_callback(request_callback_function_type&& callback, MPI_Request request,
-            check_request_eager eager)
+        bool add_request_callback(request_callback_function_type&& callback, MPI_Request request)
         {
             PIKA_ASSERT_MSG(get_register_polling_count() != 0,
                 "MPI event polling has not been enabled on any pool. Make sure that MPI event "
                 "polling is enabled on at least one thread pool.");
-
-            // if already complete, skip callback
-#ifndef DISALLOW_EAGER_POLLING_CHECK
-            if (eager == check_request_eager::yes && detail::poll_request(request))
-            {
-                PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("eager poll"), request));
-                // invoke the callback now since request has completed eagerly
-                PIKA_INVOKE(PIKA_MOVE(callback), MPI_SUCCESS);
-                // didn't increment 'in flight' counter, don't notify condition
-                return false;
-            }
-#endif
             add_to_request_callback_queue(request_callback{request, PIKA_MOVE(callback)});
             return true;
         }

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,19 +4,20 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver
-          mpi_async_storage
+set(tests # algorithm_transform_mpi
+    mpi_ring_async_sender_receiver
+    # mpi_async_storage
 )
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
-    ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100"
+    ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100" "--pika:ignore-process-mask"
     THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 
 set(mpi_async_storage_PARAMETERS
     ARGS
-        "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1"
+        "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1" "-Ipika.stacks.use_guard_pages=0" "--pika:ignore-process-mask"
     THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 # cmake-format: on

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,10 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests
-    #algorithm_transform_mpi
+set(tests # algorithm_transform_mpi
     mpi_ring_async_sender_receiver
-    #mpi_async_storage
+    # mpi_async_storage
 )
 
 # cmake-format: off

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -10,7 +10,7 @@ set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
-    ARGS "--in-flight-limit=32"
+    ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100"
     THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,9 +4,10 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests # algorithm_transform_mpi
+set(tests
+    #algorithm_transform_mpi
     mpi_ring_async_sender_receiver
-    # mpi_async_storage
+    #mpi_async_storage
 )
 
 # cmake-format: off

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -11,13 +11,14 @@ set(tests # algorithm_transform_mpi
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
-    ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100" "--pika:ignore-process-mask"
+    ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100" 
+         "--pika:ignore-process-mask"
     THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 
 set(mpi_async_storage_PARAMETERS
-    ARGS
-        "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1" "-Ipika.stacks.use_guard_pages=0" "--pika:ignore-process-mask"
+    ARGS "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1" 
+         "--pika:ignore-process-mask"
     THREADS 4 LOCALITIES 2 RUNWRAPPER mpi
 )
 # cmake-format: on

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -486,16 +486,11 @@ void init_resource_partitioner_handler(
 }
 
 //----------------------------------------------------------------------------
-void dummy_printer(std::ostream& /*os*/) {}
-
-//----------------------------------------------------------------------------
 // the normal int main function that is called at startup and runs on an OS
 // thread the user must call pika::init to start the pika runtime which
 // will execute pika_main on an pika thread
 int main(int argc, char* argv[])
 {
-    //pika::debug::detail::register_print_info(&dummy_printer);
-
     // Init MPI
     int provided = MPI_THREAD_MULTIPLE;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -104,7 +104,7 @@ inline std::uint32_t prev_rank(std::uint32_t rank, std::uint32_t size)
 // ------------------------------------------------------------
 // when messages arrive/complete in random order, it might be the
 // case that message N + x completes long before message N, so
-// we don't reuse tags immmediately and instead offset them by
+// we don't reuse tags immediately and instead offset them by
 // a multiple to ensure we don't have two with the same id in flight
 // at the same time
 inline std::uint32_t tag_no(std::uint64_t rank, std::uint64_t iteration, std::uint32_t ranks)
@@ -245,7 +245,7 @@ struct receiver
                         release_msg_buffer(buf);
                     });
 
-            // launch the receive for te next msg and launch the sending forward
+            // launch the receive for the next msg and launch the sending forward
             msr_deb<6>.debug(str<>("start_detached"), "tx_snd2", step, round);
             pika::execution::async(std::move(tx_snd2));
         }
@@ -277,7 +277,7 @@ struct receiver
                         //                release_msg_buffer(buf);
                     });
 
-            // launch the receive for te next msg and launch the sending forward
+            // launch the receive for the next msg and launch the sending forward
             msr_deb<6>.debug(str<>("start_detached"), "rx_snd2", step, round);
             pika::execution::async(std::move(rx_snd2));
             msr_deb<6>.debug(str<>("start_detached"), "tx_snd2", step, round);
@@ -369,7 +369,7 @@ int pika_main(pika::program_options::variables_map& vm)
                     tag_no(std::uint64_t(orank), std::uint64_t(i), std::uint32_t(size));
                 msg_info(rank, size, msg_type::recv, buf->token_val_, tag, 0, 0, "ringrecv");
 
-                // a handler for a receive that recursivley posts receives and handles them
+                // a handler for a receive that recursively posts receives and handles them
                 receiver reclambda(rank, orank, size, tag, num_rounds, message_size, buf);
                 // create chain of senders to make the mpi recv and handle it
                 auto rx_snd1 = ex::just(&*buf, message_size, MPI_UNSIGNED_CHAR,

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -479,19 +479,18 @@ void init_resource_partitioner_handler(
     pika::resource::partitioner& rp, pika::program_options::variables_map const& vm)
 {
     // Don't create the MPI pool if the user disabled it
-    // Don't create the MPI pool if there is a single process
     int ntasks;
     MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
     if (vm["no-mpi-pool"].as<bool>() || ntasks == 1)
     {
         // turn off pool creation
         int mode = pika::get_env_value("PIKA_MPI_COMPLETION_MODE", 1);
-        mode = mode & ~(0b01 << 2);
+        mode = mode & ~(0b01);
         setenv("PIKA_MPI_COMPLETION_MODE", std::to_string(mode).c_str(), true);
         pika::mpi::experimental::detail::get_completion_mode_default();
-        return;
     }
     //
+    msr_deb<2>.debug(str<>("init RP"), "create_pool");
     mpi::create_pool(rp, "", mpi::pool_create_mode::pika_decides);
 }
 

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -17,6 +17,7 @@
 //
 #include <boost/lockfree/stack.hpp>
 #include <fmt/format.h>
+#include <fmt/printf.h>
 //
 #include <array>
 #include <atomic>

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -447,12 +447,6 @@ int pika_main(pika::program_options::variables_map& vm)
         // the user queue should always be empty by now since our counter tracks it
         PIKA_ASSERT(mpi::get_work_count() == 0);
 
-        // don't exit until messages that are still in flight are drained
-        //        while (mpi::get_work_count() > 0)
-        //        {
-        //            pika::this_thread::yield();
-        //        }
-
         double elapsed = t.elapsed();
 
         if (rank == 0)

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -325,7 +325,7 @@ int pika_main(pika::program_options::variables_map& vm)
     // main scope with polling enabled
     // --------------------------
     {
-        // enable polling on mpi pool (regardelss of name)
+        // enable polling on mpi pool (regardless of name)
         mpi::enable_user_polling enable_polling("");
 
         // To prevent the application exiting the main scope of mpi polling

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/assert.hpp>
-#include <pika/command_line_handling/get_env_var.hpp>
+#include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/debugging/print.hpp>
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
@@ -484,7 +484,7 @@ void init_resource_partitioner_handler(
     if (vm["no-mpi-pool"].as<bool>() || ntasks == 1)
     {
         // turn off pool creation
-        int mode = pika::get_env_value("PIKA_MPI_COMPLETION_MODE", 1);
+        int mode = pika::detail::get_env_var_as<int>("PIKA_MPI_COMPLETION_MODE", 1);
         mode = mode & ~(0b01);
         setenv("PIKA_MPI_COMPLETION_MODE", std::to_string(mode).c_str(), true);
         pika::mpi::experimental::detail::get_completion_mode_default();

--- a/libs/pika/coroutines/src/thread_enums.cpp
+++ b/libs/pika/coroutines/src/thread_enums.cpp
@@ -12,7 +12,7 @@
 #include <pika/coroutines/thread_enums.hpp>
 
 #include <cstddef>
-#include <iostream>
+#include <ostream>
 
 namespace pika::threads::detail {
     namespace strings {

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -79,7 +79,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
 
     std::ostream& operator<<(std::ostream& os, ptr const& d)
     {
-        os << std::internal << std::hex << std::setw(10) << std::setfill('0') << d.data_;
+        os << std::internal << std::hex << std::setw(14) << std::setfill('0') << d.data_;
         return os;
     }
 

--- a/libs/pika/string_util/include/pika/string_util/case_conv.hpp
+++ b/libs/pika/string_util/include/pika/string_util/case_conv.hpp
@@ -17,4 +17,11 @@ namespace pika::detail {
         std::transform(
             std::begin(s), std::end(s), std::begin(s), [](int c) { return std::tolower(c); });
     }
+
+    template <typename CharT, class Traits, class Alloc>
+    void to_upper(std::basic_string<CharT, Traits, Alloc>& s)
+    {
+        std::transform(
+            std::begin(s), std::end(s), std::begin(s), [](int c) { return std::toupper(c); });
+    }
 }    // namespace pika::detail

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -411,6 +411,22 @@ namespace pika::threads::detail {
         }
 #endif
 
+        // convenience object to temporarily change priority
+        struct scoped_thread_priority
+        {
+            pika::execution::thread_priority old_priority_;
+            scoped_thread_priority(pika::execution::thread_priority new_p)
+              : old_priority_{threads::detail::get_self_id_data()->get_priority()}
+            {
+                threads::detail::get_self_id_data()->set_priority(new_p);
+            }
+
+            ~scoped_thread_priority()
+            {
+                threads::detail::get_self_id_data()->set_priority(old_priority_);
+            }
+        };
+
         constexpr execution::thread_priority get_priority() const noexcept
         {
             return priority_;

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -412,9 +412,11 @@ namespace pika::threads::detail {
 #endif
 
         // convenience object to temporarily change priority
-        struct scoped_thread_priority
+        class scoped_thread_priority
         {
             pika::execution::thread_priority old_priority_;
+
+        public:
             explicit scoped_thread_priority(pika::execution::thread_priority new_p)
               : old_priority_{threads::detail::get_self_id_data()->get_priority()}
             {
@@ -425,6 +427,11 @@ namespace pika::threads::detail {
             {
                 threads::detail::get_self_id_data()->set_priority(old_priority_);
             }
+
+            scoped_thread_priority(scoped_thread_priority&&) = delete;
+            scoped_thread_priority(scoped_thread_priority const&) = delete;
+            scoped_thread_priority& operator=(scoped_thread_priority&&) = delete;
+            scoped_thread_priority& operator=(scoped_thread_priority const&) = delete;
         };
 
         constexpr execution::thread_priority get_priority() const noexcept

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -415,7 +415,7 @@ namespace pika::threads::detail {
         struct scoped_thread_priority
         {
             pika::execution::thread_priority old_priority_;
-            scoped_thread_priority(pika::execution::thread_priority new_p)
+            explicit scoped_thread_priority(pika::execution::thread_priority new_p)
               : old_priority_{threads::detail::get_self_id_data()->get_priority()}
             {
                 threads::detail::get_self_id_data()->set_priority(new_p);


### PR DESCRIPTION
Fixes #187 and partially addresses #557

This PR reworks extensively the mpi_polling, the most important feature is that continuations are not triggered under lock, and that they can be explicitly transferred to a new task/pool.

Throttling is possible on a per stream basis, initially disabled until dlaf testing requires it. 
The number of completions to handle per poll iteration may be controlled.
env vars that control behaviour are
`PIKA_MPI_COMPLETION_MODE` sets the mode to use for handling completions 
`PIKA_MPI_POLLING_SIZE` sets the number of completions to handle per poll iteration
`PIKA_MPI_MSG_THROTTLE` sets the number of messages (per stream) to allow in-flight (disabled by default) 