### PR TITLE
Clean up `tag_invoke` module

### DIFF
--- a/libs/pika/async_base/include/pika/async_base/scheduling_properties.hpp
+++ b/libs/pika/async_base/include/pika/async_base/scheduling_properties.hpp
@@ -12,31 +12,32 @@
 
 namespace pika::execution::experimental {
     inline constexpr struct with_priority_t final
-      : pika::functional::tag<with_priority_t>
+      : pika::functional::detail::tag<with_priority_t>
     {
     } with_priority{};
 
     inline constexpr struct get_priority_t final
-      : pika::functional::tag<get_priority_t>
+      : pika::functional::detail::tag<get_priority_t>
     {
     } get_priority{};
 
     inline constexpr struct with_stacksize_t final
-      : pika::functional::tag<with_stacksize_t>
+      : pika::functional::detail::tag<with_stacksize_t>
     {
     } with_stacksize{};
 
     inline constexpr struct get_stacksize_t final
-      : pika::functional::tag<get_stacksize_t>
+      : pika::functional::detail::tag<get_stacksize_t>
     {
     } get_stacksize{};
 
     inline constexpr struct with_hint_t final
-      : pika::functional::tag<with_hint_t>
+      : pika::functional::detail::tag<with_hint_t>
     {
     } with_hint{};
 
-    inline constexpr struct get_hint_t final : pika::functional::tag<get_hint_t>
+    inline constexpr struct get_hint_t final
+      : pika::functional::detail::tag<get_hint_t>
     {
     } get_hint{};
 
@@ -49,7 +50,7 @@ namespace pika::execution::experimental {
     } with_annotation{};
 
     inline constexpr struct get_annotation_t final
-      : pika::functional::tag<get_annotation_t>
+      : pika::functional::detail::tag<get_annotation_t>
     {
     } get_annotation{};
 }    // namespace pika::execution::experimental

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -184,8 +184,9 @@ namespace pika::execution::experimental {
             auto scheduler =
                 pika::execution::experimental::get_completion_scheduler<
                     pika::execution::experimental::set_value_t>(sender);
-            return pika::functional::tag_invoke(bulk_t{}, PIKA_MOVE(scheduler),
-                PIKA_FORWARD(Sender, sender), shape, PIKA_FORWARD(F, f));
+            return pika::functional::detail::tag_invoke(bulk_t{},
+                PIKA_MOVE(scheduler), PIKA_FORWARD(Sender, sender), shape,
+                PIKA_FORWARD(F, f));
         }
 
         // clang-format off

--- a/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
@@ -41,7 +41,7 @@ namespace pika::execution::experimental {
             auto completion_scheduler =
                 pika::execution::experimental::get_completion_scheduler<
                     pika::execution::experimental::set_value_t>(sender);
-            return pika::functional::tag_invoke(transfer_t{},
+            return pika::functional::detail::tag_invoke(transfer_t{},
                 PIKA_MOVE(completion_scheduler), PIKA_FORWARD(Sender, sender),
                 PIKA_FORWARD(Scheduler, scheduler));
         }

--- a/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
+++ b/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
@@ -27,16 +27,16 @@ namespace pika::execution::experimental {
         {
             template <typename Query,
                 PIKA_CONCEPT_REQUIRES_(
-                    pika::functional::is_nothrow_tag_invocable_v<
+                    pika::functional::detail::is_nothrow_tag_invocable_v<
                         forwarding_scheduler_query_t, Query const&>)>
             constexpr bool operator()(Query const& query) const noexcept
             {
-                return pika::functional::tag_invoke(*this, query);
+                return pika::functional::detail::tag_invoke(*this, query);
             }
 
             template <typename Query,
                 PIKA_CONCEPT_REQUIRES_(
-                    !pika::functional::is_nothrow_tag_invocable_v<
+                    !pika::functional::detail::is_nothrow_tag_invocable_v<
                         forwarding_scheduler_query_t, Query const&>)>
             constexpr bool operator()(Query const&) const noexcept
             {
@@ -48,18 +48,18 @@ namespace pika::execution::experimental {
         {
             template <typename Scheduler,
                 PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler>&&
-                        pika::functional::is_nothrow_tag_invocable_v<
+                        pika::functional::detail::is_nothrow_tag_invocable_v<
                             get_forward_progress_guarantee_t,
                             Scheduler const&>)>
             constexpr forward_progress_guarantee
             operator()(Scheduler const& scheduler) const noexcept
             {
-                return pika::functional::tag_invoke(*this, scheduler);
+                return pika::functional::detail::tag_invoke(*this, scheduler);
             }
 
             template <typename Scheduler,
                 PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler> &&
-                    !pika::functional::is_nothrow_tag_invocable_v<
+                    !pika::functional::detail::is_nothrow_tag_invocable_v<
                         get_forward_progress_guarantee_t, Scheduler const&>)>
             constexpr forward_progress_guarantee
             operator()(Scheduler const&) const noexcept

--- a/libs/pika/execution/tests/include/algorithm_test_utils.hpp
+++ b/libs/pika/execution/tests/include/algorithm_test_utils.hpp
@@ -618,7 +618,7 @@ namespace tag_namespace {
         template <typename Sender>
         auto operator()(Sender&& sender) const
         {
-            return pika::functional::tag_invoke(
+            return pika::functional::detail::tag_invoke(
                 *this, std::forward<Sender>(sender));
         }
 

--- a/libs/pika/execution_base/include/pika/execution_base/completion_scheduler.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/completion_scheduler.hpp
@@ -21,7 +21,7 @@ namespace pika::execution::experimental::detail {
     template <typename CPO, typename Sender>
     struct has_completion_scheduler_impl<true, CPO, Sender>
       : pika::execution::experimental::is_scheduler<
-            pika::functional::tag_invoke_result_t<
+            pika::functional::detail::tag_invoke_result_t<
                 get_completion_scheduler_t<CPO>, std::decay_t<Sender> const&>>
     {
     };
@@ -29,7 +29,7 @@ namespace pika::execution::experimental::detail {
     template <typename CPO, typename Sender>
     struct has_completion_scheduler
       : has_completion_scheduler_impl<
-            pika::functional::is_tag_invocable_v<
+            pika::functional::detail::is_tag_invocable_v<
                 get_completion_scheduler_t<CPO>, std::decay_t<Sender> const&>,
             CPO, Sender>
     {
@@ -48,7 +48,7 @@ namespace pika::execution::experimental::detail {
 namespace pika::execution::experimental {
     template <typename Scheduler>
     struct get_completion_scheduler_t final
-      : pika::functional::tag<get_completion_scheduler_t<Scheduler>>
+      : pika::functional::detail::tag<get_completion_scheduler_t<Scheduler>>
     {
     };
 
@@ -66,16 +66,17 @@ namespace pika::execution::experimental {
         template <typename CPO, typename Sender>
         struct has_completion_scheduler_impl<true, CPO, Sender>
           : pika::execution::experimental::is_scheduler<pika::functional::
-                    tag_invoke_result_t<get_completion_scheduler_t<CPO>,
+                    detail::tag_invoke_result_t<get_completion_scheduler_t<CPO>,
                         std::decay_t<Sender> const&>>
         {
         };
 
         template <typename CPO, typename Sender>
         struct has_completion_scheduler
-          : has_completion_scheduler_impl<pika::functional::is_tag_invocable_v<
-                                              get_completion_scheduler_t<CPO>,
-                                              std::decay_t<Sender> const&>,
+          : has_completion_scheduler_impl<
+                pika::functional::detail::is_tag_invocable_v<
+                    get_completion_scheduler_t<CPO>,
+                    std::decay_t<Sender> const&>,
                 CPO, Sender>
         {
         };
@@ -95,8 +96,8 @@ namespace pika::execution::experimental {
         struct is_completion_scheduler_tag_invocable_impl<true, ReceiverCPO,
             Sender, AlgorithmCPO, Ts...>
           : std::integral_constant<bool,
-                pika::functional::is_tag_invocable_v<AlgorithmCPO,
-                    pika::functional::tag_invoke_result_t<
+                pika::functional::detail::is_tag_invocable_v<AlgorithmCPO,
+                    pika::functional::detail::tag_invoke_result_t<
                         pika::execution::experimental::
                             get_completion_scheduler_t<ReceiverCPO>,
                         Sender>,

--- a/libs/pika/execution_base/include/pika/execution_base/operation_state.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/operation_state.hpp
@@ -34,7 +34,7 @@ namespace pika::execution::experimental {
     ///       `void start();`
     ///     * Otherwise, the expression is ill-formed.
     ///
-    /// The customization is implemented in terms of `pika::functional::tag_invoke`.
+    /// The customization is implemented in terms of `pika::functional::detail::tag_invoke`.
     template <typename O>
     void start(O&& o);
 #endif
@@ -55,7 +55,7 @@ namespace pika::execution::experimental {
     struct is_operation_state;
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct start_t : pika::functional::tag_noexcept<start_t>
+    struct start_t : pika::functional::detail::tag_noexcept<start_t>
     {
     } start{};
 

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -57,7 +57,7 @@ namespace pika::execution::experimental {
     ///       `void set_value();`
     ///     * Otherwise, the expression is ill-formed.
     ///
-    /// The customization is implemented in terms of `pika::functional::tag_invoke`.
+    /// The customization is implemented in terms of `pika::functional::detail::tag_invoke`.
     template <typename R, typename... As>
     void set_value(R&& r, As&&... as);
 
@@ -71,7 +71,7 @@ namespace pika::execution::experimental {
     ///       `void set_stopped();`
     ///     * Otherwise, the expression is ill-formed.
     ///
-    /// The customization is implemented in terms of `pika::functional::tag_invoke`.
+    /// The customization is implemented in terms of `pika::functional::detail::tag_invoke`.
     template <typename R>
     void set_stopped(R&& r);
 
@@ -85,7 +85,7 @@ namespace pika::execution::experimental {
     ///       `void set_error();`
     ///     * Otherwise, the expression is ill-formed.
     ///
-    /// The customization is implemented in terms of `pika::functional::tag_invoke`.
+    /// The customization is implemented in terms of `pika::functional::detail::tag_invoke`.
     template <typename R, typename E>
     void set_error(R&& r, E&& e);
 #endif
@@ -131,17 +131,17 @@ namespace pika::execution::experimental {
     struct is_receiver_of;
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_value_t : pika::functional::tag<set_value_t>
+    struct set_value_t : pika::functional::detail::tag<set_value_t>
     {
     } set_value{};
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_error_t : pika::functional::tag_noexcept<set_error_t>
+    struct set_error_t : pika::functional::detail::tag_noexcept<set_error_t>
     {
     } set_error{};
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_stopped_t : pika::functional::tag_noexcept<set_stopped_t>
+    struct set_stopped_t : pika::functional::detail::tag_noexcept<set_stopped_t>
     {
     } set_stopped{};
 

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -71,7 +71,7 @@ namespace pika::execution::experimental {
     ///     * Otherwise, the expression is ill-formed.
     ///
     /// The customization is implemented in terms of
-    /// `pika::functional::tag_invoke`.
+    /// `pika::functional::detail::tag_invoke`.
     template <typename S, typename R>
     void connect(S&& s, R&& r);
 
@@ -92,7 +92,7 @@ namespace pika::execution::experimental {
     ///      * Otherwise, schedule(s) is ill-formed.
     ///
     /// The customization is implemented in terms of
-    /// `pika::functional::tag_invoke`.
+    /// `pika::functional::detail::tag_invoke`.
 
 #endif
     // We define an empty dummy type for compatibility. Senders can define both
@@ -219,7 +219,7 @@ namespace pika::execution::experimental {
     }    // namespace detail
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct connect_t : pika::functional::tag<connect_t>
+    struct connect_t : pika::functional::detail::tag<connect_t>
     {
     } connect{};
 
@@ -277,7 +277,7 @@ namespace pika::execution::experimental {
     }    // namespace detail
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct schedule_t : pika::functional::tag<schedule_t>
+    struct schedule_t : pika::functional::detail::tag<schedule_t>
     {
     } schedule{};
 

--- a/libs/pika/executors/include/pika/executors/execution_policy_annotation.hpp
+++ b/libs/pika/executors/include/pika/executors/execution_policy_annotation.hpp
@@ -62,7 +62,7 @@ namespace pika::execution::experimental {
     template <typename ExPolicy,
         PIKA_CONCEPT_REQUIRES_(
             pika::is_execution_policy_v<ExPolicy> &&
-            pika::functional::is_tag_invocable_v<
+            pika::functional::detail::is_tag_invocable_v<
                 pika::execution::experimental::get_annotation_t,
                 typename std::decay_t<ExPolicy>::executor_type>
         )>

--- a/libs/pika/properties/include/pika/properties/property.hpp
+++ b/libs/pika/properties/include/pika/properties/property.hpp
@@ -34,7 +34,7 @@ namespace pika::experimental {
                 prefer_t, Tag, T0&& t0, Tn&&...)
             noexcept(noexcept(PIKA_FORWARD(T0, t0)))
             -> std::enable_if_t<
-                    !pika::functional::is_tag_invocable_v<
+                    !pika::functional::detail::is_tag_invocable_v<
                         prefer_t, Tag, T0, Tn...> &&
                     !std::is_invocable_v<Tag, T0, Tn...>,
                     decltype(PIKA_FORWARD(T0, t0))>

--- a/libs/pika/properties/tests/unit/properties.cpp
+++ b/libs/pika/properties/tests/unit/properties.cpp
@@ -14,7 +14,8 @@ struct property1
     int v = 0;
 };
 
-inline constexpr struct with_property_t : pika::functional::tag<with_property_t>
+inline constexpr struct with_property_t
+  : pika::functional::detail::tag<with_property_t>
 {
 } with_property;
 

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
@@ -54,25 +54,25 @@ namespace pika::functional::detail {
         inline constexpr unspecified tag_fallback_invoke = unspecified;
     }    // namespace unspecified
 
-    /// `pika::functional::is_tag_fallback_invocable<Tag, Args...>` is std::true_type if
+    /// `pika::functional::detail::is_tag_fallback_invocable<Tag, Args...>` is std::true_type if
     /// an overload of `tag_fallback_invoke(tag, args...)` can be found via ADL.
     template <typename Tag, typename... Args>
     struct is_tag_fallback_invocable;
 
-    /// `pika::functional::is_tag_fallback_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_fallback_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_fallback_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_fallback_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_tag_fallback_invocable_v =
         is_tag_fallback_invocable<Tag, Args...>::value;
 
-    /// `pika::functional::is_nothrow_tag_fallback_invocable<Tag, Args...>` is
+    /// `pika::functional::detail::is_nothrow_tag_fallback_invocable<Tag, Args...>` is
     /// std::true_type if an overload of `tag_fallback_invoke(tag, args...)` can be
     /// found via ADL and is noexcept.
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_fallback_invocable;
 
-    /// `pika::functional::is_tag_fallback_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_fallback_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_fallback_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_fallback_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_nothrow_tag_fallback_invocable_v =
         is_nothrow_tag_fallback_invocable<Tag, Args...>::value;

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
@@ -55,25 +55,25 @@ namespace pika::functional::detail {
         inline constexpr unspecified tag_override_invoke = unspecified;
     }    // namespace unspecified
 
-    /// `pika::functional::is_tag_override_invocable<Tag, Args...>` is std::true_type if
+    /// `pika::functional::detail::is_tag_override_invocable<Tag, Args...>` is std::true_type if
     /// an overload of `tag_override_invoke(tag, args...)` can be found via ADL.
     template <typename Tag, typename... Args>
     struct is_tag_override_invocable;
 
-    /// `pika::functional::is_tag_override_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_override_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_override_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_override_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_tag_override_invocable_v =
         is_tag_override_invocable<Tag, Args...>::value;
 
-    /// `pika::functional::is_nothrow_tag_override_invocable<Tag, Args...>` is
+    /// `pika::functional::detail::is_nothrow_tag_override_invocable<Tag, Args...>` is
     /// std::true_type if an overload of `tag_override_invoke(tag, args...)` can be
     /// found via ADL and is noexcept.
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_override_invocable;
 
-    /// `pika::functional::is_tag_override_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_override_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_override_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_override_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_nothrow_tag_override_invocable_v =
         is_nothrow_tag_override_invocable<Tag, Args...>::value;

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #if defined(DOXYGEN)
-namespace pika::functional {
+namespace pika::functional::detail {
     inline namespace unspecified {
-        /// The `pika::functional::tag_invoke` name defines a constexpr object
+        /// The `pika::functional::detail::tag_invoke` name defines a constexpr object
         /// that is invocable with one or more arguments. The first argument
         /// is a 'tag' (typically a CPO). It is only invocable if an overload
         /// of tag_invoke() that accepts the same arguments could be found via
@@ -19,14 +19,14 @@ namespace pika::functional {
         /// equivalent to evaluating the unqualified call to
         /// `tag_invoke(decay-copy(tag), PIKA_FORWARD(Args, args)...)`.
         ///
-        /// `pika::functional::tag_invoke` is implemented against P1895.
+        /// `pika::functional::detail::tag_invoke` is implemented against P1895.
         ///
         /// Example:
         /// Defining a new customization point `foo`:
         /// ```
         /// namespace mylib {
         ///     inline constexpr
-        ///         struct foo_fn final : pika::functional::tag<foo_fn>
+        ///         struct foo_fn final : pika::functional::detail::tag<foo_fn>
         ///         {
         ///         } foo{};
         /// }
@@ -52,50 +52,50 @@ namespace pika::functional {
         inline constexpr unspecified tag_invoke = unspecified;
     }    // namespace unspecified
 
-    /// `pika::functional::is_tag_invocable<Tag, Args...>` is std::true_type if
+    /// `pika::functional::detail::is_tag_invocable<Tag, Args...>` is std::true_type if
     /// an overload of `tag_invoke(tag, args...)` can be found via ADL.
     template <typename Tag, typename... Args>
     struct is_tag_invocable;
 
-    /// `pika::functional::is_tag_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_tag_invocable_v = is_tag_invocable<Tag, Args...>::value;
 
-    /// `pika::functional::is_nothrow_tag_invocable<Tag, Args...>` is
+    /// `pika::functional::detail::is_nothrow_tag_invocable<Tag, Args...>` is
     /// std::true_type if an overload of `tag_invoke(tag, args...)` can be
     /// found via ADL and is noexcept.
     template <typename Tag, typename... Args>
     struct is_nothrow_tag_invocable;
 
-    /// `pika::functional::is_tag_invocable_v<Tag, Args...>` evaluates to
-    /// `pika::functional::is_tag_invocable<Tag, Args...>::value`
+    /// `pika::functional::detail::is_tag_invocable_v<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::is_tag_invocable<Tag, Args...>::value`
     template <typename Tag, typename... Args>
     constexpr bool is_nothrow_tag_invocable_v =
         is_nothrow_tag_invocable<Tag, Args...>::value;
 
-    /// `pika::functional::tag_invoke_result<Tag, Args...>` is the trait
-    /// returning the result type of the call pika::functional::tag_invoke. This
+    /// `pika::functional::detail::tag_invoke_result<Tag, Args...>` is the trait
+    /// returning the result type of the call pika::functional::detail::tag_invoke. This
     /// can be used in a SFINAE context.
     template <typename Tag, typename... Args>
     using tag_invoke_result = invoke_result<decltype(tag_invoke), Tag, Args...>;
 
-    /// `pika::functional::tag_invoke_result_t<Tag, Args...>` evaluates to
-    /// `pika::functional::tag_invoke_result_t<Tag, Args...>::type`
+    /// `pika::functional::detail::tag_invoke_result_t<Tag, Args...>` evaluates to
+    /// `pika::functional::detail::tag_invoke_result_t<Tag, Args...>::type`
     template <typename Tag, typename... Args>
     using tag_invoke_result_t = typename tag_invoke_result<Tag, Args...>::type;
 
-    /// `pika::functional::tag<Tag>` defines a base class that implements
+    /// `pika::functional::detail::tag<Tag>` defines a base class that implements
     /// the necessary tag dispatching functionality for a given type `Tag`
     template <typename Tag>
     struct tag;
 
-    /// `pika::functional::tag_noexcept<Tag>` defines a base class that implements
+    /// `pika::functional::detail::tag_noexcept<Tag>` defines a base class that implements
     /// the necessary tag dispatching functionality for a given type `Tag`
     /// The implementation has to be noexcept
     template <typename Tag>
     struct tag_noexcept;
-}    // namespace pika::functional
+}    // namespace pika::functional::detail
 #else
 
 #include <pika/config.hpp>
@@ -104,7 +104,7 @@ namespace pika::functional {
 #include <type_traits>
 #include <utility>
 
-namespace pika::functional {
+namespace pika::functional::detail {
     template <auto& Tag>
     using tag_t = std::decay_t<decltype(Tag)>;
 
@@ -256,6 +256,6 @@ namespace pika::functional {
     inline namespace tag_invoke_f_ns {
         using tag_invoke_ns::tag_invoke;
     }    // namespace tag_invoke_f_ns
-}    // namespace pika::functional
+}    // namespace pika::functional::detail
 
 #endif

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #if defined(DOXYGEN)
-namespace pika { namespace functional {
+namespace pika::functional {
     inline namespace unspecified {
         /// The `pika::functional::tag_invoke` name defines a constexpr object
         /// that is invocable with one or more arguments. The first argument
@@ -95,7 +95,7 @@ namespace pika { namespace functional {
     /// The implementation has to be noexcept
     template <typename Tag>
     struct tag_noexcept;
-}}    // namespace pika::functional
+}    // namespace pika::functional
 #else
 
 #include <pika/config.hpp>


### PR DESCRIPTION
Part of #16 
Originally attempt to move tag_invoke in the detail namespace. It has been reverted because of potential namespace clash when defining tag_invoke overloads.