### PR TITLE
Improve CUDA polling

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
@@ -17,6 +17,10 @@
 #include <string>
 
 namespace pika::cuda::experimental {
+
+    PIKA_EXPORT const std::string& get_pool_name();
+    PIKA_EXPORT void set_pool_name(const std::string&);
+
     // -----------------------------------------------------------------
     // This RAII helper class enables polling for a scoped block
     struct [[nodiscard]] enable_user_polling

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
@@ -32,10 +32,12 @@ namespace pika::cuda::experimental {
             if (pool_name_.empty())
             {
                 detail::register_polling(pika::resource::get_thread_pool(0));
+                set_pool_name("default");
             }
             else
             {
                 detail::register_polling(pika::resource::get_thread_pool(pool_name_));
+                set_pool_name(pool_name_);
             }
         }
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
@@ -32,7 +32,7 @@ namespace pika::cuda::experimental {
             if (pool_name_.empty())
             {
                 detail::register_polling(pika::resource::get_thread_pool(0));
-                set_pool_name("default");
+                set_pool_name(pika::resource::get_pool_name(0));
             }
             else
             {

--- a/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_debug.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/detail/cuda_debug.hpp
@@ -12,6 +12,7 @@
 #include <pika/debugging/print.hpp>
 
 namespace pika::cuda::experimental::detail {
-    using print_on = debug::detail::enable_print<false>;
-    static constexpr print_on cud_debug("CUDA");
+    using namespace pika::debug::detail;
+    template <int Level>
+    static print_threshold<Level, 1> cud_debug("CUDA-EX");
 }    // namespace pika::cuda::experimental::detail

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -335,4 +335,21 @@ namespace pika::cuda::experimental::detail {
         auto* sched = pool.get_scheduler();
         sched->clear_cuda_polling_function();
     }
+
+    static std::string default_pool_name = "pika:polling";
+
 }    // namespace pika::cuda::experimental::detail
+
+namespace pika::cuda::experimental {
+    PIKA_EXPORT const std::string& get_pool_name()
+    {
+        if (pika::resource::pool_exists(detail::default_pool_name))
+            return detail::default_pool_name;
+        return "default";
+    }
+
+    PIKA_EXPORT void set_pool_name(const std::string& name)
+    {
+        detail::default_pool_name = name;
+    }
+}    // namespace pika::cuda::experimental

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -74,7 +74,7 @@ namespace pika::cuda::experimental::detail {
             using pika::threads::detail::polling_status;
             using namespace pika::debug::detail;
 
-            // invoke ready event callbacks without locking
+            // invoke ready callbacks without being under lock
             detail::ready_callback ready_callback_;
             while (ready_events.try_dequeue(ready_callback_))
             {
@@ -174,6 +174,12 @@ namespace pika::cuda::experimental::detail {
                     pool.push(PIKA_MOVE(continuation.event));
                 }
             }    // end locked region
+
+            // invoke any new ready callbacks without being under lock
+            while (ready_events.try_dequeue(ready_callback_))
+            {
+                ready_callback_.f(ready_callback_.status);
+            }
 
             using pika::threads::detail::polling_status;
             return event_callback_vector.empty() ? polling_status::idle : polling_status::busy;

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -14,6 +14,8 @@
 #include <pika/async_cuda/detail/cuda_event_callback.hpp>
 #include <pika/concurrency/concurrentqueue.hpp>
 #include <pika/datastructures/detail/small_vector.hpp>
+#include <pika/resource_partitioner/detail/partitioner.hpp>
+#include <pika/runtime/thread_pool_helpers.hpp>
 #include <pika/synchronization/spinlock.hpp>
 #include <pika/threading_base/scheduler_base.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
@@ -336,20 +338,23 @@ namespace pika::cuda::experimental::detail {
         sched->clear_cuda_polling_function();
     }
 
-    static std::string default_pool_name = "pika:polling";
+    static std::string polling_pool_name = "pika:polling";
 
 }    // namespace pika::cuda::experimental::detail
 
 namespace pika::cuda::experimental {
     PIKA_EXPORT const std::string& get_pool_name()
     {
-        if (pika::resource::pool_exists(detail::default_pool_name))
-            return detail::default_pool_name;
-        return "default";
+        if (pika::resource::pool_exists(detail::polling_pool_name))
+        {
+            return detail::polling_pool_name;
+        }
+        //
+        return resource::get_partitioner().get_default_pool_name();
     }
 
     PIKA_EXPORT void set_pool_name(const std::string& name)
     {
-        detail::default_pool_name = name;
+        detail::polling_pool_name = name;
     }
 }    // namespace pika::cuda::experimental

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -336,7 +336,7 @@ namespace pika::cuda::experimental::detail {
         sched->clear_cuda_polling_function();
     }
 
-    static std::string polling_pool_name = "pika:polling";
+    static std::string polling_pool_name = "default";
 
 }    // namespace pika::cuda::experimental::detail
 


### PR DESCRIPTION
Redesign the way polling for cuda events is handled

Cuda events are polled (by any thread on the pool on which polling is enabled) and passed to a lockfree queue when ready. The polling loop first checks ready events and invokes callbacks, and only then takes the lock and checks outstanding events which are placed on the ready queue. 
This means that as soon as events are ready, any thread can invoke the callback - a single polling thread can find N events are ready and place them in the ready queue and N other threads can start handling the completions - instead of only allowing the polling thread to handle them.

The locking and completion handling has been reworked significantly and gives much better results.