### PR TITLE
Clean up macros and fix bug in `shared_priority_queue_scheduler`

### DIFF
--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -56,7 +56,7 @@
 // Used to wrap function call parameters to prevent evaluation
 // when debugging is disabled
 #define PIKA_DP_LAZY(printer, Expr) printer.eval([&] { return Expr; })
-#define PIKA_DP_ONLY(printer, Expr)                                                                \
+#define PIKA_DP(printer, Expr)                                                                     \
  if constexpr (printer.is_enabled())                                                               \
  {                                                                                                 \
   printer.Expr;                                                                                    \
@@ -69,13 +69,16 @@
 namespace PIKA_NS_DEBUG {
 
     // ------------------------------------------------------------------
-    // format as zero padded int
+    // helper for N>M true/false
     // ------------------------------------------------------------------
     template <int Level, int Threshold>
     struct check_level : std::integral_constant<bool, Level <= Threshold>
     {
     };
 
+    // ------------------------------------------------------------------
+    // format as zero padded int
+    // ------------------------------------------------------------------
     template <typename Int>
     PIKA_EXPORT void print_dec(std::ostream& os, Int const& v, int n);
 

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -60,7 +60,6 @@ namespace pika {
     template <int Level>
     static debug::detail::print_threshold<Level, debug_level> spq_deb("SPQUEUE");
     static debug::detail::print_threshold<1, 1> spq_arr("SPQUEUE");
-#define DEBUG(printer, Expr) PIKA_DP_ONLY(printer, Expr)
 }    // namespace pika
 
 // ------------------------------------------------------------
@@ -174,7 +173,7 @@ namespace pika::threads {
             core_stealing_ = has_scheduler_mode(scheduler_mode::enable_stealing);
             numa_stealing_ = has_scheduler_mode(scheduler_mode::enable_stealing_numa);
             // clang-format off
-            DEBUG(spq_deb<5>,debug(debug::detail::str<>("scheduler_mode")
+            PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("scheduler_mode")
                 , round_robin_ ? "round_robin" : "thread parent"
                 , ','
                 , steal_hp_first_ ? "steal_hp_first" : "steal after local"
@@ -220,7 +219,7 @@ namespace pika::threads {
         {
             static auto cleanup =
                 spq_deb<5>.make_timer(1, debug::detail::str<>("Cleanup"), "Global version");
-            DEBUG(spq_deb<5>, timed(cleanup));
+            PIKA_DP(spq_deb<5>, timed(cleanup));
 
             // check calling thread number has queues to clean
             std::size_t local_num = local_thread_number();
@@ -229,7 +228,7 @@ namespace pika::threads {
             {
                 // clang-format off
                 using namespace pika::threads::detail;
-                DEBUG(spq_deb<5>,debug(debug::detail::str<>("cleanup_terminated")
+                PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("cleanup_terminated")
                     , "v1 aborted"
                     , "num_workers_", num_workers_
                     , "thread_number"
@@ -246,7 +245,7 @@ namespace pika::threads {
             std::size_t domain_num = d_lookup_[local_num];
             std::size_t q_index = q_lookup_[local_num];
 
-            DEBUG(spq_deb<5>,
+            PIKA_DP(spq_deb<5>,
                 debug(debug::detail::str<>("cleanup_terminated"), "v1", "D",
                     debug::detail::dec<2>(domain_num), "Q", debug::detail::dec<3>(q_index),
                     "thread_num", debug::detail::dec<3>(local_num)));
@@ -289,13 +288,13 @@ namespace pika::threads {
             {
             case execution::thread_schedule_hint_mode::none:
             {
-                DEBUG(spq_deb<7>, set(msg, (const char*) "HINT_NONE  "));
+                PIKA_DP(spq_deb<7>, set(msg, (const char*) "HINT_NONE  "));
                 // Create thread on this worker thread if possible
                 if (PIKA_UNLIKELY(local_num == std::size_t(-1)))
                 {
                     // clang-format off
                     using namespace pika::threads::detail;
-                    DEBUG(spq_deb<7>,debug(debug::detail::str<>("create_thread")
+                    PIKA_DP(spq_deb<7>, debug(debug::detail::str<>("create_thread")
                         , "x-pool", "num_workers_", num_workers_
                         , "thread_number"
                         , "global", get_global_thread_num_tss()
@@ -316,7 +315,7 @@ namespace pika::threads {
                         domain_num = d_lookup_[thread_num];
                         q_index = q_lookup_[thread_num];
                     }
-                    DEBUG(spq_deb<7>,
+                    PIKA_DP(spq_deb<7>,
                         debug(debug::detail::str<>("create_thread"),
                             "scheduler_mode::assign_work_thread_parent", "thread_num", thread_num,
                             "pool", parent_pool_->get_pool_name()));
@@ -325,7 +324,7 @@ namespace pika::threads {
                 {
                     domain_num = d_lookup_[thread_num];
                     q_index = q_lookup_[thread_num];
-                    DEBUG(spq_deb<7>,
+                    PIKA_DP(spq_deb<7>,
                         debug(debug::detail::str<>("create_thread"),
                             "scheduler_mode::assign_work_round_robin", "thread_num", thread_num,
                             "pool", parent_pool_->get_pool_name(),
@@ -345,7 +344,7 @@ namespace pika::threads {
             }
             case execution::thread_schedule_hint_mode::thread:
             {
-                DEBUG(spq_deb<7>, set(msg, (const char*) "HINT_THREAD"));
+                PIKA_DP(spq_deb<7>, set(msg, (const char*) "HINT_THREAD"));
                 // @TODO. We should check that the thread num is valid
                 // Create thread on requested worker thread
                 thread_num = select_active_pu(l, data.schedulehint.hint);
@@ -356,7 +355,7 @@ namespace pika::threads {
             case execution::thread_schedule_hint_mode::numa:
             {
                 // Create thread on requested NUMA domain
-                DEBUG(spq_deb<7>, set(msg, (const char*) "HINT_NUMA  "));
+                PIKA_DP(spq_deb<7>, set(msg, (const char*) "HINT_NUMA  "));
                 // TODO: This case does not handle suspended PUs.
                 domain_num = fast_mod(data.schedulehint.hint, num_domains_);
                 // if the thread creating the new task is on the domain
@@ -388,11 +387,11 @@ namespace pika::threads {
             if (local_num != thread_num)
             {
                 data.run_now = false;
-                DEBUG(
+                PIKA_DP(
                     spq_deb<6>, debug(debug::detail::str<>("create_thread"), "run_now OVERRIDE "));
             }
             // clang-format off
-            DEBUG(spq_deb<5>,debug(debug::detail::str<>("create_thread")
+            PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("create_thread")
                 , "pool", parent_pool_->get_pool_name()
                 , "hint", msg
                 , "dest"
@@ -438,7 +437,7 @@ namespace pika::threads {
                 result = result || operation(domain, q_index, origin, var, false, false);
                 if (result)
                 {
-                    DEBUG(spq_deb<7>,
+                    PIKA_DP(spq_deb<7>,
                         debug(debug::detail::str<>(prefix), "local no stealing", "D",
                             debug::detail::dec<2>(domain), "Q", debug::detail::dec<3>(q_index)));
                     return result;
@@ -454,7 +453,7 @@ namespace pika::threads {
                     result = operation_HP(dom, q_index, origin, var, (d > 0), true);
                     if (result)
                     {
-                        DEBUG(spq_deb<5>,
+                        PIKA_DP(spq_deb<5>,
                             debug(debug::detail::str<>(prefix),
                                 "scheduler_mode::steal_high_priority_first BP/HP",
                                 (d == 0 ? "taken" : "stolen"), "D", debug::detail::dec<2>(domain),
@@ -472,7 +471,7 @@ namespace pika::threads {
                     result = operation(dom, q_index, origin, var, (d > 0), true);
                     if (result)
                     {
-                        DEBUG(spq_deb<5>,
+                        PIKA_DP(spq_deb<5>,
                             debug(debug::detail::str<>(prefix),
                                 "scheduler_mode::steal_high_priority_first NP/LP",
                                 (d == 0 ? "taken" : "stolen"), "D", debug::detail::dec<2>(domain),
@@ -491,7 +490,7 @@ namespace pika::threads {
                 result = result || operation(domain, q_index, origin, var, false, false);
                 if (result)
                 {
-                    DEBUG(spq_deb<5>,
+                    PIKA_DP(spq_deb<5>,
                         debug(debug::detail::str<>(prefix),
                             "scheduler_mode::steal_after_local local taken", "D",
                             debug::detail::dec<2>(domain), "Q", debug::detail::dec<3>(q_index)));
@@ -509,7 +508,7 @@ namespace pika::threads {
                         result = result || operation(domain, q_index, origin, var, true, true);
                         if (result)
                         {
-                            DEBUG(spq_deb<5>,
+                            PIKA_DP(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
                                     "scheduler_mode::steal_after_local this numa", "stolen", "D",
                                     debug::detail::dec<2>(domain), "Q",
@@ -529,7 +528,7 @@ namespace pika::threads {
                         result = operation_HP(dom, q_index, origin, var, true, true);
                         if (result)
                         {
-                            DEBUG(spq_deb<5>,
+                            PIKA_DP(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
                                     "scheduler_mode::steal_after_local other numa BP/HP",
                                     (d == 0 ? "taken" : "stolen"), "D",
@@ -546,7 +545,7 @@ namespace pika::threads {
                         result = operation(dom, q_index, origin, var, true, true);
                         if (result)
                         {
-                            DEBUG(spq_deb<5>,
+                            PIKA_DP(spq_deb<5>,
                                 debug(debug::detail::str<>(prefix),
                                     "scheduler_mode::steal_after_local other numa NP/LP",
                                     (d == 0 ? "taken" : "stolen"), "D",
@@ -571,7 +570,7 @@ namespace pika::threads {
             // just cleanup the thread we were called by rather than all threads
             static auto getnext = spq_deb<5>.make_timer(1, debug::detail::str<>("get_next_thread"));
             //
-            DEBUG(spq_deb<5>, timed(getnext, debug::detail::dec<>(this_thread)));
+            PIKA_DP(spq_deb<5>, timed(getnext, debug::detail::dec<>(this_thread)));
 
             auto get_next_thread_function_HP =
                 [&](std::size_t domain, std::size_t q_index, thread_holder_type* /* receiver */,
@@ -646,7 +645,7 @@ namespace pika::threads {
             std::size_t q_index = q_lookup_[this_thread];
             //
             thread_holder_type* receiver = numa_holder_[domain].queues_[q_index];
-            DEBUG(spq_deb<5>,
+            PIKA_DP(spq_deb<5>,
                 timed(w_or_add_n, "thread_num", this_thread, "q_index", q_index, "numa_stealing ",
                     numa_stealing_, "core_stealing ", core_stealing_));
 
@@ -684,7 +683,7 @@ namespace pika::threads {
             case execution::thread_schedule_hint_mode::none:
             {
                 // Create thread on this worker thread if possible
-                DEBUG(spq_deb<5>, set(msg, (const char*) "HINT_NONE  "));
+                PIKA_DP(spq_deb<5>, set(msg, (const char*) "HINT_NONE  "));
                 if (local_num == std::size_t(-1))
                 {
                     // This is a task being injected from a thread on another
@@ -693,7 +692,7 @@ namespace pika::threads {
                     q_index = 0;
                     // clang-format off
                     using namespace pika::threads::detail;
-                    DEBUG(spq_deb<5>,debug(debug::detail::str<>("schedule_thread")
+                    PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("schedule_thread")
                         , "x-pool thread schedule"
                         , "num_workers_", num_workers_
                         , "thread_number"
@@ -710,7 +709,7 @@ namespace pika::threads {
                 {
                     domain_num = d_lookup_[thread_num];
                     q_index = q_lookup_[thread_num];
-                    DEBUG(spq_deb<5>,
+                    PIKA_DP(spq_deb<5>,
                         debug(debug::detail::str<>("schedule_thread"),
                             "scheduler_mode::assign_work_thread_parent", "thread_num", thread_num,
                             debug::detail::threadinfo<threads::detail::thread_id_ref_type*>(
@@ -722,7 +721,7 @@ namespace pika::threads {
                     q_index = q_lookup_[thread_num];
                     thread_num =
                         numa_holder_[domain_num].thread_queue(q_index)->worker_next(num_workers_);
-                    DEBUG(spq_deb<5>,
+                    PIKA_DP(spq_deb<5>,
                         debug(debug::detail::str<>("schedule_thread"),
                             "scheduler_mode::assign_work_round_robin", "thread_num", thread_num,
                             debug::detail::threadinfo<threads::detail::thread_id_ref_type*>(
@@ -735,8 +734,8 @@ namespace pika::threads {
             {
                 // @TODO. We should check that the thread num is valid
                 // Create thread on requested worker thread
-                DEBUG(spq_deb<5>, set(msg, (const char*) "HINT_THREAD"));
-                DEBUG(spq_deb<5>,
+                PIKA_DP(spq_deb<5>, set(msg, (const char*) "HINT_THREAD"));
+                PIKA_DP(spq_deb<5>,
                     debug(debug::detail::str<>("schedule_thread"), "received HINT_THREAD",
                         debug::detail::dec<3>(schedulehint.hint),
                         debug::detail::threadinfo<threads::detail::thread_id_ref_type*>(&thrd)));
@@ -748,7 +747,7 @@ namespace pika::threads {
             case execution::thread_schedule_hint_mode::numa:
             {
                 // Create thread on requested NUMA domain
-                DEBUG(spq_deb<5>, set(msg, (const char*) "HINT_NUMA  "));
+                PIKA_DP(spq_deb<5>, set(msg, (const char*) "HINT_NUMA  "));
                 // TODO: This case does not handle suspended PUs.
                 domain_num = fast_mod(schedulehint.hint, num_domains_);
                 // if the thread creating the new task is on the domain
@@ -770,7 +769,7 @@ namespace pika::threads {
                     "Invalid schedule hint mode: {}", static_cast<std::size_t>(schedulehint.mode));
             }
 
-            DEBUG(spq_deb<5>,
+            PIKA_DP(spq_deb<5>,
                 debug(debug::detail::str<>("thread scheduled"), msg, "Thread",
                     debug::detail::dec<3>(thread_num), "D", debug::detail::dec<2>(domain_num), "Q",
                     debug::detail::dec<3>(q_index)));
@@ -793,7 +792,7 @@ namespace pika::threads {
             execution::thread_schedule_hint schedulehint, bool allow_fallback,
             execution::thread_priority priority = execution::thread_priority::normal) override
         {
-            DEBUG(spq_deb<5>, debug(debug::detail::str<>("schedule_thread_last")));
+            PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("schedule_thread_last")));
             schedule_work(thrd, schedulehint, allow_fallback, true,
                 priority = execution::thread_priority::normal);
         }
@@ -819,7 +818,7 @@ namespace pika::threads {
             auto d2 = d_lookup_[this_thread];
             auto q2 = q_lookup_[this_thread];
             bool xthread = ((q1 != q2) || (d1 != d2));
-            DEBUG(spq_deb<7>,
+            PIKA_DP(spq_deb<7>,
                 debug(debug::detail::str<>("destroy_thread"), "xthread", xthread, "task owned by",
                     "D", debug::detail::dec<2>(d1), "Q", debug::detail::dec<3>(q1), "this thread",
                     "D", debug::detail::dec<2>(d2), "Q", debug::detail::dec<3>(q2),
@@ -837,7 +836,7 @@ namespace pika::threads {
         //---------------------------------------------------------------------
         std::int64_t get_queue_length(std::size_t thread_num = std::size_t(-1)) const override
         {
-            DEBUG(spq_deb<5>,
+            PIKA_DP(spq_deb<5>,
                 debug(debug::detail::str<>("get_queue_length"), "thread_num ",
                     debug::detail::dec<>(thread_num)));
 
@@ -872,7 +871,7 @@ namespace pika::threads {
                 std::int64_t count =
                     numa_holder_[domain_num].thread_queue(q_index)->get_thread_count(
                         state, priority);
-                DEBUG(spq_deb<6>,
+                PIKA_DP(spq_deb<6>,
                     debug(debug::detail::str<>("get_thread_count"), "thread_num ",
                         debug::detail::dec<3>(thread_num), "count ", debug::detail::dec<4>(count)));
                 return count;
@@ -884,7 +883,7 @@ namespace pika::threads {
                 {
                     count += numa_holder_[d].get_thread_count(state, priority);
                 }
-                DEBUG(spq_deb<6>,
+                PIKA_DP(spq_deb<6>,
                     debug(debug::detail::str<>("get_thread_count"), "thread_num ",
                         debug::detail::dec<3>(thread_num), "count ", debug::detail::dec<4>(count)));
                 return count;
@@ -908,7 +907,7 @@ namespace pika::threads {
         {
             bool result = true;
 
-            DEBUG(spq_deb<5>, debug(debug::detail::str<>("enumerate_threads")));
+            PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("enumerate_threads")));
 
             for (std::size_t d = 0; d < num_domains_; ++d)
             {
@@ -920,7 +919,7 @@ namespace pika::threads {
         ///////////////////////////////////////////////////////////////////////
         void on_start_thread(std::size_t local_thread) override
         {
-            DEBUG(spq_deb<5>,
+            PIKA_DP(spq_deb<5>,
                 debug(debug::detail::str<>("start_thread"), "local_thread", local_thread));
 
             auto const& topo = ::pika::threads::detail::create_topology();
@@ -1121,7 +1120,7 @@ namespace pika::threads {
                         }
                     }
 
-                    DEBUG(spq_deb<5>,
+                    PIKA_DP(spq_deb<5>,
                         debug(debug::detail::str<>("thread holder"), "local_thread", local_thread,
                             "domain", domain, "index", index, "local_id", local_id, "owner_mask",
                             owner_mask));

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -782,8 +782,7 @@ namespace pika::threads {
             execution::thread_schedule_hint schedulehint, bool allow_fallback,
             execution::thread_priority priority = execution::thread_priority::normal) override
         {
-            schedule_work(thrd, schedulehint, allow_fallback, false,
-                priority = execution::thread_priority::normal);
+            schedule_work(thrd, schedulehint, allow_fallback, false, priority);
         }
 
         /// Put task on the back of the queue : not yet implemented
@@ -793,8 +792,7 @@ namespace pika::threads {
             execution::thread_priority priority = execution::thread_priority::normal) override
         {
             PIKA_DP(spq_deb<5>, debug(debug::detail::str<>("schedule_thread_last")));
-            schedule_work(thrd, schedulehint, allow_fallback, true,
-                priority = execution::thread_priority::normal);
+            schedule_work(thrd, schedulehint, allow_fallback, true, priority);
         }
 
         //---------------------------------------------------------------------

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -11,6 +11,12 @@
 #include <cstdint>
 #include <thread>
 
+#if defined(__linux) || defined(linux) || defined(__linux__)
+# include <linux/unistd.h>
+# include <sys/mman.h>
+# define DEBUGGING_PRINT_LINUX
+#endif
+
 // ------------------------------------------------------------
 /// \cond NODETAIL
 namespace pika::debug::detail {

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -14,7 +14,7 @@
 #if defined(__linux) || defined(linux) || defined(__linux__)
 # include <linux/unistd.h>
 # include <sys/mman.h>
-# define DEBUGGING_PRINT_LINUX
+# define PIKA_DEBUGGING_PRINT_LINUX
 #endif
 
 // ------------------------------------------------------------
@@ -85,7 +85,7 @@ namespace pika::debug::detail {
                 os << hex<12, std::uintptr_t>(reinterpret_cast<std::uintptr_t>(dummy)) << " ";
             }
             os << hex<12, std::thread::id>(std::this_thread::get_id())
-#ifdef DEBUGGING_PRINT_LINUX
+#ifdef PIKA_DEBUGGING_PRINT_LINUX
                << " cpu " << debug::detail::dec<3, int>(sched_getcpu()) << " ";
 #else
                << " cpu "


### PR DESCRIPTION
A small fix to the scheduler where a wrong param is set, plus some debug cleanup that is needed for other cuda/mpi polling branches