### PR TITLE
Add more verbose message when default thread pool doesn't have any threads assigned to it

### DIFF
--- a/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
+++ b/libs/pika/affinity/include/pika/affinity/affinity_data.hpp
@@ -50,6 +50,11 @@ namespace pika::detail {
             return num_threads_;
         }
 
+        bool using_process_mask() const noexcept
+        {
+            return use_process_mask_;
+        }
+
         threads::detail::mask_cref_type get_pu_mask(
             threads::detail::topology const& topo, std::size_t num_thread) const;
 


### PR DESCRIPTION
This makes the error message more verbose when the default thread pool doesn't have any threads assigned to it.

In addition to saying "check your bindings/options" this will now also print the number of threads that pika is trying to use and the number of thread pools that it's configured to use. It will also print the process mask that pika has detected (if it's configured to use one). It will also print the value of `OMP_PROC_BIND` (if set). Finally, it prints two possible reasons for this happening. I hope this is an improvement, but I think there is still lots of room for improvement.

@rmeli, @albestro, @rasolca wishes and comments would be very much appreciated, even ones that may be a bit more difficult to implement. We may get to them some other day and it's good to know what actually helps you.


Two things that I'm not doing here are:
- print the assignment of threads to pools, because this error happens while assigning threads to pools. I think we could do something reasonable here because at least in theory all threads should already be assigned at this point, but this needs more work.
- Explain what exactly is setting various options (i.e. if the number of threads is set by command line or config file or something else). This would need bigger changes to the configuration module.

Also adds a member function to `affinity_data` to query if it is using a process mask.