### PR TITLE
Add GitHub merge queue branches to CI configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ branch_filter: &branch_filter
           # Bors branches
           - trying
           - staging
+          # GitHub merge queue branches
+          - /gh-readonly-queue.*/
 
 working_dir_default: &working_dir_default
     working_directory: /pika/build

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -7,6 +7,7 @@
 name: Linux CI (Debug)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -7,6 +7,7 @@
 name: Linux CI (HIP, Debug)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -7,6 +7,7 @@
 name: Linux CI (Release, FetchContent)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -7,6 +7,7 @@
 name: Linux CI (asan/ubsan)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -7,6 +7,7 @@
 name: Linux CI (Tracy)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/macos_arm64_debug.yml
+++ b/.github/workflows/macos_arm64_debug.yml
@@ -7,6 +7,7 @@
 name: macOS Arm64 CI (Debug)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -7,6 +7,7 @@
 name: macOS CI (Debug)
 
 on:
+  merge_group:
   push:
     branches:
       # Development and release branches


### PR DESCRIPTION
I'm testing if this could replace bors. I'm not removing the bors branches or app yet, and we can quickly turn this off in the settings if it doesn't work as well as bors, but in theory it works exactly the same (except for the a missing `bors try` equivalent).