### PR TITLE
Miscellaneous cleanup of debug print macros

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,10 @@ public API. Any other headers are internal implementation details.
 - ``pika/shared_mutex.hpp``
 - ``pika/thread.hpp``
 
+All functionality in a namespace containing ``detail`` and all macros prefixed
+with ``PIKA_DETAIL`` are implementation details and may change without warning
+at any time.
+
 Acknowledgements
 ================
 

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -130,7 +130,7 @@ namespace pika::cuda::experimental::detail {
                             }
 
                             // Forward successes and other errors to the callback
-                            PIKA_DP(cud_debug<5>,
+                            PIKA_DETAIL_DP(cud_debug<5>,
                                 debug(str<>("set ready vector"), "event",
                                     hex<8>(continuation.event), "enqueued events",
                                     dec<3>(get_number_of_enqueued_events()), "active events",
@@ -163,7 +163,7 @@ namespace pika::cuda::experimental::detail {
                         status = e.get_error();
                     }
 
-                    PIKA_DP(cud_debug<5>,
+                    PIKA_DETAIL_DP(cud_debug<5>,
                         debug(debug::detail::str<>("set ready queue"), "event",
                             debug::detail::hex<8>(continuation.event), "enqueued events",
                             debug::detail::dec<3>(get_number_of_enqueued_events()), "active events",
@@ -200,7 +200,7 @@ namespace pika::cuda::experimental::detail {
                 "CUDA event polling has not been enabled on any pool. Make sure that CUDA event "
                 "polling is enabled on at least one thread pool.");
 
-            PIKA_DP(cud_debug<5>,
+            PIKA_DETAIL_DP(cud_debug<5>,
                 debug(str<>("event queued"), "event", hex<8>(event), "enqueued events",
                     dec<3>(get_number_of_enqueued_events()), "active events",
                     dec<3>(get_number_of_active_events())));
@@ -232,7 +232,7 @@ namespace pika::cuda::experimental::detail {
             event_callback_vector.push_back(PIKA_MOVE(continuation));
             ++active_events_counter;
 
-            PIKA_DP(cud_debug<5>,
+            PIKA_DETAIL_DP(cud_debug<5>,
                 debug(str<>("event callback moved from queue to vector"), "event",
                     hex<8>(continuation.event), "enqueued events",
                     dec<3>(get_number_of_enqueued_events()), "active events",
@@ -316,7 +316,7 @@ namespace pika::cuda::experimental::detail {
 #if defined(PIKA_DEBUG)
         ++get_register_polling_count();
 #endif
-        PIKA_DP(cud_debug<2>, debug(str<>("enable polling"), pool.get_pool_name()));
+        PIKA_DETAIL_DP(cud_debug<2>, debug(str<>("enable polling"), pool.get_pool_name()));
         auto* sched = pool.get_scheduler();
         sched->set_cuda_polling_functions(&pika::cuda::experimental::detail::poll, &get_work_count);
     }
@@ -331,7 +331,7 @@ namespace pika::cuda::experimental::detail {
                 "sure CUDA event polling is not disabled too early.");
         }
 #endif
-        PIKA_DP(cud_debug<2>, debug(str<>("disable polling"), pool.get_pool_name()));
+        PIKA_DETAIL_DP(cud_debug<2>, debug(str<>("disable polling"), pool.get_pool_name()));
         auto* sched = pool.get_scheduler();
         sched->clear_cuda_polling_function();
     }
@@ -353,7 +353,7 @@ namespace pika::cuda::experimental {
 
     PIKA_EXPORT void set_pool_name(const std::string& name)
     {
-        PIKA_DP(detail::cud_debug<2>, debug(debug::detail::str<>("set pool name"), name));
+        PIKA_DETAIL_DP(detail::cud_debug<2>, debug(debug::detail::str<>("set pool name"), name));
         detail::polling_pool_name = name;
     }
 }    // namespace pika::cuda::experimental

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -55,18 +55,18 @@
 
 // Used to wrap function call parameters to prevent evaluation
 // when debugging is disabled
-#define PIKA_DP_LAZY(printer, Expr) printer.eval([&] { return Expr; })
-#define PIKA_DP(printer, Expr)                                                                     \
+#define PIKA_DETAIL_DP_LAZY(printer, Expr) printer.eval([&] { return Expr; })
+#define PIKA_DETAIL_DP(printer, Expr)                                                              \
  if constexpr (printer.is_enabled())                                                               \
  {                                                                                                 \
   printer.Expr;                                                                                    \
  };
 
-#define PIKA_NS_DEBUG pika::debug::detail
+#define PIKA_DETAIL_NS_DEBUG pika::debug::detail
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace PIKA_NS_DEBUG {
+namespace PIKA_DETAIL_NS_DEBUG {
 
     // ------------------------------------------------------------------
     // helper for N>M true/false
@@ -626,5 +626,5 @@ namespace PIKA_NS_DEBUG {
         // inherit constructor
         using base_type::base_type;
     };
-}    // namespace PIKA_NS_DEBUG
+}    // namespace PIKA_DETAIL_NS_DEBUG
 /// \endcond

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -37,7 +37,7 @@ PIKA_EXPORT char** freebsd_environ = nullptr;
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace PIKA_NS_DEBUG {
+namespace PIKA_DETAIL_NS_DEBUG {
 
     // ------------------------------------------------------------------
     // format as zero padded int
@@ -292,5 +292,5 @@ namespace PIKA_NS_DEBUG {
     }
 
     template PIKA_EXPORT void print_array(std::string const&, std::size_t const*, std::size_t);
-}    // namespace PIKA_NS_DEBUG
+}    // namespace PIKA_DETAIL_NS_DEBUG
 /// \endcond

--- a/libs/pika/debugging/tests/unit/print.cpp
+++ b/libs/pika/debugging/tests/unit/print.cpp
@@ -41,13 +41,13 @@ int main()
 
     // ---------------------------------------------------------
     // Test if normal debug messages trigger argument evaluation
-    // use the PIKA_DP_LAZY macro to prevent evaluation when disabled
+    // use the PIKA_DETAIL_DP_LAZY macro to prevent evaluation when disabled
     // we expect the counter to increment
     p_enabled.debug("Increment", increment(enabled_counter));
     PIKA_TEST_EQ(enabled_counter, 1);
 
     // we expect the counter to increment as LAZY will be evaluated
-    p_enabled.debug("Increment", PIKA_DP_LAZY(p_enabled, increment(enabled_counter)));
+    p_enabled.debug("Increment", PIKA_DETAIL_DP_LAZY(p_enabled, increment(enabled_counter)));
     PIKA_TEST_EQ(enabled_counter, 2);
 
     // we do not expect the counter to increment
@@ -57,17 +57,17 @@ int main()
     }
     PIKA_TEST_EQ(disabled_counter, 0);
 
-    // we do not expect the counter to increment: PIKA_DP_LAZY will not be evaluated
-    p_disabled.debug("Increment", PIKA_DP_LAZY(p_disabled, increment(disabled_counter)));
+    // we do not expect the counter to increment: PIKA_DETAIL_DP_LAZY will not be evaluated
+    p_disabled.debug("Increment", PIKA_DETAIL_DP_LAZY(p_disabled, increment(disabled_counter)));
     PIKA_TEST_EQ(disabled_counter, 0);
 
     // ---------------------------------------------------------
     // Test that scoped log messages behave as expected
     {
-        auto s_enabled =
-            p_enabled.scope("scoped block", PIKA_DP_LAZY(p_enabled, increment(enabled_counter)));
-        [[maybe_unused]] auto s_disabled =
-            p_disabled.scope("scoped block", PIKA_DP_LAZY(p_disabled, increment(disabled_counter)));
+        auto s_enabled = p_enabled.scope(
+            "scoped block", PIKA_DETAIL_DP_LAZY(p_enabled, increment(enabled_counter)));
+        [[maybe_unused]] auto s_disabled = p_disabled.scope(
+            "scoped block", PIKA_DETAIL_DP_LAZY(p_disabled, increment(disabled_counter)));
     }
     PIKA_TEST_EQ(enabled_counter, 3);
     PIKA_TEST_EQ(disabled_counter, 0);
@@ -75,16 +75,18 @@ int main()
     // ---------------------------------------------------------
     // Test that debug only variables behave as expected
     // create high resolution timers to see if they count
-    auto var1 = p_enabled.declare_variable<int>(PIKA_DP_LAZY(p_enabled, enabled_counter + 4));
+    auto var1 =
+        p_enabled.declare_variable<int>(PIKA_DETAIL_DP_LAZY(p_enabled, enabled_counter + 4));
     (void) var1;    // silenced unused var when optimized out
 
-    auto var2 = p_disabled.declare_variable<int>(PIKA_DP_LAZY(p_disabled, disabled_counter + 10));
+    auto var2 =
+        p_disabled.declare_variable<int>(PIKA_DETAIL_DP_LAZY(p_disabled, disabled_counter + 10));
     (void) var2;    // silenced unused var when optimized out
 
-    p_enabled.debug(
-        "var 1", pika::debug::detail::dec<>(PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
-    p_disabled.debug(
-        "var 2", pika::debug::detail::dec<>(PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
+    p_enabled.debug("var 1",
+        pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_enabled, enabled_counter += var1)));
+    p_disabled.debug("var 2",
+        pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_disabled, disabled_counter += var2)));
 
     PIKA_TEST_EQ(enabled_counter, 10);
     PIKA_TEST_EQ(disabled_counter, 0);
@@ -92,10 +94,10 @@ int main()
     p_enabled.set(var1, 5);
     p_disabled.set(var2, 5);
 
-    p_enabled.debug(
-        "var 1", pika::debug::detail::dec<>(PIKA_DP_LAZY(p_enabled, enabled_counter += var1)));
-    p_disabled.debug(
-        "var 2", pika::debug::detail::dec<>(PIKA_DP_LAZY(p_disabled, disabled_counter += var2)));
+    p_enabled.debug("var 1",
+        pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_enabled, enabled_counter += var1)));
+    p_disabled.debug("var 2",
+        pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_disabled, disabled_counter += var2)));
 
     PIKA_TEST_EQ(enabled_counter, 15);
     PIKA_TEST_EQ(disabled_counter, 0);
@@ -111,10 +113,10 @@ int main()
     while (std::chrono::duration_cast<std::chrono::seconds>(end - start).count() < 2)
     {
         p_enabled.timed(t_enabled, "enabled",
-            debug::detail::dec<3>(PIKA_DP_LAZY(p_enabled, ++enabled_counter)));
+            debug::detail::dec<3>(PIKA_DETAIL_DP_LAZY(p_enabled, ++enabled_counter)));
 
         p_disabled.timed(t_disabled, "disabled",
-            debug::detail::dec<3>(PIKA_DP_LAZY(p_disabled, ++disabled_counter)));
+            debug::detail::dec<3>(PIKA_DETAIL_DP_LAZY(p_disabled, ++disabled_counter)));
         end = std::chrono::system_clock::now();
     }
     PIKA_TEST_EQ(enabled_counter > 10, true);


### PR DESCRIPTION
- Rename macros to be prefixed by `PIKA_DETAIL`
- Remove unnecessary casts in debug print macro calls
- Add note about meaning of detail to README