### PR TITLE
Clean up `include` module

### DIFF
--- a/.inshpect.toml
+++ b/.inshpect.toml
@@ -337,6 +337,7 @@ patterns = [
     { pattern = '\bstd::any(|_cast)\b', include = 'any' },
     { pattern = '\bstd::error_(code|condition|category)\b', include = 'system_error' },
     { pattern = '\bstd::system_error\b', include = 'system_error' },
+    { pattern = '\bstd::chrono\b', include = 'chrono' },
     { pattern = '\bpika::intrusive_ptr\b', include = 'pika/memory/intrusive_ptr.hpp' },
     { pattern = '\bpika::detail::from_string\b', include = 'pika/string_util/from_string.hpp' },
     { pattern = '\bpika::detail::to_string\b', include = 'pika/string_util/to_string.hpp' },

--- a/examples/1d_stencil/1d_stencil_1.cpp
+++ b/examples/1d_stencil/1d_stencil_1.cpp
@@ -14,6 +14,7 @@
 #include <pika/chrono.hpp>
 #include <pika/init.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/examples/1d_stencil/1d_stencil_2.cpp
+++ b/examples/1d_stencil/1d_stencil_2.cpp
@@ -23,6 +23,7 @@
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/examples/1d_stencil/1d_stencil_3.cpp
+++ b/examples/1d_stencil/1d_stencil_3.cpp
@@ -18,6 +18,7 @@
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/examples/balancing/thread_phase.cpp
+++ b/examples/balancing/thread_phase.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/barrier.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/init.hpp>
 #include <pika/mutex.hpp>
 #include <pika/thread.hpp>

--- a/examples/jacobi_smp/jacobi_nonuniform_pika.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_pika.cpp
@@ -8,7 +8,7 @@
 #include "jacobi_nonuniform.hpp"
 
 #include <pika/chrono.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/future.hpp>
 
 #include <cstddef>

--- a/examples/jacobi_smp/jacobi_nonuniform_pika.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_pika.cpp
@@ -11,6 +11,7 @@
 #include <pika/functional/bind.hpp>
 #include <pika/future.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <iostream>

--- a/examples/jacobi_smp/jacobi_omp.hpp
+++ b/examples/jacobi_smp/jacobi_omp.hpp
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <pika/chrono.hpp>
+#include <pika/timing/high_resolution_timer.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/examples/jacobi_smp/jacobi_pika.cpp
+++ b/examples/jacobi_smp/jacobi_pika.cpp
@@ -10,6 +10,7 @@
 #include <pika/chrono.hpp>
 #include <pika/future.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <memory>

--- a/examples/quickstart/fibonacci.cpp
+++ b/examples/quickstart/fibonacci.cpp
@@ -18,6 +18,7 @@
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 

--- a/examples/quickstart/fibonacci_await.cpp
+++ b/examples/quickstart/fibonacci_await.cpp
@@ -9,14 +9,14 @@
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3564.pdf). The
 // necessary transformations are performed by hand.
 
-#include <pika/chrono.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/examples/quickstart/fibonacci_dataflow.cpp
+++ b/examples/quickstart/fibonacci_dataflow.cpp
@@ -17,6 +17,7 @@
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <string>

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -14,6 +14,7 @@
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/libs/pika/async_combinators/tests/unit/when_any_std_array.cpp
+++ b/libs/pika/async_combinators/tests/unit/when_any_std_array.cpp
@@ -14,6 +14,7 @@
 #include <pika/thread.hpp>
 
 #include <array>
+#include <chrono>
 #include <string>
 #include <thread>
 #include <utility>

--- a/libs/pika/async_combinators/tests/unit/when_some_std_array.cpp
+++ b/libs/pika/async_combinators/tests/unit/when_some_std_array.cpp
@@ -14,6 +14,7 @@
 #include <pika/thread.hpp>
 
 #include <array>
+#include <chrono>
 #include <string>
 #include <thread>
 #include <utility>

--- a/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
+++ b/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
@@ -27,6 +27,7 @@
 #include <whip.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <iostream>

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -36,6 +36,7 @@
 #include <whip.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <iostream>

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -29,7 +29,7 @@
 #include <pika/chrono.hpp>
 #include <pika/cuda.hpp>
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind_front.hpp>
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
 

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -6,7 +6,7 @@
 
 #include <pika/cuda.hpp>
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind_front.hpp>
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
 

--- a/libs/pika/execution/include/pika/execution/executors/auto_chunk_size.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/auto_chunk_size.hpp
@@ -16,6 +16,7 @@
 #include <pika/execution_base/execution.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>

--- a/libs/pika/execution/include/pika/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/pika/execution/include/pika/execution/executors/persistent_auto_chunk_size.hpp
@@ -13,6 +13,7 @@
 #include <pika/modules/timing.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -6,7 +6,6 @@
 
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
-#include <pika/modules/functional.hpp>
 #include <pika/testing.hpp>
 
 #include <cstddef>

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -6,7 +6,6 @@
 
 #include <pika/condition_variable.hpp>
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
 #include <pika/init.hpp>
 #include <pika/mutex.hpp>
 #include <pika/testing.hpp>

--- a/libs/pika/functional/tests/regressions/bind_sfinae_5488.cpp
+++ b/libs/pika/functional/tests/regressions/bind_sfinae_5488.cpp
@@ -6,7 +6,7 @@
 
 // #5488: pika::util::detail::bind doesn't bounds-check placeholders
 
-#include <pika/modules/functional.hpp>
+#include <pika/functional/bind.hpp>
 
 #include <type_traits>
 

--- a/libs/pika/functional/tests/unit/function_object_size.cpp
+++ b/libs/pika/functional/tests/unit/function_object_size.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <pika/modules/functional.hpp>
+#include <pika/functional/function.hpp>
 #include <pika/testing.hpp>
 
 #include <cstdint>

--- a/libs/pika/futures/src/future_data.cpp
+++ b/libs/pika/futures/src/future_data.cpp
@@ -20,6 +20,7 @@
 #include <pika/threading_base/annotated_function.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <exception>
 #include <functional>

--- a/libs/pika/include/docs/index.rst
+++ b/libs/pika/include/docs/index.rst
@@ -12,8 +12,7 @@ include
 =============
 
 This module provides no functionality in itself. Instead it provides headers
-that group together other headers that often appear together. This module
-provides local-only headers.
+that group together other headers that often appear together.
 
 See the :ref:`API reference <modules_include_api>` of this module for
 more details.

--- a/libs/pika/include/include/pika/chrono.hpp
+++ b/libs/pika/include/include/pika/chrono.hpp
@@ -6,5 +6,4 @@
 
 #pragma once
 
-#include <pika/timing/high_resolution_timer.hpp>
 #include <pika/timing/steady_clock.hpp>

--- a/libs/pika/include/include/pika/functional.hpp
+++ b/libs/pika/include/include/pika/functional.hpp
@@ -6,21 +6,5 @@
 
 #pragma once
 
-#include <pika/functional/bind.hpp>
-#include <pika/functional/bind_back.hpp>
-#include <pika/functional/bind_front.hpp>
-#include <pika/functional/function.hpp>
-#include <pika/functional/invoke.hpp>
-#include <pika/functional/invoke_fused.hpp>
-#include <pika/functional/traits/is_bind_expression.hpp>
-#include <pika/functional/unique_function.hpp>
 #include <pika/threading_base/annotated_function.hpp>
 #include <pika/threading_base/scoped_annotation.hpp>
-
-namespace pika {
-    using pika::detail::is_bind_expression;
-    using pika::util::detail::function;
-    using pika::util::detail::invoke;
-    using pika::util::detail::invoke_fused;
-    using pika::util::detail::unique_function;
-}    // namespace pika

--- a/libs/pika/include/include/pika/stop_token.hpp
+++ b/libs/pika/include/include/pika/stop_token.hpp
@@ -8,5 +8,3 @@
 
 #include <pika/config.hpp>
 #include <pika/synchronization/stop_token.hpp>
-
-// C++20 stop_token

--- a/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
@@ -17,6 +17,7 @@
 #include <pika/testing.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <exception>

--- a/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_external_future.cpp
@@ -9,7 +9,7 @@
 #include <pika/chrono.hpp>
 #include <pika/errors/try_catch_exception_ptr.hpp>
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/invoke.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 #include <pika/memory/intrusive_ptr.hpp>
@@ -41,7 +41,7 @@ struct external_future_executor
     decltype(auto) async_execute_helper(std::true_type, F&& f, Ts&&... ts)
     {
         // The completion of f is signalled out-of-band.
-        pika::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
+        pika::util::detail::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
         return pika::async([]() { pika::util::yield_while([]() { return !done; }); });
     }
 
@@ -49,7 +49,7 @@ struct external_future_executor
     decltype(auto) async_execute_helper(std::false_type, F&& f, Ts&&... ts)
     {
         // The completion of f is signalled out-of-band.
-        auto&& r = pika::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
+        auto&& r = pika::util::detail::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
         return pika::async([r = std::move(r)]() {
             pika::util::yield_while([]() { return !done; });
             return r;
@@ -123,7 +123,8 @@ struct external_future_additional_argument_executor
     decltype(auto) async_execute_helper(std::true_type, F&& f, Ts&&... ts)
     {
         // The completion of f is signalled out-of-band.
-        pika::invoke(std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
+        pika::util::detail::invoke(
+            std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
         return pika::async([]() { pika::util::yield_while([]() { return !done; }); });
     }
 
@@ -131,7 +132,8 @@ struct external_future_additional_argument_executor
     decltype(auto) async_execute_helper(std::false_type, F&& f, Ts&&... ts)
     {
         // The completion of f is signalled out-of-band.
-        auto&& r = pika::invoke(std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
+        auto&& r = pika::util::detail::invoke(
+            std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
         return pika::async([r = std::move(r)]() {
             pika::util::yield_while([]() { return !done; });
             return r;

--- a/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/async_customization.cpp
@@ -8,7 +8,8 @@
 
 #include <pika/debugging/demangle_helper.hpp>
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/deferred_call.hpp>
+#include <pika/functional/invoke_fused.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 #include <pika/modules/resource_partitioner.hpp>

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -14,7 +14,7 @@
 // problems such as lockups.
 
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind_back.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 #include <pika/modules/resource_partitioner.hpp>

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -23,6 +23,7 @@
 #include <pika/thread.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <iostream>
 #include <random>

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
@@ -19,6 +19,7 @@
 #include <pika/thread.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -18,6 +18,7 @@
 #include <pika/threading_base/annotated_function.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <iostream>
 #include <string>

--- a/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
@@ -12,6 +12,7 @@
 #include <pika/synchronization/channel_mpmc.hpp>
 #include <pika/thread.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
@@ -12,6 +12,7 @@
 #include <pika/synchronization/channel_mpsc.hpp>
 #include <pika/thread.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/libs/pika/synchronization/tests/performance/channel_spsc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_spsc_throughput.cpp
@@ -12,6 +12,7 @@
 #include <pika/synchronization/channel_spsc.hpp>
 #include <pika/thread.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/libs/pika/thread_manager/src/thread_manager.cpp
+++ b/libs/pika/thread_manager/src/thread_manager.cpp
@@ -12,6 +12,7 @@
 #include <pika/assert.hpp>
 #include <pika/async_combinators/wait_all.hpp>
 #include <pika/execution_base/this_thread.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/futures/future.hpp>
 #include <pika/modules/errors.hpp>
 #include <pika/modules/logging.hpp>

--- a/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
+++ b/libs/pika/thread_pool_util/include/pika/thread_pool_util/thread_pool_suspension_helpers.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <pika/config.hpp>
+#include <pika/functional/function.hpp>
 #include <pika/futures/future.hpp>
-#include <pika/modules/functional.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
 #include <cstddef>

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -26,6 +26,7 @@
 
 #include <fmt/format.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/libs/pika/threading_base/tests/unit/annotation_check_futures.cpp
+++ b/libs/pika/threading_base/tests/unit/annotation_check_futures.cpp
@@ -18,6 +18,7 @@
 #include <apex_options.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <iostream>
 #include <string>

--- a/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
+++ b/libs/pika/threading_base/tests/unit/annotation_check_senders.cpp
@@ -6,7 +6,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/execution.hpp>
-#include <pika/functional.hpp>
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
 

--- a/testing/performance_testing/src/performance.cpp
+++ b/testing/performance_testing/src/performance.cpp
@@ -9,6 +9,7 @@
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/tests/performance/local/async_overheads.cpp
+++ b/tests/performance/local/async_overheads.cpp
@@ -12,6 +12,7 @@
 #include "worker_timed.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/tests/performance/local/heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/heterogeneous_timed_task_spawn.cpp
@@ -7,7 +7,7 @@
 
 #include <pika/config.hpp>
 #if !defined(PIKA_COMPUTE_DEVICE_CODE)
-# include <pika/functional.hpp>
+# include <pika/functional/bind.hpp>
 # include <pika/init.hpp>
 # include <pika/modules/thread_manager.hpp>
 # include <pika/modules/timing.hpp>

--- a/tests/performance/local/htts_v2/htts2_pika.cpp
+++ b/tests/performance/local/htts_v2/htts2_pika.cpp
@@ -8,7 +8,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/barrier.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/init.hpp>
 #include <pika/thread.hpp>
 

--- a/tests/performance/local/parent_vs_child_stealing.cpp
+++ b/tests/performance/local/parent_vs_child_stealing.cpp
@@ -14,6 +14,7 @@
 # include <fmt/ostream.h>
 # include <fmt/printf.h>
 
+# include <chrono>
 # include <cstddef>
 # include <cstdint>
 # include <iostream>

--- a/tests/performance/local/skynet.cpp
+++ b/tests/performance/local/skynet.cpp
@@ -21,6 +21,7 @@
 #include <pika/future.hpp>
 #include <pika/init.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <vector>

--- a/tests/performance/local/wait_all_timings.cpp
+++ b/tests/performance/local/wait_all_timings.cpp
@@ -16,6 +16,7 @@
 # include <fmt/ostream.h>
 # include <fmt/printf.h>
 
+# include <chrono>
 # include <cstddef>
 # include <cstdint>
 # include <iostream>

--- a/tests/performance/local/worker_timed.hpp
+++ b/tests/performance/local/worker_timed.hpp
@@ -11,6 +11,7 @@
 
 #include <pika/modules/timing.hpp>
 
+#include <chrono>
 #include <cstdint>
 
 PIKA_FORCEINLINE void worker_timed(std::uint64_t delay_ns) noexcept

--- a/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_pika_thread_exceptions_3304.cpp
@@ -6,7 +6,8 @@
 
 #include <pika/condition_variable.hpp>
 #include <pika/exception.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
+#include <pika/functional/function.hpp>
 #include <pika/init.hpp>
 #include <pika/mutex.hpp>
 #include <pika/runtime/run_as_pika_thread.hpp>

--- a/tests/regressions/threads/thread_suspend_duration.cpp
+++ b/tests/regressions/threads/thread_suspend_duration.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/barrier.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
 #include <pika/thread.hpp>

--- a/tests/regressions/threads/thread_suspend_pending.cpp
+++ b/tests/regressions/threads/thread_suspend_pending.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/barrier.hpp>
-#include <pika/functional.hpp>
+#include <pika/functional/bind.hpp>
 #include <pika/init.hpp>
 #include <pika/testing.hpp>
 #include <pika/thread.hpp>


### PR DESCRIPTION
Part of #16.

Remove includes that contain detail-only functionality from e.g. `pika/functional.hpp`. Replace includes of `pika/functional.hpp` with more specific includes when required for detail functionality.