### PR TITLE
Use `find`'s `-depth` option when finding directories to delete in CI

### DIFF
--- a/.jenkins/cscs-ault/batch.sh
+++ b/.jenkins/cscs-ault/batch.sh
@@ -17,7 +17,7 @@ build_dir="${pika_dir}/build_${job_name}"
 install_dir="${pika_dir}/install_${job_name}"
 
 # Clean up directories older than 4 days, find fails if dir does not exist
-test -d ${pika_dir} && find ${pika_dir} -mindepth 1 -type d -ctime +4 -exec rm -rf {} \; 2> /dev/null
+test -d ${pika_dir} && find ${pika_dir} -depth -mindepth 1 -type d -ctime +4 -exec rm -rf {} \;
 
 rm -rf "${src_dir}" "${build_dir}"
 # Copy source directory to /dev/shm for faster builds


### PR DESCRIPTION
This means using depth-first search, which avoids having `find` try to access directories that have just been deleted. This also removes the redirection of errors to `/dev/null` since that shouldn't be needed anymore.