### PR TITLE
Make `async_rw_mutex` part of public API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Documentation
 Documentation is a work in progress. The following headers are part of the
 public API. Any other headers are internal implementation details.
 
+- ``pika/async_rw_mutex.hpp``
 - ``pika/barrier.hpp``
 - ``pika/channel.hpp``
 - ``pika/condition_variable.hpp``

--- a/libs/pika/include/CMakeLists.txt
+++ b/libs/pika/include/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(include_headers
+    pika/async_rw_mutex.hpp
     pika/barrier.hpp
     pika/channel.hpp
     pika/chrono.hpp
@@ -51,6 +52,7 @@ pika_add_module(
     pika_futures
     pika_lcos
     pika_runtime
+    pika_synchronization
     ${include_additional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/pika/include/include/pika/async_rw_mutex.hpp
+++ b/libs/pika/include/include/pika/async_rw_mutex.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/synchronization/async_rw_mutex.hpp>

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/assert.hpp>
+#include <pika/async_rw_mutex.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
 #include <pika/mutex.hpp>
-#include <pika/synchronization/async_rw_mutex.hpp>
 #include <pika/testing.hpp>
 
 #include <atomic>


### PR DESCRIPTION
Fixes #646.

- Adds the header `pika/async_rw_mutex.hpp`
- Moves the `async_rw_mutex_access_type` enum out of the `detail` namespace
- Moves the `async_rw_mutex_access_wrapper` out of the `detail` namespace