### PR TITLE
Make posix utility guards consistent in Boost coroutines implementation

### DIFF
--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_generic_context.hpp
@@ -91,8 +91,7 @@ namespace pika::threads::coroutines {
 
             void* allocate(std::size_t size) const
             {
-# if defined(_POSIX_VERSION) &&                                                                    \
-     !(defined(__APPLE__) && (defined(arm64) || defined(__arm64) || defined(__arm64__)))
+# if defined(_POSIX_VERSION)
                 void* limit = posix::alloc_stack(size);
                 posix::watermark_stack(limit, size);
 # else


### PR DESCRIPTION
This should fix problems seen on Apple M1/M2 systems.