### PR TITLE
Fix checks for `PIKA_HAVE_THREAD_DEADLOCK_DETECTION`

### DIFF
--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -275,9 +275,9 @@ namespace pika {
                 util::disable_lock_detection();
             }
 #endif
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
-            threads::detail::set_minimal_deadlock_detection_enabled(
-                cmdline.rtcfg_.enable_minimal_deadlock_detection());
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
+            threads::detail::set_deadlock_detection_enabled(
+                cmdline.rtcfg_.enable_deadlock_detection());
 #endif
 #ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION
             util::detail::set_spinlock_break_on_deadlock_enabled(

--- a/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
+++ b/libs/pika/runtime_configuration/include/pika/runtime_configuration/runtime_configuration.hpp
@@ -62,7 +62,7 @@ namespace pika::util {
         bool enable_global_lock_detection() const;
 
         // Enable minimal deadlock detection for pika threads
-        bool enable_minimal_deadlock_detection() const;
+        bool enable_deadlock_detection() const;
         bool enable_spinlock_deadlock_detection() const;
         std::size_t get_spinlock_deadlock_detection_limit() const;
         std::size_t get_spinlock_deadlock_warning_limit() const;

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -99,11 +99,11 @@ namespace pika::util {
 #endif
             "throw_on_held_lock = ${PIKA_THROW_ON_HELD_LOCK:1}",
 #endif
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
 #ifdef PIKA_DEBUG
-            "minimal_deadlock_detection = ${PIKA_MINIMAL_DEADLOCK_DETECTION:1}",
+            "deadlock_detection = ${PIKA_DEADLOCK_DETECTION:1}",
 #else
-            "minimal_deadlock_detection = ${PIKA_MINIMAL_DEADLOCK_DETECTION:0}",
+            "deadlock_detection = ${PIKA_DEADLOCK_DETECTION:0}",
 #endif
 #endif
 #ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION
@@ -436,15 +436,15 @@ namespace pika::util {
     }
 
     // Enable minimal deadlock detection for pika threads
-    bool runtime_configuration::enable_minimal_deadlock_detection() const
+    bool runtime_configuration::enable_deadlock_detection() const
     {
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
         if (pika::detail::section const* sec = get_section("pika"); nullptr != sec)
         {
 # ifdef PIKA_DEBUG
-            return pika::detail::get_entry_as<int>(*sec, "minimal_deadlock_detection", 1) != 0;
+            return pika::detail::get_entry_as<int>(*sec, "deadlock_detection", 1) != 0;
 # else
-            return pika::detail::get_entry_as<int>(*sec, "minimal_deadlock_detection", 0) != 0;
+            return pika::detail::get_entry_as<int>(*sec, "deadlock_detection", 0) != 0;
 # endif
         }
 

--- a/libs/pika/schedulers/include/pika/schedulers/deadlock_detection.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/deadlock_detection.hpp
@@ -10,8 +10,8 @@
 #include <pika/config.hpp>
 
 namespace pika::threads::detail {
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
-    PIKA_EXPORT void set_minimal_deadlock_detection_enabled(bool enabled);
-    PIKA_EXPORT bool get_minimal_deadlock_detection_enabled();
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
+    PIKA_EXPORT void set_deadlock_detection_enabled(bool enabled);
+    PIKA_EXPORT bool get_deadlock_detection_enabled();
 #endif
 }    // namespace pika::threads::detail

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -1061,9 +1061,9 @@ namespace pika::threads::detail {
                 }
             }
 
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
             // no new work is available, are we deadlocked?
-            if (PIKA_UNLIKELY(get_minimal_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
+            if (PIKA_UNLIKELY(get_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
             {
                 bool suspended_only = true;
 

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -769,9 +769,9 @@ namespace pika::threads::detail {
                 }
             }
 
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
             // no new work is available, are we deadlocked?
-            if (PIKA_UNLIKELY(get_minimal_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
+            if (PIKA_UNLIKELY(get_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
             {
                 bool suspended_only = true;
 

--- a/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
@@ -36,14 +36,14 @@ namespace pika::threads::detail {
     bool dump_suspended_threads(
         std::size_t num_thread, Map& tm, std::int64_t& idle_loop_count, bool running)
     {
-#if !defined(PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION)
+#if !defined(PIKA_HAVE_THREAD_DEADLOCK_DETECTION)
         PIKA_UNUSED(num_thread);
         PIKA_UNUSED(tm);
         PIKA_UNUSED(idle_loop_count);
         PIKA_UNUSED(running);    //-V601
         return false;
 #else
-        if (!get_minimal_deadlock_detection_enabled())
+        if (!get_deadlock_detection_enabled())
             return false;
 
         // attempt to output possibly deadlocked threads occasionally only

--- a/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
@@ -118,9 +118,9 @@ namespace pika::threads::detail {
                 return true;
             }
 
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
             // no new work is available, are we deadlocked?
-            if (PIKA_UNLIKELY(get_minimal_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
+            if (PIKA_UNLIKELY(get_deadlock_detection_enabled() && LPIKA_ENABLED(error)))
             {
                 bool suspended_only = true;
 

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -1059,13 +1059,13 @@ namespace pika::threads::detail {
         bool dump_suspended_threads(
             std::size_t num_thread, std::int64_t& idle_loop_count, bool running)
         {
-#if !defined(PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION)
+#if !defined(PIKA_HAVE_THREAD_DEADLOCK_DETECTION)
             PIKA_UNUSED(num_thread);
             PIKA_UNUSED(idle_loop_count);
             PIKA_UNUSED(running);
             return false;
 #else
-            if (get_minimal_deadlock_detection_enabled())
+            if (get_deadlock_detection_enabled())
             {
                 std::lock_guard<mutex_type> lk(mtx_);
                 return detail::dump_suspended_threads(

--- a/libs/pika/schedulers/src/deadlock_detection.cpp
+++ b/libs/pika/schedulers/src/deadlock_detection.cpp
@@ -9,17 +9,17 @@
 #include <pika/schedulers/deadlock_detection.hpp>
 
 namespace pika::threads {
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
-    static bool minimal_deadlock_detection_enabled = false;
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
+    static bool deadlock_detection_enabled = false;
 
-    void set_minimal_deadlock_detection_enabled(bool enabled)
+    void set_deadlock_detection_enabled(bool enabled)
     {
-        minimal_deadlock_detection_enabled = enabled;
+        deadlock_detection_enabled = enabled;
     }
 
-    bool get_minimal_deadlock_detection_enabled()
+    bool get_deadlock_detection_enabled()
     {
-        return minimal_deadlock_detection_enabled;
+        return deadlock_detection_enabled;
     }
 #endif
 }    // namespace pika::threads

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -327,7 +327,7 @@ namespace pika::threads::detail {
         }
 #endif
 
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
         void set_marked_state(thread_schedule_state mark) const noexcept
         {
             marked_state_ = mark;
@@ -563,7 +563,7 @@ namespace pika::threads::detail {
         std::size_t parent_thread_phase_;
 #endif
 
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
         mutable thread_schedule_state marked_state_;
 #endif
 

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -58,7 +58,7 @@ namespace pika::threads::detail {
       , parent_thread_id_(init_data.parent_id)
       , parent_thread_phase_(init_data.parent_phase)
 #endif
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
       , marked_state_(thread_schedule_state::unknown)
 #endif
 #ifdef PIKA_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
@@ -198,7 +198,7 @@ namespace pika::threads::detail {
         parent_thread_id_ = init_data.parent_id;
         parent_thread_phase_ = init_data.parent_phase;
 #endif
-#ifdef PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+#ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
         set_marked_state(thread_schedule_state::unknown);
 #endif
 #ifdef PIKA_HAVE_THREAD_BACKTRACE_ON_SUSPENSION


### PR DESCRIPTION
Rename the checks from `PIKA_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION` to `PIKA_HAVE_THREAD_DEADLOCK_DETECTION`.

Fixes #635.