### PR TITLE
Disable scheduler idle backoff by default at runtime

### DIFF
--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
@@ -70,8 +70,7 @@ namespace pika::threads {
             enable_stealing |
             enable_stealing_numa |
             assign_work_round_robin |
-            steal_after_local |
-            enable_idle_backoff,
+            steal_after_local,
         /// This enables all available options.
         all_flags =
             do_background_work |


### PR DESCRIPTION
Second of N PRs to try to improve performance in DLA-Future. This is one of the changes in https://github.com/pika-org/pika/compare/main...disable-cruft-scheduler where we see up to 25% improvement in DLA-Future miniapps. This branch needs to be benchmarked to see if it makes a difference on its own.

https://github.com/pika-org/pika/tree/disable-idle-backoff-default-compile-time needs to be benchmarked together with this branch to ensure that its enough to disable idle backoff at runtime instead of compile time.