### PR TITLE
Disable guard pages by default

### DIFF
--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -167,7 +167,7 @@ namespace pika::util {
                 PIKA_PP_EXPAND(PIKA_HUGE_STACK_SIZE)) "}",
 #if defined(__linux) || defined(linux) || defined(__linux__) ||                \
     defined(__FreeBSD__)
-            "use_guard_pages = ${PIKA_USE_GUARD_PAGES:1}",
+            "use_guard_pages = ${PIKA_USE_GUARD_PAGES:0}",
 #endif
 
             "[pika.thread_queue]",


### PR DESCRIPTION
Fourth of N PRs to try to improve performance in DLA-Future. This is one of the changes in https://github.com/pika-org/pika/compare/main...disable-cruft-scheduler where we see up to 25% improvement in DLA-Future miniapps. This branch needs to be benchmarked to see if it makes a difference on its own.

https://github.com/pika-org/pika/tree/disable-guard-pages-default-compile-time needs to be benchmarked together with this branch to ensure that its enough to disable guard pages at runtime instead of compile time.