### PR TITLE
Remove `fast_idle` and `delay_exit` scheduler modes and related scheduling loop checks

### DIFF
--- a/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/pika/resource_partitioner/examples/guided_pool_test.cpp
@@ -229,7 +229,7 @@ void init_resource_partitioner_handler(
                 init.affinity_data_, thread_queue_init, "shared-priority-scheduler");
             std::unique_ptr<high_priority_sched> scheduler(new high_priority_sched(scheduler_init));
 
-            init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
+            init.mode_ = scheduler_mode();
 
             std::unique_ptr<pika::threads::detail::thread_pool_base> pool(
                 new pika::threads::detail::scheduled_thread_pool<high_priority_sched>(

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -62,7 +62,6 @@ int pika_main(variables_map& vm)
             scheduler_mode::steal_high_priority_first);
         sched->remove_scheduler_mode(scheduler_mode::assign_work_thread_parent |
             scheduler_mode::steal_after_local | scheduler_mode::reduce_thread_priority |
-            scheduler_mode::delay_exit | scheduler_mode::fast_idle_mode |
             scheduler_mode::enable_elasticity);
     }
 

--- a/libs/pika/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/pika/schedulers/tests/unit/schedule_last.cpp
@@ -52,8 +52,7 @@ void test_scheduler(int argc, char* argv[])
                 std::unique_ptr<Scheduler> scheduler(new Scheduler(init));
 
                 thread_pool_init.mode_ = pika::threads::scheduler_mode(
-                    pika::threads::scheduler_mode::reduce_thread_priority |
-                    pika::threads::scheduler_mode::delay_exit);
+                    pika::threads::scheduler_mode::reduce_thread_priority);
 
                 std::unique_ptr<pika::threads::detail::thread_pool_base> pool(
                     new pika::threads::detail::scheduled_thread_pool<Scheduler>(

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_mode.hpp
@@ -20,48 +20,37 @@ namespace pika::threads {
         /// The kernel priority of the os-thread driving the scheduler will be
         /// reduced below normal.
         reduce_thread_priority = 0x001,
-        /// The scheduler will wait for some unspecified amount of time before
-        /// exiting the scheduling loop while being terminated to make sure no
-        /// other work is being scheduled during processing the shutdown
-        /// request.
-        delay_exit = 0x002,
-        /// Some schedulers have the capability to act as 'embedded'
-        /// schedulers. In this case it needs to periodically invoke a provided
-        /// callback into the outer scheduler more frequently than normal. This
-        /// option enables this behavior.
-        fast_idle_mode = 0x004,
         /// This option allows for the scheduler to dynamically increase and
         /// reduce the number of processing units it runs on. Setting this value
         /// not succeed for schedulers that do not support this functionality.
-        enable_elasticity = 0x008,
+        enable_elasticity = 0x002,
         /// This option allows schedulers that support work thread/stealing to
         /// enable/disable it
-        enable_stealing = 0x010,
+        enable_stealing = 0x004,
         /// This option allows schedulersthat support it to disallow stealing
         /// between numa domains
-        enable_stealing_numa = 0x020,
+        enable_stealing_numa = 0x008,
         /// This option tells schedulersthat support it to add tasks round
         /// robin to queues on each core
-        assign_work_round_robin = 0x040,
+        assign_work_round_robin = 0x010,
         /// This option tells schedulers that support it to add tasks round to
         /// the same core/queue that the parent task is running on
-        assign_work_thread_parent = 0x080,
+        assign_work_thread_parent = 0x020,
         /// This option tells schedulers that support it to always (try to)
         /// steal high priority tasks from other queues before finishing their
         /// own lower priority tasks
-        steal_high_priority_first = 0x100,
+        steal_high_priority_first = 0x040,
         /// This option tells schedulers that support it to steal tasks only
         /// when their local queues are empty
-        steal_after_local = 0x200,
+        steal_after_local = 0x080,
         /// This option allows for certain schedulers to explicitly disable
         /// exponential idle-back off
-        enable_idle_backoff = 0x0400,
+        enable_idle_backoff = 0x100,
 
         // clang-format off
         /// This option represents the default mode.
         default_mode =
             reduce_thread_priority |
-            delay_exit |
             enable_stealing |
             enable_stealing_numa |
             assign_work_round_robin |
@@ -70,8 +59,6 @@ namespace pika::threads {
         /// This enables all available options.
         all_flags =
             reduce_thread_priority |
-            delay_exit |
-            fast_idle_mode |
             enable_elasticity |
             enable_stealing |
             enable_stealing_numa |


### PR DESCRIPTION
Fifth of N PRs to try to improve performance in DLA-Future. This is one of the changes in https://github.com/pika-org/pika/compare/main...disable-cruft-scheduler where we see up to 25% improvement in DLA-Future miniapps. This branch needs to be benchmarked to see if it makes a difference on its own.

One change that have in the `disable-cruft-scheduler` branch is to unconditionally enable stealing always. It may be worth checking if that makes a difference, though I suspect the effect may be small.