### PR TITLE
Revert "Always steal tasks if scheduler mode allows for it" #670

### DIFF
--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduling_loop.hpp
@@ -406,12 +406,16 @@ namespace pika::threads::detail {
             thread_id_ref_type thrd = PIKA_MOVE(next_thrd);
 
             // Get the next pika thread from the queue
-            bool const running =
-                this_state.load(std::memory_order_relaxed) < runtime_state::pre_sleep;
+            bool running = this_state.load(std::memory_order_relaxed) < runtime_state::pre_sleep;
 
             // extract the stealing mode once per loop iteration
-            bool const enable_stealing = scheduler.SchedulingPolicy::has_scheduler_mode(
+            bool enable_stealing = scheduler.SchedulingPolicy::has_scheduler_mode(
                 ::pika::threads::scheduler_mode::enable_stealing);
+
+            // stealing staged threads is enabled only after normal stealing has
+            // failed for a while
+            bool enable_stealing_staged =
+                enable_stealing && idle_loop_count > params.max_idle_loop_count_ / 2;
 
             if (PIKA_LIKELY(thrd ||
                     scheduler.SchedulingPolicy::get_next_thread(
@@ -556,8 +560,8 @@ namespace pika::threads::detail {
                         if (PIKA_LIKELY(next_thrd == nullptr))
                         {
                             // schedule other work
-                            scheduler.SchedulingPolicy::wait_or_add_new(
-                                num_thread, running, idle_loop_count, enable_stealing, added);
+                            scheduler.SchedulingPolicy::wait_or_add_new(num_thread, running,
+                                idle_loop_count, enable_stealing_staged, added);
                         }
 
                         // schedule this thread again, make sure it ends up at
@@ -582,8 +586,8 @@ namespace pika::threads::detail {
                             else
                             {
                                 // schedule other work
-                                scheduler.SchedulingPolicy::wait_or_add_new(
-                                    num_thread, running, idle_loop_count, enable_stealing, added);
+                                scheduler.SchedulingPolicy::wait_or_add_new(num_thread, running,
+                                    idle_loop_count, enable_stealing_staged, added);
 
                                 // schedule this thread again immediately with
                                 // boosted priority
@@ -644,7 +648,7 @@ namespace pika::threads::detail {
                 ++idle_loop_count;
 
                 if (scheduler.SchedulingPolicy::wait_or_add_new(
-                        num_thread, running, idle_loop_count, enable_stealing, added))
+                        num_thread, running, idle_loop_count, enable_stealing_staged, added))
                 {
                     // Clean up terminated threads before trying to exit
                     bool can_exit = !running &&


### PR DESCRIPTION
Reverts #670. It seems it introduced a performance regression, at least in the future overhead benchmark. It did show a small performance improvement in DLA-Future, so I'm guessing the effect of the change is very much workload dependent. We might instead have to consider tweaking the threshold when we enable stealing.