### PR TITLE
Eagerly reset shared state in `async_rw_mutex`

### DIFF
--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -460,6 +460,7 @@ namespace pika::execution::experimental {
                         // add a continuation to be triggered when the previous
                         // state is released.
                         p->add_continuation(PIKA_MOVE(continuation));
+                        os.state.reset();
                         os.prev_state.reset();
                     }
                     else
@@ -655,6 +656,7 @@ namespace pika::execution::experimental {
                         // add a continuation to be triggered when the previous
                         // state is released.
                         p->add_continuation(PIKA_MOVE(continuation));
+                        os.state.reset();
                         os.prev_state.reset();
                     }
                     else


### PR DESCRIPTION
Eagerly reset the shared state held by the operation state to allow continuations to run as early as possible. This fixes a deadlock that occurred in the added test case.