### PR TITLE
Fix `PIKA_WITH_VERIFY_LOCKS_BACKTRACE=ON` build

### DIFF
--- a/libs/pika/lock_registration/src/register_locks.cpp
+++ b/libs/pika/lock_registration/src/register_locks.cpp
@@ -7,6 +7,7 @@
 
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
+#include <pika/debugging/backtrace/backtrace.hpp>
 #include <pika/lock_registration/detail/register_locks.hpp>
 #include <pika/modules/errors.hpp>
 #include <pika/type_support/unused.hpp>
@@ -39,7 +40,7 @@ namespace pika::util {
           : ignore_(false)
           , user_data_(data)
 # ifdef PIKA_HAVE_VERIFY_LOCKS_BACKTRACE
-          , backtrace_(pika::detail::trace(trace_depth))
+          , backtrace_(pika::debug::detail::trace(trace_depth))
 # endif
         {
 # ifndef PIKA_HAVE_VERIFY_LOCKS_BACKTRACE

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -87,7 +87,11 @@ int pika_main()
     // randomly create tasks that run on a random pool
     // attach continuations to them that run on different
     // random pools
-    int const loops = 500;
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+    constexpr int loops = 20;
+#else
+    constexpr int loops = 500;
+#endif
     //
     std::cout << "1: Starting HP " << loops << std::endl;
     std::atomic<int> counter(loops);

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -28,6 +28,12 @@
 #include <utility>
 #include <vector>
 
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+inline constexpr std::size_t num_tasks_per_worker_thread = 100;
+#else
+inline constexpr std::size_t num_tasks_per_worker_thread = 10000;
+#endif
+
 std::size_t const max_threads =
     (std::min)(std::size_t(4), std::size_t(pika::threads::detail::hardware_concurrency()));
 
@@ -61,7 +67,7 @@ int pika_main()
         {
             std::vector<pika::future<void>> fs;
 
-            for (std::size_t i = 0; i < worker_pool_threads * 10000; ++i)
+            for (std::size_t i = 0; i < worker_pool_threads * num_tasks_per_worker_thread; ++i)
             {
                 fs.push_back(pika::async(worker_exec, []() {}));
             }
@@ -84,7 +90,7 @@ int pika_main()
         {
             std::vector<pika::future<void>> fs;
 
-            for (std::size_t i = 0; i < worker_pool_threads * 10000; ++i)
+            for (std::size_t i = 0; i < worker_pool_threads * num_tasks_per_worker_thread; ++i)
             {
                 fs.push_back(pika::async(worker_exec, []() {}));
             }
@@ -115,7 +121,8 @@ int pika_main()
 
             std::vector<pika::future<void>> fs;
 
-            for (std::size_t i = 0; i < pika::resource::get_num_threads("default") * 10000; ++i)
+            for (std::size_t i = 0;
+                 i < pika::resource::get_num_threads("default") * num_tasks_per_worker_thread; ++i)
             {
                 fs.push_back(pika::async(worker_exec, []() {}));
             }

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -186,7 +186,9 @@ int main(int argc, char* argv[])
 #endif
         pika::resource::scheduling_policy::static_,
         pika::resource::scheduling_policy::static_priority,
+#if !defined(PIKA_HAVE_VERIFY_LOCKS)
         pika::resource::scheduling_policy::shared_priority,
+#endif
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
@@ -32,7 +32,9 @@ struct data
     int data_[8];
 };
 
-#if PIKA_DEBUG
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+constexpr int NUM_TESTS = 10000;
+#elif PIKA_DEBUG
 constexpr int NUM_TESTS = 1000000;
 #else
 constexpr int NUM_TESTS = 100000000;

--- a/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
@@ -32,7 +32,9 @@ struct data
     int data_[8];
 };
 
-#if PIKA_DEBUG
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+constexpr int NUM_TESTS = 10000;
+#elif PIKA_DEBUG
 constexpr int NUM_TESTS = 1000000;
 #else
 constexpr int NUM_TESTS = 100000000;

--- a/libs/pika/synchronization/tests/performance/channel_spsc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_spsc_throughput.cpp
@@ -32,7 +32,9 @@ struct data
     int data_[8];
 };
 
-#if PIKA_DEBUG
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+constexpr int NUM_TESTS = 10000;
+#elif PIKA_DEBUG
 constexpr int NUM_TESTS = 1000000;
 #else
 constexpr int NUM_TESTS = 100000000;

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -305,7 +305,11 @@ int pika_main(pika::program_options::variables_map& vm)
     test_moved(async_rw_mutex<std::size_t>{0});
     test_moved(async_rw_mutex<mytype, mytype_base>{mytype{}});
 
+#if defined(PIKA_HAVE_VERIFY_LOCKS)
+    constexpr std::size_t iterations = 50;
+#else
     constexpr std::size_t iterations = 1000;
+#endif
     test_multiple_accesses(async_rw_mutex<void>{}, iterations);
     test_multiple_accesses(async_rw_mutex<std::size_t>{0}, iterations);
     test_multiple_accesses(async_rw_mutex<mytype, mytype_base>{mytype{}}, iterations);


### PR DESCRIPTION
Also adds the option to one CI configuration.