### PR TITLE
Disable `suspend_thread` test with `shared_priority_queue_scheduler`

### DIFF
--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -222,7 +222,9 @@ int main(int argc, char* argv[])
             pika::resource::scheduling_policy::abp_priority_fifo,
             pika::resource::scheduling_policy::abp_priority_lifo,
 #endif
-            pika::resource::scheduling_policy::shared_priority,
+            // This is disabled because it frequently fails with
+            // std::system_error "Resource temporarily unavailable"
+            // pika::resource::scheduling_policy::shared_priority,
         };
 
         for (auto const scheduler : schedulers)


### PR DESCRIPTION
It's been failing very frequently recently, but I went back and tried older versions and it seems to fail frequently there as well. E.g. https://cdash.cscs.ch/test/80449656:

```
# d_lookup_         : {0004} : 0, 0, 0, 0, 
# q_lookup_         : {0004} : 0, 1, 2, 3, 
# q_counts_         : {0001} : 4, 
# q_offset_         : {0001} : 0, 
# schedcpu_         : {0004} : 6, 7, 8, 10, 

{os-thread}: pika/worker-thread/pool:default/global:0/local:0
{what}: mmap() failed to allocate thread stack: pika(unhandled_exception)

{os-thread}: pika/worker-thread/pool:default/global:1/local:1
{what}: mmap() failed to allocate thread stack: pika(unhandled_exception)



{os-thread}: pika/worker-thread/pool:default/global:2/local:2
{what}: mmap() failed to allocate thread stack: pika(unhandled_exception)
```