### PR TITLE
Fix deadlocks in `condition_variable`

### DIFF
--- a/libs/pika/synchronization/src/detail/condition_variable.cpp
+++ b/libs/pika/synchronization/src/detail/condition_variable.cpp
@@ -100,6 +100,7 @@ namespace pika::detail {
         // swap the list
         queue_type queue;
         queue.swap(queue_);
+        lock.unlock();
 
         if (!queue.empty())
         {
@@ -117,6 +118,7 @@ namespace pika::detail {
 
                 if (PIKA_UNLIKELY(!ctx))
                 {
+                    lock.lock();
                     prepend_entries(lock, queue);
                     lock.unlock();
 
@@ -124,8 +126,6 @@ namespace pika::detail {
                         "condition_variable::notify_all", "null thread id encountered");
                     return;
                 }
-
-                [[maybe_unused]] util::ignore_while_checking il(&lock);
 
                 ctx.resume();
 

--- a/libs/pika/threading_base/src/set_thread_state.cpp
+++ b/libs/pika/threading_base/src/set_thread_state.cpp
@@ -133,7 +133,7 @@ namespace pika::threads::detail {
                 else
                 {
                     pika::execution::this_thread::detail::yield_k(
-                        k % 16, "pika::threads::detail::set_thread_state");
+                        k, "pika::threads::detail::set_thread_state");
                     ++k;
 
                     // NOLINTNEXTLINE(bugprone-branch-clone)


### PR DESCRIPTION
This fixes deadlocks that started appearing after #672 which disabled yielding for `spinlock`.

(One of) the deadlock(s) was the following scenario:

| thread 1 | thread 2 |
|-|-|
| wait_until | |
| take lock | |
| add self to cv queue | | 
| release lock | |
| timed suspend | |
| | notify_all |
| | take lock |
| timed resume | attempt to set thread 1 to pending |
| attempt to take lock | fail because thread 1 is active |
| spin trying to take lock | spin waiting for thread 1 to not be active |
| deadlock | deadlock |

This PR changes `notify_all` to not hold the lock while resuming threads that need to be woken up. I see no reason to keep the lock for that time since there is anyway a delay between setting a thread to `pending` and the thread actually being run by a worker thread, with the latter _not_ happening under a lock already right now. This PR just relaxes that constraint further. It also significantly reduces the time the lock is held in `notify_all`. I'm quite sure this change is safe but we'll need to continue looking out for failures in CI in case I've missed something.

I've also reverted the change in `set_thread_state` to never yield from #672. Since the lock in `notify_all` is no longer held while resuming threads it's again safe to yield in `set_thread_state`.

I think spurious wakeups were probably possible before this change, but if they weren't they're now definitely possible with pika's `condition_variable`. 