### PR TITLE
Enable stdexec in GCC 13 CI configuration

### DIFF
--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -10,7 +10,7 @@ boost_version="1.79.0"
 hwloc_version="2.6.0"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-broadwell"
-stdexec_version="7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d"
+stdexec_version="e81dd21338da3b497d0b6c206502b1d3dda394b1"
 
 spack_spec="pika@main arch=${spack_arch} %${spack_compiler} cxxflags=-stdlib=libc++ malloc=system cxxstd=${cxx_std} +stdexec ^boost@${boost_version} ^hwloc@${hwloc_version} ^fmt cxxflags=-stdlib=libc++ ^stdexec@${stdexec_version}"
 

--- a/.jenkins/cscs/env-clang-14-cuda.sh
+++ b/.jenkins/cscs/env-clang-14-cuda.sh
@@ -11,7 +11,7 @@ hwloc_version="2.7.0"
 cuda_version="11.5.0"
 spack_compiler="clang@${clang_version}"
 spack_arch="cray-cnl7-haswell"
-stdexec_version="7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d"
+stdexec_version="e81dd21338da3b497d0b6c206502b1d3dda394b1"
 
 spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} +stdexec ^boost@${boost_version} ^cuda@${cuda_version} +allow-unsupported-compilers ^hwloc@${hwloc_version} ^stdexec@${stdexec_version}"
 

--- a/.jenkins/cscs/env-gcc-13.sh
+++ b/.jenkins/cscs/env-gcc-13.sh
@@ -8,13 +8,15 @@ cxx_std="20"
 gcc_version="13.1.0"
 boost_version="1.82.0"
 hwloc_version="2.9.1"
+stdexec_version="7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d"
 spack_compiler="gcc@${gcc_version}"
 spack_arch="cray-cnl7-broadwell"
 
-spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version}"
+spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=system cxxstd=${cxx_std} +stdexec ^boost@${boost_version} ^hwloc@${hwloc_version} ^stdexec@${stdexec_version}"
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
+configure_extra_options+=" -DPIKA_WITH_STDEXEC=ON"
 configure_extra_options+=" -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 # In release mode GCC 13 emits a false-positive array-bounds warning so we

--- a/.jenkins/cscs/env-gcc-13.sh
+++ b/.jenkins/cscs/env-gcc-13.sh
@@ -8,7 +8,7 @@ cxx_std="20"
 gcc_version="13.1.0"
 boost_version="1.82.0"
 hwloc_version="2.9.1"
-stdexec_version="7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d"
+stdexec_version="e81dd21338da3b497d0b6c206502b1d3dda394b1"
 spack_compiler="gcc@${gcc_version}"
 spack_arch="cray-cnl7-broadwell"
 

--- a/.jenkins/cscs/env-nvhpc.sh
+++ b/.jenkins/cscs/env-nvhpc.sh
@@ -7,7 +7,7 @@
 cxx_std="20"
 boost_version="1.78.0"
 hwloc_version="2.7.0"
-stdexec_version="7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d"
+stdexec_version="e81dd21338da3b497d0b6c206502b1d3dda394b1"
 nvhpc_version="22.11"
 spack_compiler="nvhpc@${nvhpc_version}"
 spack_arch="cray-cnl7-haswell"

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -150,7 +150,7 @@ namespace pika::cuda::experimental {
             };
 
             friend env tag_invoke(
-                pika::execution::experimental::get_env_t, cuda_scheduler_sender const& s)
+                pika::execution::experimental::get_env_t, cuda_scheduler_sender const& s) noexcept
             {
                 return {s.scheduler};
             }

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -204,8 +204,8 @@ namespace pika::cuda::experimental {
                         PIKA_FORWARD(Receiver, receiver), s.f, s.sched});
             }
 
-            friend auto tag_invoke(
-                pika::execution::experimental::get_env_t, then_on_host_sender_type const& s)
+            friend auto tag_invoke(pika::execution::experimental::get_env_t,
+                then_on_host_sender_type const& s) noexcept
             {
                 return pika::execution::experimental::get_env(s.sender);
             }

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -544,8 +544,8 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 PIKA_FORWARD(Receiver, receiver), s.f, s.sched, s.sender);
         }
 
-        friend auto tag_invoke(
-            pika::execution::experimental::get_env_t, then_with_cuda_stream_sender_type const& s)
+        friend auto tag_invoke(pika::execution::experimental::get_env_t,
+            then_with_cuda_stream_sender_type const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);
         }

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -77,7 +77,7 @@ struct const_reference_cuda_sender
     };
 
     friend env tag_invoke(
-        pika::execution::experimental::get_env_t, const_reference_cuda_sender const& s)
+        pika::execution::experimental::get_env_t, const_reference_cuda_sender const& s) noexcept
     {
         return {s.sched};
     }
@@ -133,8 +133,8 @@ struct const_reference_error_cuda_sender
         }
     };
 
-    friend env tag_invoke(
-        pika::execution::experimental::get_env_t, const_reference_error_cuda_sender const& s)
+    friend env tag_invoke(pika::execution::experimental::get_env_t,
+        const_reference_error_cuda_sender const& s) noexcept
     {
         return {s.sched};
     }

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -60,7 +60,7 @@ namespace pika::bulk_detail {
         static constexpr bool sends_done = false;
 
         friend constexpr decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, bulk_sender_type const& s)
+            pika::execution::experimental::get_env_t, bulk_sender_type const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -121,7 +121,7 @@ namespace pika::drop_value_detail {
         }
 
         friend constexpr decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, drop_value_sender_type const& s)
+            pika::execution::experimental::get_env_t, drop_value_sender_type const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -91,7 +91,7 @@ namespace pika::schedule_from_detail {
         };
 
         friend auto tag_invoke(
-            pika::execution::experimental::get_env_t, schedule_from_sender_type const& s)
+            pika::execution::experimental::get_env_t, schedule_from_sender_type const& s) noexcept
         {
             auto e = pika::execution::experimental::get_env(s.predecessor_sender);
             return env<std::decay_t<decltype(e)>>{std::move(e), s.scheduler};

--- a/libs/pika/execution/tests/include/algorithm_test_utils.hpp
+++ b/libs/pika/execution/tests/include/algorithm_test_utils.hpp
@@ -479,7 +479,7 @@ struct scheduler
             }
         };
 
-        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s)
+        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s) noexcept
         {
             return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
         }
@@ -564,7 +564,7 @@ struct scheduler2
             }
         };
 
-        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s)
+        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s) noexcept
         {
             return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
         }
@@ -673,7 +673,7 @@ namespace my_namespace {
                 }
             };
 
-            friend env tag_invoke(pika::execution::experimental::get_env_t, sender const&)
+            friend env tag_invoke(pika::execution::experimental::get_env_t, sender const&) noexcept
             {
                 return {};
             }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -206,7 +206,7 @@ struct sender_with_completion_scheduler : void_sender
         }
     };
 
-    friend env tag_invoke(ex::get_env_t, sender_with_completion_scheduler const& s)
+    friend env tag_invoke(ex::get_env_t, sender_with_completion_scheduler const& s) noexcept
     {
         return {s.sched};
     }

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -107,7 +107,8 @@ namespace pika::execution::experimental {
                 }
             };
 
-            friend constexpr env tag_invoke(pika::execution::experimental::get_env_t, sender const&)
+            friend constexpr env tag_invoke(
+                pika::execution::experimental::get_env_t, sender const&) noexcept
             {
                 return {};
             }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -231,7 +231,8 @@ namespace pika::execution::experimental {
                 }
             };
 
-            friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s)
+            friend env tag_invoke(
+                pika::execution::experimental::get_env_t, sender const& s) noexcept
             {
                 return {s.scheduler};
             }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -507,7 +507,7 @@ namespace pika::thread_pool_bulk_detail {
         }
 
         friend constexpr auto tag_invoke(
-            pika::execution::experimental::get_env_t, thread_pool_bulk_sender const& s)
+            pika::execution::experimental::get_env_t, thread_pool_bulk_sender const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);
         }


### PR DESCRIPTION
Fixes #683. Also makes all `get_env_t` overloads `noexcept` as that is required by the latest `stdexec` versions.