### PR TITLE
Allow compilation with fmt 10 with CUDA/HIP

### DIFF
--- a/.jenkins/cscs/env-gcc-cuda-12.sh
+++ b/.jenkins/cscs/env-gcc-cuda-12.sh
@@ -9,10 +9,11 @@ gcc_version="12.1.0"
 boost_version="1.82.0"
 hwloc_version="2.9.1"
 cuda_version="12.0.0"
+fmt_version="10.0.0"
 spack_compiler="gcc@${gcc_version}"
 spack_arch="cray-cnl7-haswell"
 
-spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^cuda@${cuda_version}"
+spack_spec="pika@main arch=${spack_arch} %${spack_compiler} +cuda malloc=system cxxstd=${cxx_std} ^boost@${boost_version} ^hwloc@${hwloc_version} ^cuda@${cuda_version} ^fmt@${fmt_version}"
 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -78,7 +78,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 std::make_exception_ptr(pika::exception(pika::error::unknown_error,
                     fmt::format(
                         "Getting event after CUDA stream transform failed with status {} ({})",
-                        status, whip::get_error_string(status)))));
+                        static_cast<int>(status), whip::get_error_string(status)))));
         }
     }
 

--- a/libs/pika/async_cuda/tests/unit/cublas_handle.cu
+++ b/libs/pika/async_cuda/tests/unit/cublas_handle.cu
@@ -137,7 +137,8 @@ int main()
         }
         catch (cu::cublas_exception const& e)
         {
-            PIKA_TEST_EQ(e.get_cublas_errorcode(), CUBLAS_STATUS_NOT_INITIALIZED);
+            PIKA_TEST_EQ(static_cast<int>(e.get_cublas_errorcode()),
+                static_cast<int>(CUBLAS_STATUS_NOT_INITIALIZED));
         }
         catch (...)
         {

--- a/libs/pika/debugging/tests/unit/print.cpp
+++ b/libs/pika/debugging/tests/unit/print.cpp
@@ -44,22 +44,22 @@ int main()
     // use the PIKA_DETAIL_DP_LAZY macro to prevent evaluation when disabled
     // we expect the counter to increment
     p_enabled.debug("Increment", increment(enabled_counter));
-    PIKA_TEST_EQ(enabled_counter, 1);
+    PIKA_TEST_EQ(enabled_counter.load(), 1);
 
     // we expect the counter to increment as LAZY will be evaluated
     p_enabled.debug("Increment", PIKA_DETAIL_DP_LAZY(p_enabled, increment(enabled_counter)));
-    PIKA_TEST_EQ(enabled_counter, 2);
+    PIKA_TEST_EQ(enabled_counter.load(), 2);
 
     // we do not expect the counter to increment
     if (p_disabled.is_enabled())
     {
         p_disabled.debug("Increment", increment(disabled_counter));
     }
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     // we do not expect the counter to increment: PIKA_DETAIL_DP_LAZY will not be evaluated
     p_disabled.debug("Increment", PIKA_DETAIL_DP_LAZY(p_disabled, increment(disabled_counter)));
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     // ---------------------------------------------------------
     // Test that scoped log messages behave as expected
@@ -69,8 +69,8 @@ int main()
         [[maybe_unused]] auto s_disabled = p_disabled.scope(
             "scoped block", PIKA_DETAIL_DP_LAZY(p_disabled, increment(disabled_counter)));
     }
-    PIKA_TEST_EQ(enabled_counter, 3);
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(enabled_counter.load(), 3);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     // ---------------------------------------------------------
     // Test that debug only variables behave as expected
@@ -88,8 +88,8 @@ int main()
     p_disabled.debug("var 2",
         pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_disabled, disabled_counter += var2)));
 
-    PIKA_TEST_EQ(enabled_counter, 10);
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(enabled_counter.load(), 10);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     p_enabled.set(var1, 5);
     p_disabled.set(var2, 5);
@@ -99,8 +99,8 @@ int main()
     p_disabled.debug("var 2",
         pika::debug::detail::dec<>(PIKA_DETAIL_DP_LAZY(p_disabled, disabled_counter += var2)));
 
-    PIKA_TEST_EQ(enabled_counter, 15);
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(enabled_counter.load(), 15);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     // ---------------------------------------------------------
     // Test that timed log messages behave as expected
@@ -119,8 +119,8 @@ int main()
             debug::detail::dec<3>(PIKA_DETAIL_DP_LAZY(p_disabled, ++disabled_counter)));
         end = std::chrono::system_clock::now();
     }
-    PIKA_TEST_EQ(enabled_counter > 10, true);
-    PIKA_TEST_EQ(disabled_counter, 0);
+    PIKA_TEST_EQ(enabled_counter.load() > 10, true);
+    PIKA_TEST_EQ(disabled_counter.load(), 0);
 
     std::cout << "enabled  counter " << enabled_counter << std::endl;
     std::cout << "disabled counter " << disabled_counter << std::endl;

--- a/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_sync_wait.cpp
@@ -55,7 +55,7 @@ int pika_main()
 
     {
         int x = 42;
-        PIKA_TEST_EQ(tt::sync_wait(ex::just(const_reference_sender<int>{x})).x, 42);
+        PIKA_TEST_EQ(tt::sync_wait(ex::just(const_reference_sender<int>{x})).x.get(), 42);
     }
 
     // operator| overload

--- a/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/pika/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -79,8 +79,8 @@ void test_get_chunk_size()
             test_chunk_size{}, pika::execution::par.executor(), [](std::size_t) { return 0; }, 1,
             1);
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -90,8 +90,8 @@ void test_get_chunk_size()
         pika::parallel::execution::get_chunk_size(
             test_chunk_size{}, test_executor_get_chunk_size{}, [](std::size_t) { return 0; }, 1, 1);
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -147,8 +147,8 @@ void test_maximal_number_of_chunks()
         pika::parallel::execution::maximal_number_of_chunks(
             test_number_of_chunks{}, pika::execution::par.executor(), 1, 1);
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -158,8 +158,8 @@ void test_maximal_number_of_chunks()
         pika::parallel::execution::maximal_number_of_chunks(
             test_number_of_chunks{}, test_executor_maximal_number_of_chunks{}, 1, 1);
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -213,8 +213,8 @@ void test_reset_thread_distribution()
         pika::parallel::execution::reset_thread_distribution(
             test_thread_distribution{}, pika::execution::par.executor());
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -224,8 +224,8 @@ void test_reset_thread_distribution()
         pika::parallel::execution::reset_thread_distribution(
             test_thread_distribution{}, test_executor_reset_thread_distribution{});
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -281,8 +281,8 @@ void test_processing_units_count()
         pika::parallel::execution::processing_units_count(
             test_processing_units{}, pika::execution::par.executor());
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -292,8 +292,8 @@ void test_processing_units_count()
         pika::parallel::execution::processing_units_count(
             test_processing_units{}, test_executor_processing_units_count{});
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -371,8 +371,8 @@ void test_mark_begin_execution()
         pika::parallel::execution::mark_begin_execution(
             test_begin_end{}, pika::execution::par.executor());
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -382,8 +382,8 @@ void test_mark_begin_execution()
         pika::parallel::execution::mark_begin_execution(
             test_begin_end{}, test_executor_begin_end{});
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -396,8 +396,8 @@ void test_mark_end_of_scheduling()
         pika::parallel::execution::mark_end_of_scheduling(
             test_begin_end{}, pika::execution::par.executor());
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -407,8 +407,8 @@ void test_mark_end_of_scheduling()
         pika::parallel::execution::mark_end_of_scheduling(
             test_begin_end{}, test_executor_begin_end{});
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 
@@ -421,8 +421,8 @@ void test_mark_end_execution()
         pika::parallel::execution::mark_end_execution(
             test_begin_end{}, pika::execution::par.executor());
 
-        PIKA_TEST_EQ(params_count, std::size_t(1));
-        PIKA_TEST_EQ(exec_count, std::size_t(0));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(1));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(0));
     }
 
     {
@@ -431,8 +431,8 @@ void test_mark_end_execution()
 
         pika::parallel::execution::mark_end_execution(test_begin_end{}, test_executor_begin_end{});
 
-        PIKA_TEST_EQ(params_count, std::size_t(0));
-        PIKA_TEST_EQ(exec_count, std::size_t(1));
+        PIKA_TEST_EQ(params_count.load(), std::size_t(0));
+        PIKA_TEST_EQ(exec_count.load(), std::size_t(1));
     }
 }
 

--- a/libs/pika/executors/tests/unit/limiting_executor.cpp
+++ b/libs/pika/executors/tests/unit/limiting_executor.cpp
@@ -107,7 +107,7 @@ void test_limit()
     // to be exceeded by the number of threads in the worst case.
     std::cout << "Exec 1 had max " << task_1_max << " (allowed = " << max1 << ") from a total of "
               << task_1_total << std::endl;
-    PIKA_TEST_LTE(task_1_max, max1);
+    PIKA_TEST_LTE(task_1_max.load(), max1);
     // if the test fails by a small number, then this would fix it
     // PIKA_TEST_LTE(task_1_max, max1 + pika::get_num_worker_threads());
 }

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -151,7 +151,7 @@ void test_sender_receiver_then_wait()
     });
     tt::sync_wait(std::move(work2));
 
-    PIKA_TEST_EQ(then_count, std::size_t(2));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(2));
     PIKA_TEST(executed);
 }
 
@@ -169,7 +169,7 @@ void test_sender_receiver_then_sync_wait()
         return 42;
     });
     auto result = tt::sync_wait(std::move(work));
-    PIKA_TEST_EQ(then_count, std::size_t(1));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(1));
     static_assert(
         std::is_same<int, std::decay_t<decltype(result)>>::value, "result should be an int");
     PIKA_TEST_EQ(result, 42);
@@ -199,7 +199,7 @@ void test_sender_receiver_then_arguments()
         return 2 * s.size();
     });
     auto result = tt::sync_wait(std::move(work3));
-    PIKA_TEST_EQ(then_count, std::size_t(3));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(3));
     static_assert(std::is_same<std::size_t, std::decay_t<decltype(result)>>::value,
         "result should be a std::size_t");
     PIKA_TEST_EQ(result, std::size_t(12));
@@ -703,8 +703,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             3);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -725,7 +725,7 @@ void test_ensure_started_when_all()
             std::unique_lock l{mtx};
             cond.wait(l, [&]() { return started; });
         }
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
         auto succ1 = s | ex::then([&](int const& x) {
             ++successor_task_calls;
             return x + 1;
@@ -737,8 +737,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -770,8 +770,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 }
 
@@ -821,8 +821,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             3);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -843,8 +843,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -865,8 +865,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 }
 

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -158,7 +158,7 @@ void test_sender_receiver_then_wait()
     });
     tt::sync_wait(std::move(work2));
 
-    PIKA_TEST_EQ(then_count, std::size_t(2));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(2));
     PIKA_TEST(executed);
 }
 
@@ -176,7 +176,7 @@ void test_sender_receiver_then_sync_wait()
         return 42;
     });
     auto result = tt::sync_wait(std::move(work));
-    PIKA_TEST_EQ(then_count, std::size_t(1));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(1));
     static_assert(
         std::is_same<int, std::decay_t<decltype(result)>>::value, "result should be an int");
     PIKA_TEST_EQ(result, 42);
@@ -206,7 +206,7 @@ void test_sender_receiver_then_arguments()
         return 2 * s.size();
     });
     auto result = tt::sync_wait(std::move(work3));
-    PIKA_TEST_EQ(then_count, std::size_t(3));
+    PIKA_TEST_EQ(then_count.load(), std::size_t(3));
     static_assert(std::is_same<std::size_t, std::decay_t<decltype(result)>>::value,
         "result should be a std::size_t");
     PIKA_TEST_EQ(result, std::size_t(12));
@@ -816,7 +816,7 @@ void test_future_sender()
         tt::sync_wait(sf);
         tt::sync_wait(sf);
         tt::sync_wait(std::move(sf));
-        PIKA_TEST_EQ(calls, std::size_t(1));
+        PIKA_TEST_EQ(calls.load(), std::size_t(1));
 
         bool exception_thrown = false;
         try
@@ -844,7 +844,7 @@ void test_future_sender()
         PIKA_TEST_EQ(tt::sync_wait(sf), 42);
         PIKA_TEST_EQ(tt::sync_wait(sf), 42);
         PIKA_TEST_EQ(tt::sync_wait(std::move(sf)), 42);
-        PIKA_TEST_EQ(calls, std::size_t(1));
+        PIKA_TEST_EQ(calls.load(), std::size_t(1));
 
         bool exception_thrown = false;
         try
@@ -994,8 +994,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             3);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -1016,7 +1016,7 @@ void test_ensure_started_when_all()
             std::unique_lock l{mtx};
             cond.wait(l, [&]() { return started; });
         }
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
         auto succ1 = s | ex::then([&](int const& x) {
             ++successor_task_calls;
             return x + 1;
@@ -1028,8 +1028,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -1061,8 +1061,8 @@ void test_ensure_started_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 }
 
@@ -1112,8 +1112,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             3);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -1134,8 +1134,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 
     {
@@ -1156,8 +1156,8 @@ void test_split_when_all()
         PIKA_TEST_EQ(tt::sync_wait(ex::when_all(succ1, succ2) |
                          ex::then([](int const& x, int const& y) { return x + y; })),
             9);
-        PIKA_TEST_EQ(first_task_calls, std::size_t(1));
-        PIKA_TEST_EQ(successor_task_calls, std::size_t(2));
+        PIKA_TEST_EQ(first_task_calls.load(), std::size_t(1));
+        PIKA_TEST_EQ(successor_task_calls.load(), std::size_t(2));
     }
 }
 
@@ -1509,7 +1509,7 @@ void test_keep_future_sender()
         tt::sync_wait(sf | ex::keep_future());
         tt::sync_wait(sf | ex::keep_future());
         tt::sync_wait(std::move(sf) | ex::keep_future());
-        PIKA_TEST_EQ(calls, std::size_t(1));
+        PIKA_TEST_EQ(calls.load(), std::size_t(1));
 
         bool exception_thrown = false;
         try
@@ -1534,7 +1534,7 @@ void test_keep_future_sender()
         PIKA_TEST_EQ(tt::sync_wait(sf | ex::keep_future()).get(), 42);
         PIKA_TEST_EQ(tt::sync_wait(sf | ex::keep_future()).get(), 42);
         PIKA_TEST_EQ(tt::sync_wait(std::move(sf) | ex::keep_future()).get(), 42);
-        PIKA_TEST_EQ(calls, std::size_t(1));
+        PIKA_TEST_EQ(calls.load(), std::size_t(1));
 
         bool exception_thrown = false;
         try

--- a/libs/pika/lcos/tests/unit/dataflow.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow.cpp
@@ -115,11 +115,11 @@ void function_pointers()
     PIKA_TEST_EQ(f3.get(), 163);
     PIKA_TEST_EQ(f4.get(), 10 * 84);
     PIKA_TEST_EQ(f5.get(), 126);
-    PIKA_TEST_EQ(void_f_count, 1u);
-    PIKA_TEST_EQ(int_f_count, 1u);
-    PIKA_TEST_EQ(void_f1_count, 1u);
-    PIKA_TEST_EQ(int_f1_count, 16u);
-    PIKA_TEST_EQ(int_f2_count, 1u);
+    PIKA_TEST_EQ(void_f_count.load(), 1u);
+    PIKA_TEST_EQ(int_f_count.load(), 1u);
+    PIKA_TEST_EQ(void_f1_count.load(), 1u);
+    PIKA_TEST_EQ(int_f1_count.load(), 16u);
+    PIKA_TEST_EQ(int_f2_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -184,7 +184,7 @@ void future_function_pointers()
 
     f1.wait();
 
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
     future_void_f1_count.store(0);
 
     future<void> f2 =
@@ -192,23 +192,23 @@ void future_function_pointers()
             async(&future_void_sf1, shared_future<void>(make_ready_future())));
 
     f2.wait();
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
-    PIKA_TEST_EQ(future_void_f2_count, 1u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_void_f2_count.load(), 1u);
     future_void_f1_count.store(0);
     future_void_f2_count.store(0);
 
     future<int> f3 = dataflow(&future_int_f1, make_ready_future());
 
     PIKA_TEST_EQ(f3.get(), 1);
-    PIKA_TEST_EQ(future_int_f1_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 1u);
     future_int_f1_count.store(0);
 
     future<int> f4 = dataflow(&future_int_f2, dataflow(&future_int_f1, make_ready_future()),
         dataflow(&future_int_f1, make_ready_future()));
 
     PIKA_TEST_EQ(f4.get(), 2);
-    PIKA_TEST_EQ(future_int_f1_count, 2u);
-    PIKA_TEST_EQ(future_int_f2_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_int_f2_count.load(), 1u);
     future_int_f1_count.store(0);
     future_int_f2_count.store(0);
 
@@ -260,10 +260,10 @@ void plain_arguments()
         future<int> f2 = dataflow(&int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 1u);
+        PIKA_TEST_EQ(void_f4_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 1u);
+        PIKA_TEST_EQ(int_f4_count.load(), 1u);
     }
 
     {
@@ -271,10 +271,10 @@ void plain_arguments()
         future<int> f2 = dataflow(pika::launch::async, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 2u);
+        PIKA_TEST_EQ(void_f4_count.load(), 2u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 2u);
+        PIKA_TEST_EQ(int_f4_count.load(), 2u);
     }
 
     void_f5_count.store(0);
@@ -285,10 +285,10 @@ void plain_arguments()
         future<int> f2 = dataflow(&int_f5, 42, async(&int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 
     {
@@ -296,10 +296,10 @@ void plain_arguments()
         future<int> f2 = dataflow(pika::launch::async, &int_f5, 42, async(&int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 2u);
+        PIKA_TEST_EQ(void_f5_count.load(), 2u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 2u);
+        PIKA_TEST_EQ(int_f5_count.load(), 2u);
     }
 }
 
@@ -313,10 +313,10 @@ void plain_deferred_arguments()
         future<int> f2 = dataflow(pika::launch::deferred, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 1u);
+        PIKA_TEST_EQ(void_f4_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 1u);
+        PIKA_TEST_EQ(int_f4_count.load(), 1u);
     }
 
     void_f5_count.store(0);
@@ -327,10 +327,10 @@ void plain_deferred_arguments()
         future<int> f2 = dataflow(&int_f5, 42, async(pika::launch::deferred, &int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 
@@ -346,10 +346,10 @@ void plain_arguments_lazy()
         future<int> f2 = dataflow(policy1, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 1u);
+        PIKA_TEST_EQ(void_f4_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 1u);
+        PIKA_TEST_EQ(int_f4_count.load(), 1u);
     }
 
     auto policy2 = pika::launch::select([]() { return pika::launch::async; });
@@ -359,10 +359,10 @@ void plain_arguments_lazy()
         future<int> f2 = dataflow(policy2, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 2u);
+        PIKA_TEST_EQ(void_f4_count.load(), 2u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 2u);
+        PIKA_TEST_EQ(int_f4_count.load(), 2u);
     }
 
     void_f5_count.store(0);
@@ -380,10 +380,10 @@ void plain_arguments_lazy()
         future<int> f2 = dataflow(policy3, &int_f5, 42, async(&int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 

--- a/libs/pika/lcos/tests/unit/dataflow_executor.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_executor.cpp
@@ -118,11 +118,11 @@ void function_pointers(Executor& exec)
     PIKA_TEST_EQ(f3.get(), 163);
     PIKA_TEST_EQ(f4.get(), 10 * 84);
     PIKA_TEST_EQ(f5.get(), 126);
-    PIKA_TEST_EQ(void_f_count, 1u);
-    PIKA_TEST_EQ(int_f_count, 1u);
-    PIKA_TEST_EQ(void_f1_count, 1u);
-    PIKA_TEST_EQ(int_f1_count, 16u);
-    PIKA_TEST_EQ(int_f2_count, 1u);
+    PIKA_TEST_EQ(void_f_count.load(), 1u);
+    PIKA_TEST_EQ(int_f_count.load(), 1u);
+    PIKA_TEST_EQ(void_f1_count.load(), 1u);
+    PIKA_TEST_EQ(int_f1_count.load(), 16u);
+    PIKA_TEST_EQ(int_f2_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -194,7 +194,7 @@ void future_function_pointers(Executor& exec)
 
     f1.wait();
 
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
     future_void_f1_count.store(0);
 
     future<void> f2 = dataflow(exec, &future_void_f2,
@@ -202,8 +202,8 @@ void future_function_pointers(Executor& exec)
         async(&future_void_sf1, shared_future<void>(make_ready_future())));
 
     f2.wait();
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
-    PIKA_TEST_EQ(future_void_f2_count, 1u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_void_f2_count.load(), 1u);
 
     future_void_f1_count.store(0);
     future_void_f2_count.store(0);
@@ -213,7 +213,7 @@ void future_function_pointers(Executor& exec)
     future<int> f3 = dataflow(exec, &future_int_f1, make_ready_future());
 
     PIKA_TEST_EQ(f3.get(), 1);
-    PIKA_TEST_EQ(future_int_f1_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 1u);
     future_int_f1_count.store(0);
 
     future<int> f4 =
@@ -221,8 +221,8 @@ void future_function_pointers(Executor& exec)
             dataflow(exec, &future_int_f1, make_ready_future()));
 
     PIKA_TEST_EQ(f4.get(), 2);
-    PIKA_TEST_EQ(future_int_f1_count, 2u);
-    PIKA_TEST_EQ(future_int_f2_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_int_f2_count.load(), 1u);
     future_int_f1_count.store(0);
     future_int_f2_count.store(0);
 
@@ -235,8 +235,8 @@ void future_function_pointers(Executor& exec)
     future<int> f5 = dataflow(exec, &future_int_f_vector, std::ref(vf));
 
     PIKA_TEST_EQ(f5.get(), 10);
-    PIKA_TEST_EQ(future_int_f1_count, 10u);
-    PIKA_TEST_EQ(future_int_f_vector_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 10u);
+    PIKA_TEST_EQ(future_int_f_vector_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -277,10 +277,10 @@ void plain_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 1u);
+        PIKA_TEST_EQ(void_f4_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 1u);
+        PIKA_TEST_EQ(int_f4_count.load(), 1u);
     }
 
     void_f5_count.store(0);
@@ -291,10 +291,10 @@ void plain_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f5, 42, async(&int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 
@@ -309,10 +309,10 @@ void plain_deferred_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f5, 42, async(pika::launch::deferred, &int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 

--- a/libs/pika/lcos/tests/unit/dataflow_executor_additional_arguments.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_executor_additional_arguments.cpp
@@ -153,11 +153,11 @@ void function_pointers(Executor& exec)
     PIKA_TEST_EQ(f3.get(), 163);
     PIKA_TEST_EQ(f4.get(), 10 * 84);
     PIKA_TEST_EQ(f5.get(), 126);
-    PIKA_TEST_EQ(void_f_count, 1u);
-    PIKA_TEST_EQ(int_f_count, 1u);
-    PIKA_TEST_EQ(void_f1_count, 1u);
-    PIKA_TEST_EQ(int_f1_count, 16u);
-    PIKA_TEST_EQ(int_f2_count, 1u);
+    PIKA_TEST_EQ(void_f_count.load(), 1u);
+    PIKA_TEST_EQ(int_f_count.load(), 1u);
+    PIKA_TEST_EQ(void_f1_count.load(), 1u);
+    PIKA_TEST_EQ(int_f1_count.load(), 16u);
+    PIKA_TEST_EQ(int_f2_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -229,7 +229,7 @@ void future_function_pointers(Executor& exec)
 
     f1.wait();
 
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
     future_void_f1_count.store(0);
 
     future<void> f2 = dataflow(exec, &future_void_f2,
@@ -237,8 +237,8 @@ void future_function_pointers(Executor& exec)
         async(&future_void_sf1, shared_future<void>(make_ready_future())));
 
     f2.wait();
-    PIKA_TEST_EQ(future_void_f1_count, 2u);
-    PIKA_TEST_EQ(future_void_f2_count, 1u);
+    PIKA_TEST_EQ(future_void_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_void_f2_count.load(), 1u);
 
     future_void_f1_count.store(0);
     future_void_f2_count.store(0);
@@ -248,7 +248,7 @@ void future_function_pointers(Executor& exec)
     future<int> f3 = dataflow(exec, &future_int_f1, make_ready_future());
 
     PIKA_TEST_EQ(f3.get(), 1);
-    PIKA_TEST_EQ(future_int_f1_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 1u);
     future_int_f1_count.store(0);
 
     future<int> f4 =
@@ -256,8 +256,8 @@ void future_function_pointers(Executor& exec)
             dataflow(exec, &future_int_f1, make_ready_future()));
 
     PIKA_TEST_EQ(f4.get(), 2);
-    PIKA_TEST_EQ(future_int_f1_count, 2u);
-    PIKA_TEST_EQ(future_int_f2_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 2u);
+    PIKA_TEST_EQ(future_int_f2_count.load(), 1u);
     future_int_f1_count.store(0);
     future_int_f2_count.store(0);
 
@@ -270,8 +270,8 @@ void future_function_pointers(Executor& exec)
     future<int> f5 = dataflow(exec, &future_int_f_vector, std::ref(vf));
 
     PIKA_TEST_EQ(f5.get(), 10);
-    PIKA_TEST_EQ(future_int_f1_count, 10u);
-    PIKA_TEST_EQ(future_int_f_vector_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 10u);
+    PIKA_TEST_EQ(future_int_f_vector_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -312,10 +312,10 @@ void plain_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f4, 42);
 
         f1.wait();
-        PIKA_TEST_EQ(void_f4_count, 1u);
+        PIKA_TEST_EQ(void_f4_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 84);
-        PIKA_TEST_EQ(int_f4_count, 1u);
+        PIKA_TEST_EQ(int_f4_count.load(), 1u);
     }
 
     void_f5_count.store(0);
@@ -326,10 +326,10 @@ void plain_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f5, 42, async(&int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 
@@ -344,10 +344,10 @@ void plain_deferred_arguments(Executor& exec)
         future<int> f2 = dataflow(exec, &int_f5, 42, async(pika::launch::deferred, &int_f));
 
         f1.wait();
-        PIKA_TEST_EQ(void_f5_count, 1u);
+        PIKA_TEST_EQ(void_f5_count.load(), 1u);
 
         PIKA_TEST_EQ(f2.get(), 126);
-        PIKA_TEST_EQ(int_f5_count, 1u);
+        PIKA_TEST_EQ(int_f5_count.load(), 1u);
     }
 }
 

--- a/libs/pika/lcos/tests/unit/dataflow_small_vector.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_small_vector.cpp
@@ -126,11 +126,11 @@ void function_pointers(std::uint32_t num)
     PIKA_TEST_EQ(f3.get(), 163);
     PIKA_TEST_EQ(f4.get(), int(num * 84));
     PIKA_TEST_EQ(f5.get(), 126);
-    PIKA_TEST_EQ(void_f_count, 1u);
-    PIKA_TEST_EQ(int_f_count, 1u);
-    PIKA_TEST_EQ(void_f1_count, 1u);
-    PIKA_TEST_EQ(int_f1_count, 6u + num);
-    PIKA_TEST_EQ(int_f2_count, 1u);
+    PIKA_TEST_EQ(void_f_count.load(), 1u);
+    PIKA_TEST_EQ(int_f_count.load(), 1u);
+    PIKA_TEST_EQ(void_f1_count.load(), 1u);
+    PIKA_TEST_EQ(int_f1_count.load(), 6u + num);
+    PIKA_TEST_EQ(int_f2_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -193,8 +193,8 @@ void future_function_pointers(std::uint32_t num)
     pika::future<int> f5 = pika::dataflow(&future_int_f_vector, std::ref(vf));
 
     PIKA_TEST_EQ(f5.get(), int(num));
-    PIKA_TEST_EQ(future_int_f1_count, num);
-    PIKA_TEST_EQ(future_int_f_vector_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), num);
+    PIKA_TEST_EQ(future_int_f_vector_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/pika/lcos/tests/unit/dataflow_std_array.cpp
+++ b/libs/pika/lcos/tests/unit/dataflow_std_array.cpp
@@ -118,11 +118,11 @@ void function_pointers()
     PIKA_TEST_EQ(f3.get(), 163);
     PIKA_TEST_EQ(f4.get(), 10 * 84);
     PIKA_TEST_EQ(f5.get(), 126);
-    PIKA_TEST_EQ(void_f_count, 1u);
-    PIKA_TEST_EQ(int_f_count, 1u);
-    PIKA_TEST_EQ(void_f1_count, 1u);
-    PIKA_TEST_EQ(int_f1_count, 16u);
-    PIKA_TEST_EQ(int_f2_count, 1u);
+    PIKA_TEST_EQ(void_f_count.load(), 1u);
+    PIKA_TEST_EQ(int_f_count.load(), 1u);
+    PIKA_TEST_EQ(void_f1_count.load(), 1u);
+    PIKA_TEST_EQ(int_f1_count.load(), 16u);
+    PIKA_TEST_EQ(int_f2_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -185,8 +185,8 @@ void future_function_pointers()
     future<int> f5 = dataflow(&future_int_f_vector, std::ref(vf));
 
     PIKA_TEST_EQ(f5.get(), 10);
-    PIKA_TEST_EQ(future_int_f1_count, 10u);
-    PIKA_TEST_EQ(future_int_f_vector_count, 1u);
+    PIKA_TEST_EQ(future_int_f1_count.load(), 10u);
+    PIKA_TEST_EQ(future_int_f_vector_count.load(), 1u);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/pika/pack_traversal/tests/unit/unwrap.cpp
+++ b/libs/pika/pack_traversal/tests/unit/unwrap.cpp
@@ -444,7 +444,7 @@ namespace legacy_tests {
                 PIKA_TEST_EQ(64U, result_counter.load());
 
                 for (std::size_t i = 0; i < 64; ++i)
-                    PIKA_TEST_EQ(true, values[i]);
+                    PIKA_TEST_EQ(true, bool(values[i]));
 
                 result_counter.store(0);
             }
@@ -461,7 +461,7 @@ namespace legacy_tests {
                 PIKA_TEST_EQ(64U, result_counter.load());
 
                 for (std::size_t i = 0; i < 64; ++i)
-                    PIKA_TEST_EQ(true, values[i]);
+                    PIKA_TEST_EQ(true, bool(values[i]));
 
                 result_counter.store(0);
             }

--- a/libs/pika/program_options/tests/unit/options_exception.cpp
+++ b/libs/pika/program_options/tests/unit/options_exception.cpp
@@ -243,7 +243,9 @@ void test_missing_value()
     }
     catch (invalid_command_line_syntax& e)
     {
-        PIKA_TEST_EQ(e.kind(), invalid_syntax::missing_parameter);
+        PIKA_TEST_EQ(static_cast<std::underlying_type_t<invalid_syntax::kind_t>>(e.kind()),
+            static_cast<std::underlying_type_t<invalid_syntax::kind_t>>(
+                invalid_syntax::missing_parameter));
         PIKA_TEST_EQ(e.tokens(), "--cfgfile");
     }
 }

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_binding_check.cpp
@@ -81,7 +81,7 @@ void threadLoop()
 
     pika::deb_schbin.debug(
         pika::debug::detail::str<15>("complete"), pika::debug::detail::dec<4>(count_down));
-    PIKA_TEST_EQ(count_down, 0);
+    PIKA_TEST_EQ(count_down.load(), 0);
 }
 
 int pika_main()

--- a/libs/pika/synchronization/tests/regressions/ignore_while_locked_1485.cpp
+++ b/libs/pika/synchronization/tests/regressions/ignore_while_locked_1485.cpp
@@ -90,7 +90,7 @@ void test_condition_with_mutex()
     }
 
     thread.join();
-    PIKA_TEST_EQ(data.woken, 1u);
+    PIKA_TEST_EQ(data.woken.load(), 1u);
 }
 
 int pika_main()

--- a/libs/pika/synchronization/tests/unit/barrier.cpp
+++ b/libs/pika/synchronization/tests/unit/barrier.cpp
@@ -51,11 +51,11 @@ void test_barrier_empty_oncomplete()
         }
 
         b.arrive_and_wait();    // wait for all threads to enter the barrier
-        PIKA_TEST_EQ(threads, c1);
+        PIKA_TEST_EQ(threads, c1.load());
 
         pika::wait_all(results);
 
-        PIKA_TEST_EQ(threads, c2);
+        PIKA_TEST_EQ(threads, c2.load());
     }
 }
 
@@ -102,12 +102,12 @@ void test_barrier_oncomplete()
         }
 
         b.arrive_and_wait();    // wait for all threads to enter the barrier
-        PIKA_TEST_EQ(threads, c1);
+        PIKA_TEST_EQ(threads, c1.load());
 
         pika::wait_all(results);
 
-        PIKA_TEST_EQ(threads, c2);
-        PIKA_TEST_EQ(complete, std::size_t(1));
+        PIKA_TEST_EQ(threads, c2.load());
+        PIKA_TEST_EQ(complete.load(), std::size_t(1));
     }
 }
 
@@ -146,11 +146,11 @@ void test_barrier_empty_oncomplete_split()
         }
 
         b.arrive_and_wait();    // wait for all threads to enter the barrier
-        PIKA_TEST_EQ(threads, c1);
+        PIKA_TEST_EQ(threads, c1.load());
 
         pika::wait_all(results);
 
-        PIKA_TEST_EQ(threads, c2);
+        PIKA_TEST_EQ(threads, c2.load());
     }
 }
 
@@ -189,12 +189,12 @@ void test_barrier_oncomplete_split()
         }
 
         b.arrive_and_wait();    // wait for all threads to enter the barrier
-        PIKA_TEST_EQ(threads, c1);
+        PIKA_TEST_EQ(threads, c1.load());
 
         pika::wait_all(results);
 
-        PIKA_TEST_EQ(threads, c2);
-        PIKA_TEST_EQ(complete, std::size_t(1));
+        PIKA_TEST_EQ(threads, c2.load());
+        PIKA_TEST_EQ(complete.load(), std::size_t(1));
     }
 }
 

--- a/libs/pika/synchronization/tests/unit/event.cpp
+++ b/libs/pika/synchronization/tests/unit/event.cpp
@@ -72,7 +72,7 @@ int pika_main(variables_map& vm)
         // Wait for all the our threads to finish executing.
         pika::wait_all(futs);
 
-        PIKA_TEST_EQ(pxthreads, c);
+        PIKA_TEST_EQ(pxthreads, c.load());
 
         // Make sure that waiting on a set event works.
         e.wait();

--- a/libs/pika/synchronization/tests/unit/sliding_semaphore.cpp
+++ b/libs/pika/synchronization/tests/unit/sliding_semaphore.cpp
@@ -43,7 +43,7 @@ int pika_main()
 
     sem.wait(initial_count + num_tasks);
 
-    PIKA_TEST_EQ(count, num_tasks);
+    PIKA_TEST_EQ(count.load(), num_tasks);
 
     // Since sem.signal(++count) (in worker) is not an atomic operation we wait
     // for the tasks to finish here. The task which signals the count that

--- a/libs/pika/threading/tests/unit/error_callback.cpp
+++ b/libs/pika/threading/tests/unit/error_callback.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
     }
 
     PIKA_TEST(caught_exception);
-    PIKA_TEST_EQ(count_error_handler, std::size_t(1));
+    PIKA_TEST_EQ(count_error_handler.load(), std::size_t(1));
 
     return 0;
 }


### PR DESCRIPTION
Fixes compilation by explicitly casting the enums to `int`s for printing, since they are no longer implicitly converted for printing by fmt 10.

Also adds fmt 10 to the CUDA 12 CI configuration.

Fixes #686.