### PR TITLE
Fix warnings about includes and `#pragma once`

### DIFF
--- a/libs/pika/coroutines/src/thread_enums.cpp
+++ b/libs/pika/coroutines/src/thread_enums.cpp
@@ -12,6 +12,7 @@
 #include <pika/coroutines/thread_enums.hpp>
 
 #include <cstddef>
+#include <iostream>
 
 namespace pika::threads::detail {
     namespace strings {

--- a/libs/pika/threading_base/src/reset_backtrace.cpp
+++ b/libs/pika/threading_base/src/reset_backtrace.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#pragma once
-
 #include <pika/config.hpp>
 
 #ifdef PIKA_HAVE_THREAD_BACKTRACE_ON_SUSPENSION

--- a/libs/pika/threading_base/src/reset_lco_description.cpp
+++ b/libs/pika/threading_base/src/reset_lco_description.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#pragma once
-
 #include <pika/config.hpp>
 
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)


### PR DESCRIPTION
Fix a couple of warnings/errors that appeared when unity build was disabled. 