### PR TITLE
Add missing include to `transfer.hpp`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/transfer.hpp
@@ -13,6 +13,7 @@
 #else
 # include <pika/concepts/concepts.hpp>
 # include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+# include <pika/execution/algorithms/schedule_from.hpp>
 # include <pika/execution_base/completion_scheduler.hpp>
 # include <pika/execution_base/receiver.hpp>
 # include <pika/execution_base/sender.hpp>


### PR DESCRIPTION
`transfer.hpp` needs to include `schedule_from.hpp` from since it uses it.