### PR TITLE
Improve check for consistent process masks

### DIFF
--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -1137,16 +1137,8 @@ namespace pika {
                     // print the mask for the current PU
                     threads::detail::mask_cref_type pu_mask = rp.get_pu_mask(i);
 
-                    if (!threads::detail::any(pu_mask))
-                    {
-                        strm << std::setw(4) << i    //-V112
-                             << ": thread binding disabled" << std::endl;
-                    }
-                    else
-                    {
-                        std::string pool_name = tm.get_pool(i).get_pool_name();
-                        top.print_affinity_mask(strm, i, pu_mask, pool_name);
-                    }
+                    std::string pool_name = tm.get_pool(i).get_pool_name();
+                    top.print_affinity_mask(strm, i, pu_mask, pool_name);
 
                     // Make sure the mask does not contradict the CPU bindings
                     // returned by the system (see #973: Would like option to

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -924,6 +924,13 @@ namespace pika::threads::detail {
         pika::detail::ios_flags_saver ifs(os);
         bool first = true;
 
+        if (!threads::detail::any(m))
+        {
+            os << std::setw(4) << num_thread << ": thread binding disabled"
+               << ", on pool \"" << pool_name << "\"" << std::endl;
+            return;
+        }
+
         for (std::size_t i = 0; i != num_of_pus_; ++i)
         {
             hwloc_obj_t obj = hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, unsigned(i));


### PR DESCRIPTION
1. This slightly simplifies `handle_print_bind` by moving the printing of empty process masks into `topology`. When a mask is empty, the thread pool is also printed now to be consistent with the output when there is a mask. The output looks like this:
```
*******************************************************************************
rank: 0
   0: thread binding disabled, on pool "default"
   1: thread binding disabled, on pool "default"
   2: thread binding disabled, on pool "default"
   3: thread binding disabled, on pool "default"
```
2. Fixes the consistency check with hwloc. When binding is disabled, the check would previously fail because hwloc reported a full mask and pika an empty mask. Since the two are equivalent we let this pass by first transforming any empty masks to full masks before comparing them.