### PR TITLE
Attach debugger after printing failure information

### DIFF
--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -56,8 +56,6 @@ namespace pika::detail {
 
         handling_assertion = true;
 
-        pika::util::may_attach_debugger("exception");
-
         std::ostringstream strm;
         strm << "Assertion '" << expr << "' failed";
         if (!msg.empty())
@@ -69,6 +67,9 @@ namespace pika::detail {
         std::cerr << pika::diagnostic_information(pika::detail::get_exception(
                          e, loc.function_name, loc.file_name, loc.line_number))
                   << std::endl;
+
+        pika::util::may_attach_debugger("exception");
+
         std::abort();
     }
 


### PR DESCRIPTION
When an assertion is handled we optionally allow attaching a debugger before terminating. Currently on `main` the debugger can be attached before printing the error message. This PR moves `may_attach_debugger` to after the error message has been printed so that one can see the reason for failure before deciding to attach a debugger.