### PR TITLE
Fix memory leak with stack overflow detection enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
     docker:
-      - image: pikaorg/pika-ci-base:16
+      - image: pikaorg/pika-ci-base:17
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/hip/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-hip:8
+    container: pikaorg/pika-ci-hip:10
     steps:
     - uses: actions/checkout@v3
     - name: Update apt repositories for ccache

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/sanitizers/leak
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (lsan)
+
+on:
+  merge_group:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/sanitizers/leak
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:15
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-sanitizers-leak
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_COMPILER_WARNINGS=ON \
+              -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
+              -DPIKA_WITH_SANITIZERS=On \
+              -DCMAKE_CXX_FLAGS="-fsanitize=leak -fno-omit-frame-pointer" \
+              -DPIKA_WITH_STACKOVERFLOW_DETECTION=On
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+          cmake --build build --target examples
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --timeout 120 \
+            --output-on-failure \
+            --tests-regex tests.examples

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/fetchcontent/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/sanitizers/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: github/linux/tracy/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:15
+    container: pikaorg/pika-ci-base:17
 
     steps:
     - name: Check out Tracy

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -257,6 +257,10 @@ namespace pika::threads::coroutines {
 # endif
                     posix::free_stack(m_stack, static_cast<std::size_t>(m_stack_size));
                 }
+
+# if defined(PIKA_HAVE_STACKOVERFLOW_DETECTION) && !defined(PIKA_HAVE_ADDRESS_SANITIZER)
+                free(segv_stack.ss_sp);
+# endif
             }
 
 # if defined(PIKA_HAVE_STACKOVERFLOW_DETECTION) && !defined(PIKA_HAVE_ADDRESS_SANITIZER)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
@@ -312,6 +312,10 @@ namespace pika::threads::coroutines {
             {
                 if (m_stack)
                     free_stack(m_stack, m_stack_size);
+
+# if defined(PIKA_HAVE_STACKOVERFLOW_DETECTION)
+                free(segv_stack.ss_sp);
+# endif
             }
 
             // Return the size of the reserved stack address space.


### PR DESCRIPTION
When stack overflow detection is enabled an alternate stack is allocated (where the signal handler can run; since if a stack overflow happens the regular stack can't be used anymore). However, that alternate stack was never freed.

This would lead to particularly bad memory leaks if pika is repeatedly restarted multiple times in the same process since we pre-allocate a number of stacks at startup. If they're never freed when shutting down we'll keep leaking memory and keep allocating more alternate stacks every time pika is started.

LeakSanitizer caught this so I'm adding a CI workflow with LeakSanitizer enabled. I only tested this on `hello_world`, but I'm tentatively running all examples in CI now. If there are a lot of other leaks I may reduce the test to only `hello_world` for now. I'm also bumping all CI image tags since I added `llvm-symbolizer` to the CI image.