### PR TITLE
Allow explicitly resetting `{unique_,}any_sender`

### DIFF
--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -631,13 +631,49 @@ void test_globals()
 
 void test_empty_any_sender()
 {
-    ex::unique_any_sender<> uas{};
-    ex::any_sender<> as{};
+    {
+        ex::unique_any_sender<> uas{};
+        ex::any_sender<> as{};
 
-    PIKA_TEST(uas.empty());
-    PIKA_TEST(!uas);
-    PIKA_TEST(as.empty());
-    PIKA_TEST(!as);
+        PIKA_TEST(uas.empty());
+        PIKA_TEST(!uas);
+        PIKA_TEST(as.empty());
+        PIKA_TEST(!as);
+    }
+
+    {
+        ex::unique_any_sender<> uas{ex::just()};
+        ex::any_sender<> as{ex::just()};
+
+        PIKA_TEST(!uas.empty());
+        PIKA_TEST(uas);
+        PIKA_TEST(!as.empty());
+        PIKA_TEST(as);
+
+        uas.reset(ex::just());
+        as.reset(ex::just());
+
+        PIKA_TEST(!uas.empty());
+        PIKA_TEST(uas);
+        PIKA_TEST(!as.empty());
+        PIKA_TEST(as);
+
+        uas.reset();
+        as.reset();
+
+        PIKA_TEST(uas.empty());
+        PIKA_TEST(!uas);
+        PIKA_TEST(as.empty());
+        PIKA_TEST(!as);
+
+        uas.reset(ex::unique_any_sender<>{});
+        as.reset(ex::any_sender<>{});
+
+        PIKA_TEST(uas.empty());
+        PIKA_TEST(!uas);
+        PIKA_TEST(as.empty());
+        PIKA_TEST(!as);
+    }
 }
 
 void test_make_any_sender()


### PR DESCRIPTION
Adds `reset()` and `reset(Sender)` members to `{unique_,}any_sender` to reset the sender to the empty state or to reset it with a new sender. 