### PR TITLE
Add `execution::unpack` to unpack tuple-like types sent by predecessors

### DIFF
--- a/libs/pika/execution/CMakeLists.txt
+++ b/libs/pika/execution/CMakeLists.txt
@@ -26,6 +26,7 @@ set(execution_headers
     pika/execution/algorithms/then.hpp
     pika/execution/algorithms/transfer.hpp
     pika/execution/algorithms/transfer_just.hpp
+    pika/execution/algorithms/unpack.hpp
     pika/execution/algorithms/when_all.hpp
     pika/execution/algorithms/when_all_vector.hpp
     pika/execution/detail/async_launch_policy_dispatch.hpp

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -1,0 +1,209 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/concepts/concepts.hpp>
+#include <pika/errors/try_catch_exception_ptr.hpp>
+#include <pika/execution/algorithms/detail/partial_algorithm.hpp>
+#include <pika/execution_base/completion_scheduler.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/functional/bind_front.hpp>
+#include <pika/functional/detail/invoke.hpp>
+#include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/type_support/pack.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace pika::unpack_detail {
+    template <typename Receiver>
+    struct unpack_receiver_impl
+    {
+        struct unpack_receiver_type;
+    };
+
+    template <typename Receiver>
+    using unpack_receiver = typename unpack_receiver_impl<Receiver>::unpack_receiver_type;
+
+    template <typename Receiver>
+    struct unpack_receiver_impl<Receiver>::unpack_receiver_type
+    {
+        using is_receiver = void;
+
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+        template <typename Error>
+        friend void tag_invoke(pika::execution::experimental::set_error_t, unpack_receiver_type&& r,
+            Error&& error) noexcept
+        {
+            pika::execution::experimental::set_error(
+                PIKA_MOVE(r.receiver), PIKA_FORWARD(Error, error));
+        }
+
+        friend void tag_invoke(
+            pika::execution::experimental::set_stopped_t, unpack_receiver_type&& r) noexcept
+        {
+            pika::execution::experimental::set_stopped(PIKA_MOVE(r.receiver));
+        }
+
+        template <typename Ts>
+        friend void tag_invoke(
+            pika::execution::experimental::set_value_t, unpack_receiver_type&& r, Ts&& ts) noexcept
+        {
+            std::apply(pika::util::detail::bind_front(
+                           pika::execution::experimental::set_value, PIKA_MOVE(r.receiver)),
+                PIKA_FORWARD(Ts, ts));
+        }
+    };
+
+#if defined(PIKA_HAVE_STDEXEC)
+    template <typename IndexPack, typename T>
+    struct make_value_type;
+
+    template <typename T, std::size_t... Is>
+    struct make_value_type<pika::util::detail::index_pack<Is...>, T>
+    {
+        using type = pika::execution::experimental::set_value_t(
+            decltype(std::get<Is>(std::declval<T>()))...);
+    };
+
+    template <typename... Ts>
+    struct invoke_result_helper
+    {
+        static_assert(sizeof...(Ts) == 0,
+            "unpack expects the predecessor sender to send exactly one tuple-like type in each "
+            "variant");
+    };
+
+    template <typename T>
+    struct invoke_result_helper<T>
+    {
+        using type = typename make_value_type<
+            pika::util::detail::make_index_pack_t<std::tuple_size_v<std::decay_t<T>>>, T>::type;
+    };
+
+    template <typename... Ts>
+    using invoke_result_helper_t = pika::execution::experimental::completion_signatures<
+        typename invoke_result_helper<Ts...>::type>;
+#else
+    template <typename Tuple>
+    struct invoke_result_helper;
+
+    template <template <typename...> class Tuple, typename... Ts>
+    struct invoke_result_helper<Tuple<Ts...>>
+    {
+        static_assert(sizeof(Tuple<Ts...>) == 0,
+            "unpack expects the predecessor sender to send exactly one tuple-like type in each "
+            "variant");
+    };
+
+    template <typename IndexPack, template <typename...> class Tuple, typename T>
+    struct make_value_type;
+
+    template <template <typename...> class Tuple, typename T, std::size_t... Is>
+    struct make_value_type<pika::util::detail::index_pack<Is...>, Tuple, T>
+    {
+        using type = Tuple<decltype(std::get<Is>(std::declval<T>()))...>;
+    };
+
+    template <template <typename...> class Tuple, typename T>
+    struct invoke_result_helper<Tuple<T>>
+    {
+        using type = typename make_value_type<
+            pika::util::detail::make_index_pack_t<std::tuple_size_v<std::decay_t<T>>>, Tuple,
+            T>::type;
+    };
+
+    template <template <typename...> class Tuple>
+    struct invoke_result_helper<Tuple<>>
+    {
+        using type = Tuple<>;
+    };
+#endif
+
+    template <typename Sender>
+    struct unpack_sender_impl
+    {
+        struct unpack_sender_type;
+    };
+
+    template <typename Sender>
+    using unpack_sender = typename unpack_sender_impl<Sender>::unpack_sender_type;
+
+    template <typename Sender>
+    struct unpack_sender_impl<Sender>::unpack_sender_type
+    {
+        using is_sender = void;
+
+        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+
+#if defined(PIKA_HAVE_STDEXEC)
+        using completion_signatures =
+            pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
+                pika::execution::experimental::empty_env,
+                pika::execution::experimental::completion_signatures<
+                    pika::execution::experimental::set_error_t(std::exception_ptr)>,
+                invoke_result_helper_t>;
+#else
+        template <template <typename...> class Tuple, template <typename...> class Variant>
+        using value_types = pika::util::detail::unique_t<
+            pika::util::detail::transform_t<typename pika::execution::experimental::sender_traits<
+                                                Sender>::template value_types<Tuple, Variant>,
+                invoke_result_helper>>;
+
+        template <template <typename...> class Variant>
+        using error_types = typename pika::execution::experimental::sender_traits<
+            Sender>::template error_types<Variant>;
+
+        static constexpr bool sends_done = false;
+#endif
+
+        template <typename Receiver>
+        friend auto tag_invoke(
+            pika::execution::experimental::connect_t, unpack_sender_type&& s, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(
+                PIKA_MOVE(s.sender), unpack_receiver<Receiver>{PIKA_FORWARD(Receiver, receiver)});
+        }
+
+        template <typename Receiver>
+        friend auto tag_invoke(pika::execution::experimental::connect_t,
+            unpack_sender_type const& r, Receiver&& receiver)
+        {
+            return pika::execution::experimental::connect(
+                r.sender, unpack_receiver<Receiver>{PIKA_FORWARD(Receiver, receiver)});
+        }
+
+        friend decltype(auto) tag_invoke(
+            pika::execution::experimental::get_env_t, unpack_sender_type const& s)
+        {
+            return pika::execution::experimental::get_env(s.sender);
+        }
+    };
+}    // namespace pika::unpack_detail
+
+namespace pika::execution::experimental {
+    inline constexpr struct unpack_t final : pika::functional::detail::tag_fallback<unpack_t>
+    {
+    private:
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(unpack_t, Sender&& sender)
+        {
+            return unpack_detail::unpack_sender<Sender>{PIKA_FORWARD(Sender, sender)};
+        }
+
+        friend constexpr PIKA_FORCEINLINE auto tag_invoke(unpack_t)
+        {
+            return detail::partial_algorithm<unpack_t>{};
+        }
+    } unpack{};
+}    // namespace pika::execution::experimental

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tests
     algorithm_then
     algorithm_transfer
     algorithm_transfer_just
+    algorithm_unpack
     algorithm_when_all
     algorithm_when_all_vector
     bulk_async

--- a/libs/pika/execution/tests/unit/algorithm_unpack.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_unpack.cpp
@@ -1,0 +1,215 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/modules/execution.hpp>
+#include <pika/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#if defined(PIKA_HAVE_STDEXEC)
+# include <concepts>
+#endif
+
+namespace ex = pika::execution::experimental;
+
+namespace test {
+    struct my_type
+    {
+        std::atomic<bool>& tag_invoke_overload_called;
+    };
+
+    auto tag_invoke(ex::unpack_t, my_type t)
+    {
+        t.tag_invoke_overload_called = true;
+        return ex::unpack(ex::just(std::tuple(t)));
+    }
+}    // namespace test
+
+void tag_invoke() = delete;
+
+int main()
+{
+#if defined(PIKA_HAVE_STDEXEC)
+    static_assert(std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple()))),
+                                   ex::empty_env, std::tuple, std::variant>,
+        std::variant<std::tuple<>>>);
+    static_assert(std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple(42)))),
+                                   ex::empty_env, std::tuple, std::variant>,
+        std::variant<std::tuple<int&&>>>);
+    static_assert(
+        std::same_as<ex::value_types_of_t<decltype(ex::unpack(std::declval<
+                                              const_reference_sender<std::tuple<int>>>())),
+                         ex::empty_env, std::tuple, std::variant>,
+            std::variant<std::tuple<int const&>>>);
+    static_assert(std::same_as<
+        ex::value_types_of_t<decltype(ex::unpack(ex::just(std::declval<std::tuple<int&>>()))),
+            ex::empty_env, std::tuple, std::variant>,
+        std::variant<std::tuple<int&>>>);
+    static_assert(
+        std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple(42, 3.14f)))),
+                         ex::empty_env, std::tuple, std::variant>,
+            std::variant<std::tuple<int&&, float&&>>>);
+#else
+    static_assert(
+        std::is_same_v<ex::sender_traits<decltype(ex::unpack(ex::just(
+                           std::tuple())))>::template value_types<std::tuple, std::variant>,
+            std::variant<std::tuple<>>>);
+    static_assert(std::is_same_v<ex::sender_traits<decltype(ex::unpack(ex::just(std::tuple(
+                                     42))))>::template value_types<std::tuple, std::variant>,
+        std::variant<std::tuple<int&&>>>);
+    static_assert(std::is_same_v<ex::sender_traits<decltype(ex::unpack(
+                                     std::declval<const_reference_sender<std::tuple<int>>>()))>::
+                                     template value_types<std::tuple, std::variant>,
+        std::variant<std::tuple<int const&>>>);
+    static_assert(
+        std::is_same_v<ex::sender_traits<decltype(ex::unpack(ex::just(std::declval<
+                           std::tuple<int&>>())))>::template value_types<std::tuple, std::variant>,
+            std::variant<std::tuple<int&>>>);
+    static_assert(std::is_same_v<ex::sender_traits<decltype(ex::unpack(ex::just(std::tuple(
+                                     42, 3.14f))))>::template value_types<std::tuple, std::variant>,
+        std::variant<std::tuple<int&&, float&&>>>);
+#endif
+
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::unpack(ex::just(std::tuple()));
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::unpack(ex::just(std::tuple<int>(1)));
+        auto f = [](int x) { PIKA_TEST_EQ(x, 1); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::tuple<int> x = 42;
+        auto s = ex::unpack(const_reference_sender<decltype(x)>{x});
+        auto f = [](int x) { PIKA_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        int x = 42;
+        double y = 3.14;
+        std::tuple<int&, double&> t{x, y};
+        auto s = ex::unpack(const_reference_sender<decltype(t)>{t});
+        auto f = [](int& x, double& y) {
+            PIKA_TEST_EQ(x, 42);
+            PIKA_TEST_EQ(y, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        int x = 43;
+        std::tuple<int&> t{x};
+        auto s = ex::unpack(const_reference_sender<decltype(t)>{t});
+        auto f = [](int& x) { PIKA_TEST_EQ(x, 43); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::unpack(ex::just(std::tuple(custom_type_non_default_constructible{42})));
+        auto f = [](auto x) { PIKA_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::unpack(
+            ex::just(std::tuple(custom_type_non_default_constructible_non_copyable{42})));
+        auto f = [](auto x) { PIKA_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just(std::tuple(42, 3.14f)) | ex::unpack() |
+            ex::then([](int x, float y) { return std::tuple(x, y); });
+        auto f = [](auto t) { PIKA_TEST(t == std::tuple(42, 3.14f)); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), r);
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::unpack(test::my_type{tag_invoke_overload_called});
+        auto f = [](test::my_type x) { PIKA_TEST(x.tag_invoke_overload_called); };
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(receiver_set_value_called);
+        PIKA_TEST(tag_invoke_overload_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::unpack(
+            ex::then(ex::just(), []() -> std::tuple<> { throw std::runtime_error("error"); }));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::unpack(ex::then(const_reference_error_sender{}, [] { return std::tuple(); }));
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_error_called);
+    }
+
+    test_adl_isolation(ex::unpack(my_namespace::my_sender<std::tuple<my_namespace::my_type>>{}));
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #717.

This supports anything that `std::apply`/`std::get` supports, i.e. not only `tuple`s. Currently it supports sending only exactly one tuple-like type from the predecessor per variant (i.e. there can be more than one variant, but only one tuple-like per variant). The predecessor also can't send nothing, although in principle that would be straightforward to support by also sending nothing from this adaptor. I'm going to leave that as a potential future enhancement if there's a good use for it.

Feedback on the naming and/or supported use cases welcome.