### PR TITLE
Add documentation with deployment to GitHub pages

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -12,6 +12,7 @@ status = [
   "github/linux/sanitizers/fast",
   "github/linux/tracy/fast",
   "github/macos/debug",
+  "github/documentation/build",
   # "github/macos_arm64/debug",
 
   # CircleCI static checks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Documentation
+
+on:
+  merge_group:
+  pull_request:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/documentation/build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install sphinx and a theme
+      run: |
+          sudo apt update
+          sudo apt install \
+              --allow-downgrades \
+              --allow-remove-essential \
+              --allow-change-held-packages \
+              python3 python3-pip
+          pip install sphinx sphinx-material
+    - name: Build documentation
+      run: sphinx-build -W -n -a -b html docs build/docs
+    - name: Upload HTML output as artifact
+      uses: actions/upload-pages-artifact@v2
+      with:
+        path: build/docs
+
+  deploy:
+    needs: build
+    name: github/documentation/deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.repository == 'pika-org/pika'
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy documentation to GitHub Pages
+      uses: actions/deploy-pages@v2
+      id: deployment

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (c) 2022 ETH Zurich
+    Copyright (c) 2022-2023 ETH Zurich
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/README.rst
+++ b/README.rst
@@ -111,22 +111,6 @@ All functionality in a namespace containing ``detail`` and all macros prefixed
 with ``PIKA_DETAIL`` are implementation details and may change without warning
 at any time.
 
-Acknowledgements
-================
-
-pika is a fork of `HPX <https://hpx.stellar-group.org>`_ focusing on the
-single-node use case complemented by minimal MPI support.
-
-Name
-====
-
-Pick your favourite meaning from the following:
-
-* `pika the animal <https://en.wikipedia.org/wiki/Pika>`_
-* `pika- as a prefix for fast in Finnish
-  <https://en.wiktionary.org/wiki/pika->`_
-* `pika in various other languages <https://en.wiktionary.org/wiki/pika>`_
-
 .. |bors_enabled| image:: https://bors.tech/images/badge_small.svg
      :target: https://app.bors.tech/repositories/41470
      :alt: Bors enabled

--- a/README.rst
+++ b/README.rst
@@ -22,72 +22,7 @@ pika is a C++ library for concurrency and parallelism. It implements
 senders/receivers (as proposed in `P2300 <https://wg21.link/p2300>`_) for CPU
 thread pools, MPI, and CUDA.
 
-To get started using pika see the `documentation <https://pika-org.github.io/pika>`_.
-
-Dependencies
-============
-
-pika requires:
-
-* a C++17-capable compiler:
-
-  * `GCC <https://gcc.gnu.org>`_ 9 or greater
-  * `clang <https://clang.llvm.org>`_ 11 or greater
-  * MSVC may work but it is not tested
-
-* `CMake <https://cmake.org>`_ 3.22.0 or greater
-* `header-only Boost <https://boost.org>`_ 1.71.0 or greater
-* `hwloc <https://www-lb.open-mpi.org/projects/hwloc/>`_ 1.11.5 or greater
-* `fmt <https://fmt.dev/latest/index.html>`_
-
-pika optionally requires:
-
-* `gperftools/tcmalloc <https://github.com/gperftools/gperftools>`_, `jemalloc
-  <http://jemalloc.net/>`_, or `mimalloc
-  <https://github.com/microsoft/mimalloc>`_
-* `CUDA <https://docs.nvidia.com/cuda/>`_ 11.0 or greater
-* `HIP <https://rocmdocs.amd.com/en/latest/index.html>`_ 5.2.0 or greater
-* `MPI <https://www.mpi-forum.org/>`_
-* `Boost.Context, Thread, and Chrono <https://boost.org>`_ on macOS
-* `stdexec <https://github.com/NVIDIA/stdexec>`_ when ``PIKA_WITH_STDEXEC`` is
-  enabled (currently tested with commit
-  `48c52df0f81c6151eecf4f39fa5eed2dc0216204
-  <https://github.com/NVIDIA/stdexec/commit/48c52df0f81c6151eecf4f39fa5eed2dc0216204>`_).
-  The integration is experimental.
-
-
-Building
-========
-
-pika is built using CMake. Please see the documentation of
-CMake for help on how to use it. Dependencies are usually available in
-distribution repositories. Alternatively, pika can be built using `spack
-<https://spack.readthedocs.io>`_ (`pika spack package
-<https://spack.readthedocs.io/en/latest/package_list.html#pika>`_). The pika
-repository also includes a ``shell.nix`` file for use with `nix
-<https://nixos.org/download.html#download-nix>`_. The file includes dependencies
-for regular development. It is provided for convenience only and is not
-comprehensive or guaranteed to be up to date. It may require the nixos unstable
-channel.
-
-pika is configured using CMake variables. The most important variables are:
-
-* ``PIKA_WITH_MALLOC``: This defaults to ``mimalloc`` which requires mimalloc to be installed.  Can
-  be set to ``tcmalloc``, ``jemalloc``, ``mimalloc``, or ``system``. Setting it to ``system`` can be
-  useful in debug builds.
-* ``PIKA_WITH_CUDA``: Enable CUDA support.
-* ``PIKA_WITH_HIP``: Enable HIP support.
-* ``PIKA_WITH_MPI``: Enable MPI support.
-* ``PIKA_WITH_BOOST_CONTEXT``: Enable the use of Boost.Context for fiber context switching. This has
-  to be enabled on non-Linux and non-x86 platforms.
-
-Tests and examples are disabled by default and can be enabled with
-``PIKA_WITH_TESTS``, ``PIKA_WITH_TESTS_*``, and ``PIKA_WITH_EXAMPLES``. Note
-that reconfiguring pika with ``PIKA_WITH_TESTS=ON`` after the option has been
-off the individual subcategories of ``PIKA_WITH_TESTS_*`` must be also enabled
-explicitly. Use e.g. ``ccmake`` or ``CMakeCache.txt`` for a list of
-subcategories. The tests must be explicitly built before running them, e.g.
-with ```cmake --build . --target tests && ctest --output-on-failure``.
+To get started using pika see the `documentation <https://pikacpp.org>`_.
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,8 @@ pika is a C++ library for concurrency and parallelism. It implements
 senders/receivers (as proposed in `P2300 <https://wg21.link/p2300>`_) for CPU
 thread pools, MPI, and CUDA.
 
+To get started using pika see the `documentation <https://pika-org.github.io/pika>`_.
+
 Dependencies
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -24,30 +24,6 @@ thread pools, MPI, and CUDA.
 
 To get started using pika see the `documentation <https://pikacpp.org>`_.
 
-Documentation
-=============
-
-Documentation is a work in progress. The following headers are part of the
-public API. Any other headers are internal implementation details.
-
-- ``pika/async_rw_mutex.hpp``
-- ``pika/barrier.hpp``
-- ``pika/channel.hpp``
-- ``pika/condition_variable.hpp``
-- ``pika/cuda.hpp``
-- ``pika/execution.hpp``
-- ``pika/latch.hpp``
-- ``pika/mpi.hpp``
-- ``pika/mutex.hpp``
-- ``pika/runtime.hpp``
-- ``pika/semaphore.hpp``
-- ``pika/shared_mutex.hpp``
-- ``pika/thread.hpp``
-
-All functionality in a namespace containing ``detail`` and all macros prefixed
-with ``PIKA_DETAIL`` are implementation details and may change without warning
-at any time.
-
 .. |bors_enabled| image:: https://bors.tech/images/badge_small.svg
      :target: https://app.bors.tech/repositories/41470
      :alt: Bors enabled

--- a/docs/_static/pika.css
+++ b/docs/_static/pika.css
@@ -1,0 +1,32 @@
+/* Copyright (c) 2023 ETH Zurich */
+/* SPDX-License-Identifier: BSL-1.0 */
+/* Distributed under the Boost Software License, Version 1.0. (See accompanying */
+/* file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) */
+
+.md-typeset h1 {
+    color: black;
+    font-weight: 700;
+    margin: 1em 0 0 0;
+}
+
+.md-typeset h2 {
+    color: black;
+    font-weight: 500;
+    margin: 1em 0 0 0;
+}
+
+.md-typeset ul li {
+    margin-bottom: 0;
+}
+
+.md-typeset ul li p {
+    margin: 0 0;
+}
+
+.pre {
+    font-family: monospace;
+}
+
+.md-header-nav__topic {
+    font-weight: bold;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,37 @@
+..
+    Copyright (c) 2023 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _api:
+
+=============
+API reference
+=============
+
+pika follows `semver <https://semver.org>`_. pika is currently at a 0.X version which means that
+minor versions may break the API. pika gives no guarantees about ABI stability. The ABI may change
+even in patch versions.
+
+The API reference is a work in progress. The following headers are part of the public API. Any other
+headers are internal implementation details.
+
+- ``pika/async_rw_mutex.hpp``
+- ``pika/barrier.hpp``
+- ``pika/channel.hpp``
+- ``pika/condition_variable.hpp``
+- ``pika/cuda.hpp``
+- ``pika/execution.hpp``
+- ``pika/latch.hpp``
+- ``pika/mpi.hpp``
+- ``pika/mutex.hpp``
+- ``pika/runtime.hpp``
+- ``pika/semaphore.hpp``
+- ``pika/shared_mutex.hpp``
+- ``pika/thread.hpp``
+
+All functionality in a namespace containing ``detail`` and all macros prefixed
+with ``PIKA_DETAIL`` are implementation details and may change without warning
+at any time.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ html_theme_options = {
     "nav_title": "pika",
     "color_primary": "blue-grey",
     "color_accent": "orange",
-    "base_url": "https://pika-org.github.io/pika-docs",
+    "base_url": "https://pikacpp.org",
     "repo_url": "https://github.com/pika-org/pika",
     "repo_name": "pika",
     "html_minify": False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from datetime import datetime
+
+# Project settings
+project = "pika"
+project_copyright = f"2022-{datetime.now().year}, ETH Zurich"
+author = "ETH Zurich"
+version = ""
+release = version
+
+# General sphinx settings
+extensions = []
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+source_suffix = [".rst"]
+language = "English"
+primary_domain = "cpp"
+highlight_language = "cpp"
+
+# HTML settings
+html_title = "pika"
+html_theme = "sphinx_material"
+html_static_path = ["_static"]
+html_css_files = ["pika.css"]
+html_show_sourcelink = False
+html_sidebars = {
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+}
+html_theme_options = {
+    "nav_title": "pika",
+    "color_primary": "blue-grey",
+    "color_accent": "orange",
+    "base_url": "https://pika-org.github.io/pika-docs",
+    "repo_url": "https://github.com/pika-org/pika",
+    "repo_name": "pika",
+    "html_minify": False,
+    "html_prettify": True,
+    "logo_icon": "&#xe88a;",
+    "css_minify": True,
+    "repo_type": "github",
+    "globaltoc_depth": 2,
+    "master_doc": False,
+    "nav_links": [
+        {"href": "index", "internal": True, "title": "Overview"},
+        {"href": "usage", "internal": True, "title": "Usage"},
+    ],
+    "heroes": {
+        "index": "Concurrency and parallelism built on C++ std::execution",
+    },
+    "version_dropdown": False,
+    "table_classes": ["plain"],
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ html_theme_options = {
     "nav_links": [
         {"href": "index", "internal": True, "title": "Overview"},
         {"href": "usage", "internal": True, "title": "Usage"},
+        {"href": "api", "internal": True, "title": "API reference"},
     ],
     "heroes": {
         "index": "Concurrency and parallelism built on C++ std::execution",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,22 @@ Overview
 <https://wg21.link/p2300>`_ by providing a CPU runtime with user-level threads, as well as
 integration with CUDA, HIP, and MPI. See :ref:`getting_started` to get started.
 
+Acknowledgements
+================
+
+pika is a fork of `HPX <https://hpx.stellar-group.org>`_ focusing on the
+single-node use case complemented by minimal MPI support.
+
+Name
+====
+
+Pick your favourite meaning from the following:
+
+* `pika the animal <https://en.wikipedia.org/wiki/Pika>`_
+* `pika- as a prefix for fast in Finnish
+  <https://en.wiktionary.org/wiki/pika->`_
+* `pika in various other languages <https://en.wiktionary.org/wiki/pika>`_
+
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,3 +34,4 @@ Pick your favourite meaning from the following:
    :hidden:
 
    usage
+   api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+..
+    Copyright (c) 2023 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+========
+Overview
+========
+
+**pika** is a C++ library that builds on the `std::execution (P2300) proposal
+<https://wg21.link/p2300>`_ by providing a CPU runtime with user-level threads, as well as
+integration with CUDA, HIP, and MPI. See :ref:`getting_started` to get started.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   usage

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -62,7 +62,7 @@ pika optionally depends on:
 * `MPI <https://www.mpi-forum.org/>`_. MPI support can be enabled with ``PIKA_WITH_MPI=ON``.
 * `Boost.Context <https://boost.org>`_ on macOS or exotic platforms which are not supported by the
   default user-level thread implementations in pika. This can be enabled with
-  ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON`` (TODO rename option...).
+  ``PIKA_WITH_BOOST_CONTEXT=ON``.
 * `stdexec <https://github.com/NVIDIA/stdexec>`_. stdexec support can be enabled with
   ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d
   <https://github.com/NVIDIA/stdexec/commit/7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d>`_).  The
@@ -104,15 +104,22 @@ of CMake options you can use to customize the installation.
 - ``PIKA_WITH_CUDA``: Enable CUDA support.
 - ``PIKA_WITH_HIP``: Enable HIP support.
 - ``PIKA_WITH_MPI``: Enable MPI support.
-- ``PIKA_WITH_STDEXEC``: Enable `stdexec <https://github.com/NVIDIA/stdexec`_ support.
+- ``PIKA_WITH_STDEXEC``: Enable `stdexec <https://github.com/NVIDIA/stdexec>`_ support.
 - ``PIKA_WITH_APEX``: Enable `APEX <https://uo-oaciss.github.io/apex>`_ support.
 - ``PIKA_WITH_TRACY``: Enable `Tracy <https://github.com/wolfpld/tracy>`_ support.
-- ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enable the use of Boost.Context for fiber context
-  switching.
+- ``PIKA_WITH_BOOST_CONTEXT``: Use Boost.Context for user-level thread context switching.
 - ``PIKA_WITH_TESTS``: Enable tests. Tests can be built with ``cmake --build . --target tests`` and
   run with ``ctest --output-on-failure``.
 - ``PIKA_WITH_EXAMPLES``: Enable examples. Binaries will be placed under ``bin`` in the build
   directory.
+
+Testing
+-------
+
+Tests and examples are disabled by default and can be enabled with ``PIKA_WITH_TESTS``,
+``PIKA_WITH_TESTS_{BENCHMARKS,REGRESSIONS,UNIT}``, and ``PIKA_WITH_EXAMPLES``. The tests must be
+explicitly built before running them, e.g.  with ``cmake --build . --target tests && ctest
+--output-on-failure``.
 
 .. _pika_stdexec:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,137 @@
+..
+    Copyright (c) 2022-2023 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _usage:
+
+=====
+Usage
+=====
+
+.. _getting_started:
+
+Getting started
+===============
+
+The recommended way to install pika is through `spack <https://spack.readthedocs.io>`_:
+
+.. code-block:: bash
+
+   spack install pika
+
+See
+
+.. code-block:: bash
+
+   spack info pika
+
+for available options.
+
+Manual installation
+-------------------
+
+If you'd like to build pika manually you will need CMake 3.22.0 or greater and a recent C++ compiler
+supporting C++17:
+
+- `GCC <https://gcc.gnu.org>`_ 9 or greater
+- `clang <https://clang.llvm.org>`_ 11 or greater
+
+Additionally, pika depends on:
+
+- `header-only Boost <https://boost.org>`_ 1.71.0 or greater
+- `hwloc <https://www-lb.open-mpi.org/projects/hwloc/>`_ 1.11.5 or greater
+- `fmt <https://fmt.dev/latest/index.html>`_ 9.0.0 or greater
+
+pika optionally depends on:
+
+* `gperftools/tcmalloc <https://github.com/gperftools/gperftools>`_, `jemalloc
+  <http://jemalloc.net/>`_, or `mimalloc <https://github.com/microsoft/mimalloc>`_. It is *highly*
+  recommended to use one of these allocators as they perform significantly better than the system
+  allocators. You can set the allocator through the CMake variable ``PIKA_WITH_MALLOC``. If you want
+  to use the system allocator (e.g. for debugging) you can do so by setting
+  ``PIKA_WITH_MALLOC=system``.
+* `CUDA <https://docs.nvidia.com/cuda/>`_ 11.0 or greater. CUDA support can be enabled with
+  ``PIKA_WITH_CUDA=ON``. pika can also be built with nvc++ from the `NVIDIA HPC SDK
+  <https://developer.nvidia.com/hpc-sdk>`_. In the latter case, set ``CMAKE_CXX_COMPILER`` to
+  ``nvc++``.
+* `HIP <https://rocmdocs.amd.com/en/latest/index.html>`_ 5.2.0 or greater. HIP support can be
+  enabled with ``PIKA_WITH_HIP=ON``.
+* `MPI <https://www.mpi-forum.org/>`_. MPI support can be enabled with ``PIKA_WITH_MPI=ON``.
+* `Boost.Context <https://boost.org>`_ on macOS or exotic platforms which are not supported by the
+  default user-level thread implementations in pika. This can be enabled with
+  ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON`` (TODO rename option...).
+* `stdexec <https://github.com/NVIDIA/stdexec>`_. stdexec support can be enabled with
+  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d
+  <https://github.com/NVIDIA/stdexec/commit/7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d>`_).  The
+  integration is experimental. See :ref:`pika_stdexec` for more information about the integration.
+
+If you are using `nix <https://nixos.org>`_ you can also use the ``shell.nix`` file provided at the
+root of the repository to quickly enter a development environment:
+
+.. code-block:: bash
+
+   nix-shell <pika-root>/shell.nix
+
+The ``nixpkgs`` version is not pinned and may break occasionally.
+
+Including in CMake projects
+---------------------------
+
+Once installed, pika can be used in a CMake project through the ``pika::pika`` target:
+
+.. code-block:: cmake
+
+   find_package(pika REQUIRED)
+   add_executable(app main.cpp)
+   target_link_libraries(app PRIVATE pika::pika)
+
+Other ways of depending on pika are likely to work but are not officially supported.
+
+.. _cmake_configuration:
+
+Customizing the pika installation
+=================================
+
+The most important CMake options are listed in :ref:`getting_started`. Below is a more complete list
+of CMake options you can use to customize the installation.
+
+- ``PIKA_WITH_MALLOC``: This defaults to ``mimalloc`` which requires mimalloc to be installed.  Can
+  be set to ``tcmalloc``, ``jemalloc``, ``mimalloc``, or ``system``. Setting it to ``system`` can be
+  useful in debug builds.
+- ``PIKA_WITH_CUDA``: Enable CUDA support.
+- ``PIKA_WITH_HIP``: Enable HIP support.
+- ``PIKA_WITH_MPI``: Enable MPI support.
+- ``PIKA_WITH_STDEXEC``: Enable `stdexec <https://github.com/NVIDIA/stdexec`_ support.
+- ``PIKA_WITH_APEX``: Enable `APEX <https://uo-oaciss.github.io/apex>`_ support.
+- ``PIKA_WITH_TRACY``: Enable `Tracy <https://github.com/wolfpld/tracy>`_ support.
+- ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enable the use of Boost.Context for fiber context
+  switching.
+- ``PIKA_WITH_TESTS``: Enable tests. Tests can be built with ``cmake --build . --target tests`` and
+  run with ``ctest --output-on-failure``.
+- ``PIKA_WITH_EXAMPLES``: Enable examples. Binaries will be placed under ``bin`` in the build
+  directory.
+
+.. _pika_stdexec:
+
+Relation to std::execution and stdexec
+======================================
+
+When pika was first created as a fork of `HPX <https://github.com/STEllAR-GROUP/hpx>`_ in 2022
+stdexec was in its infancy. Because of this, pika contains an implementation of a subset of the
+earlier revisions of P2300. The main differences to stdexec and the proposed facilities are:
+
+- The pika implementation uses C++17 and thus does not make use of concepts or coroutines. This
+  allows compatibility with slightly older compiler versions and e.g. nvcc.
+- The pika implementation uses ``value_types``, ``error_types``, and ``sends_done`` instead of
+  ``completion_signatures`` in sender types, as in the `first 3 revisions of P2300
+  <https://wg21.link/p2300r3>`_.
+
+pika has an experimental CMake option ``PIKA_WITH_STDEXEC`` which can be enabled to use stdexec for
+the P2300 facilities. pika brings the ``stdexec`` namespace into ``pika::execution::experimental``,
+but provides otherwise no guarantees of interchangeable functionality. pika only implements a subset
+of the proposed sender algorithms which is why we recommend that you enable ``PIKA_WITH_STDEXEC``
+whenever possible. We plan to deprecate and remove the P2300 implementation in pika in favour of
+stdexec and/or standard library implementations.

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,8 @@ pkgs.mkShell.override { stdenv = pkgs.gcc11Stdenv; } {
     mpich
     ninja
     pkgconfig
+    python311Packages.sphinx
+    python311Packages.sphinx-material
   ];
 
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
This adds v0.0.1-gamma (i.e. the most very basic) of a documentation page using sphinx.

It more or less contains the contents of the current `README.rst` with a little added section about pika's relation to stdexec/std::execution.

This is deployed using a couple of GitHub actions that use deployments (https://github.com/pika-org/pika/deployments) which as far as I can tell keeps it away from the git history and environments (https://github.com/pika-org/pika/settings/environments) for branch protections.

In this PR I will still:
- [x] remove duplicated content from `README.rst`
- [x] link to documentation in `README.rst`
- [x] Add a basic API page which lists the public headers that are currently in `README.rst`
- [x] Re-enable branch filters so that the the documentation is only deployed from `main` (but still built on PRs)
- [x] Fix any suggestions you have for the content that is included now

I will not:
- Add an API reference outside of the public headers
- Add examples
- Add other technical content (like explanations of how the CUDA/HIP/MPI integrations work, or how the thread pool works)

~The logo... leaves room for improvement. We may be better off without anything for now.~ The "logo" is just a home icon to go back to the index page.

This branch deploys already now to https://pika-org.github.io/pika/ so you can have a look at the result.

@aurianer and @biddisco I'd appreciate any and all feedback you have on the current content in this PR. Please comment on #49 for any _additional_ content you'd like to see, especially the priority of the type of content you'd like to see, so that we can try to work through the list in order of importance.