### PR TITLE
Add `max_line_length` option to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,4 @@ indent_size = 4
 charset = latin1
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100


### PR DESCRIPTION
Some editors will pick this up for e.g. wrapping comments.