### PR TITLE
Rename `PIKA_WITH_GENERIC_CONTEXT_COROUTINES` to `PIKA_WITH_BOOST_CONTEXT`

### DIFF
--- a/.jenkins/cscs/env-gcc-9.sh
+++ b/.jenkins/cscs/env-gcc-9.sh
@@ -16,7 +16,7 @@ spack_spec="pika@main +generic_coroutines arch=${spack_arch} %${spack_compiler} 
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
-configure_extra_options+=" -DPIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON"
+configure_extra_options+=" -DPIKA_WITH_BOOST_CONTEXT=ON"
 configure_extra_options+=" -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 build_extra_options+=" -j10"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,7 +1082,7 @@ if("${PIKA_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   set(__use_generic_coroutine_context ON)
 endif()
 pika_option(
-  PIKA_WITH_GENERIC_CONTEXT_COROUTINES
+  PIKA_WITH_BOOST_CONTEXT
   BOOL
   "Use Boost.Context as the underlying coroutines context switch implementation."
   ${__use_generic_coroutine_context}
@@ -1230,7 +1230,7 @@ if(WIN32)
   if(NOT CMAKE_CL_64)
     pika_add_config_cond_define(BOOST_NO_ALIGNMENT)
   endif()
-  if(NOT PIKA_WITH_GENERIC_CONTEXT_COROUTINES)
+  if(NOT PIKA_WITH_BOOST_CONTEXT)
     pika_add_config_define(PIKA_HAVE_FIBER_BASED_COROUTINES)
   endif()
   pika_add_config_cond_define(PSAPI_VERSION 1)
@@ -1509,14 +1509,14 @@ endif()
 # with incompatible options with the currently selected platform.
 #
 
-if(PIKA_WITH_GENERIC_CONTEXT_COROUTINES)
+if(PIKA_WITH_BOOST_CONTEXT)
   # Check if we can use generic coroutine contexts without any problems
   if(NOT Boost_CONTEXT_FOUND)
     pika_error(
       "The usage of Boost.Context was selected but Boost.Context was not found."
     )
   endif()
-  pika_add_config_define(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES)
+  pika_add_config_define(PIKA_HAVE_BOOST_CONTEXT)
 endif()
 
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,11 +1082,9 @@ if("${PIKA_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   set(__use_generic_coroutine_context ON)
 endif()
 pika_option(
-  PIKA_WITH_BOOST_CONTEXT
-  BOOL
-  "Use Boost.Context as the underlying coroutines context switch implementation."
-  ${__use_generic_coroutine_context}
-  ADVANCED
+  PIKA_WITH_BOOST_CONTEXT BOOL
+  "Use Boost.Context for user-level thread context switching."
+  ${__use_generic_coroutine_context} ADVANCED
 )
 
 # ##############################################################################

--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,8 @@ pika is configured using CMake variables. The most important variables are:
 * ``PIKA_WITH_CUDA``: Enable CUDA support.
 * ``PIKA_WITH_HIP``: Enable HIP support.
 * ``PIKA_WITH_MPI``: Enable MPI support.
-* ``PIKA_WITH_GENERIC_CONTEXT_COROUTINES``: Enable the use of Boost.Context for
-  fiber context switching. This has to be enabled on non-Linux and non-x86
-  platforms.
+* ``PIKA_WITH_BOOST_CONTEXT``: Enable the use of Boost.Context for fiber context switching. This has
+  to be enabled on non-Linux and non-x86 platforms.
 
 Tests and examples are disabled by default and can be enabled with
 ``PIKA_WITH_TESTS``, ``PIKA_WITH_TESTS_*``, and ``PIKA_WITH_EXAMPLES``. Note

--- a/cmake/pika_setup_boost.cmake
+++ b/cmake/pika_setup_boost.cmake
@@ -40,7 +40,7 @@ if(NOT TARGET pika_dependencies_boost)
   endif()
 
   set(__boost_libraries "")
-  if(PIKA_WITH_GENERIC_CONTEXT_COROUTINES)
+  if(PIKA_WITH_BOOST_CONTEXT)
     set(__boost_libraries ${__boost_libraries} context)
   endif()
 

--- a/libs/pika/config/include/pika/config/threads_stack.hpp
+++ b/libs/pika/config/include/pika/config/threads_stack.hpp
@@ -40,7 +40,7 @@
 #endif
 
 #if !defined(PIKA_SMALL_STACK_SIZE)
-#  if defined(PIKA_WINDOWS) && !defined(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES)
+#  if defined(PIKA_WINDOWS) && !defined(PIKA_HAVE_BOOST_CONTEXT)
 #    define PIKA_SMALL_STACK_SIZE    0x4000        // 16kByte
 #  else
 #    if defined(PIKA_DEBUG)

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
@@ -98,11 +98,11 @@
      make copyable.
 */
 
-#if defined(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES) && defined(PIKA_HAVE_FIBER_BASED_COROUTINES)
-#   error PIKA_HAVE_GENERIC_CONTEXT_COROUTINES and PIKA_HAVE_FIBER_BASED_COROUTINES cannot be defined at the same time.
+#if defined(PIKA_HAVE_BOOST_CONTEXT) && defined(PIKA_HAVE_FIBER_BASED_COROUTINES)
+#   error PIKA_HAVE_BOOST_CONTEXT and PIKA_HAVE_FIBER_BASED_COROUTINES cannot be defined at the same time.
 #endif
 
-#if defined(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES)
+#if defined(PIKA_HAVE_BOOST_CONTEXT)
 
 # include <pika/coroutines/detail/context_generic_context.hpp>
 namespace pika { namespace threads { namespace coroutines { namespace detail {
@@ -142,6 +142,6 @@ namespace pika { namespace threads { namespace coroutines { namespace detail {
 
 # error No default context switching implementation available for this system. \
     Your platform may be supported with the CMake option \
-    PIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON (requires Boost.Context).
+    PIKA_WITH_BOOST_CONTEXT=ON (requires Boost.Context).
 
-#endif    // PIKA_HAVE_GENERIC_CONTEXT_COROUTINES
+#endif    // PIKA_HAVE_BOOST_CONTEXT

--- a/libs/pika/coroutines/src/detail/context_posix.cpp
+++ b/libs/pika/coroutines/src/detail/context_posix.cpp
@@ -10,7 +10,7 @@
 // The preprocessor conditions below are kept in sync with those used in
 // context_impl.hpp
 
-#if defined(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES)
+#if defined(PIKA_HAVE_BOOST_CONTEXT)
 
 // left empty on purpose
 
@@ -38,4 +38,4 @@ namespace pika { namespace threads { namespace coroutines { namespace detail { n
 
 # error No default_context_impl available for this system
 
-#endif    // PIKA_HAVE_GENERIC_CONTEXT_COROUTINES
+#endif    // PIKA_HAVE_BOOST_CONTEXT

--- a/libs/pika/coroutines/src/swapcontext.cpp
+++ b/libs/pika/coroutines/src/swapcontext.cpp
@@ -7,7 +7,7 @@
 
 #include <pika/config.hpp>
 
-#if !defined(PIKA_HAVE_GENERIC_CONTEXT_COROUTINES)
+#if !defined(PIKA_HAVE_BOOST_CONTEXT)
 
 # if (defined(__linux) || defined(linux) || defined(__linux__) || defined(__FreeBSD__)) &&         \
      !defined(__bgq__) && !defined(__powerpc__) && !defined(__s390x__) && !defined(__arm__) &&     \
@@ -20,7 +20,7 @@
 #  else
 #   error You are trying to use x86 context switching on a non-x86 platform. Your \
     platform may be supported with the CMake option \
-    PIKA_WITH_GENERIC_CONTEXT_COROUTINES=ON (requires Boost.Context).
+    PIKA_WITH_BOOST_CONTEXT=ON (requires Boost.Context).
 #  endif
 
 # endif


### PR DESCRIPTION
C.f. https://github.com/pika-org/pika/pull/723.

What do you think? Should we keep the old name? Is the new name better?

_If_ we change this option I would update the spack package to have a new variant `boost_context` which is enforced to be exactly the same as `generic_coroutines` so that one can still use the old variant.