### PR TITLE
Fix apt warning in arm64 CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,6 +529,7 @@ jobs:
               rm cmake.tar.gz
             cmake --version
             # Install pika dependencies
+            sudo apt update
             sudo apt install --allow-downgrades \
               --allow-remove-essential --allow-change-held-packages \
               clang \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,8 @@ jobs:
               rm cmake.tar.gz
             cmake --version
             # Install pika dependencies
-            sudo apt install -y \
+            sudo apt install --allow-downgrades \
+              --allow-remove-essential --allow-change-held-packages \
               clang \
               ninja-build \
               libboost-context-dev \


### PR DESCRIPTION
Fixes the warning `W: --force-yes is deprecated, use one of the options starting with --allow instead.`