### PR TITLE
Add devcontainer.json configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "docker.io/pikaorg/pika-ci-base:17",
+  "features": {},
+  "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
+  "extensions": [
+    "ms-vscode.cpptools-extension-pack",
+    "ms-vsliveshare.vsliveshare"
+  ]
+}


### PR DESCRIPTION
This allows using "codespaces" with our CI image. It additionally configures pika on creation and adds a couple of useful extensions. In particular, the liveshare extension allows sharing an editing session.