### PR TITLE
Add `--pika:process-mask` command line option

### DIFF
--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -59,6 +59,7 @@ namespace pika::detail {
         std::string affinity_bind_;
         std::size_t numa_sensitive_;
         bool use_process_mask_;
+        std::string process_mask_;
         bool cmd_line_parsed_;
         bool info_printed_;
         bool version_printed_;

--- a/libs/pika/command_line_handling/src/parse_command_line.cpp
+++ b/libs/pika/command_line_handling/src/parse_command_line.cpp
@@ -373,6 +373,13 @@ namespace pika::detail {
                   "values. Do not use with --pika:pu-step, --pika:pu-offset, or "
                   "--pika:affinity options. Implies --pika:numa-sensitive=1"
                   "(--pika:bind=none disables defining thread affinities).")
+                ("pika:process-mask", value<std::string>(),
+                  "a process mask in hexadecimal form to restrict cores available for "
+                  "the pika runtime. If a mask has been set externally on the executable, "
+                  "this option overrides that mask. Has no effect if "
+                  "--pika:ignore-process-mask is used. This option does not set the "
+                  "process mask for the main thread. The mask only affects threads spawned "
+                  "by the pika runtime.")
                 ("pika:ignore-process-mask", "ignore the process mask to restrict "
                  "available hardware resources, use all available processing units")
                 ("pika:print-bind",

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -125,6 +125,7 @@ namespace pika::util {
 
             // add placeholders for keys to be added by command line handling
             "ignore_process_mask = 0",
+            "process_mask = ${PIKA_PROCESS_MASK:}",
             "os_threads = cores",
             "cores = all",
             "localities = 1",

--- a/libs/pika/topology/include/pika/topology/topology.hpp
+++ b/libs/pika/topology/include/pika/topology/topology.hpp
@@ -245,6 +245,7 @@ namespace pika::threads::detail {
             std::size_t num_core, std::size_t num_pu, error_code& ec = throws) const;
 
         mask_type get_cpubind_mask_main_thread(error_code& ec = throws) const;
+        void set_cpubind_mask_main_thread(mask_type, error_code& ec = throws);
         mask_type get_cpubind_mask(error_code& ec = throws) const;
         mask_type get_cpubind_mask(std::thread& handle, error_code& ec = throws) const;
 

--- a/libs/pika/topology/tests/unit/CMakeLists.txt
+++ b/libs/pika/topology/tests/unit/CMakeLists.txt
@@ -1,5 +1,22 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2023 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests from_string_cpu_mask)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  pika_add_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/Modules/Topology"
+  )
+
+  pika_add_unit_test("modules.topology" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
+++ b/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
@@ -1,0 +1,89 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/string_util/from_string.hpp>
+#include <pika/testing.hpp>
+#include <pika/topology/cpu_mask.hpp>
+
+#include <cstddef>
+#include <set>
+#include <string>
+#include <vector>
+
+struct test_input
+{
+    std::string str;
+    std::size_t expected_size;
+    std::set<std::size_t> expected_bits;
+};
+
+void test_valid()
+{
+    const std::vector<test_input> tests
+    {
+        {"0x0", 4, {}}, {"0x1", 4, {0}}, {"0x2", 4, {1}}, {"0xb", 4, {0, 1, 3}},
+            {"0xf", 4, {0, 1, 2, 3}}, {"0xff", 2 * 4, {0, 1, 2, 3, 4, 5, 6, 7}},
+            {"0x808080", 6 * 4, {7, 15, 23}},
+            {"0x0f0f0f0f0f0f0f0f", 16 * 4,
+                {0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 40, 41,
+                    42, 43, 48, 49, 50, 51, 56, 57, 58, 59}},
+            {"0x0f0e0d0c04030201", 16 * 4,
+                {0, 9, 16, 17, 26, 34, 35, 40, 42, 43, 49, 50, 51, 56, 57, 58, 59}},
+            {"       0x808080     \t  ", 6 * 4, {7, 15, 23}},
+#if !defined(PIKA_HAVE_MAX_CPU_COUNT)
+            {"0xff00000000000000000000", 22 * 4, {80, 81, 82, 83, 84, 85, 86, 87}},
+#endif
+    };
+
+    for (const auto& t : tests)
+    {
+        auto mask = pika::detail::from_string<pika::threads::detail::mask_type>(t.str);
+#if defined(PIKA_HAVE_MAX_CPU_COUNT)
+        PIKA_TEST_EQ(pika::threads::detail::mask_size(mask), std::size_t(64));
+#else
+        PIKA_TEST_EQ(pika::threads::detail::mask_size(mask), t.expected_size);
+#endif
+        for (std::size_t i = 0; i < pika::threads::detail::mask_size(mask); ++i)
+        {
+            if (pika::threads::detail::test(mask, i))
+            {
+                PIKA_TEST(t.expected_bits.find(i) != t.expected_bits.cend());
+            }
+            else { PIKA_TEST(t.expected_bits.find(i) == t.expected_bits.cend()); }
+        }
+    }
+}
+
+void test_invalid()
+{
+    const std::vector<std::string> tests{
+        "", "0", "0x", "Ob", "foobar", "x0xff", "0xffg", " 0xabcdefgh\t"};
+
+    for (const auto& t : tests)
+    {
+        try
+        {
+            (void) pika::detail::from_string<pika::threads::detail::mask_type>(t);
+            PIKA_TEST(false);
+        }
+        catch (pika::detail::bad_lexical_cast const&)
+        {
+            PIKA_TEST(true);
+        }
+        catch (...)
+        {
+            PIKA_TEST(false);
+        }
+    }
+}
+
+int main()
+{
+    test_valid();
+    test_invalid();
+
+    return 0;
+}

--- a/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
+++ b/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
@@ -42,7 +42,11 @@ void test_valid()
     {
         auto mask = pika::detail::from_string<pika::threads::detail::mask_type>(t.str);
 #if defined(PIKA_HAVE_MAX_CPU_COUNT)
+# if defined(PIKA_HAVE_MORE_THAN_64_THREADS)
+        PIKA_TEST_EQ(pika::threads::detail::mask_size(mask), std::size_t(PIKA_HAVE_MAX_CPU_COUNT));
+# else
         PIKA_TEST_EQ(pika::threads::detail::mask_size(mask), std::size_t(64));
+# endif
 #else
         PIKA_TEST_EQ(pika::threads::detail::mask_size(mask), t.expected_size);
 #endif


### PR DESCRIPTION
And corresponding `pika.override_process_mask` configuration option.

Part of #568.

This includes #738. #738 should be merged first.

This allows overriding the process mask detected by pika at startup, for the cases where we are not able to read the mask before e.g. OpenMP binds the main thread to a single core. The option accepts masks in hexadecimal form. The mask itself can be bigger than the number of cores available on the system, but I've now made it stop with an error if there are set bits outside of the number of available cores. E.g. on a 4-core system a mask of `0x0000f` is allowed, but `0x1000f` is not. Related, leading zeros are counted towards the size of the mask, but the internal check in `topology` normalizes it to the number of available cores (with a check).

I currently only parse hexadecimal masks. Binary literals `0b...` are not supported. Literals must have at least one digit, i.e. `0x` is not a valid mask. `--pika:override-process-mask` is currently ignored if `--pika:ignore-process-mask` is set.

In an environment where the process mask has been set, `hwloc-bind` can be used to read the process mask before the pika-enabled application is run and one can then pass that to `--pika:override-process-mask`. E.g.:
```
hello_world --pika:override-process-mask=$(hwloc-bind --get --taskset)
```

Note, the `--taskset` option is important. Otherwise `hwloc-bind` prints the hwloc-specific format, which may include multiple masks separated by commas.

The `taskset` command can also be used but, as far as I'm aware, it needs some additional parsing of the output. If on `bash`, one can get the mask of the current shell like this:
```
> taskset --pid $BASHPID
pid 703180's current affinity mask: ff
```
where `ff` would need to be extracted into `0xff` for use with pika.

Alternatively, with e.g. slurm one may also find the mask in an environment variable such as `SLURM_CPU_BIND_LIST`:
```
> srun -N 1 -n 4 -c 9 --cpu-bind=core env | rg BIND
[snip]
SLURM_CPU_BIND_LIST=0x00000001F00000001F,0x0007C00000007C0000,0x0000003E00000003E0,0x00F8000000
[snip]
```
Extracting the mask from that list is currently left as an exercise for the user, though with enough requests I may consider adding logic for reading that from the environment. For the moment I prefer to keep the functionality as simple as possible in pika though.

Finally, with `hwloc-calc` one can in fact replace the previously removed binding grammar that could be passed to `--pika:bind`. E.g. this can be passed to `--pika:override-process-mask`:
```
> hwloc-calc node:1.pu:2-4
0x000002a0
```

Alternative names: `--pika:force-process-mask`, `--pika:set-process-mask`, others?

Does the above sound reasonable? Do you think any of the constraints and behaviour should be changed?