### PR TITLE
Increase test timeout on Jenkins

### DIFF
--- a/.jenkins/cscs/ctest.cmake
+++ b/.jenkins/cscs/ctest.cmake
@@ -7,7 +7,7 @@
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-set(CTEST_TEST_TIMEOUT 300)
+set(CTEST_TEST_TIMEOUT 600)
 set(CTEST_CMAKE_GENERATOR Ninja)
 set(CTEST_SITE "cscs(daint)")
 set(CTEST_UPDATE_COMMAND "git")


### PR DESCRIPTION
I'm increasing the test timeout on the Piz Daint Jenkins configuration in the hope that it will reduce test failures that are just timeouts while building header tests. I'm doubling it to start with. Let's revisit this depending on what effect this change has.