### PR TITLE
Use fewer build jobs in Jenkins HIP configuration to avoid OOM

### DIFF
--- a/.jenkins/cscs-ault/env-hipcc.sh
+++ b/.jenkins/cscs-ault/env-hipcc.sh
@@ -23,3 +23,5 @@ configure_extra_options+=" -DPIKA_WITH_HIP=ON"
 configure_extra_options+=" -DPIKA_WITH_CXX_STANDARD=${cxx_std}"
 configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
 configure_extra_options+=" -DPIKA_WITH_STDEXEC=ON"
+
+build_extra_options+=" -j16"


### PR DESCRIPTION
I think the HIP jobs have been failing quite frequently because of OOM. This attempts to avoid that by only building with 16 jobs in the HIP configuration.