### PR TITLE
Remove `get_component_id` and `get_self_component_id` from `thread_data`

### DIFF
--- a/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_helpers.hpp
@@ -81,9 +81,8 @@ namespace pika::threads::detail {
                 if (running)
                 {
                     LTM_(warning)
-                        .format("queue({}): {}({}.{:02x}/{:08x})", num_thread,
-                            get_thread_state_name(state), *it, thrd->get_thread_phase(),
-                            thrd->get_component_id())
+                        .format("queue({}): {}({}.{:02x})", num_thread,
+                            get_thread_state_name(state), *it, thrd->get_thread_phase())
 # ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
                         .format(" P{}", thrd->get_parent_thread_id())
 # endif
@@ -92,9 +91,8 @@ namespace pika::threads::detail {
                 else
                 {
                     LPIKA_CONSOLE_(pika::util::logging::level::warning)
-                        .format("queue({}): {}({}.{:02x}/{:08x})", num_thread,
-                            get_thread_state_name(state), *it, thrd->get_thread_phase(),
-                            thrd->get_component_id())
+                        .format("queue({}): {}({}.{:02x})", num_thread,
+                            get_thread_state_name(state), *it, thrd->get_thread_phase())
 # ifdef PIKA_HAVE_THREAD_PARENT_REFERENCE
                         .format(" P{}", thrd->get_parent_thread_id())
 # endif

--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -229,13 +229,6 @@ namespace pika::threads::detail {
         }
 
     public:
-        /// Return the id of the component this thread is running in
-        constexpr std::uint64_t    // same as naming::address_type
-        get_component_id() const noexcept
-        {
-            return 0;
-        }
-
 #if !defined(PIKA_HAVE_THREAD_DESCRIPTION)
         ::pika::detail::thread_description get_description() const
         {
@@ -635,14 +628,6 @@ namespace pika::threads::detail {
     ///       code was compiled with PIKA_HAVE_THREAD_PARENT_REFERENCE
     ///       being defined.
     PIKA_EXPORT std::uint32_t get_parent_locality_id();
-
-    /// The function \a get_self_component_id returns the lva of the
-    /// component the current thread is acting on
-    ///
-    /// \note This function will return a meaningful value only if the
-    ///       code was compiled with PIKA_HAVE_THREAD_TARGET_ADDRESS
-    ///       being defined.
-    PIKA_EXPORT std::uint64_t get_self_component_id();
 }    // namespace pika::threads::detail
 
 #include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -339,17 +339,6 @@ namespace pika::threads::detail {
     }
 #endif
 
-    std::uint64_t get_self_component_id()
-    {
-#ifndef PIKA_HAVE_THREAD_TARGET_ADDRESS
-        return 0;
-#else
-        thread_data* thrd_data = get_self_id_data();
-        if (PIKA_LIKELY(nullptr != thrd_data)) { return thrd_data->get_component_id(); }
-        return 0;
-#endif
-    }
-
 #if defined(PIKA_HAVE_APEX)
     std::shared_ptr<pika::detail::external_timer::task_wrapper> get_self_timer_data()
     {


### PR DESCRIPTION
They are unused.