### PR TITLE
Add `pika::start` overload which takes no function

### DIFF
--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -141,6 +141,8 @@ namespace pika {
         init_params const& params = init_params());
     PIKA_EXPORT bool start(std::nullptr_t, int argc, const char* const* argv,
         init_params const& params = init_params());
+    PIKA_EXPORT bool start(
+        int argc, const char* const* argv, init_params const& params = init_params());
     PIKA_EXPORT int finalize(error_code& ec = throws);
     PIKA_EXPORT int stop(error_code& ec = throws);
     PIKA_EXPORT int wait(error_code& ec = throws);

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -167,6 +167,12 @@ namespace pika {
         return 0 == detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, false);
     }
 
+    bool start(int argc, const char* const* argv, init_params const& params)
+    {
+        util::detail::function<int(pika::program_options::variables_map&)> main_f;
+        return 0 == detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, false);
+    }
+
     int finalize(error_code& ec)
     {
         if (!is_running())


### PR DESCRIPTION
This is equivalent to the `nullptr_t` overload that already exists.

We could arguably remove the `pika::init(nullptr_t, ...)` overload (since it's blocking, and providing no entry point is a bit weird), but I'm leaving it unchanged in light of #754.
