### PR TITLE
Add very early initialization of topology to work around OpenMP resetting process masks

### DIFF
--- a/cmake/pika_setup_target.cmake
+++ b/cmake/pika_setup_target.cmake
@@ -98,6 +98,8 @@ function(pika_setup_target target)
       ${target} PRIVATE "PIKA_APPLICATION_NAME=${name}"
                         "PIKA_APPLICATION_STRING=\"${name}\""
     )
+
+    target_link_libraries(${target} PRIVATE pika_omp_hack)
   endif()
 
   if("${_type}" STREQUAL "LIBRARY")

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -108,3 +108,5 @@ endif()
 if(PIKA_WITH_ITTNOTIFY)
   target_link_libraries(pika PUBLIC pika_internal::amplifier)
 endif()
+
+add_subdirectory(pika_omp_hack)

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -192,7 +192,11 @@ namespace pika::threads::detail {
 
     static struct init_topology_t
     {
-        init_topology_t() { get_topology(); }
+        init_topology_t()
+        {
+            std::cerr << "getting topology in libpika\n";
+            get_topology();
+        }
     } init_topology{};
 
 #if !defined(PIKA_HAVE_MAX_CPU_COUNT)

--- a/libs/pika_omp_hack/CMakeLists.txt
+++ b/libs/pika_omp_hack/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(GNUInstallDirs)
+
+add_library(pika_omp_hack STATIC src/pika_omp_hack.cpp)
+target_link_libraries(pika_omp_hack PRIVATE pika::pika)
+install(
+  TARGETS pika_omp_hack
+  EXPORT pika_targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT pika_omp_hack
+)
+pika_export_targets(pika_omp_hack)

--- a/libs/pika_omp_hack/src/pika_omp_hack.cpp
+++ b/libs/pika_omp_hack/src/pika_omp_hack.cpp
@@ -1,0 +1,16 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/topology/topology.hpp>
+
+namespace pika::detail {
+    void preinit_get_topology() { pika::threads::detail::get_topology(); }
+
+    // Based on the example in https://reviews.llvm.org/D20646?id=58513
+    [[maybe_unused]] __attribute__((section(".preinit_array"), used)) void (*pika_preinit_array)(
+        void) = preinit_get_topology;
+
+}    // namespace pika::detail


### PR DESCRIPTION
This is a draft. I'm currently just testing if all compilers are happy with the `.preinit_array` section.

If there's a risk of this ever failing (compilation, linking, runtime) we should be quite conservative about this. If it's enabled by defualt, there must be a way to disable it so that one can fall back to using `--pika:process-mask`. Probably we need:
- A feature check for `.preinit_array`. Must do linking as well. However, this may still fail if the user application for some reason uses a linker that doesn't support the section. What's the failure case?
- A CMake flag? Off or on by defualt?
- A CMake target to explicitly link or automatically link to executables?
- A better name for the target.