### PR TITLE
Update numpy version due to CVE-2021-41495 and others

### DIFF
--- a/tools/perftests_ci/requirements.txt
+++ b/tools/perftests_ci/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.22.2
 matplotlib
 python-dateutil
 lxml


### PR DESCRIPTION
Following the report for the pika repo on app.snyk.io, this aims at fixing 3 low severity CVEs: CVE-2021-41495, CVE-2021-34141, CVE-2021-41496