### PR TITLE
Remove `PIKA_WITH_DISABLED_SIGNAL_EXCEPTION_HANDLERS` CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,17 +430,6 @@ pika_option(
   ADVANCED
 )
 
-pika_option(
-  PIKA_WITH_DISABLED_SIGNAL_EXCEPTION_HANDLERS
-  BOOL
-  "Disables the mechanism that produces debug output for caught signals and unhandled exceptions (default: OFF)"
-  OFF
-  ADVANCED
-)
-if(PIKA_WITH_DISABLED_SIGNAL_EXCEPTION_HANDLERS)
-  pika_add_config_define(PIKA_HAVE_DISABLED_SIGNAL_EXCEPTION_HANDLERS)
-endif()
-
 # Thread Manager related build options
 
 set(PIKA_MAX_CPU_COUNT_DEFAULT "")

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -410,14 +410,12 @@ namespace pika {
                 &pika::detail::registered_locks_error_handler);
             pika::util::set_register_locks_predicate(&pika::detail::register_locks_predicate);
 #endif
-#if !defined(PIKA_HAVE_DISABLED_SIGNAL_EXCEPTION_HANDLERS)
             if (pika::detail::get_entry_as<bool>(
                     cmdline.rtcfg_, "pika.install_signal_handlers", false))
             {
                 set_signal_handlers();
             }
 
-#endif
             pika::threads::detail::set_get_default_pool(&pika::detail::get_default_pool);
             pika::threads::detail::set_get_locality_id(&get_locality_id);
             pika::parallel::execution::detail::set_get_pu_mask(&pika::detail::get_pu_mask);


### PR DESCRIPTION
The signal handlers are already disabled by default at runtime and there's no good reason to hide this behind a compile-time option.