### PR TITLE
Add workaround to ensure `PIKA_PROCESS_MASK` is respected

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -142,12 +142,14 @@ how many threads to use for the runtime. ``hwloc-bind`` can also be used to manu
 mask on the application. When a process mask is set, the default behaviour is to use only one thread
 per core in the process mask. Setting ``--pika:threads`` to a number higher than the number of cores
 available in the mask is not allowed. Using ``--pika:threads=all`` will use all the hyperthreads in
-the process mask. The process mask can explicitly be ignored with the option
-``--pika:ignore-process-mask``. In that case pika behaves as if no process mask is set. In addition
-to setting the mask with batch systems or ``hwloc-bind``, the mask used by the runtime can also be
-overridden with ``--pika:process-mask``. The option takes an explicit hexadecimal string (beginning
-with ``0x``) representing the process mask to use. ``--pika:print-bind`` can be used to verify that
-the bindings used by pika are correct.
+the process mask.
+
+The process mask can explicitly be ignored with the option ``--pika:ignore-process-mask`` or
+overridden with ``--pika:process-mask``. With ``--pika:ignore-process-mask`` pika behaves as if no
+process mask is set. ``--pika:process-mask`` takes an explicit hexadecimal string (beginning with
+``0x``) representing the process mask to use. The mask can also be set with the environment variable
+``PIKA_PROCESS_MASK``. ``--pika:process-mask`` takes precedence over ``PIKA_PROCESS_MASK``.
+``--pika:print-bind`` can be used to verify that the bindings used by pika are correct.
 
 Interaction with OpenMP
 -----------------------

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -113,6 +114,9 @@ namespace pika::detail {
         pika::program_options::variables_map& vm, bool use_process_mask)
     {
         std::string mask_string = cfgmap.get_value<std::string>("pika.process_mask", "");
+
+        char const* mask_env = std::getenv("PIKA_PROCESS_MASK");
+        if (nullptr != mask_env) { mask_string = mask_env; }
 
         if (vm.count("pika:process-mask"))
         {

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -1160,6 +1160,15 @@ namespace pika::threads::detail {
                 fmt::streamed(mask), concurrency);
         }
 
+        if (!any(mask))
+        {
+            PIKA_THROWS_IF(ec, pika::error::bad_parameter,
+                "pika::threads::detail::topology::set_cpubind_mask_main_thread",
+                "CPU mask is empty ({}), make sure it has at least one bit set through "
+                "PIKA_PROCESS_MASK or --pika:process-mask",
+                fmt::streamed(mask));
+        }
+
         main_thread_affinity_mask_ = std::move(mask);
     }
 


### PR DESCRIPTION
Fixes #743. However, this only special cases the handling for `PIKA_PROCESS_MASK` and doesn't fix the behaviour for any other configuration options. The proper fix would require doing #745. This also adds an additional check for empty process masks when set through `PIKA_PROCESS_MASK` or `--pika:process-mask` to give a better error message when the mask is empty.