### PR TITLE
Remove `GLIBC_TUNABLES` for `std_thread_scheduler` test fom CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,15 +399,6 @@ jobs:
               export OMPI_ALLOW_RUN_AS_ROOT=1
               export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-              # The glibc tcache _may_ be causing issues with the
-              # std_thread_scheduler test. See
-              # https://github.com/pika-org/pika/pull/250#issuecomment-1150765258
-              # for more details and links. This is disabled to check if it has
-              # a noticeable effect on the error rate in the test. This should
-              # be revisited to see if newer versions of glibc can do without
-              # disabling this.
-              export GLIBC_TUNABLES=glibc.malloc.tcache_count=0
-
               ulimit -c unlimited
               ctest \
                 -j2 \


### PR DESCRIPTION
It was added as a potential fix for the `std_thread_scheduler` test failing, but the test definitely still fails so I suspect the option isn't the source of the failures.