### PR TITLE
Fix a few instances of the wrong type being forwarded with `PIKA_FORWARD`

### DIFF
--- a/.jenkins/cscs/env-clang-14-cuda.sh
+++ b/.jenkins/cscs/env-clang-14-cuda.sh
@@ -23,6 +23,9 @@ configure_extra_options+=" -DPIKA_WITH_STDEXEC=ON"
 configure_extra_options+=" -DCMAKE_CUDA_COMPILER=c++"
 configure_extra_options+=" -DCMAKE_CUDA_ARCHITECTURES=60"
 
+# Force this option to off to test the fallback implementation of PIKA_FORWARD
+configure_extra_options+=" -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
+
 # The build unit test with pika in Debug and the hello_world project in Debug
 # mode hangs on this configuration. Release-Debug, Debug-Release, and
 # Release-Release do not hang.

--- a/.jenkins/cscs/env-gcc-cuda-12.sh
+++ b/.jenkins/cscs/env-gcc-cuda-12.sh
@@ -20,6 +20,9 @@ configure_extra_options+=" -DPIKA_WITH_MALLOC=system"
 configure_extra_options+=" -DPIKA_WITH_CUDA=ON"
 configure_extra_options+=" -DCMAKE_CUDA_ARCHITECTURES=60"
 
+# Force this option to off to test the fallback implementation of PIKA_FORWARD
+configure_extra_options+=" -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
+
 # All async_cuda tests are disabled from running because the driver on Piz Daint
 # is too old for CUDA 12.
 test_extra_options+=" EXCLUDE async_cuda"

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -397,7 +397,14 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 then_with_cuda_stream_receiver&& r, Ts&&... ts) noexcept
                 -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...))
             {
+                // nvcc fails to compile this with std::forward<Ts>(ts)...  or
+                // static_cast<Ts&&>(ts)... so we explicitly use
+                // static_cast<decltype(ts)>(ts)... as a workaround.
+#if defined(PIKA_HAVE_CUDA)
+                r.set_value(static_cast<decltype(ts)&&>(ts)...);
+#else
                 r.set_value(PIKA_FORWARD(Ts, ts)...);
+#endif
             }
 
             using operation_state_type =

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -185,7 +185,14 @@ namespace pika::schedule_from_detail {
                                         PIKA_FORWARD(Ts, ts)...),
                         void())
                 {
+                    // nvcc fails to compile this with std::forward<Ts>(ts)...
+                    // or static_cast<Ts&&>(ts)... so we explicitly use
+                    // static_cast<decltype(ts)>(ts)... as a workaround.
+# if defined(PIKA_HAVE_CUDA)
+                    r.op_state.set_value_predecessor_sender(static_cast<decltype(ts)&&>(ts)...);
+# else
                     r.op_state.set_value_predecessor_sender(PIKA_FORWARD(Ts, ts)...);
+# endif
                 }
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -507,7 +507,7 @@ namespace pika::split_tuple_detail {
         unique_ptr p(allocator_traits::allocate(alloc, 1),
             pika::detail::allocator_deleter<other_allocator>{alloc});
 
-        new (p.get()) shared_state_type{PIKA_FORWARD(Sender_, sender), allocator};
+        new (p.get()) shared_state_type{PIKA_FORWARD(Sender, sender), allocator};
         pika::intrusive_ptr<shared_state_type> state = p.release();
 
         // nvcc does not like decay_t, so this uses decay<>::type instead.

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -325,7 +325,7 @@ namespace pika::when_all_impl {
 
             template <typename Receiver_, typename SendersPack_>
             operation_state(Receiver_&& receiver, SendersPack_&& senders)
-              : base_type(PIKA_FORWARD(Receiver_, receiver), PIKA_FORWARD(SendersPack, senders))
+              : base_type(PIKA_FORWARD(Receiver_, receiver), PIKA_FORWARD(SendersPack_, senders))
               , op_state(pika::execution::experimental::connect(
 # if defined(PIKA_CUDA_VERSION)
                     std::forward<SendersPack_>(senders).template get<i>(),


### PR DESCRIPTION
The default implementation of `PIKA_FORWARD` doesn't actually use the type argument (the first argument), but instead uses `decltype` for the cast. This means that the first argument may actually be wrong and the compiler won't notice because it's unused. This means that if `PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE` is off things will fail to compile because then the type argument is actually used. I think we introduced the fallback `PIKA_FORWARD` implementation mainly for MSVC but it doesn't hurt to check that it still works, so I've turned `PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE` off in a few CI configurations.

It also turns out that nvcc fails to compile anything but the `PIKA_FORWARD` implementation with `decltype` in some situations, so I've hardcoded the choice in those cases.