### PR TITLE
Remove `PIKA_WITH_THREAD_GUARD_PAGE` CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,11 +850,6 @@ pika_option(
   CATEGORY "Debugging"
   ADVANCED
 )
-pika_option(
-  PIKA_WITH_THREAD_GUARD_PAGE BOOL "Enable thread guard page (default: ON)" ON
-  CATEGORY "Debugging"
-  ADVANCED
-)
 
 if(PIKA_WITH_VERIFY_LOCKS)
   pika_add_config_define(PIKA_HAVE_VERIFY_LOCKS)
@@ -864,10 +859,6 @@ if(PIKA_WITH_VERIFY_LOCKS)
 endif()
 
 # Additional debug support
-if(NOT WIN32 AND PIKA_WITH_THREAD_GUARD_PAGE)
-  pika_add_config_define(PIKA_HAVE_THREAD_GUARD_PAGE)
-endif()
-
 if(NOT WIN32 AND PIKA_WITH_THREAD_STACK_MMAP)
   pika_add_config_define(PIKA_HAVE_THREAD_STACK_MMAP)
 endif()

--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
@@ -80,29 +80,26 @@ namespace pika::threads::coroutines::detail::posix {
 
     inline void* to_stack_with_guard_page(void* stack)
     {
-#  if defined(PIKA_HAVE_THREAD_GUARD_PAGE)
         if (use_guard_pages)
         {
             return static_cast<void*>(static_cast<void**>(stack) - (EXEC_PAGESIZE / sizeof(void*)));
         }
-#  endif
+
         return stack;
     }
 
     inline void* to_stack_without_guard_page(void* stack)
     {
-#  if defined(PIKA_HAVE_THREAD_GUARD_PAGE)
         if (use_guard_pages)
         {
             return static_cast<void*>(static_cast<void**>(stack) + (EXEC_PAGESIZE / sizeof(void*)));
         }
-#  endif
+
         return stack;
     }
 
     inline void add_guard_page(void* stack)
     {
-#  if defined(PIKA_HAVE_THREAD_GUARD_PAGE)
         if (use_guard_pages)
         {
             int r = ::mprotect(stack, EXEC_PAGESIZE, PROT_NONE);
@@ -113,16 +110,12 @@ namespace pika::threads::coroutines::detail::posix {
                 throw std::runtime_error(error_message);
             }
         }
-#  else
-        PIKA_UNUSED(stack);
-#  endif
     }
 
     inline std::size_t stack_size_with_guard_page(std::size_t size)
     {
-#  if defined(PIKA_HAVE_THREAD_GUARD_PAGE)
         if (use_guard_pages) { return size + EXEC_PAGESIZE; }
-#  endif
+
         return size;
     }
 
@@ -140,7 +133,6 @@ namespace pika::threads::coroutines::detail::posix {
 
         if (real_stack == MAP_FAILED)
         {
-#  if defined(PIKA_HAVE_THREAD_GUARD_PAGE)
             if (ENOMEM == errno && use_guard_pages)
             {
                 char const* error_message =
@@ -150,7 +142,6 @@ namespace pika::threads::coroutines::detail::posix {
                     "consumption.";
                 throw std::runtime_error(error_message);
             }
-#  endif
 
             std::string error_message = "mmap failed to allocate thread stack with errno " +
                 std::to_string(errno) + " (" + std::strerror(errno) + ")";


### PR DESCRIPTION
This option can be controlled sufficiently at runtime.