### PR TITLE
Remove `thread_priority::critical`

### DIFF
--- a/libs/pika/coroutines/include/pika/coroutines/thread_enums.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/thread_enums.hpp
@@ -122,11 +122,6 @@ namespace pika::execution {
             high priority queue and will never be stolen by another thread
             after initial assignment. This should be used for thread placement
             tasks such as OpenMP type for loops. */
-
-        /// \cond NOINTERNAL
-        // obsolete, kept for compatibility only
-        critical = high_recursive,
-        /// \endcond
     };
     // clang-format on
 

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -77,7 +77,7 @@ int pika_main(/*pika::program_options::variables_map& vm*/)
 
     // create an executor with high priority for important tasks
     pika::execution::parallel_executor high_priority_executor(
-        pika::this_thread::get_pool(), pika::execution::thread_priority::critical);
+        pika::this_thread::get_pool(), pika::execution::thread_priority::high_recursive);
     pika::execution::parallel_executor normal_priority_executor;
 
     pika::execution::parallel_executor pool_executor;

--- a/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -61,7 +61,7 @@ int pika_main(pika::program_options::variables_map&)
 
     // create an executor with high priority for important tasks
     pika::execution::parallel_executor high_priority_executor(
-        pika::this_thread::get_pool(), pika::execution::thread_priority::critical);
+        pika::this_thread::get_pool(), pika::execution::thread_priority::high_recursive);
     pika::execution::parallel_executor normal_priority_executor;
 
     pika::execution::parallel_executor pool_executor;

--- a/libs/pika/threading_base/src/create_thread.cpp
+++ b/libs/pika/threading_base/src/create_thread.cpp
@@ -61,8 +61,8 @@ namespace pika::threads::detail {
 
         if (nullptr == data.scheduler_base) data.scheduler_base = scheduler;
 
-        // Pass critical priority from parent to child (but only if there is
-        // none is explicitly specified).
+        // Pass recursive high priority from parent to child (but only if there is none is
+        // explicitly specified).
         if (self)
         {
             if (data.priority == execution::thread_priority::default_ &&

--- a/libs/pika/threading_base/src/create_work.cpp
+++ b/libs/pika/threading_base/src/create_work.cpp
@@ -68,7 +68,7 @@ namespace pika::threads::detail {
 
         if (nullptr == data.scheduler_base) data.scheduler_base = scheduler;
 
-        // Pass critical priority from parent to child.
+        // Pass recursive high priority from parent to child.
         if (self)
         {
             if (data.priority == execution::thread_priority::default_ &&


### PR DESCRIPTION
It's only an alias to `high_recursive` and unused.