### PR TITLE
Fix `move`/`forward` mismatch in `ensure_started` and fix compilation with `nvcc` at the same time

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -234,8 +234,8 @@ namespace pika::ensure_started_detail {
 
                 void operator()(error_type&& error)
                 {
-                    pika::detail::visit(error_visitor<Receiver>{PIKA_FORWARD(Receiver, receiver)},
-                        PIKA_MOVE(error));
+                    pika::detail::visit(
+                        error_visitor<Receiver>{PIKA_MOVE(receiver)}, PIKA_MOVE(error));
                 }
 
                 template <typename T,
@@ -244,8 +244,8 @@ namespace pika::ensure_started_detail {
                         std::is_same_v<std::decay_t<T>, value_type>>>
                 void operator()(T&& t)
                 {
-                    pika::detail::visit(value_visitor<Receiver>{PIKA_FORWARD(Receiver, receiver)},
-                        PIKA_FORWARD(T, t));
+                    pika::detail::visit(
+                        value_visitor<Receiver>{PIKA_MOVE(receiver)}, PIKA_FORWARD(T, t));
                 }
             };
 


### PR DESCRIPTION
`nvcc` was mis-detecting the types used with the `PIKA_FORWARD` expression which made compilation fail since the receiver is not copyable (`PIKA_FORWARD` was resulting in a `const&` of the receiver). `PIKA_MOVE` fixes compilation, and fits the rest of the code better as well, since we know that the receiver is never a reference in that context.