### PR TITLE
Change `pkgconfig` to `pkg-config` in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ pkgs.mkShell.override { stdenv = pkgs.gcc11Stdenv; } {
     hwloc
     mpich
     ninja
-    pkgconfig
+    pkg-config
     python311Packages.sphinx
     python311Packages.sphinx-material
   ];


### PR DESCRIPTION
`pkgconfig` was for a long time an alias to `pkg-config`. Now the `pkgconfig` alias has been removed on unstable nixpkgs.