### PR TITLE
Fix use-after-free in `ensure_started`

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -1,0 +1,68 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (valgrind)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/valgrind
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:20
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux-valgrind
+    - name: Configure
+      shell: bash
+      # -gdwarf-4 because of https://github.com/llvm/llvm-project/issues/56550
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_CXX_FLAGS="-gdwarf-4" \
+              -DPIKA_WITH_UNITY_BUILD=ON \
+              -DPIKA_WITH_MALLOC=system \
+              -DPIKA_WITH_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS=ON \
+              -DPIKA_WITH_TESTS_EXAMPLES=ON \
+              -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
+              -DPIKA_WITH_TESTS_HEADERS=OFF \
+              -DPIKA_WITH_TESTS_MAX_THREADS=2 \
+              -DPIKA_WITH_TESTS_VALGRIND=ON \
+              -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
+              -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target tests.unit.modules.execution
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            -L VALGRIND \
+            --timeout 300 \
+            --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,19 @@ pika_option(
 )
 
 pika_option(
+  PIKA_WITH_TESTS_VALGRIND BOOL "Run selected tests with valgrind." OFF
+  CATEGORY "Debugging"
+  ADVANCED
+)
+
+pika_option(
+  PIKA_WITH_TESTS_VALGRIND_OPTIONS STRING
+  "Use these options when running tests under valgrind." "--error-exitcode=1"
+  CATEGORY "Debugging"
+  ADVANCED
+)
+
+pika_option(
   PIKA_WITH_SANITIZERS BOOL "Configure with sanitizer instrumentation support."
   OFF
   CATEGORY "Debugging"

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -297,8 +297,12 @@ namespace pika::ensure_started_detail {
 
                 if (continuation)
                 {
-                    continuation.value()();
-                    continuation.reset();
+                    // We move the continuation to a local variable to release it once the
+                    // continuation has been called. We cannot call reset on continuation after the
+                    // invocation because the shared state may already be released by the
+                    // continuation itself.
+                    auto continuation_local = PIKA_MOVE(continuation.value());
+                    continuation_local();
                 }
             }
 

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -30,12 +30,26 @@ set(tests
     scheduler_queries
 )
 
-set(future_then_executor_PARAMETERS THREADS 4)
+set(algorithm_bulk_PARAMETERS VALGRIND)
+set(algorithm_drop_value_PARAMETERS VALGRIND)
+set(algorithm_ensure_started_PARAMETERS VALGRIND)
+set(algorithm_execute_PARAMETERS VALGRIND)
+set(algorithm_just_PARAMETERS VALGRIND)
+set(algorithm_let_error_PARAMETERS VALGRIND)
+set(algorithm_let_value_PARAMETERS VALGRIND)
+set(algorithm_split_PARAMETERS VALGRIND)
+set(algorithm_split_tuple_PARAMETERS VALGRIND)
+set(algorithm_start_detached_PARAMETERS VALGRIND)
+set(algorithm_then_PARAMETERS VALGRIND)
+set(algorithm_transfer_PARAMETERS VALGRIND)
+set(algorithm_transfer_just_PARAMETERS VALGRIND)
+set(algorithm_unpack_PARAMETERS VALGRIND)
+set(algorithm_when_all_PARAMETERS VALGRIND)
+set(algorithm_when_all_vector_PARAMETERS VALGRIND)
+set(scheduler_queries_PARAMETERS VALGRIND)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
-
-  set(${test}_PARAMETERS THREADS 4)
 
   source_group("Source Files" FILES ${sources})
 
@@ -51,6 +65,7 @@ foreach(test ${tests})
 
   target_link_libraries(${test}_test PRIVATE pika_execution_test_utilities)
 
-  pika_add_unit_test("modules.execution" ${test} ${${test}_PARAMETERS})
-
+  pika_add_unit_test(
+    "modules.execution" ${test} ${${test}_PARAMETERS} THREADS 4
+  )
 endforeach()

--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -4,10 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <pika/execution.hpp>
+#include <pika/execution_base/tests/algorithm_test_utils.hpp>
+#include <pika/latch.hpp>
 #include <pika/modules/execution.hpp>
 #include <pika/testing.hpp>
-
-#include <pika/execution_base/tests/algorithm_test_utils.hpp>
 
 #include <atomic>
 #include <exception>
@@ -159,6 +160,24 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         PIKA_TEST(set_error_called);
+    }
+
+    // This test makes sure that a 1. continuation is registered for later invocation in
+    // ensure_started and 2. that continuation holds the last reference to the ensure_started shared
+    // state. Using a latch to delay the completion of the then operation means that by the time
+    // start_detached is connected a continuation has to be registered in ensure_started rather than
+    // running the continuation immediately inline. This fulfills 2. Since the ensure_started sender
+    // is moved into start_detached the last reference to the ensure_started shared state is
+    // released in the continuation of ensure_started.
+    //
+    // If the released shared state is accessed after it's released this test will fail under
+    // valgrind (e.g. while resetting the continuation right after invoking it).
+    {
+        pika::latch l(2);
+        auto s = ex::schedule(ex::std_thread_scheduler{}) |
+            ex::then([&]() { l.arrive_and_wait(); }) | ex::ensure_started();
+        ex::start_detached(std::move(s));
+        l.arrive_and_wait();
     }
 
     // It's allowed to discard the sender from ensure_started


### PR DESCRIPTION
This makes sure that when resetting the continuation called by the `ensure_started` shared state it is not done on a potentially already freed shared state. This is circumvented by moving the continuation to a local variable before calling the continuation (similar to what is done in `split`). This adds a test that triggers the problem under valgrind. I've also added a small valgrind workflow to run some tests from the execution module under valgrind. This reproduces the error in CI before fixing the problem (https://github.com/pika-org/pika/actions/runs/6391142577/job/17345809634#step:8:98, https://gist.github.com/msimberg/c12961f11eba8ebed14a99a1815ae8fa).