### PR TITLE
Fix lifetime issue with latch in `ensure_started` test

### DIFF
--- a/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_ensure_started.cpp
@@ -12,6 +12,7 @@
 
 #include <atomic>
 #include <exception>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -173,11 +174,11 @@ int main()
     // If the released shared state is accessed after it's released this test will fail under
     // valgrind (e.g. while resetting the continuation right after invoking it).
     {
-        pika::latch l(2);
+        auto l = std::make_shared<pika::latch>(2);
         auto s = ex::schedule(ex::std_thread_scheduler{}) |
-            ex::then([&]() { l.arrive_and_wait(); }) | ex::ensure_started();
+            ex::then([l]() { l->arrive_and_wait(); }) | ex::ensure_started();
         ex::start_detached(std::move(s));
-        l.arrive_and_wait();
+        l->arrive_and_wait();
     }
 
     // It's allowed to discard the sender from ensure_started


### PR DESCRIPTION
Assertions inside the latch can fire from reading variables that have gone out of scope after both uses of the latch have been arrived at. These are harmless for the test, but ensuring that the latch lives long enough in both threads means we avoid false positives in the test.