### PR TITLE
Fix one more lifetime bug in `ensure_started` for cases when the sender is dropped without connecting it

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -58,6 +58,7 @@ jobs:
       shell: bash
       run: |
           cmake --build build --target tests.unit.modules.execution
+          cmake --build build --target std_thread_scheduler_test
     - name: Test
       shell: bash
       run: |

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -158,14 +158,14 @@ namespace pika::ensure_started_detail {
 
                 template <typename Error>
                 friend void tag_invoke(pika::execution::experimental::set_error_t,
-                    ensure_started_receiver&& r, Error&& error) noexcept
+                    ensure_started_receiver r, Error&& error) noexcept
                 {
                     r.state->v.template emplace<error_type>(error_type(PIKA_FORWARD(Error, error)));
                     r.state->set_predecessor_done();
                 }
 
                 friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                    ensure_started_receiver&& r) noexcept
+                    ensure_started_receiver r) noexcept
                 {
                     r.state->set_predecessor_done();
                 };
@@ -188,7 +188,7 @@ namespace pika::ensure_started_detail {
 
                 template <typename... Ts>
                 friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                    ensure_started_receiver&& r, Ts&&... ts) noexcept
+                    ensure_started_receiver r, Ts&&... ts) noexcept
                     -> decltype(std::declval<
                                     pika::detail::variant<pika::detail::monostate, value_type>>()
                                     .template emplace<value_type>(

--- a/libs/pika/executors/tests/unit/CMakeLists.txt
+++ b/libs/pika/executors/tests/unit/CMakeLists.txt
@@ -20,6 +20,8 @@ set(tests
     thread_pool_scheduler
 )
 
+set(std_thread_scheduler_PARAMETERS VALGRIND)
+
 # nvc++ causes test failures in release mode. This is assumed to be a code
 # generation bug.
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
@@ -33,8 +35,6 @@ endif()
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
-  set(${test}_PARAMETERS THREADS 4)
-
   source_group("Source Files" FILES ${sources})
 
   set(folder_name "Tests/Unit/Modules/Executors")
@@ -47,6 +47,7 @@ foreach(test ${tests})
     FOLDER ${folder_name}
   )
 
-  pika_add_unit_test("modules.executors" ${test} ${${test}_PARAMETERS})
-
+  pika_add_unit_test(
+    "modules.executors" ${test} ${${test}_PARAMETERS} THREADS 4
+  )
 endforeach()


### PR DESCRIPTION
If the `ensure_started` sender is not connected (i.e. there are no continuations) the `ensure_started_receiver` holds the last reference to the shared state. This will be released when releasing the operation state until the `ensure_started` operation state, since the `ensure_started_receiver` will be released with the operation state. This happens because the `ensure_started_receiver` is taken by rvalue reference in `set_*`. This PR changes them to take the receiver by value, ensuring that the reference count stays non-zero also after the operation state has explicitly been reset.

This is another way to fix #795 but I'm keeping that change as it doesn't hurt. Importantly, this fixes a distinct bug that is reported by valgrind in the `std_thread_scheduler` test (the test that calls `ensure_started` but drops the sender immediately). I've enabled valgrind testing with the `std_thread_scheduler_test` in this PR.