### PR TITLE
Print MPI rank in place of locality in `--pika:print-bind`

### DIFF
--- a/libs/pika/runtime/CMakeLists.txt
+++ b/libs/pika/runtime/CMakeLists.txt
@@ -44,6 +44,10 @@ set(runtime_sources
     thread_stacktrace.cpp
 )
 
+if(PIKA_WITH_MPI)
+  list(APPEND runtime_additional_module_dependencies pika_mpi_base)
+endif()
+
 include(pika_add_module)
 pika_add_module(
   pika runtime
@@ -65,5 +69,6 @@ pika_add_module(
     pika_thread_manager
     pika_timing
     pika_topology
+    ${runtime_additional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -993,7 +993,6 @@ namespace pika {
                 std::ostringstream strm;
 
                 strm << std::string(79, '*') << '\n';
-                strm << "locality: " << pika::get_locality_id() << '\n';
                 for (std::size_t i = 0; i != num_threads; ++i)
                 {
                     // print the mask for the current PU

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -37,6 +37,10 @@
 #include <pika/topology/topology.hpp>
 #include <pika/version.hpp>
 
+#if defined(PIKA_HAVE_MPI)
+# include <pika/mpi_base/mpi.hpp>
+#endif
+
 #if defined(PIKA_HAVE_TRACY)
 # include <common/TracySystem.hpp>
 #endif
@@ -993,6 +997,19 @@ namespace pika {
                 std::ostringstream strm;
 
                 strm << std::string(79, '*') << '\n';
+
+#if defined(PIKA_HAVE_MPI)
+                int mpi_initialized = 0;
+                if (MPI_Initialized(&mpi_initialized) == MPI_SUCCESS && mpi_initialized)
+                {
+                    int rank = 0;
+                    if (MPI_Comm_rank(MPI_COMM_WORLD, &rank) == MPI_SUCCESS)
+                    {
+                        strm << "MPI rank: " << rank << '\n';
+                    }
+                }
+#endif
+
                 for (std::size_t i = 0; i != num_threads; ++i)
                 {
                     // print the mask for the current PU


### PR DESCRIPTION
Until now we've been printing the locality in `--pika:print-bind` but it's always zero. This changes it to print the MPI rank (if pika was compiled with MPI support).