### PR TITLE
Print warning message if `--pika:process-mask` is used on macOS

### DIFF
--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -129,15 +129,15 @@ namespace pika::detail {
         if (!mask_string.empty())
         {
             fmt::print(std::cerr,
-                "Explicit process mask is set with --pika:process-mask, but thread binding is not "
-                "supported on macOS. The process mask will be ignored.");
+                "Explicit process mask is set with --pika:process-mask or PIKA_PROCESS_MASK, but "
+                "thread binding is not supported on macOS. The process mask will be ignored.");
             mask_string = "";
         }
 #else
         if (!mask_string.empty() && !use_process_mask)
         {
             fmt::print(std::cerr,
-                "Explicit process mask is set with --pika:process-mask, but "
+                "Explicit process mask is set with --pika:process-mask or PIKA_PROCESS_MASK, but "
                 "--pika:ignore-process-mask is also set. The process mask will be ignored.\n");
         }
 #endif

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -123,12 +123,24 @@ namespace pika::detail {
             mask_string = vm["pika:process-mask"].as<std::string>();
         }
 
+#if defined(__APPLE__)
+        PIKA_UNUSED(use_process_mask);
+
+        if (!mask_string.empty())
+        {
+            fmt::print(std::cerr,
+                "Explicit process mask is set with --pika:process-mask, but thread binding is not "
+                "supported on macOS. The process mask will be ignored.");
+            mask_string = "";
+        }
+#else
         if (!mask_string.empty() && !use_process_mask)
         {
             fmt::print(std::cerr,
                 "Explicit process mask is set with --pika:process-mask, but "
                 "--pika:ignore-process-mask is also set. The process mask will be ignored.\n");
         }
+#endif
 
         return mask_string;
     }


### PR DESCRIPTION
Process masks are not supported on macOS, so print a warning message about it.