### PR TITLE
Fix handling of explicitly specified process masks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,11 +590,15 @@ jobs:
           command: |
             cd build
             ulimit -c unlimited
+            # The process_mask_flag test assumes that there are two hardware threads per core, but
+            # the ARM test environment doesn't have that
             ctest \
               -j2 \
               --timeout 500 \
               -T test \
-              -E 'tests.unit.modules.threading.condition_variable2' \
+              -E \
+            "tests.unit.modules.threading.condition_variable2|\
+            tests.unit.modules.runtime.process_mask_flag" \
               --no-compress-output \
               --output-on-failure
       - run:

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -76,7 +76,11 @@ jobs:
         shell: bash
         run: |
             cd build
+            # The process_mask_flag test assumes that there are two hardware
+            # threads per core, but the test environment only has one per core
             ctest \
               --timeout 120 \
               --output-on-failure \
-              -E tests.examples
+              -E \
+            "tests.examples|\
+            tests.unit.modules.runtime.process_mask_flag"

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -78,7 +78,8 @@ jobs:
               --exclude-regex \
             "tests.unit.modules.execution.standalone_thread_pool_executor|\
             tests.unit.modules.executors.std_thread_scheduler|\
-            tests.unit.modules.resource_partitioner.used_pus"
+            tests.unit.modules.resource_partitioner.used_pus|\
+            tests.unit.modules.runtime.process_mask_flag"
       - name: Install
         shell: bash
         run: |

--- a/libs/pika/runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/runtime/tests/unit/CMakeLists.txt
@@ -4,8 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests thread_mapper)
+set(tests process_mask_flag thread_mapper)
 
+set(process_mask_flag_PARAMETERS THREADS 2 RUN_SERIAL)
 set(thread_mapper_PARAMETERS THREADS 4)
 
 foreach(test ${tests})
@@ -22,5 +23,17 @@ foreach(test ${tests})
   )
 
   pika_add_unit_test("modules.runtime" ${test} ${${test}_PARAMETERS})
-
 endforeach()
+
+string(
+  CONCAT
+    process_mask_flag_expected_output
+    "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\), Socket L#0\\(P#0\\)(, NUMANode L#0\\(P#0\\))?, on pool \"default\"\n"
+    "   1: PU L#2\\(P#1\\), Core L#1\\(P#1\\), Socket L#0\\(P#0\\)(, NUMANode L#0\\(P#0\\))?, on pool \"default\"\n"
+    "All tests passed."
+)
+
+set_tests_properties(
+  tests.unit.modules.runtime.process_mask_flag
+  PROPERTIES PASS_REGULAR_EXPRESSION "${process_mask_flag_expected_output}"
+)

--- a/libs/pika/runtime/tests/unit/process_mask_flag.cpp
+++ b/libs/pika/runtime/tests/unit/process_mask_flag.cpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2023 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test checks that the runtime correctly converts physical pu indices to logical ones when
+// setting the process mask. This test assumes that the system has two hardware threads per core.
+//
+// The test sets an explicit mask with --pika:process-mask and prints the resulting bindings with
+// --pika:print-bind. The test runner checks that the output is as expected.
+//
+// We set the mask to 0x3 (i.e. two first bits set). This should result in two threads being created
+// by the runtime as the first to physical hardware threads are on separate cores. If the mask is
+// interpreted as logical indices the runtime will only start use one thread, as hardware threads
+// within a core are consecutive with logical indices.
+
+#include <pika/init.hpp>
+#include <pika/testing.hpp>
+
+int main(int argc, char** argv)
+{
+    pika::init_params init_args;
+    init_args.cfg = {"--pika:process-mask=0x3", "--pika:print-bind"};
+
+    pika::start(nullptr, argc, argv, init_args);
+    pika::finalize();
+    pika::stop();
+
+    PIKA_TEST(true);
+
+    return 0;
+}


### PR DESCRIPTION
Process masks come in two flavours: using physical/OS indices and logical indices. The latter is what hwloc prefers to use for most operations, while the former is what the operating system reports (and what `taskset`, `hwloc-bind --get --taskset`, and slurm masks use). In pika we deal with logical masks. When reading the mask from the process, we already convert the mask from physical to logical indices. When I did https://github.com/pika-org/pika/pull/739 I didn't take this into account and simply used the mask passed to `--pika:process-mask` directly as if it contained logical indices. This adds the conversion from physical to logical indices before the explicit mask is stored.

The physical/OS/logical terminology is what's used in the hwloc manual. It contains more information about how they're handled.

This also adds a simple test where we check that the output of `--pika:print-bind` is what we expect with the fixed indices. The test fails before these changes. The test is somewhat system specific in that it expects two hardware threads per core. We may also have to disable it e.g. for macOS.