### PR TITLE
Update branch filters for yaml linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,7 +6,14 @@
 
 name: Lint Yaml Files
 
-on: [push, pull_request]
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
 
 jobs:
   build:


### PR DESCRIPTION
Don't trigger linter on all pushes, and include merge queue branches.