### PR TITLE
Opt-in senders and receivers used for tests to newer stdexec sender and receiver concepts

### DIFF
--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -20,6 +20,8 @@
 
 struct void_sender
 {
+    using is_sender = void;
+
     template <template <typename...> class Tuple, template <typename...> class Variant>
     using value_types = Variant<Tuple<>>;
 
@@ -52,6 +54,8 @@ struct void_sender
 template <typename... Ts>
 struct error_sender
 {
+    using is_sender = void;
+
     template <template <typename...> class Tuple, template <typename...> class Variant>
     using value_types = Variant<Tuple<Ts...>>;
 
@@ -92,6 +96,8 @@ struct error_sender
 template <typename... Ts>
 struct const_reference_error_sender
 {
+    using is_sender = void;
+
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<Ts...>>;
 
@@ -126,6 +132,8 @@ struct const_reference_error_sender
 template <typename F>
 struct callback_receiver
 {
+    using is_receiver = void;
+
     std::decay_t<F> f;
     std::atomic<bool>& set_value_called;
 
@@ -160,6 +168,8 @@ struct callback_receiver
 template <typename F>
 struct error_callback_receiver
 {
+    using is_receiver = void;
+
     std::decay_t<F> f;
     std::atomic<bool>& set_error_called;
     bool expect_set_value = false;
@@ -222,6 +232,8 @@ void check_exception_ptr(std::exception_ptr eptr)
 
 struct custom_sender_tag_invoke
 {
+    using is_sender = void;
+
     std::atomic<bool>& tag_invoke_overload_called;
 
     template <template <typename...> class Tuple, template <typename...> class Variant>
@@ -251,6 +263,8 @@ struct custom_sender_tag_invoke
 
 struct custom_sender
 {
+    using is_sender = void;
+
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
     std::atomic<bool>& tag_invoke_overload_called;
@@ -290,6 +304,8 @@ struct custom_sender
 template <typename T>
 struct custom_typed_sender
 {
+    using is_sender = void;
+
     std::decay_t<T> x;
 
     std::atomic<bool>& start_called;
@@ -340,6 +356,8 @@ struct custom_sender2 : custom_sender
 template <typename T>
 struct const_reference_sender
 {
+    using is_sender = void;
+
     std::reference_wrapper<std::decay_t<T>> x;
 
     template <template <class...> class Tuple, template <class...> class Variant>
@@ -433,6 +451,8 @@ struct scheduler
 
     struct sender
     {
+        using is_sender = void;
+
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
         std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
@@ -512,6 +532,8 @@ struct scheduler2
 
     struct sender
     {
+        using is_sender = void;
+
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
         std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
@@ -614,6 +636,8 @@ namespace my_namespace {
     {
         struct sender
         {
+            using is_sender = void;
+
             template <template <class...> class Tuple, template <class...> class Variant>
             using value_types = Variant<Tuple<>>;
 
@@ -681,6 +705,8 @@ namespace my_namespace {
     template <typename... Ts>
     struct my_sender
     {
+        using is_sender = void;
+
         template <template <typename...> class Tuple, template <typename...> class Variant>
         using value_types = Variant<Tuple<Ts...>>;
 


### PR DESCRIPTION
Add `using is_receiver = void` and `using is_sender = void`.