### PR TITLE
Use the `NUM_PROCS` variable provided by the custom cscs build gitlab-runner

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -6,6 +6,8 @@ ARG BUILD_DIR
 
 ARG CMAKE_COMMON_FLAGS
 ARG CMAKE_FLAGS
+# Provided by the gitlab runner of .container-builder
+ARG NUM_PROCS
 
 COPY . ${SOURCE_DIR}
 
@@ -15,6 +17,6 @@ RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
 
 # Run compile only tests and tests.unit.build
 RUN spack build-env $spack_spec -- bash -c "ctest -L COMPILE_ONLY --test-dir ${BUILD_DIR} \
-    --verbose -j$(nproc) --timeout 30 --output-on-failure --no-compress-output -R tests \
-    && ctest --test-dir ${BUILD_DIR} --verbose -j$(nproc) --timeout 15 --output-on-failure \
+    --verbose -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests \
+    && ctest --test-dir ${BUILD_DIR} --verbose -j${NUM_PROCS} --timeout 15 --output-on-failure \
     --no-compress-output -R tests.unit.build"


### PR DESCRIPTION
Fix #816

CSCS's `.container-builder` is actually setting a default of build arguments for the dockerfile provided. I simply added `NUM_PROCS` as an argument in our dockerfile to be able to use it. I also set a default argument in case we want to build the dockerfile locally.