### PR TITLE
Update error message when connect requires a movable sender

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -446,8 +446,8 @@ namespace pika::ensure_started_detail {
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The ensure_started sender is not copyable and thus "
-                "not l-value connectable. Make sure you are passing an r-value reference of the "
-                "sender.");
+                "not l-value connectable. Make sure you are passing a non-const r-value reference "
+                "of the sender.");
         }
     };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -280,8 +280,8 @@ namespace pika::let_error_detail {
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The let_error sender is not copyable and thus not "
-                "l-value connectable. Make sure you are passing an r-value reference of the "
-                "sender.");
+                "l-value connectable. Make sure you are passing a non-const r-value reference of "
+                "the sender.");
         }
     };
 }    // namespace pika::let_error_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -305,8 +305,8 @@ namespace pika::let_value_detail {
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The let_value sender is not copyable and thus not "
-                "l-value connectable. Make sure you are passing an r-value reference of the "
-                "sender.");
+                "l-value connectable. Make sure you are passing a non-const r-value reference of "
+                "the sender.");
         }
     };
 }    // namespace pika::let_value_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -479,8 +479,8 @@ namespace pika::split_tuple_detail {
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The split_tuple sender is not copyable and thus not "
-                "l-value connectable. Make sure you are passing an r-value reference of the "
-                "sender.");
+                "l-value connectable. Make sure you are passing a non-const r-value reference of "
+                "the sender.");
         }
     };
 

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -730,8 +730,8 @@ namespace pika::execution::experimental {
         {
             static_assert(sizeof(R) == 0,
                 "Are you missing a std::move? unique_any_sender is not copyable and thus not "
-                "l-value connectable. Make sure you are passing an r-value reference of the "
-                "sender.");
+                "l-value connectable. Make sure you are passing a non-const r-value reference of "
+                "the sender.");
             PIKA_UNREACHABLE;
         }
 


### PR DESCRIPTION
Specify explicitly that r-value reference is not enough, a non-const r-value reference is required.