### PR TITLE
Trigger error in CI pipeline if no tests run + small changes of ctest options

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -18,6 +18,4 @@ RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
 # Run compile only tests and tests.unit.build
 RUN spack build-env $spack_spec -- bash -c "ctest --label-regex COMPILE_ONLY \
     --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output \
-    -R tests --no-tests=error \
-    && ctest --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 15 --output-on-failure \
-    --no-tests=error --no-compress-output -R tests.unit.build"
+    -R tests --no-tests=error"

--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -16,7 +16,8 @@ RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
     $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && cmake --build ${BUILD_DIR} --target all tests examples"
 
 # Run compile only tests and tests.unit.build
-RUN spack build-env $spack_spec -- bash -c "ctest -L COMPILE_ONLY --test-dir ${BUILD_DIR} \
-    -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests --no-tests=error \
+RUN spack build-env $spack_spec -- bash -c "ctest --label-regex COMPILE_ONLY \
+    --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output \
+    -R tests --no-tests=error \
     && ctest --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 15 --output-on-failure \
     --no-tests=error --no-compress-output -R tests.unit.build"

--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -17,6 +17,6 @@ RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
 
 # Run compile only tests and tests.unit.build
 RUN spack build-env $spack_spec -- bash -c "ctest -L COMPILE_ONLY --test-dir ${BUILD_DIR} \
-    -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests \
+    -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests --no-tests=error \
     && ctest --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 15 --output-on-failure \
-    --no-compress-output -R tests.unit.build"
+    --no-tests=error --no-compress-output -R tests.unit.build"

--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -17,6 +17,6 @@ RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
 
 # Run compile only tests and tests.unit.build
 RUN spack build-env $spack_spec -- bash -c "ctest -L COMPILE_ONLY --test-dir ${BUILD_DIR} \
-    --verbose -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests \
-    && ctest --test-dir ${BUILD_DIR} --verbose -j${NUM_PROCS} --timeout 15 --output-on-failure \
+    -j${NUM_PROCS} --timeout 30 --output-on-failure --no-compress-output -R tests \
+    && ctest --test-dir ${BUILD_DIR} -j${NUM_PROCS} --timeout 15 --output-on-failure \
     --no-compress-output -R tests.unit.build"

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -24,5 +24,5 @@ clang14_debug_test_pika-ci-image:
     - clang14_debug_build_pika-ci-image
   image: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA
   script:
-    - ctest --test-dir ${BUILD_DIR} --verbose -j$(nproc) --timeout 120 --output-on-failure \
+    - ctest --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure \
       --no-compress-output -R tests

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -25,4 +25,4 @@ clang14_debug_test_pika-ci-image:
   image: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA
   script:
     - ctest --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure \
-      --no-compress-output -R tests
+      --no-compress-output --no-tests=error -R tests

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -69,5 +69,5 @@ gcc11_debug_test:
     - gcc11_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} --verbose -j$(nproc) --timeout 120 --output-on-failure --no-compress-output -R tests --exclude-regex tests.unit.build"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error -R tests --exclude-regex tests.unit.build"
   image: $PERSIST_IMAGE_NAME


### PR DESCRIPTION
Based on #814 
Fixes #829

- `ctest` now returns an error in case no tests are run.
- Removes `--verbose` option from `ctest` as `--output-on-failure` is sufficient.
- Make `-L` more exhaustive.