### PR TITLE
Remove unnecessary ctest command line arguments from GCC 11 pipeline config

### DIFF
--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -69,5 +69,5 @@ gcc11_debug_test:
     - gcc11_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error -R tests --exclude-regex tests.unit.build"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME


### PR DESCRIPTION
`-R tests` is unecessary because all tests contain `tests` already, and `--exclude-regex tests.unit.build` is unnecessary because the build unit tests are only build targets, not tests (https://github.com/pika-org/pika/pull/830#issuecomment-1784777396).

@aurianer this would be useful to include in the other configurations in #835.