### PR TITLE
Fix more lifetime bugs in `split`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -297,12 +297,8 @@ namespace pika::ensure_started_detail {
 
                 if (continuation)
                 {
-                    // We move the continuation to a local variable to release it once the
-                    // continuation has been called. We cannot call reset on continuation after the
-                    // invocation because the shared state may already be released by the
-                    // continuation itself.
-                    auto continuation_local = PIKA_MOVE(continuation.value());
-                    continuation_local();
+                    continuation.value()();
+                    continuation.reset();
                 }
             }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -297,13 +297,8 @@ namespace pika::split_detail {
 
                 if (!continuations.empty())
                 {
-                    // We move the continuations to a local variable to
-                    // release them once all continuations have been called.
-                    // We cannot call clear on continuations after the loop
-                    // because the shared state may already be released by
-                    // the last continuation to run.
-                    auto continuations_local = PIKA_MOVE(continuations);
-                    for (auto const& continuation : continuations_local) { continuation(); }
+                    for (auto const& continuation : continuations) { continuation(); }
+                    continuations.clear();
                 }
             }
 

--- a/libs/pika/execution/tests/regressions/CMakeLists.txt
+++ b/libs/pika/execution/tests/regressions/CMakeLists.txt
@@ -20,6 +20,6 @@ foreach(test ${tests})
   )
 
   pika_add_regression_test(
-    "modules.execution" ${test} ${${test}_PARAMETERS} THREADS 4
+    "modules.execution" ${test} ${${test}_PARAMETERS} THREADS 4 VALGRIND
   )
 endforeach()

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -26,26 +26,6 @@ set(tests
     scheduler_queries
 )
 
-set(algorithm_bulk_PARAMETERS VALGRIND)
-set(algorithm_drop_operation_state_PARAMETERS VALGRIND)
-set(algorithm_drop_value_PARAMETERS VALGRIND)
-set(algorithm_ensure_started_PARAMETERS VALGRIND)
-set(algorithm_execute_PARAMETERS VALGRIND)
-set(algorithm_just_PARAMETERS VALGRIND)
-set(algorithm_let_error_PARAMETERS VALGRIND)
-set(algorithm_let_value_PARAMETERS VALGRIND)
-set(algorithm_split_PARAMETERS VALGRIND)
-set(algorithm_split_tuple_PARAMETERS VALGRIND)
-set(algorithm_start_detached_PARAMETERS VALGRIND)
-set(algorithm_sync_wait_PARAMETERS VALGRIND)
-set(algorithm_then_PARAMETERS VALGRIND)
-set(algorithm_transfer_PARAMETERS VALGRIND)
-set(algorithm_transfer_just_PARAMETERS VALGRIND)
-set(algorithm_unpack_PARAMETERS VALGRIND)
-set(algorithm_when_all_PARAMETERS VALGRIND)
-set(algorithm_when_all_vector_PARAMETERS VALGRIND)
-set(scheduler_queries_PARAMETERS VALGRIND)
-
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
@@ -64,6 +44,6 @@ foreach(test ${tests})
   target_link_libraries(${test}_test PRIVATE pika_execution_test_utilities)
 
   pika_add_unit_test(
-    "modules.execution" ${test} ${${test}_PARAMETERS} THREADS 4
+    "modules.execution" ${test} ${${test}_PARAMETERS} THREADS 4 VALGRIND
   )
 endforeach()


### PR DESCRIPTION
Enables valgrind testing for all of the `execution` module. Description of the bug in https://github.com/pika-org/pika/commit/3291a045f9644591e97e2fe9d0c50f6f59fab5a6. The bug is very timing dependent and I can't think of a way to reproduce it with a unit test. However, for the record, here is a reproducer that triggers the problem easily: https://github.com/msimberg/pika/tree/split-continuation-clear-valgrind-reproducer. It relies on adding sleeps inside the implementation.

With these changes I've also cleaned up both `split` and `ensure_started`'s handling of clearing continuations, since in both cases the receiver holds a reference to the shared state now.