### PR TITLE
Opt-in `threading`, `threading_base`, and `topology` modules to valgrind testing

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -70,6 +70,9 @@ jobs:
               tests.{regressions,unit}.modules.execution \
               tests.unit.modules.execution_base \
               tests.unit.modules.tag_invoke \
+              tests.unit.modules.threading \
+              tests.{regressions,unit}.modules.threading_base \
+              tests.unit.modules.topology \
               std_thread_scheduler_test
       - name: Test
         shell: bash

--- a/libs/pika/threading/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading/tests/unit/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach(test ${threading_tests})
     FOLDER "Tests/Unit/Modules/Threading"
   )
 
-  pika_add_unit_test("modules.threading" ${test} ${${test}_PARAMETERS})
+  pika_add_unit_test("modules.threading" ${test} ${${test}_PARAMETERS} VALGRIND)
 
 endforeach()
 

--- a/libs/pika/threading_base/tests/regressions/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/regressions/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(test ${tests})
   )
 
   pika_add_regression_test(
-    "modules.threading_base" ${test} ${${test}_PARAMETERS}
+    "modules.threading_base" ${test} ${${test}_PARAMETERS} VALGRIND
   )
 endforeach()

--- a/libs/pika/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/unit/CMakeLists.txt
@@ -25,7 +25,9 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/ThreadingBase"
   )
 
-  pika_add_unit_test("modules.threading_base" ${test} ${${test}_PARAMETERS})
+  pika_add_unit_test(
+    "modules.threading_base" ${test} ${${test}_PARAMETERS} VALGRIND
+  )
 endforeach()
 
 if(PIKA_WITH_APEX)

--- a/libs/pika/topology/tests/unit/CMakeLists.txt
+++ b/libs/pika/topology/tests/unit/CMakeLists.txt
@@ -18,5 +18,5 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/Topology"
   )
 
-  pika_add_unit_test("modules.topology" ${test} ${${test}_PARAMETERS})
+  pika_add_unit_test("modules.topology" ${test} ${${test}_PARAMETERS} VALGRIND)
 endforeach()


### PR DESCRIPTION
No issues reported locally, so simply enabling testing in CI.