### PR TITLE
Set maximum number of threads for GitHub actions Linux tests dynamically, take two

### DIFF
--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -41,7 +41,7 @@ jobs:
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_HEADERS=OFF \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_PARALLEL_TESTS_BIND_NONE=ON
       - name: Build
         shell: bash

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -47,7 +47,7 @@ jobs:
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS_HEADERS=OFF \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -50,7 +50,7 @@ jobs:
                 -DPIKA_WITH_TESTS_BENCHMARKS=ON \
                 -DPIKA_WITH_TESTS_REGRESSIONS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -47,7 +47,7 @@ jobs:
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS_HEADERS=OFF \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -47,7 +47,7 @@ jobs:
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -77,7 +77,7 @@ jobs:
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -50,7 +50,7 @@ jobs:
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS_EXTERNAL_BUILD=OFF \
                 -DPIKA_WITH_TESTS_HEADERS=OFF \
-                -DPIKA_WITH_TESTS_MAX_THREADS=$(grep ^"core id" /proc/cpuinfo | sort -u | wc -l) \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
                 -DPIKA_WITH_VALGRIND=ON \
                 -DPIKA_WITH_TESTS_VALGRIND=ON \
                 -DPIKA_WITH_TESTS_VALGRIND_OPTIONS="--error-exitcode=1;--leak-check=full;--fair-sched=yes;--gen-suppressions=all;--suppressions=$PWD/tools/valgrind/memcheck.supp" \


### PR DESCRIPTION
C.f. #842. Use processing units, not cores, as the maximum number of threads in tests because they are what `hardware_concurrency` report, and the actual maximum pika supports ignoring real oversubscription.