### PR TITLE
Enable valgrind testing for `functional` module

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -69,6 +69,7 @@ jobs:
               tests.unit.modules.errors \
               tests.{regressions,unit}.modules.execution \
               tests.unit.modules.execution_base \
+              tests.{regressions,unit}.modules.functional \
               tests.unit.modules.tag_invoke \
               tests.unit.modules.threading \
               tests.{regressions,unit}.modules.threading_base \

--- a/libs/pika/functional/tests/regressions/CMakeLists.txt
+++ b/libs/pika/functional/tests/regressions/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(test ${function_tests})
     FOLDER "Tests/Regressions/Modules/Functional"
   )
 
-  pika_add_regression_test("modules.functional" ${test} ${${test}_PARAMETERS})
+  pika_add_regression_test("modules.functional" ${test} VALGRIND)
 endforeach()
 
 if(PIKA_WITH_COMPILE_ONLY_TESTS)

--- a/libs/pika/functional/tests/unit/CMakeLists.txt
+++ b/libs/pika/functional/tests/unit/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(test ${function_tests})
     FOLDER "Tests/Unit/Modules/Functional"
   )
 
-  pika_add_unit_test("modules.functional" ${test})
+  pika_add_unit_test("modules.functional" ${test} VALGRIND)
 
 endforeach()
 


### PR DESCRIPTION
I have 2 errors locally for both `test_empty_ref()` and `test_exception()` in the unit test `functional_test`