### PR TITLE
Remove `CSCS_REBUILD_POLICY` always

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -20,4 +20,3 @@ base_spack_image:
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_COMMIT"]'
-    CSCS_REBUILD_POLICY: always


### PR DESCRIPTION
I committed this when I added the rm on the tarball (with the spack commit unchanged), but this doesn't need to be here, we only need this step to run when the `SPACK_COMMIT` is changing now