### PR TITLE
Don't create more streams than required in `cuda_pool`

### DIFF
--- a/libs/pika/async_cuda/src/cuda_pool.cpp
+++ b/libs/pika/async_cuda/src/cuda_pool.cpp
@@ -9,6 +9,7 @@
 #include <pika/async_cuda/cuda_stream.hpp>
 #include <pika/concurrency/cache_line_data.hpp>
 #include <pika/coroutines/thread_enums.hpp>
+#include <pika/runtime/runtime_fwd.hpp>
 #include <pika/threading_base/thread_num_tss.hpp>
 #include <pika/topology/topology.hpp>
 
@@ -20,7 +21,8 @@ namespace pika::cuda::experimental {
     cuda_pool::streams_holder::streams_holder(int device, std::size_t num_streams_per_thread,
         pika::execution::thread_priority priority, unsigned int flags)
       : num_streams_per_thread(num_streams_per_thread)
-      , concurrency(pika::threads::detail::hardware_concurrency())
+      , concurrency(pika::get_runtime_ptr() ? pika::get_num_worker_threads() :
+                                              pika::threads::detail::hardware_concurrency())
       , streams(num_streams_per_thread * concurrency, cuda_stream{device, priority, flags})
       , active_stream_indices(concurrency, {0})
     {


### PR DESCRIPTION
Create number of streams based on `get_num_worker_threads` if the runtime is up, otherwise fall back to `hardware_concurrency`. This is intended to work around issues with HIP event creation being significantly slower if many streams are created. E.g. on an AMD EPYC system with 128 hardware threads (`hardware_concurrency == 128`) the `cuda_pool` would create `(3 + 3) * hardware_concurrency = 768` streams per rank, even if the runtime is only started with e.g. 8 threads (8 ranks per node, without hyperthreading). If the actual number of runtime threads is used, the number of threads created is instead 48. This can significantly improve performance if many kernels are submitted.

The `cuda_pool` still falls back to using `hardware_concurrency` if it's created before the pika runtime is started.