### PR TITLE
Print spack spec in CSCS CI pika building step

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -11,6 +11,9 @@ ARG NUM_PROCS
 
 COPY . ${SOURCE_DIR}
 
+# Print spack spec since not printed if the compiler image is found on jfrog
+RUN spack spec -lI $spack_spec
+
 # Configure & Build
 RUN spack build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
     $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && cmake --build ${BUILD_DIR} --target all tests examples"


### PR DESCRIPTION
In case the compiler image is already up-to-date on jfrog, this image is used and the spec is not printed, I find it handy to have it printed in the pika build step too