### PR TITLE
Reduce test parallelism in CI to `$(nproc)/2`

### DIFF
--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -69,5 +69,5 @@ clang11_debug_test:
     - clang11_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -73,5 +73,5 @@ clang12_debug_test:
     - clang12_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -70,5 +70,5 @@ clang13_debug_test:
     - clang13_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -68,5 +68,5 @@ clang15_debug_test:
     - clang15_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -68,5 +68,5 @@ clang16_debug_test:
     - clang16_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -69,5 +69,5 @@ gcc11_debug_test:
     - gcc11_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -68,5 +68,5 @@ gcc12_debug_test:
     - gcc12_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -70,5 +70,5 @@ gcc13_debug_test:
     - gcc13_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -69,5 +69,5 @@ gcc9_debug_test:
     - gcc9_debug_build
   script:
     - spack arch
-    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(nproc) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+    - spack build-env $spack_spec -- bash -c "ctest --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
   image: $PERSIST_IMAGE_NAME


### PR DESCRIPTION
As pointed by @msimberg the timeout in the binary semaphore tests might be due to oversubscription, this PR is an attemps to fix that