### PR TITLE
Update gpu machines common pipeline CSCS CI

### DIFF
--- a/.gitlab/includes/common_pipeline.yml
+++ b/.gitlab/includes/common_pipeline.yml
@@ -36,7 +36,19 @@ variables:
     - .test_common
     - .container-runner-daint-mc
 
-.test_common_gpu:
+.test_common_gpu_daint_cuda:
   extends:
     - .test_common
     - .container-runner-daint-gpu
+  variables:
+    SLURM_PARTITION: normal
+
+.test_common_gpu_clariden_cuda:
+  extends:
+    - .test_common
+    - .container-runner-clariden-a100
+
+.test_common_gpu_clariden_hip:
+  extends:
+    - .test_common
+    - .container-runner-clariden-mi200


### PR DESCRIPTION
As I have several draft PR open in parallel that would be nice to have this on main so that they can all use it
`test_common_gpu` was not used yet so it doesn't have an impact