### PR TITLE
Add `PIKA_WITH_PARALLEL_TESTS_BIND_NONE` in CSCS CI

### DIFF
--- a/.gitlab/includes/common_pipeline.yml
+++ b/.gitlab/includes/common_pipeline.yml
@@ -22,7 +22,8 @@ variables:
     CMAKE_COMMON_FLAGS: "-GNinja -DPIKA_WITH_COMPILER_WARNINGS=ON \
                          -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                          -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON \
-                         -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON"
+                         -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON \
+                         -DPIKA_WITH_PARALLEL_TESTS_BIND_NONE=ON"
 
 .test_common:
   variables:


### PR DESCRIPTION
It was enabled by default in `ctest.cmake` in jenkins (cf https://github.com/pika-org/pika/blob/main/.jenkins/cscs/ctest.cmake#L69)