### PR TITLE
Fix minor cmake var use when undefined problem

### DIFF
--- a/cmake/pika_add_test.cmake
+++ b/cmake/pika_add_test.cmake
@@ -55,13 +55,13 @@ function(pika_add_test category name)
   endif()
 
   set(args "--pika:threads=${${name}_THREADS}")
-  if(${PIKA_WITH_TESTS_DEBUG_LOG})
+  if(PIKA_WITH_TESTS_DEBUG_LOG)
     set(args ${args}
              "--pika:debug-pika-log=${PIKA_WITH_TESTS_DEBUG_LOG_DESTINATION}"
     )
   endif()
 
-  if(${PIKA_WITH_PARALLEL_TESTS_BIND_NONE}
+  if(PIKA_WITH_PARALLEL_TESTS_BIND_NONE
      AND NOT run_serial
      AND NOT "${name}_RUNWRAPPER"
   )


### PR DESCRIPTION
When reusing some pika cmake macros in another project, I noticed a couple of places where variables are dereferenced when possibly unused, these should be used 'bare' to avoid errors