### PR TITLE
Update spack commit to use patched version of fmt 10 for clang CUDA CSCS CI configuration

### DIFF
--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -14,7 +14,7 @@ include:
     BUILD_TYPE: Debug
     COMPILER: clang@14.0.6
     CXXSTD: 17
-    SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD ^fmt@9 \
+    SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
                  ^boost@1.79.0 ^cuda@11.5.0 +allow-unsupported-compilers ^hwloc@2.7.0"
 
 clang14_cuda11_spack_image:

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: 495252f7f6f1e51842ccf37a44b8bf2c8ddb8950
+  SPACK_COMMIT: 27c0dab5ca1944d686894f17e2a05bc7ddac3061
 
 base_spack_image:
   stage: spack_base


### PR DESCRIPTION
Includes https://github.com/spack/spack/pull/41578.