### PR TITLE
Push performance benchmark data to elastic database

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -17,9 +17,11 @@ RUN apt-get update && apt-get -yqq install --no-install-recommends \
     gcc \
     git \
     gnupg2 \
+    jq \
     libtool \
     locales \
     m4 \
+    moreutils \
     openssl \
     pkgconf \
     python3 \

--- a/.gitlab/docker/Dockerfile.spack_build_performance
+++ b/.gitlab/docker/Dockerfile.spack_build_performance
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG SOURCE_DIR
+ARG BUILD_DIR
+
+ARG CMAKE_COMMON_FLAGS
+ARG CMAKE_FLAGS
+# Provided by the gitlab runner of .container-builder
+ARG NUM_PROCS
+
+COPY . ${SOURCE_DIR}
+
+# Configure & Build
+RUN spack build-env $spack_spec -- bash -c \
+    "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
+    $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && \
+    cmake --build ${BUILD_DIR} -j ${NUM_PROCS} --target task_overhead_report_test task_size_test"

--- a/.gitlab/includes/performance_gcc13_pipeline.yml
+++ b/.gitlab/includes/performance_gcc13_pipeline.yml
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include:
+  - local: '.gitlab/includes/common_pipeline.yml'
+  - local: '.gitlab/includes/common_spack_pipeline.yml'
+
+.variables_performance_gcc13_config:
+  variables:
+    ARCH: linux-ubuntu22.04-broadwell
+    BUILD_TYPE: Release
+    COMPILER: gcc@13.1.0
+    CXXSTD: 20
+    SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=mimalloc cxxstd=$CXXSTD \
+                 ^boost@1.83.0 ^hwloc@2.9.1"
+
+performance_gcc13_spack_image:
+  stage: spack_configs
+  needs: [base_spack_image]
+  extends:
+    - .container-builder
+    - .variables_performance_gcc13_config
+  before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
+    - compiler=${COMPILER/@/-}
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+  variables:
+    DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
+  artifacts:
+    reports:
+      dotenv: compiler.env
+
+performance_gcc13_release_build:
+  stage: build
+  extends:
+    - .container-builder
+    - .variables_performance_gcc13_config
+    - .cmake_variables_common
+  needs:
+    - performance_gcc13_spack_image
+  before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
+    - configuration=${configuration//-D/}
+    - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG
+    - echo -e "CMAKE_FLAGS=$CMAKE_FLAGS" >> build.env
+    - echo -e "PERSIST_IMAGE_NAME=$PERSIST_IMAGE_NAME" >> build.env
+  variables:
+    DOCKERFILE: .gitlab/docker/Dockerfile.spack_build_performance
+    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD"
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE","SOURCE_DIR","BUILD_DIR","CMAKE_COMMON_FLAGS","CMAKE_FLAGS"]'
+  artifacts:
+    reports:
+      dotenv: build.env
+
+performance_gcc13_release_test:
+  extends:
+    - .variables_performance_gcc13_config
+    - .test_common_mc
+    - .cmake_variables_common
+  needs:
+    - performance_gcc13_release_build
+  image: $PERSIST_IMAGE_NAME
+  script:
+    - export MIMALLOC_EAGER_COMMIT_DELAY=0
+    - export MIMALLOC_LARGE_OS_PAGES=1
+    - "${SOURCE_DIR}/.gitlab/scripts/run_performance_benchmarks.sh"

--- a/.gitlab/pipeline.yml
+++ b/.gitlab/pipeline.yml
@@ -18,3 +18,4 @@ include:
   - local: '.gitlab/includes/clang14_cuda11_pipeline.yml'
   - local: '.gitlab/includes/clang15_pipeline.yml'
   - local: '.gitlab/includes/clang16_pipeline.yml'
+  - local: '.gitlab/includes/performance_gcc13_pipeline.yml'

--- a/.gitlab/scripts/run_performance_benchmarks.sh
+++ b/.gitlab/scripts/run_performance_benchmarks.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set -euo pipefail
+
+function submit_performance_result {
+    echo Submitting performance result to logstash:
+    jq . "${1}"
+
+    curl \
+        --request POST \
+        --header "Content-Type: application/json" \
+        --data "@${1}" \
+        "${CSCS_LOGSTASH_URL}"
+}
+
+function json_merge {
+    # Merge json files according to
+    # https://stackoverflow.com/questions/19529688/how-to-merge-2-json-objects-from-2-files-using-jq
+    #
+    # --slurp adds all the objects from different files into an array, and add merges the objects
+    # --sort-keys is used only to always have the keys in the same order
+    echo $(jq --slurp --sort-keys add "${1}" "${2}") > "${3}"
+}
+
+function json_add_value {
+    file=${1}
+    key=${2}
+    value=${3}
+
+    jq --arg value "${value}" ".${key} += \$value" "${file}" | sponge "${file}"
+}
+
+function json_add_value_json {
+    file=${1}
+    key=${2}
+    value=${3}
+
+    jq --argjson value "${value}" ".${key} += \$value" "${file}" | sponge "${file}"
+}
+
+function json_add_from_env {
+    file=${1}
+    key=${2}
+
+    for var in ${@:3}; do
+        jq --arg value "${!var:-}" ".${key}.${var} += \$value" "${file}" | sponge "${file}"
+    done
+}
+
+function json_add_from_command {
+    file=${1}
+    key=${2}
+
+    for cmd in ${@:3}; do
+        jq --arg value "$(${cmd})" ".${key}.${cmd} += \$value" "${file}" | sponge "${file}"
+    done
+}
+
+metadata_file=$(mktemp --tmpdir metadata.XXXXXXXXXX.json)
+echo '{}' > "${metadata_file}"
+
+# Logstash data stream metadata section
+json_add_value "${metadata_file}" "data_stream.type" "logs"
+json_add_value "${metadata_file}" "data_stream.dataset" "service.pika"
+json_add_value "${metadata_file}" "data_stream.namespace" "alps"
+
+# CI/git metadata section
+json_add_value "${metadata_file}" "ci.organization" "pika-org"
+json_add_value "${metadata_file}" "ci.repository" "pika"
+json_add_from_env \
+    "${metadata_file}" "ci" \
+    CI_COMMIT_AUTHOR \
+    CI_COMMIT_BRANCH \
+    CI_COMMIT_DESCRIPTION \
+    CI_COMMIT_MESSAGE \
+    CI_COMMIT_SHA \
+    CI_COMMIT_SHORT_SHA \
+    CI_COMMIT_TIMESTAMP \
+    CI_COMMIT_TITLE \
+    CI_JOB_IMAGE
+
+# System section
+json_add_from_command "${metadata_file}" "system" "hostname"
+
+# Slurm section
+json_add_from_env \
+    "${metadata_file}" "slurm" \
+    SLURM_CLUSTER_NAME \
+    SLURM_CPUS_ON_NODE \
+    SLURM_CPU_BIND \
+    SLURM_JOBID \
+    SLURM_JOB_NAME \
+    SLURM_JOB_NODELIST \
+    SLURM_JOB_NUM_NODES \
+    SLURM_JOB_PARTITION \
+    SLURM_NODELIST \
+    SLURM_NTASKS \
+    SLURM_TASKS_PER_NODE
+
+# Build configuration section
+json_add_from_env \
+    "${metadata_file}" "build_configuration" \
+    ARCH \
+    BUILD_TYPE \
+    CMAKE_COMMON_FLAGS \
+    CMAKE_FLAGS \
+    COMPILER \
+    SPACK_COMMIT \
+    SPACK_SPEC
+
+pika_targets=(
+"task_overhead_report_test"
+"task_size_test"
+)
+pika_test_options=(
+"--pika:ini=pika.thread_queue.init_threads_count=100 \
+--pika:queuing=local-priority \
+--repetitions=100 \
+--tasks=500000"
+
+"--tasks-per-thread=10000 \
+--task-size-growth-factor=1.01 \
+--target-efficiency=0.95 \
+--perftest-json")
+
+index=0
+for executable in "${pika_targets[@]}"; do
+    test_opts=${pika_test_options[$index]}
+    raw_result_file=$(mktemp --tmpdir "${executable}_raw.XXXXXXXXXX.json")
+    result_file=$(mktemp --tmpdir "${executable}_raw.XXXXXXXXXX.json")
+    echo '{}' > "${result_file}"
+
+    "${BUILD_DIR}/bin/${executable}" ${test_opts[@]} > "${raw_result_file}"
+
+    # Append command and command line options
+    json_add_value "${result_file}" "metric.benchmark.command" "${executable}"
+    json_add_value "${result_file}" "metric.benchmark.command_options" "${test_opts}"
+
+    # Extract name and timing data from raw result file
+    benchmark_name=$(jq '.outputs[0].name' "${raw_result_file}")
+    benchmark_series=$(jq '.outputs[0].series' "${raw_result_file}")
+    json_add_value_json "${result_file}" "metric.benchmark.name" "${benchmark_name}"
+    json_add_value_json "${result_file}" "metric.benchmark.series" "${benchmark_series}"
+
+    json_merge "${metadata_file}" "${result_file}" "${result_file}"
+    submit_performance_result "${result_file}"
+
+    index=$((index + 1))
+done


### PR DESCRIPTION
Pushes performance benchmark data to elastic (via logstash). The json blob that is sent is structured as follows:
```
{
  "build_configuration": {
    "ARCH": "linux-ubuntu22.04-broadwell",
    "BUILD_TYPE": "Release",
    "CMAKE_COMMON_FLAGS": "-GNinja -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_PARALLEL_TESTS_BIND_NONE=ON",
    "CMAKE_FLAGS": "",
    "COMPILER": "gcc@13.1.0",
    "SPACK_COMMIT": "27c0dab5ca1944d686894f17e2a05bc7ddac3061",
    "SPACK_SPEC": "pika@main arch=linux-ubuntu22.04-broadwell %gcc@13.1.0 malloc=mimalloc cxxstd=20 ^boost@1.83.0 ^hwloc@2.9.1"
  },
  "ci": {
    "CI_COMMIT_AUTHOR": "Mikael Simberg <mikael.simberg@iki.fi>",
    "CI_COMMIT_BRANCH": "__CSCSCI__pr891",
    "CI_COMMIT_DESCRIPTION": "",
    "CI_COMMIT_MESSAGE": "Add CSCS CI job to submit benchmark data to elasticsearch\n",
    "CI_COMMIT_SHA": "12399ef6cd1d27043fbbbecc6f3829ad420dde27",
    "CI_COMMIT_SHORT_SHA": "12399ef6",
    "CI_COMMIT_TIMESTAMP": "2023-12-18T11:51:57+01:00",
    "CI_COMMIT_TITLE": "Add CSCS CI job to submit benchmark data to elasticsearch",
    "CI_JOB_IMAGE": "...",
    "organization": "pika-org",
    "repository": "pika"
  },
  "data_stream": {
    "dataset": "service.pika",
    "namespace": "alps",
    "type": "logs"
  },
  "metric": {
    "benchmark": {
      "command": "task_size_test",
      "command_options": "--tasks-per-thread=10000 --task-size-growth-factor=1.01 --target-efficiency=0.95 --perftest-json",
      "name": "task_size - thread_pool_scheduler",
      "series": [
        0.000144773
      ]
    }
  },
  "slurm": {
    "SLURM_CLUSTER_NAME": "...",
    "SLURM_CPUS_ON_NODE": "...",
    "SLURM_CPU_BIND": "...",
    "SLURM_JOBID": "...",
    "SLURM_JOB_NAME": "...",
    "SLURM_JOB_NODELIST": "...",
    "SLURM_JOB_NUM_NODES": "...",
    "SLURM_JOB_PARTITION": "...",
    "SLURM_NODELIST": "...",
    "SLURM_NTASKS": "...",
    "SLURM_TASKS_PER_NODE": "..."
  },
  "system": {
    "hostname": "..."
  }
}
```
The idea is that metadata goes into the `build_configuration`, `slurm`, `ci`, `system` fields. `data_stream` defines the stream that elastic will use for indexing. `metric` contains the actual output of whatever metric we care about in a particular case. A stream can not contain different types of data in the same fields, but not all fields need to be present in the document. This means that we can extend this to later have e.g. `metric.tests` to contain test statistics and it won't collide with the benchmark field. We might also consider having a `metric.generic` field or similar for simple key-value metrics that don't fit nicely into other categories. In this first iteration, however, I'm only pushing benchmarking data which consists of:
- an executable
- command line options
- a test name
- timings (in an array of floats, each entry is one repetition)