### PR TITLE
Put CSCS CI base images into `/base` namespace to avoid cleanup

### DIFF
--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -26,7 +26,7 @@ clang11_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -26,7 +26,7 @@ clang12_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -27,7 +27,7 @@ clang13_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -27,7 +27,7 @@ clang14_cuda11_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -26,7 +26,7 @@ clang15_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -26,7 +26,7 @@ clang16_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -26,7 +26,7 @@ gcc11_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -27,7 +27,7 @@ gcc12_cuda12_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -26,7 +26,7 @@ gcc12_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -27,7 +27,7 @@ gcc13_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -26,7 +26,7 @@ gcc9_cuda11_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -26,7 +26,7 @@ gcc9_spack_image:
   before_script:
     - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler:$CONFIG_TAG
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
     - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
     BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT


### PR DESCRIPTION
See https://gitlab.com/cscs-ci/ci-testing/containerised_ci_doc/-/blob/main/image_cleanup.md for documentation. `/base` images are kept longer, and cleaned up only after other images are cleaned up.