### PR TITLE
Task overhead cleanup

### DIFF
--- a/.jenkins/cscs-perftests/launch_perftests.sh
+++ b/.jenkins/cscs-perftests/launch_perftests.sh
@@ -11,7 +11,7 @@ set -ex
 pika_targets=("task_overhead_report_test")
 pika_test_options=(
     "--pika:ini=pika.thread_queue.init_threads_count=100 \
-    --pika:queuing=local-priority --pika:threads=4 --test-all \
+    --pika:queuing=local-priority --pika:threads=4 \
     --repetitions=100 --tasks=500000")
 
 # Build binaries for performance tests

--- a/testing/performance_testing/include/pika/testing/performance.hpp
+++ b/testing/performance_testing/include/pika/testing/performance.hpp
@@ -24,7 +24,7 @@ namespace pika::util {
         // Json output for performance reports
         class json_perf_times
         {
-            using key_t = std::tuple<std::string, std::string>;
+            using key_t = std::tuple<std::string>;
             using value_t = std::vector<double>;
             using map_t = std::map<key_t, value_t>;
 
@@ -40,7 +40,6 @@ namespace pika::util {
                     if (outputs) strm << ",";
                     strm << "\n    {\n";
                     strm << "      \"name\" : \"" << std::get<0>(item.first) << "\",\n";
-                    strm << "      \"executor\" : \"" << std::get<1>(item.first) << "\",\n";
                     strm << "      \"series\" : [";
                     int series = 0;
                     for (auto val : item.second)
@@ -60,20 +59,17 @@ namespace pika::util {
             }
 
         public:
-            void add(std::string const& name, std::string const& executor, double time)
-            {
-                m_map[key_t(name, executor)].push_back(time);
-            }
+            void add(std::string const& name, double time) { m_map[key_t(name)].push_back(time); }
         };
 
         json_perf_times& times();
 
         // Add time to the map for performance report
-        void add_time(std::string const& test_name, std::string const& executor, double time);
+        void add_time(std::string const& test_name, double time);
     }    // namespace detail
 
-    PIKA_EXPORT void perftests_report(std::string const& name, std::string const& exec,
-        const std::size_t steps, detail::function<void(void)>&& test);
+    PIKA_EXPORT void perftests_report(
+        std::string const& name, const std::size_t steps, detail::function<void(void)>&& test);
 
     PIKA_EXPORT void perftests_print_times();
 

--- a/testing/performance_testing/src/performance.cpp
+++ b/testing/performance_testing/src/performance.cpp
@@ -26,15 +26,12 @@ namespace pika::util {
             return res;
         }
 
-        void add_time(std::string const& test_name, std::string const& executor, double time)
-        {
-            times().add(test_name, executor, time);
-        }
+        void add_time(std::string const& test_name, double time) { times().add(test_name, time); }
 
     }    // namespace detail
 
-    void perftests_report(std::string const& name, std::string const& exec, const std::size_t steps,
-        detail::function<void(void)>&& test)
+    void perftests_report(
+        std::string const& name, const std::size_t steps, detail::function<void(void)>&& test)
     {
         if (steps == 0) return;
         // First iteration to cache the data
@@ -50,7 +47,7 @@ namespace pika::util {
             // default is in seconds
             auto time =
                 std::chrono::duration_cast<std::chrono::duration<double>>(timer::now() - start);
-            detail::add_time(name, exec, time.count());
+            detail::add_time(name, time.count());
         }
     }
 

--- a/tests/performance/local/task_overhead_report.cpp
+++ b/tests/performance/local/task_overhead_report.cpp
@@ -125,7 +125,6 @@ int pika_main(variables_map& vm)
         else
             numa_sensitive = 0;
 
-        bool test_all = (vm.count("test-all") > 0);
         const int repetitions = vm["repetitions"].as<int>();
 
         if (vm.count("info")) info_string = vm["info"].as<std::string>();
@@ -138,7 +137,7 @@ int pika_main(variables_map& vm)
         if (PIKA_UNLIKELY(0 == count))
             throw std::logic_error("error: count of 0 tasks specified\n");
 
-        if (test_all) { measure_function_create_thread_hierarchical_placement(count, repetitions); }
+        measure_function_create_thread_hierarchical_placement(count, repetitions);
     }
 
     pika::finalize();
@@ -159,7 +158,6 @@ int main(int argc, char* argv[])
         ("delay-iterations", value<std::uint64_t>()->default_value(0),
          "number of iterations in the delay loop")
 
-        ("test-all", "run all benchmarks")
         ("repetitions", value<int>()->default_value(1),
          "number of repetitions of the full benchmark")
 

--- a/tests/performance/local/task_overhead_report.cpp
+++ b/tests/performance/local/task_overhead_report.cpp
@@ -72,8 +72,8 @@ void measure_function_create_thread_hierarchical_placement(
     auto const num_threads = pika::get_num_worker_threads();
     pika::error_code ec;
 
-    pika::util::perftests_report("task overhead - create_thread_hierarchical - latch",
-        "no-executor", repetitions, [&]() -> void {
+    pika::util::perftests_report(
+        "task overhead - create_thread_hierarchical - latch", repetitions, [&]() -> void {
             pika::latch l(count);
 
             auto const func = [&l]() {


### PR DESCRIPTION
Separates some test cleanup that was originally part of #891.

- Remove the `--test-all` command line option from `task_overhead_report_test` since there is only one test, and it wasn't previously run by default (it is now always run)
- Remove the test-specific `executor` field from the performance test json output to allow generalization to other types of tests