### PR TITLE
Ensure CSCS CI images are rebuilt if Dockerfile or input arguments change

### DIFF
--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -24,12 +24,13 @@ clang11_spack_image:
     - .container-builder
     - .variables_clang11_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ clang11_debug_build:
   needs:
     - clang11_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -24,12 +24,13 @@ clang12_spack_image:
     - .container-builder
     - .variables_clang12_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ clang12_debug_build:
   needs:
     - clang12_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -25,12 +25,13 @@ clang13_spack_image:
     - .container-builder
     - .variables_clang13_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -46,8 +47,9 @@ clang13_debug_build:
   needs:
     - clang13_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -25,12 +25,13 @@ clang14_cuda11_spack_image:
     - .container-builder
     - .variables_clang14_cuda11_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -46,8 +47,9 @@ clang14_cuda11_debug_build:
   needs:
     - clang14_cuda11_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -24,12 +24,13 @@ clang15_spack_image:
     - .container-builder
     - .variables_clang15_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ clang15_debug_build:
   needs:
     - clang15_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -24,12 +24,13 @@ clang16_spack_image:
     - .container-builder
     - .variables_clang16_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ clang16_debug_build:
   needs:
     - clang16_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -15,8 +15,14 @@ base_spack_image:
   timeout: 2 hours
   extends: .container-builder
   before_script:
-    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-spack-base:$CONFIG_TAG
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> base.env
   variables:
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_COMMIT"]'
+  artifacts:
+    reports:
+      dotenv: base.env

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -24,12 +24,13 @@ gcc11_spack_image:
     - .container-builder
     - .variables_gcc11_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ gcc11_debug_build:
   needs:
     - gcc11_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -25,12 +25,13 @@ gcc12_cuda12_spack_image:
     - .container-builder
     - .variables_gcc12_cuda12_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -46,8 +47,9 @@ gcc12_cuda12_debug_build:
   needs:
     - gcc12_cuda12_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -24,12 +24,13 @@ gcc12_spack_image:
     - .container-builder
     - .variables_gcc12_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ gcc12_debug_build:
   needs:
     - gcc12_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -25,12 +25,13 @@ gcc13_spack_image:
     - .container-builder
     - .variables_gcc13_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -46,8 +47,9 @@ gcc13_debug_build:
   needs:
     - gcc13_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -24,12 +24,13 @@ gcc9_cuda11_spack_image:
     - .container-builder
     - .variables_gcc9_cuda11_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ gcc9_cuda11_debug_build:
   needs:
     - gcc9_cuda11_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -24,12 +24,13 @@ gcc9_spack_image:
     - .container-builder
     - .variables_gcc9_config
   before_script:
-    - CONFIG_TAG=`echo $SPACK_SPEC-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
     - compiler=${COMPILER/@/-}
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
-    - echo -e "compiler=$compiler\nBASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
   variables:
-    BASE_IMAGE: $CSCS_REGISTRY_PATH/pika-spack-base:$SPACK_COMMIT
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
   artifacts:
@@ -45,8 +46,9 @@ gcc9_debug_build:
   needs:
     - gcc9_spack_image
   before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
-    - configuration=$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG


### PR DESCRIPTION
Uses the hash of the Dockerfile and all input arguments to Dockerfile as the tag to determine if an image needs rebuilding. Split out from #891.