### PR TITLE
Update matplotlib version

### DIFF
--- a/tools/perftests_ci/requirements.txt
+++ b/tools/perftests_ci/requirements.txt
@@ -1,6 +1,6 @@
 fonttools>=4.43.0
 numpy>=1.22.2
-matplotlib
+matplotlib>=3.8.2
 pillow>=10.0.1
 python-dateutil
 lxml


### PR DESCRIPTION
The warning is not gone after requesting fonttools 3.43, I'm trying to set a minimum for matplotlib. The matplotlib version in the perftests environment is already satisfying the version requirement.