### PR TITLE
Add more task spawning methods to `task_size` performance test

### DIFF
--- a/.gitlab/scripts/run_performance_benchmarks.sh
+++ b/.gitlab/scripts/run_performance_benchmarks.sh
@@ -127,21 +127,21 @@ pika_test_options=(
 --tasks=500000"
 
 "--method=task
---tasks-per-thread=10000 \
---task-size-growth-factor=1.01 \
---target-efficiency=0.95 \
+--tasks-per-thread=1000 \
+--task-size-growth-factor=1.05 \
+--target-efficiency=0.9 \
 --perftest-json"
 
 "--method=barrier
---tasks-per-thread=10000 \
---task-size-growth-factor=1.01 \
---target-efficiency=0.95 \
+--tasks-per-thread=1000 \
+--task-size-growth-factor=1.05 \
+--target-efficiency=0.5 \
 --perftest-json"
 
 "--method=bulk
---tasks-per-thread=10000 \
---task-size-growth-factor=1.01 \
---target-efficiency=0.95 \
+--tasks-per-thread=1000 \
+--task-size-growth-factor=1.05 \
+--target-efficiency=0.5 \
 --perftest-json"
 )
 

--- a/.gitlab/scripts/run_performance_benchmarks.sh
+++ b/.gitlab/scripts/run_performance_benchmarks.sh
@@ -117,6 +117,8 @@ json_add_from_env \
 pika_targets=(
 "task_overhead_report_test"
 "task_size_test"
+"task_size_test"
+"task_size_test"
 )
 pika_test_options=(
 "--pika:ini=pika.thread_queue.init_threads_count=100 \
@@ -124,10 +126,24 @@ pika_test_options=(
 --repetitions=100 \
 --tasks=500000"
 
-"--tasks-per-thread=10000 \
+"--method=task
+--tasks-per-thread=10000 \
 --task-size-growth-factor=1.01 \
 --target-efficiency=0.95 \
---perftest-json")
+--perftest-json"
+
+"--method=barrier
+--tasks-per-thread=10000 \
+--task-size-growth-factor=1.01 \
+--target-efficiency=0.95 \
+--perftest-json"
+
+"--method=bulk
+--tasks-per-thread=10000 \
+--task-size-growth-factor=1.01 \
+--target-efficiency=0.95 \
+--perftest-json"
+)
 
 index=0
 for executable in "${pika_targets[@]}"; do

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -60,9 +60,11 @@ namespace pika::thread_pool_bulk_detail {
     class thread_pool_bulk_sender
     {
     private:
+        using shape_type = std::decay_t<Shape>;
+
         pika::execution::experimental::thread_pool_scheduler scheduler;
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
-        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
+        PIKA_NO_UNIQUE_ADDRESS shape_type shape;
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
 
     public:
@@ -161,10 +163,10 @@ namespace pika::thread_pool_bulk_detail {
                     template <typename Ts>
                     void do_work_chunk(Ts& ts, std::uint32_t const index) const
                     {
-                        auto const i_begin =
-                            static_cast<std::decay_t<Shape>>(index * task_f->chunk_size);
-                        auto const i_end = (std::min)(
-                            static_cast<std::decay_t<Shape>>((index + 1) * task_f->chunk_size),
+                        auto const i_begin = static_cast<shape_type>(index) *
+                            static_cast<shape_type>(task_f->chunk_size);
+                        auto const i_end = (std::min)((static_cast<shape_type>(index) + 1) *
+                                static_cast<shape_type>(task_f->chunk_size),
                             task_f->n);
                         for (auto i = i_begin; i < i_end; ++i)
                         {
@@ -447,7 +449,7 @@ namespace pika::thread_pool_bulk_detail {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
             std::atomic<std::decay_t<Shape>> tasks_remaining{
-                static_cast<std::decay_t<Shape>>(num_worker_threads)};
+                static_cast<shape_type>(num_worker_threads)};
             pika::util::detail::prepend_t<value_types<std::tuple, pika::detail::variant>,
                 pika::detail::monostate>
                 ts;

--- a/tests/performance/local/task_size.cpp
+++ b/tests/performance/local/task_size.cpp
@@ -16,18 +16,21 @@
 // gives reasonable parallel efficiency.
 
 #include <pika/config.hpp>
+#include <pika/barrier.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
 #include <pika/runtime.hpp>
 #include <pika/testing/performance.hpp>
 #include <pika/thread.hpp>
 
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -47,8 +50,12 @@ void task(double task_size_s) noexcept
     pika::util::yield_while([&]() { return t.elapsed() < task_size_s; }, nullptr, false);
 }
 
-void do_work(std::uint64_t tasks, double task_size_s)
+// The "task" method simply spawns total_tasks independent tasks without any special consideration
+// for grouping or affinity.
+void do_work_task(std::uint64_t tasks_per_thread, double task_size_s)
 {
+    auto const num_threads = pika::get_num_worker_threads();
+    auto const total_tasks = num_threads * tasks_per_thread;
     auto sched = ex::thread_pool_scheduler{};
     auto spawn = [=]() {
         return ex::schedule(sched) | ex::then(pika::util::detail::bind_front(task, task_size_s)) |
@@ -56,21 +63,75 @@ void do_work(std::uint64_t tasks, double task_size_s)
     };
 
     std::vector<decltype(spawn())> senders;
-    senders.reserve(tasks);
+    senders.reserve(total_tasks);
 
-    for (std::uint64_t i = 0; i < tasks; ++i) { senders.push_back(spawn()); }
+    for (std::uint64_t i = 0; i < total_tasks; ++i) { senders.push_back(spawn()); }
     tt::sync_wait(ex::when_all_vector(std::move(senders)));
+}
+
+// The "barrier" method spawns one task per worker thread and uses a barrier run the "tasks" in
+// lockstep on each worker thread.
+void do_work_barrier(std::uint64_t tasks_per_thread, double task_size_s)
+{
+    auto const num_threads = pika::get_num_worker_threads();
+    auto sched = ex::thread_pool_scheduler{};
+    pika::barrier b(num_threads);
+    auto work = [=, &b]() {
+        for (std::uint64_t i = 0; i < tasks_per_thread; ++i)
+        {
+            b.arrive_and_wait();
+            task(task_size_s);
+        }
+    };
+    auto spawn = [=]() {
+        return ex::schedule(sched) | ex::then(work) | ex::ensure_started() | ex::drop_value();
+    };
+
+    std::vector<decltype(spawn())> senders;
+    senders.reserve(num_threads);
+
+    for (std::uint64_t i = 0; i < num_threads; ++i) { senders.push_back(spawn()); }
+    tt::sync_wait(ex::when_all_vector(std::move(senders)));
+}
+
+// The "bulk" method sequences each set of num_worker_threads tasks through bulk.
+void do_work_bulk(std::uint64_t tasks_per_thread, double task_size_s)
+{
+    auto const num_threads = pika::get_num_worker_threads();
+    auto sched = ex::thread_pool_scheduler{};
+    pika::barrier b(num_threads);
+    auto work = [=](auto) { task(task_size_s); };
+
+    ex::unique_any_sender<> sender{ex::just()};
+    for (std::uint64_t i = 0; i < tasks_per_thread; ++i)
+    {
+        sender = std::move(sender) | ex::transfer(sched) | ex::bulk(num_threads, work);
+    }
+    tt::sync_wait(std::move(sender));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 int pika_main(variables_map& vm)
 {
+    auto const method = vm["method"].as<std::string>();
     auto const tasks_per_thread = vm["tasks-per-thread"].as<std::uint64_t>();
     auto const task_size_min_s = vm["task-size-min-s"].as<double>();
     auto const task_size_max_s = vm["task-size-max-s"].as<double>();
     auto const task_size_growth_factor = vm["task-size-growth-factor"].as<double>();
     auto const target_efficiency = vm["target-efficiency"].as<double>();
     auto const perftest_json = vm["perftest-json"].as<bool>();
+
+    using do_work_type = void(std::uint64_t, double);
+    do_work_type* do_work = [&]() {
+        if (method == "task") { return do_work_task; }
+        else if (method == "barrier") { return do_work_barrier; }
+        else if (method == "bulk") { return do_work_bulk; }
+        else
+        {
+            PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "task_size",
+                "--method must be \"task\", \"barrier\", or \"bulk\" ({} given)", method);
+        }
+    }();
 
     if (task_size_min_s <= 0)
     {
@@ -110,8 +171,8 @@ int pika_main(variables_map& vm)
 
     if (!perftest_json)
     {
-        fmt::print("num_threads,tasks_per_thread,task_size_s,single_threaded_reference_time,time,"
-                   "parallel_efficiency\n");
+        fmt::print("method,num_threads,tasks_per_thread,task_size_s,single_threaded_reference_time,"
+                   "time,parallel_efficiency\n");
     }
 
     double task_size_s = task_size_min_s;
@@ -121,14 +182,14 @@ int pika_main(variables_map& vm)
         double const single_threaded_reference_time = total_tasks * task_size_s;
 
         high_resolution_timer timer;
-        do_work(total_tasks, task_size_s);
+        do_work(tasks_per_thread, task_size_s);
         double time = timer.elapsed();
 
         efficiency = single_threaded_reference_time / time / num_threads;
         if (!perftest_json)
         {
-            fmt::print("{},{},{:.9f},{:.9f},{:.9f},{:.4f}\n", num_threads, tasks_per_thread,
-                task_size_s, single_threaded_reference_time, time, efficiency);
+            fmt::print("{},{},{},{:.9f},{:.9f},{:.9f},{:.4f}\n", method, num_threads,
+                tasks_per_thread, task_size_s, single_threaded_reference_time, time, efficiency);
         }
 
         task_size_s *= task_size_growth_factor;
@@ -137,7 +198,7 @@ int pika_main(variables_map& vm)
     if (perftest_json)
     {
         pika::util::detail::json_perf_times t;
-        t.add("task_size - thread_pool_scheduler", task_size_s);
+        t.add(fmt::format("task_size - thread_pool_scheduler - {}", method), task_size_s);
         std::cout << t;
     }
 
@@ -151,6 +212,7 @@ int main(int argc, char* argv[])
     options_description cmdline("usage: " PIKA_APPLICATION_STRING " [options]");
     // clang-format off
     cmdline.add_options()
+        ("method", value<std::string>()->default_value("task"), "method used to spawn tasks (\"task\", \"barrier\", or \"bulk\")")
         ("tasks-per-thread", value<std::uint64_t>()->default_value(1000), "number of tasks to invoke per thread")
         ("task-size-min-s", value<double>()->default_value(1e-6), "initial task size in seconds")
         ("task-size-max-s", value<double>()->default_value(1e-2), "maximum task size in seconds at which to stop the test")


### PR DESCRIPTION
Adds two new methods (description in the code) and pushes results to elastic. The motivation for the new methods is to stress different parts of the runtime:
- The existing "task" test generally tests the schedulers
- The "barrier" test tests how well the barrier scales
- The "bulk" test tests how well latch and general scheduling works