### PR TITLE
Use moodycamel queue also for terminated tasks in `shared_priority_queue_scheduler`

### DIFF
--- a/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
+++ b/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
@@ -1985,9 +1985,11 @@ namespace pika::concurrency::detail {
             }
 
         private:
+            // NOLINTNEXTLINE(bugprone-sizeof-expression)
             static_assert(std::alignment_of<T>::value <= sizeof(T),
                 "The queue does not support types with an alignment greater than their size at "
                 "this time");
+            // NOLINTNEXTLINE(bugprone-sizeof-expression)
             MOODYCAMEL_ALIGNED_TYPE_LIKE(char[sizeof(T) * BLOCK_SIZE], T) elements;
 
         public:

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -141,7 +141,8 @@ namespace pika::threads::detail {
         // -------------------------------------
         // terminated tasks
         // completed tasks that can be reused (stack space etc)
-        using terminated_items_type = lockfree_fifo::apply<threads::detail::thread_data*>::type;
+        using terminated_items_type =
+            concurrentqueue_fifo::apply<threads::detail::thread_data*>::type;
         terminated_items_type terminated_items_;
         mutable pika::concurrency::detail::cache_line_data<std::atomic<std::int32_t>>
             terminated_items_count_;


### PR DESCRIPTION
This improves the performance of the scheduler on systems where lockfree 128-bit atomics are not available or can't be generated. GCC 12 and older on e.g. Nvidia Grace CPUs seems to still produce lockful 128-bit atomics.