### PR TITLE
Improve `spin_k` and `yield_k` performance by pausing more

### DIFF
--- a/libs/pika/execution_base/src/this_thread.cpp
+++ b/libs/pika/execution_base/src/this_thread.cpp
@@ -104,8 +104,7 @@ namespace pika::execution {
 
         void default_agent::yield_k(std::size_t k, char const* /* desc */)
         {
-            if (k < 4) {}
-            else if (k < 16) { PIKA_SMT_PAUSE; }
+            if (k < 16) { PIKA_SMT_PAUSE; }
             else if (k < 32 || k & 1)
             {
 #if defined(PIKA_WINDOWS)

--- a/libs/pika/execution_base/src/this_thread.cpp
+++ b/libs/pika/execution_base/src/this_thread.cpp
@@ -135,8 +135,7 @@ namespace pika::execution {
 
         void default_agent::spin_k(std::size_t k, char const* /* desc */)
         {
-            if (k < 4) {}
-            else { PIKA_SMT_PAUSE; }
+            for (std::size_t i = 0; i < k; ++i) { PIKA_SMT_PAUSE; }
         }
 
         void default_agent::suspend(char const* /* desc */)

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -66,8 +66,7 @@ namespace pika::threads::detail {
 
     void execution_agent::spin_k(std::size_t k, const char*)
     {
-        if (k < 4) {}
-        else { PIKA_SMT_PAUSE; }
+        for (std::size_t i = 0; i < k; ++i) { PIKA_SMT_PAUSE; }
     }
 
     void execution_agent::resume(const char* desc)

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -58,8 +58,7 @@ namespace pika::threads::detail {
 
     void execution_agent::yield_k(std::size_t k, const char* desc)
     {
-        if (k < 4) {}
-        else if (k < 16) { PIKA_SMT_PAUSE; }
+        if (k < 16) { PIKA_SMT_PAUSE; }
         else if (k < 32 || k & 1) { do_yield(desc, thread_schedule_state::pending_boost); }
         else { do_yield(desc, thread_schedule_state::pending); }
     }


### PR DESCRIPTION
- In `yield_k`, pause every iteration before actually yielding
- In `spin_k`, add a simple backoff by spinning inside `spin_k` `k` times before returning

Especially the latter improves performance of contended barriers on Grace.