### PR TITLE
Add gcc10 apex pipeline in CSCS CI

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_compiler
+++ b/.gitlab/docker/Dockerfile.spack_compiler
@@ -5,7 +5,9 @@ SHELL ["/bin/bash", "-c"]
 
 # Disable host compatibility to be able to compile for other architectures than the one from the
 # CSCS CI's .container-builder
-RUN spack config --scope site add  concretizer:targets:host_compatible:false
+# Allow installing deprecated packages (needed for apex)
+RUN spack config --scope site add concretizer:targets:host_compatible:false && \
+    spack config --scope site add config:deprecated:true
 
 # Install compiler if not already installed
 ARG ARCH

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -15,7 +15,7 @@ include:
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
-                 ^apex@2.4.1~openmp~papi ^otf2@2.3"
+                 ^apex@2.4.1~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
                   -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include:
+  - local: '.gitlab/includes/common_pipeline.yml'
+  - local: '.gitlab/includes/common_spack_pipeline.yml'
+
+.variables_gcc10_apex_config:
+  variables:
+    ARCH: linux-ubuntu22.04-broadwell
+    BUILD_TYPE: Release
+    COMPILER: gcc@10.3.0
+    CXXSTD: 17
+    SPACK_SPEC: "pika@main +apex arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
+                 ^apex@2.4.1~openmp~papi"
+    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
+                  -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+
+gcc10_apex_spack_image:
+  stage: spack_configs
+  needs: [base_spack_image]
+  extends:
+    - .container-builder
+    - .variables_gcc10_apex_config
+  before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - CONFIG_TAG=`echo $DOCKERFILE_SHA-$ARCH-$BASE_IMAGE-$COMPILER-$SPACK_SPEC | sha256sum - | head -c 16`
+    - compiler=${COMPILER/@/-}
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/pika-$compiler:$CONFIG_TAG
+    - echo -e "compiler=$compiler" >> compiler.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> compiler.env
+  variables:
+    DOCKERFILE: .gitlab/docker/Dockerfile.spack_compiler
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE","ARCH","COMPILER","SPACK_SPEC"]'
+  artifacts:
+    reports:
+      dotenv: compiler.env
+
+gcc10_apex_release_build:
+  stage: build
+  extends:
+    - .container-builder
+    - .variables_gcc10_apex_config
+    - .build_variables_common
+    - .cmake_variables_common
+  needs:
+    - gcc10_apex_spack_image
+  before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
+    - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
+    - configuration=${configuration//-D/}
+    - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG
+    - echo -e "PERSIST_IMAGE_NAME=$PERSIST_IMAGE_NAME" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+gcc10_apex_release_test:
+  extends:
+    - .variables_gcc10_apex_config
+    - .test_common_mc
+    - .cmake_variables_common
+  needs:
+    - gcc10_apex_release_build
+  script:
+    - spack arch
+    - export CTEST_XML=$PWD/ctest.xml
+    - trap "${SOURCE_DIR}/.gitlab/scripts/collect_ctest_metrics.sh ${CTEST_XML}" EXIT
+    - spack build-env $spack_spec -- bash -c "ctest --output-junit ${CTEST_XML} --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
+  image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -15,7 +15,7 @@ include:
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
-                 ^apex@2.4.1~openmp~papi"
+                 ^apex@2.4.1~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
                   -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.gitlab/pipeline.yml
+++ b/.gitlab/pipeline.yml
@@ -8,6 +8,7 @@ include:
   - local: '.gitlab/includes/dockerhub_pipeline.yml'
   - local: '.gitlab/includes/gcc9_pipeline.yml'
   - local: '.gitlab/includes/gcc9_cuda11_pipeline.yml'
+  - local: '.gitlab/includes/gcc10_apex_pipeline.yml'
   - local: '.gitlab/includes/gcc11_pipeline.yml'
   - local: '.gitlab/includes/gcc12_pipeline.yml'
   - local: '.gitlab/includes/gcc12_cuda12_pipeline.yml'


### PR DESCRIPTION
Fix #926. Allow deprecated packages (for apex 2.4.1), otherwise concretization is failing (see https://github.com/spack/spack/issues/42037). apex version will be updated separately, see #948.