### PR TITLE
Update NVHPC CI to 23.9

### DIFF
--- a/.jenkins/cscs/env-nvhpc.sh
+++ b/.jenkins/cscs/env-nvhpc.sh
@@ -8,7 +8,7 @@ cxx_std="20"
 boost_version="1.78.0"
 hwloc_version="2.7.0"
 stdexec_version="git.nvhpc-23.09.rc4=main"
-nvhpc_version="22.11"
+nvhpc_version="23.9"
 spack_compiler="nvhpc@${nvhpc_version}"
 spack_arch="cray-cnl7-haswell"
 


### PR DESCRIPTION
Need installation on daint but it worked with my spack installation. I added gcc as a compiler for fmt as it didn't seem to find the corresponding flags for CXX20. I tried with fmt@10.1.1, fmt@10.0.0, fmt@9 and the same error occured.