### PR TITLE
Enable valgrind testing in `resource_partitioner` module

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -78,6 +78,7 @@ jobs:
               tests.{regressions,unit}.modules.functional \
               tests.unit.modules.memory \
               tests.unit.modules.properties \
+              tests.{examples,regressions,unit}.modules.resource_partitioner \
               tests.unit.modules.runtime \
               tests.unit.modules.schedulers \
               tests.unit.modules.string_util \

--- a/libs/pika/resource_partitioner/examples/CMakeLists.txt
+++ b/libs/pika/resource_partitioner/examples/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(example_program ${example_programs})
   if(PIKA_WITH_TESTS AND PIKA_WITH_TESTS_EXAMPLES)
     pika_add_example_test(
       "modules.resource_partitioner" ${example_program}
-      ${${example_program}_PARAMETERS}
+      ${${example_program}_PARAMETERS} VALGRIND
     )
   endif()
 endforeach()

--- a/libs/pika/resource_partitioner/tests/regressions/CMakeLists.txt
+++ b/libs/pika/resource_partitioner/tests/regressions/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(test ${tests})
   )
 
   pika_add_regression_test(
-    "modules.resource_partitioner" ${test} ${${test}_PARAMETERS}
+    "modules.resource_partitioner" ${test} ${${test}_PARAMETERS} VALGRIND
   )
 
 endforeach()

--- a/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(test ${tests})
   )
 
   pika_add_unit_test(
-    "modules.resource_partitioner" ${test} ${${test}_PARAMETERS}
+    "modules.resource_partitioner" ${test} ${${test}_PARAMETERS} VALGRIND
   )
 
 endforeach()

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -508,12 +508,7 @@ namespace pika::threads::detail {
         }
 
         // ----------------------------------------------------------------
-        static void deallocate(threads::detail::thread_data* p)
-        {
-            using threads::detail::thread_data;
-            p->~thread_data();
-            thread_alloc_.deallocate(p, 1);
-        }
+        static void deallocate(threads::detail::thread_data* p) { p->destroy(); }
 
         // ----------------------------------------------------------------
         void add_to_thread_map(threads::detail::thread_id_type tid)


### PR DESCRIPTION
@biddisco note the change in `queue_holder_thread.hpp`. This comes from a warning from valgrind about mismatching sizes between new/delete:
```
==817002== Thread 4:
==817002== Mismatched new/delete size value: 80
==817002==    at 0x4846702: operator delete(void*, unsigned long) (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==817002==    by 0x4C00733: std::__new_allocator<pika::threads::detail::thread_data>::deallocate(pika::threads::detail::thread_data*, unsigned long) (new_allocator.h:168)
==817002==    by 0x4BF7750: pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>::deallocate(pika::threads::detail::thread_data*) (queue_holder_thread.hpp:515)
==817002==    by 0x4BE740C: pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>::remove_from_thread_map(pika::threads::detail::thread_id, bool) (queue_holder_thread.hpp:568)
==817002==    by 0x4BD0877: pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>::cleanup_terminated(unsigned long, bool) (queue_holder_thread.hpp:345)
==817002==    by 0x4BA4274: pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::cleanup_terminated(bool) (shared_priority_queue_scheduler.hpp:251)
==817002==    by 0x4BA42C1: pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::cleanup_terminated(unsigned long, bool) (shared_priority_queue_scheduler.hpp:258)
==817002==    by 0x4BD6B95: void pika::threads::detail::scheduling_loop<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >(unsigned long, pika::threads::detail::shared_priority_queue_scheduler<std::mutex>&, pika::threads::detail::scheduling_counters&, pika::threads::detail::scheduling_callbacks&) (scheduling_loop.hpp:604)
==817002==    by 0x4BAB0B2: pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >::thread_func(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>) (scheduled_thread_pool_impl.hpp:471)
==817002==    by 0x4C1D22E: void std::__invoke_impl<void, void (pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >::*)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>), pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*, unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier> >(std::__invoke_memfun_deref, void (pika::threads::detail::scheduled_thread_pool<pi
ka::threads::detail::shared_priority_queue_scheduler<std::mutex> >::*&&)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>), pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*&&, unsigned long&&, unsigned long&&, std::shared_ptr<pika::concurrency::detail::barrier>&&) (invoke.h:74)
==817002==    by 0x4C1C7EB: std::__invoke_result<void (pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >::*)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>), pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*, unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier> >::type std::__invoke<void (pika::threads::detail::scheduled_thread_pool<pika::threads::deta
il::shared_priority_queue_scheduler<std::mutex> >::*)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>), pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*, unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier> >(void (pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >::*&&)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>),
 pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*&&, unsigned long&&, unsigned long&&, std::shared_ptr<pika::concurrency::detail::barrier>&&) (invoke.h:96)
==817002==    by 0x4C1C21C: void std::thread::_Invoker<std::tuple<void (pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >::*)(unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier>), pika::threads::detail::scheduled_thread_pool<pika::threads::detail::shared_priority_queue_scheduler<std::mutex> >*, unsigned long, unsigned long, std::shared_ptr<pika::concurrency::detail::barrier> > >::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3u
l, 4ul>) (std_thread.h:292)
==817002==  Address 0xbc21a40 is 0 bytes inside a block of size 488 alloc'd
==817002==    at 0x4842ED1: operator new(unsigned long) (in /nix/store/drfy02sf3aqzk6cdrs4lyxa8a6jprl5q-valgrind-3.22.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==817002==    by 0x4BAD1C6: std::__new_allocator<pika::threads::detail::thread_data_stackful>::allocate(unsigned long, void const*) (new_allocator.h:147)
==817002==    by 0x4B672AE: pika::threads::detail::thread_data_stackful::create(pika::threads::detail::thread_init_data&, void*, long, pika::threads::detail::thread_id_addref) (thread_data_stackful.hpp:125)
==817002==    by 0x4BAD877: pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>::create_thread_object(pika::threads::detail::thread_id_ref&, pika::threads::detail::thread_init_data&) (queue_holder_thread.hpp:476)
==817002==    by 0x4B68C59: pika::threads::detail::thread_queue_mc::add_new(long, pika::threads::detail::thread_queue_mc*, bool) (thread_queue_mc.hpp:95)
==817002==    by 0x4BE7FE9: pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>::add_new(long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, bool) (queue_holder_thread.hpp:648)
==817002==    by 0x4BD26FD: pika::threads::detail::queue_holder_numa<pika::threads::detail::thread_queue_mc>::add_new(pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long, unsigned long&, bool, bool) (queue_holder_numa.hpp:180)
==817002==    by 0x4BB0B78: pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::just_add_new(unsigned long&)::{lambda(unsigned long, unsigned long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool)#2}::operator()(unsigned long, unsigned long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool) const (shared_priority_queue_scheduler.hpp:635)
==817002==    by 0x4C0ABFD: bool pika::util::detail::callable_vtable<bool (unsigned long, unsigned long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool)>::_invoke<pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::just_add_new(unsigned long&)::{lambda(unsigned long, unsigned long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool)#2}>(void*, unsigned long&&, unsigned long&&, pika::threads::detail::qu
eue_holder_thread<pika::threads::detail::thread_queue_mc>*&&, unsigned long&, bool&&, bool&&) (callable_vtable.hpp:88)
==817002==    by 0x4BD313A: operator() (basic_function.hpp:199)
==817002==    by 0x4BD313A: bool pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::steal_by_function<unsigned long>(unsigned long, unsigned long, bool, bool, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, char const*, pika::util::detail::function<bool (unsigned long, unsigned long, pika::threads::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool)>, pika::util::detail::function<bool (unsigned long, unsigned long, pika::thread
s::detail::queue_holder_thread<pika::threads::detail::thread_queue_mc>*, unsigned long&, bool, bool)>) (shared_priority_queue_scheduler.hpp:483)
==817002==    by 0x4BA500A: pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::just_add_new(unsigned long&) (shared_priority_queue_scheduler.hpp:648)
==817002==    by 0x4BA4D20: pika::threads::detail::shared_priority_queue_scheduler<std::mutex>::get_next_thread(unsigned long, bool, pika::threads::detail::thread_id_ref&, bool) (shared_priority_queue_scheduler.hpp:600)
==817002==
```