### PR TITLE
Ensure test string is null-terminated in `const_args_init` test

### DIFF
--- a/libs/pika/init_runtime/tests/unit/const_args_init.cpp
+++ b/libs/pika/init_runtime/tests/unit/const_args_init.cpp
@@ -8,6 +8,7 @@
 #include <pika/testing.hpp>
 
 #include <cstdlib>
+#include <string>
 #include <vector>
 
 int pika_main()
@@ -19,7 +20,7 @@ int pika_main()
 int main()
 {
     int const argc = 1;
-    std::vector<char> name = {'t', 'e', 's', 't'};
+    std::string name = "test";
 
     {
         char* argv[] = {name.data(), nullptr};


### PR DESCRIPTION
`std::vector` does nothing to add a null-terminator (and doesn't guarantee that the allocation will even have space for a null-terminator). 

I'm changing it to a regular `std::string` because since C++11 it is guaranteed to be null-terminated (https://en.cppreference.com/w/cpp/string/basic_string/data):

> The returned array is null-terminated, that is, data() and [c_str()](https://en.cppreference.com/w/cpp/string/basic_string/c_str) perform the same function.
> 
> If [empty()](https://en.cppreference.com/w/cpp/string/basic_string/empty) returns true, the pointer points to a single null character.

I'm using `basic_string::data` instead of `basic_string::c_str` because the latter is const, and we want a non-const array in the test.

This should also fix the failure seen in #878.