### PR TITLE
Run valgrind tests in parallel in CI

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
             cd build
             ctest \
+              -j $(nproc) \
               -L VALGRIND \
               --timeout 300 \
               --output-on-failure


### PR DESCRIPTION
Since valgrind internally serializes execution of threads, we can run multiple tests concurrently.