### PR TITLE
Add fallback to `invoke_with_exception_info` to report `what()` from `std::exception`

### DIFF
--- a/libs/pika/errors/include/pika/errors/exception_info.hpp
+++ b/libs/pika/errors/include/pika/errors/exception_info.hpp
@@ -11,6 +11,8 @@
 #include <pika/errors/error_code.hpp>
 #include <pika/errors/exception_info.hpp>
 
+#include <fmt/format.h>
+
 #include <cstddef>
 #include <exception>
 #include <memory>
@@ -223,6 +225,10 @@ namespace pika {
         catch (exception_info const& xi)
         {
             return PIKA_FORWARD(F, f)(&xi);
+        }
+        catch (std::exception const& e)
+        {
+            return fmt::format("std::exception:\n  what():  {}", e.what());
         }
         catch (...)
         {


### PR DESCRIPTION
Fixes #868 in a very basic way. This trickles up to e.g. `report_exception_and_*` to report `std::exception::what()` instead of `<unknown>`. Non-`std::exception`s are still reported as `<unknown>`. This does not specialize for different types of `std::*_error`s and reports them all as `std::exception`.

The message will now be e.g.:
```
The pika runtime caught the following exception in the entry point (typically pika_main). The exception may be rethrown later by pika::init or pika::stop. The pika runtime will wait for all tasks to finish, but may be deadlocked because of the exception.
std::exception:
  what():  hello
terminate called after throwing an instance of 'std::runtime_error'
  what():  hello
```
where the first time is when `pika_main` catches the exception, and the second is when `pika::init/stop` rethrows the exception and leads to termination. The duplication is better than not printing anything, as the runtime may never quit in case of an exception in `pika_main`. Previously this would have been:
```
The pika runtime caught the following exception in the entry point (typically pika_main). The exception may be rethrown later by pika::init or pika::stop. The pika runtime will wait for all tasks to finish, but may be deadlocked because of the exception.
<unknown>
terminate called after throwing an instance of 'std::runtime_error'
  what():  hello
```