### PR TITLE
Use fewer iterations in `async_rw_mutex` test with valgrind

### DIFF
--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -297,7 +297,7 @@ int pika_main(pika::program_options::variables_map& vm)
     test_moved(async_rw_mutex<std::size_t>{0});
     test_moved(async_rw_mutex<mytype, mytype_base>{mytype{}});
 
-#if defined(PIKA_HAVE_VERIFY_LOCKS)
+#if defined(PIKA_HAVE_VERIFY_LOCKS) || defined(PIKA_HAVE_VALGRIND)
     constexpr std::size_t iterations = 50;
 #else
     constexpr std::size_t iterations = 1000;


### PR DESCRIPTION
The test can take near 300 seconds to run in release mode with valgrind. This reduces the number of iterations to something a bit more reasonable.