### PR TITLE
Revert "Add `--verbose` to spack install compiler and dependencies"

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_compiler
+++ b/.gitlab/docker/Dockerfile.spack_compiler
@@ -16,7 +16,7 @@ RUN spack compiler info $COMPILER > /dev/null 2> /dev/null; compiler_missing=$?;
         export spack_compiler="$spack_compiler~gold"; \
     fi && \
     if [[ $compiler_missing != 0 ]]; then \
-        spack install --verbose $spack_compiler arch=$ARCH && \
+        spack install $spack_compiler arch=$ARCH && \
         spack compiler add --scope site $(spack location -i $spack_compiler) && \
         spack clean --all; \
     fi
@@ -27,5 +27,5 @@ RUN echo "spack arch: $(spack arch)"
 ARG SPACK_SPEC
 ENV spack_spec $SPACK_SPEC
 RUN spack spec -lI $spack_spec && \
-    spack install --verbose --fail-fast --only dependencies $spack_spec && \
+    spack install --fail-fast --only dependencies $spack_spec && \
     spack clean --all


### PR DESCRIPTION
Reverts pika-org/pika#961
The logs is too big, see https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/479009878135925/5304355110917878/-/jobs/5930176665