### PR TITLE
Reenable `process_mask_flag` test everywhere in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,7 +578,7 @@ jobs:
               -j2 \
               --timeout 500 \
               -T test \
-              -E "tests.unit.modules.threading.condition_variable2"
+              -E "tests.unit.modules.threading.condition_variable2" \
               --no-compress-output \
               --output-on-failure
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,15 +574,11 @@ jobs:
             export CMAKE_PREFIX_PATH=$HOME/project/install/fmt:${CMAKE_PREFIX_PATH}
             cd build
             ulimit -c unlimited
-            # The process_mask_flag test assumes that there are two hardware threads per core, but
-            # the ARM test environment doesn't have that
             ctest \
               -j2 \
               --timeout 500 \
               -T test \
-              -E \
-            "tests.unit.modules.threading.condition_variable2|\
-            tests.unit.modules.runtime.process_mask_flag" \
+              -E "tests.unit.modules.threading.condition_variable2"
               --no-compress-output \
               --output-on-failure
       - run:

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -75,11 +75,7 @@ jobs:
         shell: bash
         run: |
             cd build
-            # The process_mask_flag test assumes that there are two hardware
-            # threads per core, but the test environment only has one per core
             ctest \
               --timeout 120 \
               --output-on-failure \
-              -E \
-            "tests.examples|\
-            tests.unit.modules.runtime.process_mask_flag"
+              -E "tests.examples"

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -77,8 +77,7 @@ jobs:
               --exclude-regex \
             "tests.unit.modules.execution.standalone_thread_pool_executor|\
             tests.unit.modules.executors.std_thread_scheduler|\
-            tests.unit.modules.resource_partitioner.used_pus|\
-            tests.unit.modules.runtime.process_mask_flag"
+            tests.unit.modules.resource_partitioner.used_pus"
       - name: Install
         shell: bash
         run: |

--- a/libs/pika/runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/runtime/tests/unit/CMakeLists.txt
@@ -24,13 +24,22 @@ foreach(test ${tests})
   pika_add_unit_test("modules.runtime" ${test} ${${test}_PARAMETERS} VALGRIND)
 endforeach()
 
-string(
-  CONCAT
-    process_mask_flag_expected_output
-    "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\), Socket L#0\\(P#0\\)(, NUMANode L#0\\(P#0\\))?, on pool \"default\"\n"
-    "   1: PU L#[0-9]+\\(P#1\\), Core L#[0-9]+\\(P#[0-9]+\\), Socket L#[0-9]+\\(P#[0-9]+\\)(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
-    "All tests passed."
-)
+if(APPLE)
+  string(
+    CONCAT process_mask_flag_expected_output
+           "   0: thread binding disabled, on pool \"default\"\n"
+           "   1: thread binding disabled, on pool \"default\"\n"
+           "All tests passed."
+  )
+else()
+  string(
+    CONCAT
+      process_mask_flag_expected_output
+      "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\), Socket L#[0-9]+\\(P#[0-9]+\\)(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
+      "   1: PU L#[0-9]+\\(P#1\\), Core L#[0-9]+\\(P#[0-9]+\\), Socket L#[0-9]+\\(P#[0-9]+\\)(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
+      "All tests passed."
+  )
+endif()
 
 set_tests_properties(
   tests.unit.modules.runtime.process_mask_flag


### PR DESCRIPTION
After #922 was merged, the test should now run pretty much in any CI environment. However, this was not quite the case. This PR further slightly relaxes the regex to not care about the socket and numa node indices. For macOS it introduces a completely separate regex which expects no bindings, because thread binding is not supported on macOS.