### PR TITLE
Add address, undefined behaviour, and thread sanitizer CI configurations

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 ETH Zurich
+# Copyright (c) 2020 EXASOL
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (asan/ubsan/lsan)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/sanitizers/address-undefined-leak
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:21
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt repositories for ccache
+        run: apt update
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ccache-linux-sanitizers-address-undefined-leak
+      - name: Configure
+        shell: bash
+        run: |
+            cmake \
+                . \
+                -Bbuild \
+                -GNinja \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DPIKA_WITH_MALLOC=system \
+                -DPIKA_WITH_EXAMPLES=ON \
+                -DPIKA_WITH_TESTS=ON \
+                -DPIKA_WITH_TESTS_EXAMPLES=ON \
+                -DPIKA_WITH_TESTS_HEADERS=OFF \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
+                -DPIKA_WITH_COMPILER_WARNINGS=ON \
+                -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
+                -DPIKA_WITH_SANITIZERS=On \
+                -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" \
+                -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
+                -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
+      - name: Build
+        if: always()
+        shell: bash
+        run: |
+            cmake --build build --target examples
+            cmake --build build --target tests
+      - name: Test
+        if: always()
+        shell: bash
+        run: |
+            export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
+            export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
+            cd build
+            ctest \
+              --timeout 300 \
+              --output-on-failure

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 ETH Zurich
+# Copyright (c) 2020 EXASOL
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (tsan)
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      # Development and release branches
+      - main
+      - release**
+      # Bors branches
+      - trying
+      - staging
+
+jobs:
+  build:
+    name: github/linux/sanitizers/thread
+    runs-on: ubuntu-latest
+    container: pikaorg/pika-ci-base:21
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt repositories for ccache
+        run: apt update
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ccache-linux-sanitizers-thread
+      - name: Configure
+        shell: bash
+        run: |
+            cmake \
+                . \
+                -Bbuild \
+                -GNinja \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DPIKA_WITH_MALLOC=system \
+                -DPIKA_WITH_EXAMPLES=ON \
+                -DPIKA_WITH_TESTS=ON \
+                -DPIKA_WITH_TESTS_EXAMPLES=ON \
+                -DPIKA_WITH_TESTS_HEADERS=OFF \
+                -DPIKA_WITH_TESTS_MAX_THREADS=$(nproc) \
+                -DPIKA_WITH_COMPILER_WARNINGS=ON \
+                -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
+                -DPIKA_WITH_SANITIZERS=On \
+                -DCMAKE_CXX_FLAGS="-fsanitize=thread -omit-frame-pointer" \
+                -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
+                -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
+      - name: Build
+        if: always()
+        shell: bash
+        run: |
+            cmake --build build --target examples
+            cmake --build build --target tests
+      - name: Test
+        if: always()
+        shell: bash
+        run: |
+            export TSAN_OPTIONS=suppressions=$PWD/tools/tsan.supp
+            cd build
+            ctest \
+              --timeout 300 \
+              --output-on-failure

--- a/libs/pika/config/include/pika/config/compiler_specific.hpp
+++ b/libs/pika/config/include/pika/config/compiler_specific.hpp
@@ -161,14 +161,17 @@
 #define PIKA_CDECL
 #endif
 
-#if defined(PIKA_HAVE_SANITIZERS)
-#  if defined(__has_feature)
-#  if __has_feature(address_sanitizer)
-#      define PIKA_HAVE_ADDRESS_SANITIZER
-#    endif
-#  elif defined(__SANITIZE_ADDRESS__)   // MSVC defines this
-#    define PIKA_HAVE_ADDRESS_SANITIZER
-#  endif
-#endif
 // clang-format on
+# if defined(PIKA_HAVE_SANITIZERS)
+#  if defined(__has_feature)
+#   if __has_feature(address_sanitizer)
+#    define PIKA_HAVE_ADDRESS_SANITIZER
+#   endif
+#   if __has_feature(thread_sanitizer)
+#    define PIKA_HAVE_THREAD_SANITIZER
+#   endif
+#  elif defined(__SANITIZE_ADDRESS__)    // MSVC defines this
+#   define PIKA_HAVE_ADDRESS_SANITIZER
+#  endif
+# endif
 #endif

--- a/libs/pika/config/include/pika/config/compiler_specific.hpp
+++ b/libs/pika/config/include/pika/config/compiler_specific.hpp
@@ -166,6 +166,9 @@
 #  if defined(__has_feature)
 #   if __has_feature(address_sanitizer)
 #    define PIKA_HAVE_ADDRESS_SANITIZER
+#    if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
+#     define PIKA_NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
+#    endif
 #   endif
 #   if __has_feature(thread_sanitizer)
 #    define PIKA_HAVE_THREAD_SANITIZER
@@ -174,4 +177,8 @@
 #   define PIKA_HAVE_ADDRESS_SANITIZER
 #  endif
 # endif
+#endif
+
+#if !defined(PIKA_NO_SANITIZE_ADDRESS)
+# define PIKA_NO_SANITIZE_ADDRESS
 #endif

--- a/libs/pika/functional/include/pika/functional/bind.hpp
+++ b/libs/pika/functional/include/pika/functional/bind.hpp
@@ -117,8 +117,10 @@ namespace pika::util::detail {
 
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         template <typename... Us>
-        constexpr PIKA_HOST_DEVICE invoke_bound_result_t<F&, util::detail::pack<Ts&...>, Us&&...>
-        operator()(Us&&... vs) &
+        // https://github.com/pika-org/pika/issues/993
+        constexpr PIKA_NO_SANITIZE_ADDRESS
+            PIKA_HOST_DEVICE invoke_bound_result_t<F&, util::detail::pack<Ts&...>, Us&&...>
+            operator()(Us&&... vs) &
         {
             return PIKA_INVOKE(_f,
                 detail::bind_eval<Ts&, sizeof...(Us)>::call(

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -552,6 +552,7 @@ namespace pika::threads::detail {
 
             if (!running) { return false; }
 
+#if !defined(PIKA_HAVE_THREAD_SANITIZER)
             if (enable_stealing)
             {
                 for (std::size_t idx : victim_threads_[num_thread].data_)
@@ -579,6 +580,13 @@ namespace pika::threads::detail {
             }
 
             return low_priority_queue_.get_next_thread(thrd);
+#else
+            PIKA_UNUSED(enable_stealing);
+
+            if (num_thread == num_queues_ - 1) { return low_priority_queue_.get_next_thread(thrd); }
+
+            return false;
+#endif
         }
 
         /// Schedule the passed thread

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -297,7 +297,7 @@ namespace pika::threads::detail {
             threads::detail::thread_id_ref_type& thrd,
             bool /*scheduler_mode::enable_stealing*/) override
         {
-            std::size_t queues_size = queues_.size();
+            [[maybe_unused]] std::size_t queues_size = queues_.size();
 
             {
                 PIKA_ASSERT(num_thread < queues_size);
@@ -315,6 +315,7 @@ namespace pika::threads::detail {
                 if (have_staged) return false;
             }
 
+#if !defined(PIKA_HAVE_THREAD_SANITIZER)
             if (!running) { return false; }
 
             bool numa_stealing = has_scheduler_mode(scheduler_mode::enable_stealing_numa);
@@ -402,6 +403,9 @@ namespace pika::threads::detail {
                     }
                 }
             }
+#else
+            PIKA_UNUSED(running);
+#endif
 
             return false;
         }

--- a/tests/performance/local/task_overhead_report.cpp
+++ b/tests/performance/local/task_overhead_report.cpp
@@ -151,7 +151,15 @@ int main(int argc, char* argv[])
 
     // clang-format off
     cmdline.add_options()("tasks",
-        value<std::uint64_t>()->default_value(500000),
+        value<std::uint64_t>()->default_value(
+            // Address sanitizer can use a lot of memory on this test, so we reduce the default
+            // number of tasks
+#if defined(PIKA_HAVE_ADDRESS_SANITIZER)
+            50000
+#else
+            500000
+#endif
+            ),
         "number of tasks to invoke")
 
         ("delay-iterations", value<std::uint64_t>()->default_value(0),

--- a/tools/asan.supp
+++ b/tools/asan.supp
@@ -1,14 +1,7 @@
-# Copyright (c) 2020 Hartmut Kaiser
+# Copyright (c) 2024 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# ASAN is reporting a memory leak from hwloc_topology_init, but we're 100% sure
-# that the corresponding hwloc_topology_destroy is being called. The reported
-# leak could be caused by HWLOC itself.
-leak:hwloc_topology_init
-
-# Tmp: Topology leak which appeared when changing the base image used for the
-# github action. Ignored temporarily as it is not related to bumping cmake
-leak:*pika::threads::detail::topology::topology*
+# No suppressions!

--- a/tools/tsan.supp
+++ b/tools/tsan.supp
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# https://github.com/pika-org/pika/issues/990
+race:pika::concurrency::detail::deque*
+race:boost::lockfree::deque*
+race:boost::lockfree::queue*
+race:pika::concurrency::detail::ConcurrentQueue*
+
+# https://github.com/pika-org/pika/issues/989
+race:pika::experimental::base_channel_mpsc

--- a/tools/ubsan.supp
+++ b/tools/ubsan.supp
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# No suppressions!


### PR DESCRIPTION
Adds two new CI pipelines with sanitizers:

- One with address (and leak, implicitly) and undefined behaviour sanitizers
- One with thread sanitizer

The existing sanitizer CI configurations are unchanged.

The address sanitizer setup seems to pass for all tests, with some suppressions. `detect_stack_use_after_return` seems problematic so it's currently disabled (#992). Additionally, the `task_overhead_report` seems to trigger very high memory usage with address sanitizer. `detect_stack_use_after_return` may be triggering similar problems in other tests. A potential use-after-scope has been suppressed for now in `bind` (#993).

For thread sanitizer I've suppressed data races coming from various lockfree queues (#990), the MPSC queue (#989). I've also disabled stealing of pending threads on the `local_*` schedulers as thread sanitizer seems to dislike stacks migrating across OS threads (see https://github.com/pika-org/pika/pull/972/commits/6a5b07454742b15a436d2ea6aaf4d60a213d9357 for more details).

In the interest of getting what works into main I'm going to go ahead with the current state of this PR without making the two new CI configurations required checks. The two already existing sanitizer CI configurations remain required checks. I'm going to continue working on the remaining failures in follow-up PRs.