### PR TITLE
Reduce sizes of various channel tests when using valgrind

### DIFF
--- a/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpmc_throughput.cpp
@@ -35,7 +35,7 @@ struct data
 
 #if defined(PIKA_HAVE_VERIFY_LOCKS)
 constexpr int NUM_TESTS = 10000;
-#elif PIKA_DEBUG
+#elif defined(PIKA_DEBUG) || defined(PIKA_HAVE_VALGRIND)
 constexpr int NUM_TESTS = 1000000;
 #else
 constexpr int NUM_TESTS = 100000000;

--- a/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
+++ b/libs/pika/synchronization/tests/performance/channel_mpsc_throughput.cpp
@@ -35,7 +35,7 @@ struct data
 
 #if defined(PIKA_HAVE_VERIFY_LOCKS)
 constexpr int NUM_TESTS = 10000;
-#elif PIKA_DEBUG
+#elif defined(PIKA_DEBUG) || defined(PIKA_HAVE_VALGRIND)
 constexpr int NUM_TESTS = 1000000;
 #else
 constexpr int NUM_TESTS = 100000000;

--- a/libs/pika/synchronization/tests/unit/channel_mpmc_shift.cpp
+++ b/libs/pika/synchronization/tests/unit/channel_mpmc_shift.cpp
@@ -20,7 +20,11 @@
 namespace ex = pika::execution::experimental;
 namespace tt = pika::this_thread::experimental;
 
+#if defined(PIKA_HAVE_VALGRIND)
+constexpr int NUM_WORKERS = 100;
+#else
 constexpr int NUM_WORKERS = 1000;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>


### PR DESCRIPTION
In the same vein of #960, reduce the number of iterations/tests in a few of the channel tests when using valgrind to make them run in a more reasonable time.