### PR TITLE
Prefer using predicated `condition_variable::wait`

### DIFF
--- a/libs/pika/execution_base/src/this_thread.cpp
+++ b/libs/pika/execution_base/src/this_thread.cpp
@@ -145,7 +145,7 @@ namespace pika::execution {
             running_ = false;
             resume_cv_.notify_all();
 
-            while (!running_) { suspend_cv_.wait(l); }
+            suspend_cv_.wait(l, [&] { return running_; });
 
             if (aborted_)
             {

--- a/libs/pika/synchronization/tests/regressions/ignore_while_locked_1485.cpp
+++ b/libs/pika/synchronization/tests/regressions/ignore_while_locked_1485.cpp
@@ -72,8 +72,7 @@ void test_condition_with_mutex()
     // wait for the thread to run
     {
         std::unique_lock<pika::concurrency::detail::spinlock> lk(local_mutex);
-        // NOLINTNEXTLINE(bugprone-infinite-loop)
-        while (!running) local_cond_var.wait(lk);
+        local_cond_var.wait(lk, [&] { return running; });
     }
 
     // now start actual test

--- a/libs/pika/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
+++ b/libs/pika/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
@@ -56,8 +56,7 @@ void test_multiple_readers()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < number_of_threads) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= number_of_threads; });
         }
 
         CHECK_LOCKED_VALUE_EQUAL(unblocked_count_mutex, unblocked_count, number_of_threads);
@@ -144,8 +143,7 @@ void test_reader_blocks_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < 1) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= 1; });
         }
 
         CHECK_LOCKED_VALUE_EQUAL(unblocked_count_mutex, unblocked_count, 1u);
@@ -208,8 +206,7 @@ void test_unlocking_writer_unblocks_all_readers()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < reader_count) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= reader_count; });
         }
 
         CHECK_LOCKED_VALUE_EQUAL(unblocked_count_mutex, unblocked_count, reader_count);
@@ -271,8 +268,7 @@ void test_unlocking_last_reader_only_unblocks_one_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < reader_count) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= reader_count; });
         }
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -284,8 +280,7 @@ void test_unlocking_last_reader_only_unblocks_one_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < (reader_count + 1)) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= reader_count + 1; });
         }
 
         CHECK_LOCKED_VALUE_EQUAL(unblocked_count_mutex, unblocked_count, reader_count + 1);

--- a/libs/pika/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
+++ b/libs/pika/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
@@ -115,8 +115,7 @@ void test_can_lock_upgrade_if_currently_locked_shared()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
-            // NOLINTNEXTLINE(bugprone-infinite-loop)
-            while (unblocked_count < (reader_count + 1)) { unblocked_condition.wait(lk); }
+            unblocked_condition.wait(lk, [&] { return unblocked_count >= reader_count + 1; });
         }
 
         CHECK_LOCKED_VALUE_EQUAL(unblocked_count_mutex, unblocked_count, reader_count + 1);


### PR DESCRIPTION
This is mostly a question of style, but it gets rid of annoying warnings that have to be suppressed with `NOLINTNEXTLINE`, and is generally a bit more compact than the manual while-loop.