### PR TITLE
Make submission to logstash quiet by default

### DIFF
--- a/.gitlab/scripts/utilities.sh
+++ b/.gitlab/scripts/utilities.sh
@@ -5,8 +5,10 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 function submit_logstash {
-    echo Submitting to logstash:
-    jq . "${1}"
+    if [[ -n "${PIKA_CI_LOGSTASH_SUBMIT_VERBOSE+x}" ]]; then
+        echo Submitting to logstash:
+        jq . "${1}"
+    fi
 
     curl \
         --request POST \


### PR DESCRIPTION
Now that a few PRs have gone in that push data to logstash/elastic and it seems to be working quite well, I'm removing the verbose output of the submission. The results can anyway be browsed through kibana, and errors are reported as usual in the log. The verbose output can still be turned on as needed with the environment variable `PIKA_CI_LOGSTASH_SUBMIT_VERBOSE`, e.g. for debugging.