### PR TITLE
Disable Jenkins configurations covered by CSCS CI

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -49,6 +49,18 @@ pipeline {
                          values 'Debug', 'Release'
                     }
                 }
+                excludes {
+                    exclude {
+                        axis {
+                            name 'build_type'
+                            values 'Debug'
+                        }
+                        axis {
+                            name 'configuration_name'
+                            notValues 'cce', 'nvhpc'
+                        }
+                    }
+                }
                 stages {
                     stage('build') {
                         steps {


### PR DESCRIPTION
Now that we have pretty extensive, and well-working, coverage of CI configurations on CSCS's CI system it makes little sense to keep configurations in both Jenkins and CSCS CI. This is an attempt at disabling the debug configurations in Jenkins, except for CCE and NVHPC, which are not (yet) covered by the CSCS CI setup.

Based on https://www.jenkins.io/blog/2019/11/22/welcome-to-the-matrix/.