### PR TITLE
Fix initialization order issue with `print_info`

### DIFF
--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -181,16 +181,20 @@ namespace PIKA_DETAIL_NS_DEBUG {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::function<void(std::ostream&)> print_info;
+    std::function<void(std::ostream&)>& get_print_info() noexcept
+    {
+        static std::function<void(std::ostream&)> print_info;
+        return print_info;
+    }
 
-    void register_print_info(void (*printer)(std::ostream&)) { print_info = printer; }
+    void register_print_info(void (*printer)(std::ostream&)) { get_print_info() = printer; }
 
     void generate_prefix(std::ostream& os)
     {
 #ifdef PIKA_DEBUG_PRINT_SHOW_TIME
         os << detail::current_time_print_helper();
 #endif
-        if (print_info) { print_info(os); }
+        if (auto& f = get_print_info()) { f(os); }
         os << detail::hostname_print_helper();
     }
 


### PR DESCRIPTION
Move debugging helper `print_info` from a global to function-local static. This avoids a dependence on static initialization order with current_thread_print_helper global. Reported by address sanitizer (with the `strict_init_order=1` option) as:

```
=================================================================
==2690384==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x7f7542609ec0 at pc 0x55ca03e14355 bp 0x7ffd495b1790 sp 0x7ffd
495b0f50
READ of size 16 at 0x7f7542609ec0 thread T0
    #0 0x55ca03e14354 in __asan_memcpy (/home/mjs/src/pika/build/nix-clang/bin/runtime_initialized_test+0x11e354)
    #1 0x7f7541407aaf in std::enable_if<__and_<std::__not_<std::__is_tuple_like<std::_Any_data>>, std::is_move_constructible<std::_Any_dat
a>, std::is_move_assignable<std::_Any_data>>::value, void>::type std::swap<std::_Any_data>(std::_Any_data&, std::_Any_data&) /nix/store/qf
qjymymsd2x29yknsgllfiq1h64s3f4-gcc-12.3.0/include/c++/12.3.0/bits/move.h:205:11
    #2 0x7f7541406a48 in std::function<void (std::ostream&)>::swap(std::function<void (std::ostream&)>&) /nix/store/qfqjymymsd2x29yknsgllf
iq1h64s3f4-gcc-12.3.0/include/c++/12.3.0/bits/std_function.h:558:2
    #3 0x7f75414032e1 in std::enable_if<std::function<void (std::ostream&)>::_Callable<void (*&)(std::ostream&), std::enable_if<!is_same<s
td::remove_cv<std::remove_reference<std::remove_cv>::type>::type, std::function<void (std::ostream&)>>::value, std::decay<std::remove_cv>>
::type::type, std::__invoke_result<std::__invoke_result&, std::ostream&>>::value, std::function<void (std::ostream&)>&>::type std::functio
n<void (std::ostream&)>::operator=<void (*&)(std::ostream&)>(std::remove_cv&&) /nix/store/qfqjymymsd2x29yknsgllfiq1h64s3f4-gcc-12.3.0/incl
ude/c++/12.3.0/bits/std_function.h:534:42
    #4 0x7f75413f435b in pika::debug::detail::register_print_info(void (*)(std::ostream&)) /home/mjs/src/pika/libs/pika/debugging/src/prin
t.cpp:186:75
    #5 0x7f7541d8dbe9 in pika::debug::detail::detail::current_thread_print_helper::current_thread_print_helper() /home/mjs/src/pika/libs/p
ika/threading_base/src/print.cpp:98:17
    #6 0x7f75412ee14f in __cxx_global_var_init.44 /home/mjs/src/pika/libs/pika/threading_base/src/print.cpp:104:66
    #7 0x7f75412ee1ab in _GLOBAL__sub_I_unity_0_cxx.cxx /home/mjs/src/pika/build/nix-clang/libs/pika/threading_base/CMakeFiles/pika_thread
ing_base.dir/Unity/unity_0_cxx.cxx
    #8 0x7f7542682ebd in call_init (/nix/store/9y8pmvk8gdwwznmkzxa6pwyah52xy3nk-glibc-2.38-27/lib/ld-linux-x86-64.so.2+0x4ebd) (BuildId: 0
ff80c6f09fbe1237ec15fc13b478ad61a93b07b)
    #9 0x7f7542682fab in _dl_init (/nix/store/9y8pmvk8gdwwznmkzxa6pwyah52xy3nk-glibc-2.38-27/lib/ld-linux-x86-64.so.2+0x4fab) (BuildId: 0f
f80c6f09fbe1237ec15fc13b478ad61a93b07b)
    #10 0x7f7542698f4f in _dl_start_user (/nix/store/9y8pmvk8gdwwznmkzxa6pwyah52xy3nk-glibc-2.38-27/lib/ld-linux-x86-64.so.2+0x1af4f) (Bui
ldId: 0ff80c6f09fbe1237ec15fc13b478ad61a93b07b)

0x7f7542609ec0 is located 0 bytes inside of global variable 'pika::debug::detail::print_info' defined in '/home/mjs/src/pika/libs/pika/deb
ugging/src/print.cpp:184' (0x7f7542609ec0) of size 32
```