### PR TITLE
Store thread pool name by value instead of reference in `thread_pool_init_parameters`

### DIFF
--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -57,7 +57,7 @@ namespace pika::threads::detail {
 
     struct thread_pool_init_parameters
     {
-        std::string const& name_;
+        std::string name_;
         std::size_t index_;
         scheduler_mode mode_;
         std::size_t num_threads_;


### PR DESCRIPTION
Storing it by reference is a huge footgun as it requires the user to make sure the name stays alive long enough. This changes the member to a regular value to avoid surprises. The member doesn't need to be a reference for performance or other reasons. The `standalone_thread_pool_scheduler` test did not keep the name alive long enough (it was passed as a prvalue).