### PR TITLE
Store `last_worker_thread_num` of `thread_data` as atomic variable

### DIFF
--- a/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp
@@ -427,11 +427,14 @@ namespace pika::threads::detail {
 
         scheduler_base* get_scheduler_base() const noexcept { return scheduler_base_; }
 
-        std::size_t get_last_worker_thread_num() const noexcept { return last_worker_thread_num_; }
+        std::size_t get_last_worker_thread_num() const noexcept
+        {
+            return last_worker_thread_num_.load(std::memory_order_relaxed);
+        }
 
         void set_last_worker_thread_num(std::size_t last_worker_thread_num) noexcept
         {
-            last_worker_thread_num_ = last_worker_thread_num;
+            last_worker_thread_num_.store(last_worker_thread_num, std::memory_order_relaxed);
         }
 
         std::ptrdiff_t get_stack_size() const noexcept { return stacksize_; }
@@ -530,7 +533,7 @@ namespace pika::threads::detail {
 
         // reference to scheduler which created/manages this thread
         scheduler_base* scheduler_base_;
-        std::size_t last_worker_thread_num_;
+        std::atomic<std::size_t> last_worker_thread_num_;
 
         std::ptrdiff_t stacksize_;
         execution::thread_stacksize stacksize_enum_;

--- a/libs/pika/threading_base/src/thread_data.cpp
+++ b/libs/pika/threading_base/src/thread_data.cpp
@@ -21,6 +21,7 @@
 
 #include <fmt/format.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -187,7 +188,7 @@ namespace pika::threads::detail {
         ran_exit_funcs_ = false;
         exit_funcs_.clear();
         scheduler_base_ = init_data.scheduler_base;
-        last_worker_thread_num_ = std::size_t(-1);
+        last_worker_thread_num_.store(std::size_t(-1), std::memory_order_relaxed);
 
         // We explicitly set the logical stack size again as it can be different
         // from what the previous use required. However, the physical stack size


### PR DESCRIPTION
Full description in the commit message. The variable can be read and written without synchronization, leading to data races. This is reported by thread sanitizer e.g. as (stacktraces abbreviated):
```
==================
WARNING: ThreadSanitizer: data race (pid=3562)
  Read of size 8 at 0x7b44000116f0 by thread T2:
    #0 pika::threads::detail::thread_data::get_last_worker_thread_num() const /__w/pika/pika/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp:430:74 (libpikad.so.0+0x6b11cd) (BuildId: 1ac0dcbdeb864e0b)
    #1 pika::threads::detail::execution_agent::do_resume(char const*, pika::threads::detail::thread_restart_state) /__w/pika/pika/libs/pika/threading_base/src/execution_agent.cpp:187:69 (libpikad.so.0+0x79f590) (BuildId: 1ac0dcbdeb864e0b)
    #2 pika::threads::detail::execution_agent::resume(char const*) /__w/pika/pika/libs/pika/threading_base/src/execution_agent.cpp:73:9 (libpikad.so.0+0x79f4fa) (BuildId: 1ac0dcbdeb864e0b)
    #3 pika::execution::detail::agent_ref::resume(char const*) /__w/pika/pika/libs/pika/execution_base/src/agent_ref.cpp:64:16 (libpikad.so.0+0x4d7eea) (BuildId: 1ac0dcbdeb864e0b)
    #4 pika::detail::condition_variable::notify_one(std::unique_lock<pika::concurrency::detail::spinlock>, pika::execution::thread_priority, pika::error_code&) /__w/pika/pika/libs/pika/synchronization/src/detail/condition_variable.cpp:84:17 (libpikad.so.0+0x615449) (BuildId: 1ac0dcbdeb864e0b)
    #5 pika::detail::condition_variable::notify_one(std::unique_lock<pika::concurrency::detail::spinlock>, pika::error_code&) /__w/pika/pika/libs/pika/synchronization/include/pika/synchronization/detail/condition_variable.hpp:100:20 (standalone_thread_pool_scheduler_test+0x1a9b38) (BuildId: 550de67c56cbc7b4)
    #6 pika::condition_variable::notify_one(pika::error_code&) /__w/pika/pika/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp:69:26 (standalone_thread_pool_scheduler_test+0x1a928c) (BuildId: 550de67c56cbc7b4)

  Previous write of size 8 at 0x7b44000116f0 by thread T1:
    #0 pika::threads::detail::thread_data::set_last_worker_thread_num(unsigned long) /__w/pika/pika/libs/pika/threading_base/include/pika/threading_base/thread_data.hpp:434:37 (libpikad.so.0+0x7a0fb1) (BuildId: 1ac0dcbdeb864e0b)
    #1 pika::threads::detail::execution_agent::do_yield(char const*, pika::threads::detail::thread_schedule_state) /__w/pika/pika/libs/pika/threading_base/src/execution_agent.cpp:148:20 (libpikad.so.0+0x79ec8a) (BuildId: 1ac0dcbdeb864e0b)
    #2 pika::threads::detail::execution_agent::suspend(char const*) /__w/pika/pika/libs/pika/threading_base/src/execution_agent.cpp:80:9 (libpikad.so.0+0x79f69a) (BuildId: 1ac0dcbdeb864e0b)
    #3 pika::execution::detail::agent_ref::suspend(char const*) /__w/pika/pika/libs/pika/execution_base/src/agent_ref.cpp:58:16 (libpikad.so.0+0x4d7dc4) (BuildId: 1ac0dcbdeb864e0b)
    #4 pika::detail::condition_variable::wait(std::unique_lock<pika::concurrency::detail::spinlock>&, char const*, pika::error_code&) /__w/pika/pika/libs/pika/synchronization/src/detail/condition_variable.cpp:156:22 (libpikad.so.0+0x6160ee) (BuildId: 1ac0dcbdeb864e0b)
    #5 pika::detail::condition_variable::wait(std::unique_lock<pika::concurrency::detail::spinlock>&, pika::error_code&) /__w/pika/pika/libs/pika/synchronization/include/pika/synchronization/detail/condition_variable.hpp:116:20 (standalone_thread_pool_scheduler_test+0x1ab1bc) (BuildId: 550de67c56cbc7b4)
    #6 void pika::condition_variable::wait<pika::concurrency::detail::spinlock>(std::unique_lock<pika::concurrency::detail::spinlock>&, pika::error_code&) /__w/pika/pika/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp:94:25 (standalone_thread_pool_scheduler_test+0x1aae6a) (BuildId: 550de67c56cbc7b4)
    #7 void pika::condition_variable::wait<pika::concurrency::detail::spinlock, pika::sync_wait_detail::sync_wait_receiver_impl<pika::then_detail::then_sender_impl<pika::execution::experimental::thread_pool_scheduler::sender<pika::execution::experimental::thread_pool_scheduler>, test_thread_pool_scheduler(pika::execution::experimental::thread_pool_scheduler)::$_1>::then_sender_type>::sync_wait_receiver_type::shared_state::wait()::'lambda'()>(std::unique_lock<pika::concurrency::detail::spinlock>&, pika::sync_wait_detail::sync_wait_receiver_impl<pika::then_detail::then_sender_impl<pika::execution::experimental::thread_pool_scheduler::sender<pika::execution::experimental::thread_pool_scheduler>, test_thread_pool_scheduler(pika::execution::experimental::thread_pool_scheduler)::$_1>::then_sender_type>::sync_wait_receiver_type::shared_state::wait()::'lambda'(), pika::error_code&) /__w/pika/pika/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp:102:31 (standalone_thread_pool_scheduler_test+0x1a2391) (BuildId: 550de67c56cbc7b4)
```