### PR TITLE
Bump CI image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
   docker:
-    - image: pikaorg/pika-ci-base:19
+    - image: pikaorg/pika-ci-base:21
 
 defaults: &defaults
   <<: *working_dir_default

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "docker.io/pikaorg/pika-ci-base:17",
+  "image": "docker.io/pikaorg/pika-ci-base:21",
   "features": {},
   "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
   "extensions": [

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -23,7 +23,7 @@ jobs:
     name: github/linux/hip/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-hip:12
+    container: pikaorg/pika-ci-hip:14
     steps:
       - uses: actions/checkout@v4
       - name: Update apt repositories for ccache

--- a/.github/workflows/linux_leaksanitizer.yml
+++ b/.github/workflows/linux_leaksanitizer.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: github/linux/sanitizers/leak
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -23,7 +23,7 @@ jobs:
     name: github/linux/fetchcontent/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -23,7 +23,7 @@ jobs:
     name: github/linux/sanitizers/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -23,7 +23,7 @@ jobs:
     name: github/linux/tracy/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:19
+    container: pikaorg/pika-ci-base:21
 
     steps:
       - name: Check out Tracy

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: github/linux/valgrind
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:20
+    container: pikaorg/pika-ci-base:21
 
     strategy:
       matrix:

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -12,7 +12,7 @@ clang14_debug_build_pika-ci-image:
   extends: .container-builder
   needs: []   # To clear the dotenv artifacts
   variables:
-    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:17
+    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:21
     DOCKERFILE: .gitlab/docker/Dockerfile.dockerhub_build
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","BUILD_DIR","SOURCE_DIR"]'
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA


### PR DESCRIPTION
Bump base to 21, HIP to 14. Importantly includes the version bump of `libpam` from https://github.com/pika-org/pika-ci-image/pull/41.