### PR TITLE
Fix forwarding of return type from `execution::then` callable

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -92,12 +92,12 @@ namespace pika::cuda::experimental {
                         // Certain versions of GCC with optimizations fail on
                         // the move with an internal compiler error.
 #if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
-                            auto&& result = PIKA_INVOKE(std::move(r.f), PIKA_FORWARD(Ts, ts)...);
+                            pika::execution::experimental::set_value(PIKA_MOVE(r.receiver),
+                                PIKA_INVOKE(std::move(r.f), PIKA_FORWARD(Ts, ts)...));
 #else
-                            auto&& result = PIKA_INVOKE(PIKA_MOVE(r.f), PIKA_FORWARD(Ts, ts)...);
+                            pika::execution::experimental::set_value(PIKA_MOVE(r.receiver),
+                                PIKA_INVOKE(PIKA_MOVE(r.f), PIKA_FORWARD(Ts, ts)...));
 #endif
-                            pika::execution::experimental::set_value(
-                                PIKA_MOVE(r.receiver), PIKA_MOVE(result));
                         }
                     },
                     [&](std::exception_ptr ep) {

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -77,12 +77,12 @@ namespace pika::then_detail {
                     // Certain versions of GCC with optimizations fail on
                     // the move with an internal compiler error.
 # if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
-                        auto&& result = PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...);
+                        pika::execution::experimental::set_value(PIKA_MOVE(receiver),
+                            PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...));
 # else
-                        auto&& result = PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...);
+                        pika::execution::experimental::set_value(PIKA_MOVE(receiver),
+                            PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...));
 # endif
-                        pika::execution::experimental::set_value(
-                            PIKA_MOVE(receiver), PIKA_MOVE(result));
                     }
                 },
                 [&](std::exception_ptr ep) {

--- a/libs/pika/execution/tests/unit/algorithm_then.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_then.cpp
@@ -136,6 +136,24 @@ int main()
         PIKA_TEST(set_value_called);
     }
 
+    // This is not recommended, but allowed
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::then(ex::just(), []() -> int& {
+            static int x = 3;
+            return x;
+        });
+        auto s2 = ex::then(std::move(s1), [](int& x) -> int& {
+            x *= 4;
+            return x;
+        });
+        auto f = [](int& x) { PIKA_TEST_EQ(x, 12); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        PIKA_TEST(set_value_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};


### PR DESCRIPTION
The result of the callable in `then` (and `cuda::then_on_host`) was previously taken by universal reference (`auto&&`) but then moved into the successor receiver. This would be wrong when the return type of the callable is a reference, and fail to compile if the successor receiver also expects a reference. This moves the call of the callable to simply directly pass the result into `set_value` instead of going via an intermediate local variable. This also adds a regression test for `then`.