### PR TITLE
Add `python-dev` to base CI image

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get -yqq install --no-install-recommends \
     pipx \
     pkgconf \
     python3 \
+    python3-dev \
     python3-pip \
     tar \
     unzip \


### PR DESCRIPTION
Attempt to fix the missing Python.h include (example https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/479009878135925/5304355110917878/-/jobs/6027637946)
Applying fix suggested in: https://github.com/spack/spack/issues/42315#issue-2102133765