### PR TITLE
Use static call operator when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1059,9 +1059,10 @@ pika_option(
 # ##############################################################################
 # C++ feature tests
 # ##############################################################################
-# Need to include the CUDA setup before the config test to enable the CUDA
-# language
+# Need to set up CUDA/HIP before feature tests to enable the respective
+# languages
 include(pika_setup_cuda)
+include(pika_setup_hip)
 include(pika_perform_cxx_feature_tests)
 pika_perform_cxx_feature_tests()
 
@@ -1482,7 +1483,6 @@ include(pika_setup_fmt)
 include(pika_setup_allocator)
 include(pika_setup_hwloc)
 include(pika_setup_mpi)
-include(pika_setup_hip)
 include(pika_setup_whip)
 include(pika_setup_apex)
 include(pika_setup_valgrind)

--- a/cmake/pika_add_config_test.cmake
+++ b/cmake/pika_add_config_test.cmake
@@ -172,11 +172,17 @@ function(pika_add_config_test variable)
       if(PIKA_WITH_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
         set(cuda_parameters CUDA_STANDARD ${CMAKE_CUDA_STANDARD})
       endif()
+      if(PIKA_WITH_HIP)
+        set(hip_parameters HIP_STANDARD ${CMAKE_HIP_STANDARD})
+      endif()
       set(CMAKE_CXX_FLAGS
           "${CMAKE_CXX_FLAGS} ${additional_cmake_flags} ${${variable}_CXXFLAGS}"
       )
       set(CMAKE_CUDA_FLAGS
           "${CMAKE_CUDA_FLAGS} ${additional_cmake_flags} ${${variable}_CXXFLAGS}"
+      )
+      set(CMAKE_HIP_FLAGS
+          "${CMAKE_HIP_FLAGS} ${additional_cmake_flags} ${${variable}_CXXFLAGS}"
       )
       # cmake-format: off
       try_compile(
@@ -193,6 +199,7 @@ function(pika_add_config_test variable)
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS FALSE
         ${cuda_parameters}
+        ${hip_parameters}
         COPY_FILE ${test_binary}
       )
       # cmake-format: on
@@ -456,6 +463,40 @@ function(pika_check_for_cxx20_trivial_virtual_destructor)
     SOURCE cmake/tests/cxx20_trivial_virtual_destructor.cpp
     FILE ${ARGN}
   )
+endfunction()
+
+# ##############################################################################
+function(pika_check_for_cxx23_static_call_operator)
+  pika_add_config_test(
+    PIKA_WITH_CXX23_STATIC_CALL_OPERATOR
+    SOURCE cmake/tests/cxx23_static_call_operator.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
+function(pika_check_for_cxx23_static_call_operator_gpu)
+  if(PIKA_WITH_GPU_SUPPORT)
+    set(static_call_operator_test_extension "cpp")
+    if(PIKA_WITH_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+      set(static_call_operator_test_extension "cu")
+    elseif(PIKA_WITH_HIP)
+      set(static_call_operator_test_extension "hip")
+    endif()
+
+    set(extra_cxxflags)
+    if(PIKA_WITH_CUDA AND CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+      set(extra_cxxflags "-x cu")
+    endif()
+
+    pika_add_config_test(
+      PIKA_WITH_CXX23_STATIC_CALL_OPERATOR_GPU
+      SOURCE
+        cmake/tests/cxx23_static_call_operator.${static_call_operator_test_extension}
+        GPU
+      FILE ${ARGN}
+    )
+  endif()
 endfunction()
 
 # ##############################################################################

--- a/cmake/pika_perform_cxx_feature_tests.cmake
+++ b/cmake/pika_perform_cxx_feature_tests.cmake
@@ -56,6 +56,14 @@ function(pika_perform_cxx_feature_tests)
     DEFINITIONS PIKA_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR
   )
 
+  pika_check_for_cxx23_static_call_operator(
+    DEFINITIONS PIKA_HAVE_CXX23_STATIC_CALL_OPERATOR
+  )
+
+  pika_check_for_cxx23_static_call_operator_gpu(
+    DEFINITIONS PIKA_HAVE_CXX23_STATIC_CALL_OPERATOR_GPU
+  )
+
   pika_check_for_cxx_lambda_capture_decltype(
     DEFINITIONS PIKA_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE
   )

--- a/cmake/pika_setup_cuda.cmake
+++ b/cmake/pika_setup_cuda.cmake
@@ -20,6 +20,14 @@ if(PIKA_WITH_CUDA AND NOT TARGET pika_internal::cuda)
       pika_internal::cuda INTERFACE CUDA::cublas CUDA::cusolver
     )
 
+    # nvc++ warns about the static keyword coming after the return type. We make
+    # use of static coming after the return type in the
+    # PIKA_STATIC_CALL_OPERATOR macro. Since the order has no significance we
+    # outright disable the warning.
+    target_compile_options(
+      pika_internal::cuda INTERFACE --diag_suppress storage_class_not_first
+    )
+
     if(NOT PIKA_FIND_PACKAGE)
       target_link_libraries(pika_base_libraries INTERFACE pika_internal::cuda)
     endif()

--- a/cmake/pika_setup_cuda.cmake
+++ b/cmake/pika_setup_cuda.cmake
@@ -30,6 +30,9 @@ if(PIKA_WITH_CUDA AND NOT TARGET pika_internal::cuda)
 
     if(NOT PIKA_FIND_PACKAGE)
       target_link_libraries(pika_base_libraries INTERFACE pika_internal::cuda)
+      target_compile_options(
+        pika_private_flags INTERFACE --display_error_number
+      )
     endif()
   else()
     # nvcc or clang are only used for cu files with CMake's CUDA language

--- a/cmake/tests/cxx23_static_call_operator.cpp
+++ b/cmake/tests/cxx23_static_call_operator.cpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+struct s
+{
+    static void operator()() {}
+};
+
+int main() { s::operator()(); }

--- a/cmake/tests/cxx23_static_call_operator.cu
+++ b/cmake/tests/cxx23_static_call_operator.cu
@@ -1,0 +1,1 @@
+../../cmake/tests/cxx23_static_call_operator.cpp

--- a/cmake/tests/cxx23_static_call_operator.hip
+++ b/cmake/tests/cxx23_static_call_operator.hip
@@ -1,0 +1,1 @@
+../../cmake/tests/cxx23_static_call_operator.cpp

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -621,14 +621,14 @@ namespace pika::cuda::experimental {
     inline constexpr struct then_with_stream_t final
     {
         template <typename Sender, typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(Sender&& sender, F&& f) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(Sender&& sender, F&& f)
         {
             return then_with_stream_detail::then_with_cuda_stream(PIKA_FORWARD(Sender, sender),
                 then_with_stream_detail::cuda_stream_callable<F>{PIKA_FORWARD(F, f)});
         }
 
         template <typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(F&& f) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(F&& f)
         {
             return pika::execution::experimental::detail::partial_algorithm<then_with_stream_t, F>{
                 PIKA_FORWARD(F, f)};
@@ -647,7 +647,7 @@ namespace pika::cuda::experimental {
     {
         template <typename Sender, typename F>
         constexpr PIKA_FORCEINLINE auto
-        operator()(Sender&& sender, F&& f, cublasPointerMode_t pointer_mode) const
+        PIKA_STATIC_CALL_OPERATOR(Sender&& sender, F&& f, cublasPointerMode_t pointer_mode)
         {
             return then_with_stream_detail::then_with_cuda_stream(PIKA_FORWARD(Sender, sender),
                 then_with_stream_detail::cublas_handle_callable<F>{
@@ -655,7 +655,8 @@ namespace pika::cuda::experimental {
         }
 
         template <typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(F&& f, cublasPointerMode_t pointer_mode) const
+        constexpr PIKA_FORCEINLINE auto
+        PIKA_STATIC_CALL_OPERATOR(F&& f, cublasPointerMode_t pointer_mode)
         {
             return pika::execution::experimental::detail::partial_algorithm<then_with_cublas_t, F,
                 cublasPointerMode_t>{PIKA_FORWARD(F, f), pointer_mode};
@@ -673,14 +674,14 @@ namespace pika::cuda::experimental {
     inline constexpr struct then_with_cusolver_t final
     {
         template <typename Sender, typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(Sender&& sender, F&& f) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(Sender&& sender, F&& f)
         {
             return then_with_stream_detail::then_with_cuda_stream(PIKA_FORWARD(Sender, sender),
                 then_with_stream_detail::cusolver_handle_callable<F>{PIKA_FORWARD(F, f)});
         }
 
         template <typename F>
-        constexpr PIKA_FORCEINLINE auto operator()(F&& f) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(F&& f)
         {
             return pika::execution::experimental::detail::partial_algorithm<then_with_cusolver_t,
                 F>{PIKA_FORWARD(F, f)};

--- a/libs/pika/config/CMakeLists.txt
+++ b/libs/pika/config/CMakeLists.txt
@@ -21,6 +21,7 @@ set(config_headers
     pika/config/forward.hpp
     pika/config/manual_profiling.hpp
     pika/config/move.hpp
+    pika/config/static_call_operator.hpp
     pika/config/threads_stack.hpp
     pika/config/warnings_prefix.hpp
     pika/config/warnings_suffix.hpp

--- a/libs/pika/config/include/pika/config.hpp
+++ b/libs/pika/config/include/pika/config.hpp
@@ -29,6 +29,7 @@
 #include <pika/config/manual_profiling.hpp>
 #include <pika/config/modules_enabled.hpp>
 #include <pika/config/move.hpp>
+#include <pika/config/static_call_operator.hpp>
 #include <pika/config/threads_stack.hpp>
 #include <pika/config/version.hpp>
 

--- a/libs/pika/config/include/pika/config/static_call_operator.hpp
+++ b/libs/pika/config/include/pika/config/static_call_operator.hpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#if defined(PIKA_HAVE_CXX23_STATIC_CALL_OPERATOR) &&                                               \
+    (!defined(PIKA_HAVE_GPU_SUPPORT) || defined(PIKA_HAVE_CXX23_STATIC_CALL_OPERATOR_GPU))
+# define PIKA_STATIC_CALL_OPERATOR(...) static operator()(__VA_ARGS__)
+#else
+# define PIKA_STATIC_CALL_OPERATOR(...) operator()(__VA_ARGS__) const
+#endif

--- a/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
@@ -326,7 +326,7 @@ namespace std {
     template <>
     struct hash<::pika::threads::detail::thread_id>
     {
-        std::size_t operator()(::pika::threads::detail::thread_id const& v) const noexcept
+        std::size_t PIKA_STATIC_CALL_OPERATOR(::pika::threads::detail::thread_id const& v) noexcept
         {
             std::hash<std::size_t> hasher_;
             return hasher_(reinterpret_cast<std::size_t>(v.get()));
@@ -336,7 +336,8 @@ namespace std {
     template <>
     struct hash<::pika::threads::detail::thread_id_ref>
     {
-        std::size_t operator()(::pika::threads::detail::thread_id_ref const& v) const noexcept
+        std::size_t PIKA_STATIC_CALL_OPERATOR(
+            ::pika::threads::detail::thread_id_ref const& v) noexcept
         {
             std::hash<std::size_t> hasher_;
             return hasher_(reinterpret_cast<std::size_t>(v.get().get()));

--- a/libs/pika/datastructures/include/pika/datastructures/detail/variant.hpp
+++ b/libs/pika/datastructures/include/pika/datastructures/detail/variant.hpp
@@ -451,7 +451,7 @@ namespace pika::variant_ns {
 #else
       struct equal_to {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
       };
 #endif
@@ -461,7 +461,7 @@ namespace pika::variant_ns {
 #else
       struct not_equal_to {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
       };
 #endif
@@ -471,7 +471,7 @@ namespace pika::variant_ns {
 #else
       struct less {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
       };
 #endif
@@ -481,7 +481,7 @@ namespace pika::variant_ns {
 #else
       struct greater {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
       };
 #endif
@@ -491,7 +491,7 @@ namespace pika::variant_ns {
 #else
       struct less_equal {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
       };
 #endif
@@ -501,7 +501,7 @@ namespace pika::variant_ns {
 #else
       struct greater_equal {
         template <typename Lhs, typename Rhs>
-        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+        inline constexpr auto PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs)
           PIKA_VARIANT_RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
       };
 #endif
@@ -1117,14 +1117,14 @@ namespace pika::variant_ns {
         template <std::size_t I, bool Dummy = true>
         struct get_alt_impl {
           template <typename V>
-          inline constexpr AUTO_REFREF operator()(V &&v) const
+          inline constexpr AUTO_REFREF PIKA_STATIC_CALL_OPERATOR(V &&v)
             AUTO_REFREF_RETURN(get_alt_impl<I - 1>{}(lib::forward<V>(v).tail_))
         };
 
         template <bool Dummy>
         struct get_alt_impl<0, Dummy> {
           template <typename V>
-          inline constexpr AUTO_REFREF operator()(V &&v) const
+          inline constexpr AUTO_REFREF PIKA_STATIC_CALL_OPERATOR(V &&v)
             AUTO_REFREF_RETURN(lib::forward<V>(v).head_)
         };
 
@@ -1407,13 +1407,13 @@ namespace pika::variant_ns {
 
           template <std::size_t... Is>
           struct impl<lib::index_sequence<Is...>> {
-            inline constexpr AUTO operator()() const
+            inline constexpr AUTO PIKA_STATIC_CALL_OPERATOR()
               AUTO_RETURN(&dispatch<Is...>)
           };
 
           template <typename Is, std::size_t... Js, typename... Ls>
           struct impl<Is, lib::index_sequence<Js...>, Ls...> {
-            inline constexpr AUTO operator()() const
+            inline constexpr AUTO PIKA_STATIC_CALL_OPERATOR()
               AUTO_RETURN(
                   make_farray(impl<lib::push_back_t<Is, Js>, Ls...>{}()...))
           };
@@ -1746,7 +1746,7 @@ namespace pika::variant_ns {
 #pragma warning(disable : 4100)
 #endif
       template <typename Alt>
-      inline void operator()(Alt &alt) const noexcept { alt.~Alt(); }
+      inline void PIKA_STATIC_CALL_OPERATOR(Alt &alt) noexcept { alt.~Alt(); }
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -1820,7 +1820,7 @@ namespace pika::variant_ns {
 #ifndef PIKA_VARIANT_GENERIC_LAMBDAS
       struct ctor {
         template <typename LhsAlt, typename RhsAlt>
-        inline void operator()(LhsAlt &lhs_alt, RhsAlt &&rhs_alt) const {
+        inline void PIKA_STATIC_CALL_OPERATOR(LhsAlt &lhs_alt, RhsAlt &&rhs_alt) {
           constructor::construct_alt(lhs_alt,
                                      lib::forward<RhsAlt>(rhs_alt).value);
         }
@@ -1977,7 +1977,7 @@ namespace pika::variant_ns {
       template <typename That>
       struct assigner {
         template <typename ThisAlt, typename ThatAlt>
-        inline void operator()(ThisAlt &this_alt, ThatAlt &&that_alt) const {
+        inline void PIKA_STATIC_CALL_OPERATOR(ThisAlt &this_alt, ThatAlt &&that_alt) {
           self->assign_alt(this_alt, lib::forward<ThatAlt>(that_alt).value);
         }
         assignment *self;
@@ -1997,10 +1997,10 @@ namespace pika::variant_ns {
 #endif
         } else {
           struct {
-            void operator()(std::true_type) const {
+            void PIKA_STATIC_CALL_OPERATOR(std::true_type) {
               this_->emplace<I>(lib::forward<Arg>(arg_));
             }
-            void operator()(std::false_type) const {
+            void PIKA_STATIC_CALL_OPERATOR(std::false_type) {
               this_->emplace<I>(T(lib::forward<Arg>(arg_)));
             }
             assignment *this_;
@@ -2174,7 +2174,7 @@ namespace pika::variant_ns {
 #ifndef PIKA_VARIANT_GENERIC_LAMBDAS
       struct swapper {
         template <typename ThisAlt, typename ThatAlt>
-        inline void operator()(ThisAlt &this_alt, ThatAlt &that_alt) const {
+        inline void PIKA_STATIC_CALL_OPERATOR(ThisAlt &this_alt, ThatAlt &that_alt) {
           using std::swap;
           swap(this_alt.value, that_alt.value);
         }
@@ -2447,7 +2447,7 @@ namespace pika::variant_ns {
     struct generic_get_impl {
       constexpr generic_get_impl(int) noexcept {}
 
-      constexpr AUTO_REFREF operator()(V &&v) const
+      constexpr AUTO_REFREF PIKA_STATIC_CALL_OPERATOR(V &&v)
         AUTO_REFREF_RETURN(
             access::variant::get_alt<I>(lib::forward<V>(v)).value)
     };
@@ -2542,7 +2542,7 @@ namespace pika::variant_ns {
     template <typename RelOp>
     struct convert_to_bool {
       template <typename Lhs, typename Rhs>
-      inline constexpr bool operator()(Lhs &&lhs, Rhs &&rhs) const {
+      inline constexpr bool PIKA_STATIC_CALL_OPERATOR(Lhs &&lhs, Rhs &&rhs) {
         static_assert(std::is_convertible<lib::invoke_result_t<RelOp, Lhs, Rhs>,
                                           bool>::value,
                       "relational operators must return a type"
@@ -2796,7 +2796,7 @@ namespace std {
     using argument_type = pika::variant_ns::variant<Ts...>;
     using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &v) const {
+    inline result_type PIKA_STATIC_CALL_OPERATOR(const argument_type &v) {
       using pika::variant_ns::detail::visitation::variant;
       std::size_t result =
           v.valueless_by_exception()
@@ -2821,7 +2821,7 @@ namespace std {
 #ifndef PIKA_VARIANT_GENERIC_LAMBDAS
     struct hasher {
       template <typename Alt>
-      inline std::size_t operator()(const Alt &alt) const {
+      inline std::size_t PIKA_STATIC_CALL_OPERATOR(const Alt &alt) {
         using alt_type = pika::variant_ns::lib::decay_t<Alt>;
         using value_type =
             pika::variant_ns::lib::remove_const_t<typename alt_type::value_type>;
@@ -2840,7 +2840,7 @@ namespace std {
     using argument_type = pika::variant_ns::monostate;
     using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &) const noexcept {
+    inline result_type PIKA_STATIC_CALL_OPERATOR(const argument_type &) noexcept {
       return 66740831;  // return a fundamentally attractive random value.
     }
   };

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -239,12 +239,12 @@ namespace pika::execution::experimental {
     inline constexpr struct drop_operation_state_t final
     {
         template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
-        constexpr PIKA_FORCEINLINE auto operator()(Sender&& sender) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(Sender&& sender)
         {
             return drop_op_state_detail::drop_op_state_sender<Sender>{PIKA_FORWARD(Sender, sender)};
         }
 
-        constexpr PIKA_FORCEINLINE auto operator()() const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR()
         {
             return detail::partial_algorithm<drop_operation_state_t>{};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -133,12 +133,13 @@ namespace pika::execution::experimental {
       : pika::functional::detail::tag_fallback<drop_value_t>
     {
         template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
-        constexpr PIKA_FORCEINLINE auto operator()(Sender&& sender) const
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(drop_value_t, Sender&& sender)
         {
             return drop_value_detail::drop_value_sender<Sender>{PIKA_FORWARD(Sender, sender)};
         }
 
-        constexpr PIKA_FORCEINLINE auto operator()() const
+        // TODO: Use static operator() here, will go to customization afterwards anyway.
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(drop_value_t)
         {
             return detail::partial_algorithm<drop_value_t>{};
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -120,7 +120,7 @@ namespace pika::execution::experimental {
     inline constexpr struct just_t final
     {
         template <typename... Ts>
-        constexpr PIKA_FORCEINLINE auto operator()(Ts&&... ts) const
+        constexpr PIKA_FORCEINLINE auto PIKA_STATIC_CALL_OPERATOR(Ts&&... ts)
         {
             return just_detail::just_sender<
                 typename pika::util::detail::make_index_pack<sizeof...(Ts)>::type, Ts...>{

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -118,7 +118,7 @@ namespace pika::let_error_detail {
 
                 struct start_visitor
                 {
-                    [[noreturn]] void operator()(pika::detail::monostate) const
+                    [[noreturn]] void PIKA_STATIC_CALL_OPERATOR(pika::detail::monostate)
                     {
                         PIKA_UNREACHABLE;
                     }
@@ -126,7 +126,7 @@ namespace pika::let_error_detail {
                     template <typename OperationState_,
                         typename = std::enable_if_t<!std::is_same_v<std::decay_t<OperationState_>,
                             pika::detail::monostate>>>
-                    void operator()(OperationState_& op_state) const
+                    void PIKA_STATIC_CALL_OPERATOR(OperationState_& op_state)
                     {
                         pika::execution::experimental::start(op_state);
                     }

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -174,7 +174,7 @@ namespace pika::let_value_detail {
 
                 struct start_visitor
                 {
-                    [[noreturn]] void operator()(pika::detail::monostate) const
+                    [[noreturn]] void PIKA_STATIC_CALL_OPERATOR(pika::detail::monostate)
                     {
                         PIKA_UNREACHABLE;
                     }
@@ -182,7 +182,7 @@ namespace pika::let_value_detail {
                     template <typename OperationState_,
                         typename = std::enable_if_t<!std::is_same_v<std::decay_t<OperationState_>,
                             pika::detail::monostate>>>
-                    void operator()(OperationState_& op_state) const
+                    void PIKA_STATIC_CALL_OPERATOR(OperationState_& op_state)
                     {
                         pika::execution::experimental::start(op_state);
                     }

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -32,10 +32,10 @@
 namespace pika::sync_wait_detail {
     struct sync_wait_error_visitor
     {
-        void operator()(std::exception_ptr ep) const { std::rethrow_exception(ep); }
+        void PIKA_STATIC_CALL_OPERATOR(std::exception_ptr ep) { std::rethrow_exception(ep); }
 
         template <typename Error>
-        void operator()(Error& error) const
+        void PIKA_STATIC_CALL_OPERATOR(Error& error)
         {
             throw error;
         }

--- a/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
+++ b/libs/pika/execution/include/pika/execution/scheduler_queries.hpp
@@ -28,15 +28,15 @@ namespace pika::execution::experimental {
             template <typename Query,
                 PIKA_CONCEPT_REQUIRES_(pika::functional::detail::is_nothrow_tag_invocable_v<
                     forwarding_scheduler_query_t, Query const&>)>
-            constexpr bool operator()(Query const& query) const noexcept
+            constexpr bool PIKA_STATIC_CALL_OPERATOR(Query const& query) noexcept
             {
-                return pika::functional::detail::tag_invoke(*this, query);
+                return pika::functional::detail::tag_invoke(forwarding_scheduler_query_t{}, query);
             }
 
             template <typename Query,
                 PIKA_CONCEPT_REQUIRES_(!pika::functional::detail::is_nothrow_tag_invocable_v<
                                        forwarding_scheduler_query_t, Query const&>)>
-            constexpr bool operator()(Query const&) const noexcept
+            constexpr bool PIKA_STATIC_CALL_OPERATOR(Query const&) noexcept
             {
                 return false;
             }
@@ -49,16 +49,18 @@ namespace pika::execution::experimental {
                         pika::functional::detail::is_nothrow_tag_invocable_v<
                             get_forward_progress_guarantee_t, Scheduler const&>)>
             constexpr forward_progress_guarantee
-            operator()(Scheduler const& scheduler) const noexcept
+            PIKA_STATIC_CALL_OPERATOR(Scheduler const& scheduler) noexcept
             {
-                return pika::functional::detail::tag_invoke(*this, scheduler);
+                return pika::functional::detail::tag_invoke(
+                    get_forward_progress_guarantee_t{}, scheduler);
             }
 
             template <typename Scheduler,
                 PIKA_CONCEPT_REQUIRES_(is_scheduler_v<Scheduler> &&
                     !pika::functional::detail::is_nothrow_tag_invocable_v<
                         get_forward_progress_guarantee_t, Scheduler const&>)>
-            constexpr forward_progress_guarantee operator()(Scheduler const&) const noexcept
+            constexpr forward_progress_guarantee
+            PIKA_STATIC_CALL_OPERATOR(Scheduler const&) noexcept
             {
                 return forward_progress_guarantee::weakly_parallel;
             }

--- a/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
+++ b/libs/pika/iterator_support/include/pika/iterator_support/zip_iterator.hpp
@@ -206,7 +206,7 @@ namespace pika::util {
         struct increment_iterator
         {
             template <typename T>
-            PIKA_HOST_DEVICE void operator()(T& iter) const
+            PIKA_HOST_DEVICE void PIKA_STATIC_CALL_OPERATOR(T& iter)
             {
                 ++iter;
             }
@@ -215,7 +215,7 @@ namespace pika::util {
         struct decrement_iterator
         {
             template <typename T>
-            PIKA_HOST_DEVICE void operator()(T& iter) const
+            PIKA_HOST_DEVICE void PIKA_STATIC_CALL_OPERATOR(T& iter)
             {
                 --iter;
             }

--- a/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
+++ b/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
@@ -334,7 +334,7 @@ namespace std {
     {
         using result_type = std::size_t;
 
-        result_type operator()(pika::memory::intrusive_ptr<T> const& p) const noexcept
+        result_type PIKA_STATIC_CALL_OPERATOR(pika::memory::intrusive_ptr<T> const& p) noexcept
         {
             return hash<T*>{}(p.get());
         }

--- a/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
@@ -124,7 +124,7 @@ namespace pika::program_options::detail {
 
     struct null_deleter
     {
-        void operator()(void const*) const {}
+        void PIKA_STATIC_CALL_OPERATOR(void const*) {}
     };
 
     template <class Char>

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
@@ -116,10 +116,10 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Tag tag, Ts&&... ts) const
-                noexcept(
-                    noexcept(tag_fallback_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
-                    -> decltype(tag_fallback_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            PIKA_STATIC_CALL_OPERATOR(Tag tag, Ts&&... ts) noexcept(
+                noexcept(tag_fallback_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
+                -> decltype(tag_fallback_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
             {
                 return tag_fallback_invoke(tag, PIKA_FORWARD(Ts, ts)...);
             }
@@ -247,23 +247,22 @@ namespace pika::functional::detail {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args,
                 typename Enable = std::enable_if_t<is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
-                    -> tag_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
+                -> tag_invoke_result_t<Tag, Args&&...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // is not tag-dispatchable
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args,
                 typename Enable = std::enable_if_t<!is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
-                    -> tag_fallback_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
+                -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
-                return tag_fallback_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_fallback_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
         };
 
@@ -277,21 +276,19 @@ namespace pika::functional::detail {
             // is nothrow tag-fallback dispatchable
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args>
-            PIKA_HOST_DEVICE constexpr auto
-            tag_fallback_invoke_impl(std::false_type, Args&&... /*args*/) const noexcept
-                -> not_tag_fallback_noexcept_dispatchable<Tag, Args...>
+            PIKA_HOST_DEVICE constexpr static auto tag_fallback_invoke_impl(std::false_type,
+                Args&&... /*args*/) noexcept -> not_tag_fallback_noexcept_dispatchable<Tag, Args...>
             {
                 return not_tag_fallback_noexcept_dispatchable<Tag, Args...>{};
             }
 
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
-            tag_fallback_invoke_impl(std::true_type, Args&&... args) const noexcept
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr static auto
+            tag_fallback_invoke_impl(std::true_type, Args&&... args) noexcept
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
-                return tag_fallback_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_fallback_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
         public:
@@ -299,10 +296,10 @@ namespace pika::functional::detail {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args,
                 typename Enable = std::enable_if_t<is_nothrow_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
-            operator()(Args&&... args) const noexcept -> tag_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept -> tag_invoke_result_t<Tag, Args&&...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // is not nothrow tag-dispatchable
@@ -311,7 +308,7 @@ namespace pika::functional::detail {
                 typename IsFallbackDispatchable = is_nothrow_tag_fallback_invocable<Tag, Args&&...>,
                 typename Enable = std::enable_if_t<!is_nothrow_tag_invocable_v<Tag, Args&&...>>>
             PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
-            operator()(Args&&... args) const noexcept -> decltype(tag_fallback_invoke_impl(
+            PIKA_STATIC_CALL_OPERATOR(Args&&... args) noexcept -> decltype(tag_fallback_invoke_impl(
                 IsFallbackDispatchable{}, PIKA_FORWARD(Args, args)...))
             {
                 return tag_fallback_invoke_impl(

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
@@ -119,10 +119,10 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Tag tag, Ts&&... ts) const
-                noexcept(
-                    noexcept(tag_override_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
-                    -> decltype(tag_override_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            PIKA_STATIC_CALL_OPERATOR(Tag tag, Ts&&... ts) noexcept(
+                noexcept(tag_override_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
+                -> decltype(tag_override_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
             {
                 return tag_override_invoke(tag, PIKA_FORWARD(Ts, ts)...);
             }
@@ -229,12 +229,11 @@ namespace pika::functional::detail {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args,
                 typename Enable = std::enable_if_t<is_tag_override_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_override_invocable_v<Tag, Args...>)
-                    -> tag_override_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_override_invocable_v<Tag, Args...>)
+                -> tag_override_invoke_result_t<Tag, Args&&...>
             {
-                return tag_override_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_override_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // Is not tag-override-dispatchable, but tag-dispatchable
@@ -242,11 +241,11 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable = std::enable_if_t<!is_tag_override_invocable_v<Tag, Args&&...> &&
                     is_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
-                    -> tag_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
+                -> tag_invoke_result_t<Tag, Args&&...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // Is not tag-override-dispatchable, not tag-dispatchable, but
@@ -256,12 +255,11 @@ namespace pika::functional::detail {
                 typename Enable = std::enable_if_t<!is_tag_override_invocable_v<Tag, Args&&...> &&
                     !is_tag_invocable_v<Tag, Args&&...> &&
                     is_tag_fallback_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
-                    -> tag_fallback_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
+                -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
-                return tag_fallback_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_fallback_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
         };
 
@@ -278,11 +276,10 @@ namespace pika::functional::detail {
             template <typename... Args,
                 typename Enable =
                     std::enable_if_t<is_nothrow_tag_override_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept -> tag_override_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept -> tag_override_invoke_result_t<Tag, Args&&...>
             {
-                return tag_override_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_override_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // Is not nothrow tag-override-dispatchable, but nothrow
@@ -292,10 +289,10 @@ namespace pika::functional::detail {
                 typename Enable =
                     std::enable_if_t<!is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                         is_nothrow_tag_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
-            operator()(Args&&... args) const noexcept -> tag_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept -> tag_invoke_result_t<Tag, Args&&...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
 
             // Is not nothrow tag-override-dispatchable, not nothrow
@@ -306,11 +303,10 @@ namespace pika::functional::detail {
                     std::enable_if_t<!is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                         !is_nothrow_tag_invocable_v<Tag, Args&&...> &&
                         is_nothrow_tag_fallback_invocable_v<Tag, Args&&...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(
-                Args&&... args) const noexcept -> tag_fallback_invoke_result_t<Tag, Args&&...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept -> tag_fallback_invoke_result_t<Tag, Args&&...>
             {
-                return tag_fallback_invoke(
-                    static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_fallback_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
         };
     }    // namespace tag_base_ns

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -114,9 +114,10 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename Tag, typename... Ts>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Tag tag, Ts&&... ts) const
-                noexcept(noexcept(tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
-                    -> decltype(tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
+            PIKA_STATIC_CALL_OPERATOR(Tag tag, Ts&&... ts) noexcept(
+                noexcept(tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...)))
+                -> decltype(tag_invoke(std::declval<Tag>(), PIKA_FORWARD(Ts, ts)...))
             {
                 return tag_invoke(tag, PIKA_FORWARD(Ts, ts)...);
             }
@@ -201,11 +202,11 @@ namespace pika::functional::detail {
         {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto operator()(Args&&... args) const
-                noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
-                    -> tag_invoke_result_t<Tag, Args...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
+                -> tag_invoke_result_t<Tag, Args...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
         };
 
@@ -215,10 +216,10 @@ namespace pika::functional::detail {
             PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
             template <typename... Args,
                 typename Enable = std::enable_if_t<is_nothrow_tag_invocable_v<Tag, Args...>>>
-            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto
-            operator()(Args&&... args) const noexcept -> tag_invoke_result_t<Tag, decltype(args)...>
+            PIKA_HOST_DEVICE PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(
+                Args&&... args) noexcept -> tag_invoke_result_t<Tag, decltype(args)...>
             {
-                return tag_invoke(static_cast<Tag const&>(*this), PIKA_FORWARD(Args, args)...);
+                return tag_invoke(Tag{}, PIKA_FORWARD(Args, args)...);
             }
         };
     }    // namespace tag_base_ns

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -278,7 +278,7 @@ namespace std {
     template <>
     struct hash<::pika::thread::id>
     {
-        std::size_t operator()(::pika::thread::id const& id) const
+        std::size_t PIKA_STATIC_CALL_OPERATOR(::pika::thread::id const& id)
         {
             std::hash<::pika::threads::detail::thread_id_ref_type> hasher_;
             return hasher_(id.native_handle());

--- a/libs/pika/type_support/include/pika/type_support/empty_function.hpp
+++ b/libs/pika/type_support/include/pika/type_support/empty_function.hpp
@@ -11,7 +11,7 @@ namespace pika::detail {
     struct empty_function
     {
         template <typename... Ts>
-        constexpr void operator()(Ts&&...) const noexcept
+        constexpr void PIKA_STATIC_CALL_OPERATOR(Ts&&...) noexcept
         {
         }
     };


### PR DESCRIPTION
Fixes #676.

Introduces a macro that can be used in place of `operator()`. Expands to `static operator()(...)` when the feature is available, `operator()(...) const` otherwise.

This uses a feature testing macro both for host and device compilers. The feature is only enabled if both support it as this should have an effect on how functions are called, and I don't think we want to be mixing translation units with mixed support.