### PR TITLE
Print the actual spack spec passed as argument in CI

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_dependencies
+++ b/.gitlab/docker/Dockerfile.spack_dependencies
@@ -4,7 +4,8 @@ FROM $BASE_IMAGE
 ARG SPACK_SPEC
 ENV spack_spec $SPACK_SPEC
 # Install dependencies for this configuration
-RUN spack env create pika_ci && \
+RUN echo $spack_spec && \
+    spack env create pika_ci && \
     spack -e pika_ci add $spack_spec && \
     spack -e pika_ci spec -lI $spack_spec && \
     spack -e pika_ci install --fail-fast --only dependencies $spack_spec && \


### PR DESCRIPTION
We were only printing the concretized spack spec. This is useful to have the `SPACK_SPEC` variable also printed in case of typos or similar.