### PR TITLE
Removing the concretization step since already in install step

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_dependencies
+++ b/.gitlab/docker/Dockerfile.spack_dependencies
@@ -6,6 +6,5 @@ ENV spack_spec $SPACK_SPEC
 # Install dependencies for this configuration
 RUN spack env create pika_ci && \
     spack -e pika_ci add $spack_spec && \
-    spack -e pika_ci spec -lI $spack_spec && \
     spack -e pika_ci install --fail-fast --only dependencies $spack_spec && \
     spack -e pika_ci clean --all


### PR DESCRIPTION
The concretization is now printed by default by spack on the install step. This removes the print of the concretization as it is now printed twice (https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/479009878135925/5304355110917878/-/jobs/6061783815#L51).