### PR TITLE
Keep `-Werror` flags in CSCS CI builds of pika

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -15,7 +15,8 @@ COPY . ${SOURCE_DIR}
 RUN spack -e pika_ci spec -lI $spack_spec
 
 # Configure & Build
-RUN spack -e pika_ci build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
+RUN spack -e pika_ci config add "config:flags:keep_werror:all" && \
+    spack -e pika_ci build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
     $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && cmake --build ${BUILD_DIR} --target all tests examples \
     install"
 

--- a/examples/jacobi_smp/jacobi_nonuniform_omp.hpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_omp.hpp
@@ -21,7 +21,7 @@
 
 namespace jacobi_smp {
     void jacobi(crs_matrix<double> const& A, std::vector<double> const& b, std::size_t iterations,
-        std::size_t block_size)
+        [[maybe_unused]] std::size_t block_size)
     {
         using vector_type = std::vector<double>;
 


### PR DESCRIPTION
Spack disables `-Werror` flags by default. This makes some sense for building dependencies in pika, but is not so good for CI. This enables `-Werror` flags again for the build stage of pika itself, but not while building pika dependencies.