### PR TITLE
Silence potential false positive address sanitizer error in `cross_pool_injection` test

### DIFF
--- a/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
@@ -22,6 +22,13 @@ set(tests
 )
 
 set(cross_pool_injection_PARAMETERS THREADS -1 TIMEOUT 300)
+if(PIKA_WITH_SANITIZERS)
+  # This test triggers a possible false positive stack-use-after-scope in lock
+  # registration
+  list(APPEND cross_pool_injection_PARAMETERS
+       "--pika:ini=pika.lock_detection=0"
+  )
+endif()
 set(scheduler_binding_check_PARAMETERS THREADS -1)
 
 set(named_pool_executor_PARAMETERS THREADS 4)


### PR DESCRIPTION
Silences the following error reported by address sanitizer, by simply disabling lock registration in the `cross_pool_injection` test. I couldn't convince address sanitizer to ignore the error with the suppression file/ignorelist.

This may be a real error, but it's not at all clear what the issue would be in that case. The error is triggered inside standard library headers.
```
5: Starting suspending 20
=================================================================
==4462==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fac09ebd8e0 at pc 0x7fac180ca6ff bp 0x7fac09ebd890 sp 0x7fac09ebd888
WRITE of size 8 at 0x7fac09ebd8e0 thread T28
    #0 0x7fac180ca6fe in std::_Rb_tree_iterator<std::pair<void const* const, pika::util::detail::lock_data>> std::_Rb_tree<void const*, std::pair<void const* const, pika::util::detail::lock_data>, std::_Select1st<std::pair<void const* const, pika::util::detail::lock_data>>, std::less<void const*>, std::allocator<std::pair<void const* const, pika::util::detail::lock_data>>>::_M_emplace_hint_unique<std::pair<void const*, pika::util::detail::lock_data>>(std::_Rb_tree_const_iterator<std::pair<void const* const, pika::util::detail::lock_data>>, std::pair<void const*, pika::util::detail::lock_data>&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_tree.h:2461
    #1 0x7fac180ca001 in std::_Rb_tree_iterator<std::pair<void const* const, pika::util::detail::lock_data>> std::map<void const*, pika::util::detail::lock_data, std::less<void const*>, std::allocator<std::pair<void const* const, pika::util::detail::lock_data>>>::emplace_hint<std::pair<void const*, pika::util::detail::lock_data>>(std::_Rb_tree_const_iterator<std::pair<void const* const, pika::util::detail::lock_data>>, std::pair<void const*, pika::util::detail::lock_data>&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_map.h:640:16
    #2 0x7fac180c3bd7 in std::enable_if<is_constructible<std::pair<void const* const, pika::util::detail::lock_data>, std::pair<void const*, pika::util::detail::lock_data>>::value, std::pair<std::_Rb_tree_iterator<std::pair<void const* const, pika::util::detail::lock_data>>, bool>>::type std::map<void const*, pika::util::detail::lock_data, std::less<void const*>, std::allocator<std::pair<void const* const, pika::util::detail::lock_data>>>::insert<std::pair<void const*, pika::util::detail::lock_data>>(std::pair<void const*, pika::util::detail::lock_data>&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_map.h:860:15
    #3 0x7fac180c008b in pika::util::register_lock(void const*, pika::util::register_lock_data*) /__w/pika/pika/libs/pika/lock_registration/src/register_locks.cpp:173:32
    #4 0x557c7ebc8bb3 in pika::concurrency::detail::spinlock::lock() /__w/pika/pika/libs/pika/concurrency/include/pika/concurrency/spinlock.hpp:70:13
    #5 0x557c7ebc89b1 in std::unique_lock<pika::concurrency::detail::spinlock>::lock() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_lock.h:141:17
    #6 0x557c7ebc82fd in std::unique_lock<pika::concurrency::detail::spinlock>::unique_lock(pika::concurrency::detail::spinlock&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_lock.h:71:2
    #7 0x557c7ebce5bb in pika::sync_wait_detail::sync_wait_receiver_impl<pika::ensure_started_detail::ensure_started_sender_impl<pika::then_detail::then_sender_impl<pika::schedule_from_detail::schedule_from_sender_impl<pika::just_detail::just_sender_impl<pika::util::detail::pack_c<unsigned long, 0ul>, unsigned long&>::just_sender_type, pika::execution::experimental::thread_pool_scheduler>::schedule_from_sender_type, void (*)(unsigned long)>::then_sender_type, std::allocator<int>>::ensure_started_sender_type>::sync_wait_receiver_type::shared_state::wait() /__w/pika/pika/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp:143:46
```