### PR TITLE
Run debug and release builds for each CSCS CI configuration

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -4,6 +4,7 @@ FROM $BASE_IMAGE
 ARG SOURCE_DIR
 ARG BUILD_DIR
 
+ARG BUILD_TYPE
 ARG CMAKE_COMMON_FLAGS
 ARG CMAKE_FLAGS
 # Provided by the gitlab runner of .container-builder
@@ -17,8 +18,8 @@ RUN spack -e pika_ci spec -lI $spack_spec
 # Configure & Build
 RUN spack -e pika_ci config add "config:flags:keep_werror:all" && \
     spack -e pika_ci build-env $spack_spec -- bash -c "cmake -B${BUILD_DIR} ${SOURCE_DIR} \
-    $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && cmake --build ${BUILD_DIR} --target all tests examples \
-    install"
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && cmake --build ${BUILD_DIR} \
+    --target all tests examples install"
 
 # Run compile only tests and tests.unit.build, submit ctest metrics to elastic
 ARG ARCH

--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -35,9 +35,17 @@ clang11_build:
     - .variables_clang11_config
     - .build_template
 
-clang11_test:
+.clang11_test_commmon:
   needs: [clang11_build]
   extends:
     - .variables_clang11_config
     - .test_common_mc
     - .test_template
+
+clang11_test_release:
+  extends: [.clang11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang11_test_debug:
+  extends: [.clang11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_clang11_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@11.0.1
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.72.0 \
                  ^hwloc@1.11.11"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MAX_CPU_COUNT=256 -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MAX_CPU_COUNT=256 \
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 clang11_spack_compiler_image:
   extends:
@@ -31,14 +29,14 @@ clang11_spack_image:
     - .variables_clang11_config
     - .dependencies_image_template
 
-clang11_debug_build:
+clang11_build:
   needs: [clang11_spack_image]
   extends:
     - .variables_clang11_config
     - .build_template
 
-clang11_debug_test:
-  needs: [clang11_debug_build]
+clang11_test:
+  needs: [clang11_build]
   extends:
     - .variables_clang11_config
     - .test_common_mc

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_clang12_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@12.0.1
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.79.0 \
                  ^hwloc@2.2.0"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
-                  -DPIKA_WITH_COROUTINE_COUNTERS=ON \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_COROUTINE_COUNTERS=ON \
                   -DPIKA_WITH_THREAD_IDLE_RATES=ON \
                   -DPIKA_WITH_THREAD_CREATION_AND_CLEANUP_RATES=ON \
                   -DPIKA_WITH_THREAD_CUMULATIVE_COUNTS=ON -DPIKA_WITH_THREAD_QUEUE_WAITTIME=ON \
@@ -35,14 +33,14 @@ clang12_spack_image:
     - .variables_clang12_config
     - .dependencies_image_template
 
-clang12_debug_build:
+clang12_build:
   needs: [clang12_spack_image]
   extends:
     - .variables_clang12_config
     - .build_template
 
-clang12_debug_test:
-  needs: [clang12_debug_build]
+clang12_test:
+  needs: [clang12_build]
   extends:
     - .variables_clang12_config
     - .test_common_mc

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -39,9 +39,17 @@ clang12_build:
     - .variables_clang12_config
     - .build_template
 
-clang12_test:
+.clang12_test_commmon:
   needs: [clang12_build]
   extends:
     - .variables_clang12_config
     - .test_common_mc
     - .test_template
+
+clang12_test_release:
+  extends: [.clang12_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang12_test_debug:
+  extends: [.clang12_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -11,15 +11,14 @@ include:
 .variables_clang13_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@13.0.1
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} cxxflags=-stdlib=libc++ malloc=system \
                  cxxstd=$CXXSTD +stdexec ^boost@1.79.0 ^hwloc@2.6.0 ^fmt cxxflags=-stdlib=libc++ \
                  ^stdexec@git.nvhpc-23.09.rc4=main"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_STDEXEC=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
+                  -DPIKA_WITH_STDEXEC=ON"
 
 clang13_spack_compiler_image:
   extends:
@@ -32,14 +31,14 @@ clang13_spack_image:
     - .variables_clang13_config
     - .dependencies_image_template
 
-clang13_debug_build:
+clang13_build:
   needs: [clang13_spack_image]
   extends:
     - .variables_clang13_config
     - .build_template
 
-clang13_debug_test:
-  needs: [clang13_debug_build]
+clang13_test:
+  needs: [clang13_build]
   extends:
     - .variables_clang13_config
     - .test_common_mc

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -37,9 +37,17 @@ clang13_build:
     - .variables_clang13_config
     - .build_template
 
-clang13_test:
+.clang13_test_commmon:
   needs: [clang13_build]
   extends:
     - .variables_clang13_config
     - .test_common_mc
     - .test_template
+
+clang13_test_release:
+  extends: [.clang13_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang13_test_debug:
+  extends: [.clang13_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -37,9 +37,17 @@ clang14_cuda11_build:
     - .variables_clang14_cuda11_config
     - .build_template
 
-clang14_cuda11_test:
+.clang14_cuda11_test_commmon:
   needs: [clang14_cuda11_build]
   extends:
     - .variables_clang14_cuda11_config
     - .test_common_gpu_clariden_cuda
     - .test_template
+
+clang14_cuda11_test_release:
+  extends: [.clang14_cuda11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang14_cuda11_test_debug:
+  extends: [.clang14_cuda11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_clang14_cuda11_config:
   variables:
     ARCH: linux-ubuntu22.04-zen3
-    BUILD_TYPE: Debug
     COMPILER: clang@14.0.6
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
                  ^boost@1.79.0 ^cuda@11.5.0 +allow-unsupported-compilers ^hwloc@2.7.0"
     # PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE is OFF to test the fallback implementation of PIKA_FORWARD.
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=20 \
-                  -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=20 -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DCMAKE_CUDA_COMPILER=c++ \
                   -DCMAKE_CUDA_ARCHITECTURES=80 -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
 
@@ -33,14 +31,14 @@ clang14_cuda11_spack_image:
     - .variables_clang14_cuda11_config
     - .dependencies_image_template
 
-clang14_cuda11_debug_build:
+clang14_cuda11_build:
   needs: [clang14_cuda11_spack_image]
   extends:
     - .variables_clang14_cuda11_config
     - .build_template
 
-clang14_cuda11_debug_test:
-  needs: [clang14_cuda11_debug_build]
+clang14_cuda11_test:
+  needs: [clang14_cuda11_build]
   extends:
     - .variables_clang14_cuda11_config
     - .test_common_gpu_clariden_cuda

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -35,9 +35,17 @@ clang15_build:
     - .variables_clang15_config
     - .build_template
 
-clang15_test:
+.clang15_test_commmon:
   needs: [clang15_build]
   extends:
     - .variables_clang15_config
     - .test_common_mc
     - .test_template
+
+clang15_test_release:
+  extends: [.clang15_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang15_test_debug:
+  extends: [.clang15_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_clang15_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@15.0.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.80.0 \
                  ^hwloc@2.8.0"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
-                  -DPIKA_WITH_UNITY_BUILD=OFF"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_UNITY_BUILD=OFF"
 
 clang15_spack_compiler_image:
   extends:
@@ -31,14 +29,14 @@ clang15_spack_image:
     - .variables_clang15_config
     - .dependencies_image_template
 
-clang15_debug_build:
+clang15_build:
   needs: [clang15_spack_image]
   extends:
     - .variables_clang15_config
     - .build_template
 
-clang15_debug_test:
-  needs: [clang15_debug_build]
+clang15_test:
+  needs: [clang15_build]
   extends:
     - .variables_clang15_config
     - .test_common_mc

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -35,9 +35,17 @@ clang16_build:
     - .variables_clang16_config
     - .build_template
 
-clang16_test:
+.clang16_test_commmon:
   needs: [clang16_build]
   extends:
     - .variables_clang16_config
     - .test_common_mc
     - .test_template
+
+clang16_test_release:
+  extends: [.clang16_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang16_test_debug:
+  extends: [.clang16_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -11,13 +11,12 @@ include:
 .variables_clang16_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@16.0.2
     CXXSTD: 23
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.82.0 \
                  ^hwloc@2.9.1"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 clang16_spack_compiler_image:
   extends:
@@ -30,14 +29,14 @@ clang16_spack_image:
     - .variables_clang16_config
     - .dependencies_image_template
 
-clang16_debug_build:
+clang16_build:
   needs: [clang16_spack_image]
   extends:
     - .variables_clang16_config
     - .build_template
 
-clang16_debug_test:
-  needs: [clang16_debug_build]
+clang16_test:
+  needs: [clang16_build]
   extends:
     - .variables_clang16_config
     - .test_common_mc

--- a/.gitlab/includes/clang17_pipeline.yml
+++ b/.gitlab/includes/clang17_pipeline.yml
@@ -35,9 +35,17 @@ clang17_build:
     - .variables_clang17_config
     - .build_template
 
-clang17_test:
+.clang17_test_commmon:
   needs: [clang17_build]
   extends:
     - .variables_clang17_config
     - .test_common_mc
     - .test_template
+
+clang17_test_release:
+  extends: [.clang17_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang17_test_debug:
+  extends: [.clang17_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang17_pipeline.yml
+++ b/.gitlab/includes/clang17_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_clang17_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: clang@17.0.4
     CXXSTD: 23
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.83.0 \
                  ^hwloc@2.9.1"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
-                  -DPIKA_WITH_THREAD_STACK_MMAP=OFF"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_THREAD_STACK_MMAP=OFF"
 
 clang17_spack_compiler_image:
   extends:
@@ -31,14 +29,14 @@ clang17_spack_image:
     - .variables_clang17_config
     - .dependencies_image_template
 
-clang17_debug_build:
+clang17_build:
   needs: [clang17_spack_image]
   extends:
     - .variables_clang17_config
     - .build_template
 
-clang17_debug_test:
-  needs: [clang17_debug_build]
+clang17_test:
+  needs: [clang17_build]
   extends:
     - .variables_clang17_config
     - .test_common_mc

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -63,10 +63,18 @@ base_spack_image:
     reports:
       dotenv: dependencies.env
 
+.parallel_build_types:
+  parallel:
+    matrix:
+      - BUILD_TYPE:
+          - Debug
+          - Release
+
 .build_template:
   stage: build
   extends:
     - .container-builder
+    - .parallel_build_types
     - .build_variables_common
     - .cmake_variables_common
   before_script:
@@ -84,6 +92,7 @@ base_spack_image:
 .test_template:
   extends:
     - .cmake_variables_common
+    - .parallel_build_types
   script:
     - spack arch
     - export CTEST_XML=$PWD/ctest.xml

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -69,33 +69,34 @@ base_spack_image:
       - BUILD_TYPE:
           - Debug
           - Release
+  variables:
+    DOTENV_FILE: "build-$BUILD_TYPE.env"
 
 .build_template:
   stage: build
   extends:
     - .container-builder
-    - .parallel_build_types
     - .build_variables_common
     - .cmake_variables_common
+    - .parallel_build_types
   before_script:
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - build_type=`echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]'`
+    - build_type_upper=`echo $BUILD_TYPE | tr '[:lower:]' '[:upper:]'`
     - configuration=$DOCKERFILE_SHA-$BASE_IMAGE-$BUILD_DIR-$CMAKE_COMMON_FLAGS-$CMAKE_FLAGS-$CI_COMMIT_SHORT_SHA-$SOURCE_DIR
     - configuration=${configuration//-D/}
     - CONFIG_TAG=`echo $configuration | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/pika-$compiler-$build_type-build:$CONFIG_TAG
-    - echo -e "PERSIST_IMAGE_NAME=$PERSIST_IMAGE_NAME" >> build.env
+    - echo -e "PERSIST_IMAGE_NAME_${build_type_upper}=$PERSIST_IMAGE_NAME" >> $DOTENV_FILE
   artifacts:
     reports:
-      dotenv: build.env
+      dotenv: "$DOTENV_FILE"
 
 .test_template:
   extends:
     - .cmake_variables_common
-    - .parallel_build_types
   script:
     - spack arch
     - export CTEST_XML=$PWD/ctest.xml
     - trap "${SOURCE_DIR}/.gitlab/scripts/collect_ctest_metrics.sh ${CTEST_XML}" EXIT
     - spack -e pika_ci build-env $spack_spec -- bash -c "ctest --output-junit ${CTEST_XML} --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 120 --output-on-failure --no-compress-output --no-tests=error"
-  image: $PERSIST_IMAGE_NAME

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -11,13 +11,11 @@ include:
 .variables_gcc10_apex_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Release
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
                  ^apex@2.4.1~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc10_apex_spack_compiler_image:
@@ -31,14 +29,14 @@ gcc10_apex_spack_image:
     - .variables_gcc10_apex_config
     - .dependencies_image_template
 
-gcc10_apex_release_build:
+gcc10_apex_build:
   needs: [gcc10_apex_spack_image]
   extends:
     - .variables_gcc10_apex_config
     - .build_template
 
-gcc10_apex_release_test:
-  needs: [gcc10_apex_release_build]
+gcc10_apex_test:
+  needs: [gcc10_apex_build]
   extends:
     - .variables_gcc10_apex_config
     - .test_common_mc

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -35,9 +35,17 @@ gcc10_apex_build:
     - .variables_gcc10_apex_config
     - .build_template
 
-gcc10_apex_test:
+.gcc10_apex_test_commmon:
   needs: [gcc10_apex_build]
   extends:
     - .variables_gcc10_apex_config
     - .test_common_mc
     - .test_template
+
+gcc10_apex_test_release:
+  extends: [.gcc10_apex_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc10_apex_test_debug:
+  extends: [.gcc10_apex_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -11,14 +11,12 @@ include:
 .variables_gcc11_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: gcc@11.4.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.78.0 \
                  ^hwloc@2.7.0"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MAX_CPU_COUNT=256 -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MAX_CPU_COUNT=256 \
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc11_spack_compiler_image:
   extends:
@@ -31,14 +29,14 @@ gcc11_spack_image:
     - .variables_gcc11_config
     - .dependencies_image_template
 
-gcc11_debug_build:
+gcc11_build:
   needs: [gcc11_spack_image]
   extends:
     - .build_template
     - .variables_gcc11_config
 
-gcc11_debug_test:
-  needs: [gcc11_debug_build]
+gcc11_test:
+  needs: [gcc11_build]
   extends:
     - .variables_gcc11_config
     - .test_common_mc

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -35,9 +35,17 @@ gcc11_build:
     - .build_template
     - .variables_gcc11_config
 
-gcc11_test:
+.gcc11_test_commmon:
   needs: [gcc11_build]
   extends:
     - .variables_gcc11_config
     - .test_common_mc
     - .test_template
+
+gcc11_test_release:
+  extends: [.gcc11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc11_test_debug:
+  extends: [.gcc11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -11,15 +11,13 @@ include:
 .variables_gcc12_cuda12_config:
   variables:
     ARCH: linux-ubuntu22.04-zen3
-    BUILD_TYPE: Debug
     COMPILER: gcc@12.1.0
     CXXSTD: 17
     GPU_TARGET: "80"
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system \
                  cxxstd=$CXXSTD ^boost@1.82.0 ^hwloc@2.9.1 ^cuda@12.0.0 ^fmt@10.0.0"
     # PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE is OFF to test the fallback implementation of PIKA_FORWARD.
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET \
                   -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
 
@@ -34,7 +32,7 @@ gcc12_cuda12_spack_image:
     - .variables_gcc12_cuda12_config
     - .dependencies_image_template
 
-gcc12_cuda12_debug_build:
+gcc12_cuda12_build:
   needs: [gcc12_cuda12_spack_image]
   extends:
     - .variables_gcc12_cuda12_config
@@ -42,8 +40,8 @@ gcc12_cuda12_debug_build:
 
 # Test step currently commented as the cuda driver is too old on clariden:
 # https://github.com/pika-org/pika/issues/884
-#gcc12_cuda12_debug_test:
-#  needs: [gcc12_cuda12_debug_build]
+#gcc12_cuda12_test:
+#  needs: [gcc12_cuda12_build]
 #  extends:
 #    - .variables_gcc12_cuda12_config
 #    - .test_common_gpu_clariden_cuda

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -32,17 +32,25 @@ gcc12_cuda12_spack_image:
     - .variables_gcc12_cuda12_config
     - .dependencies_image_template
 
-gcc12_cuda12_build:
-  needs: [gcc12_cuda12_spack_image]
-  extends:
-    - .variables_gcc12_cuda12_config
-    - .build_template
-
 # Test step currently commented as the cuda driver is too old on clariden:
 # https://github.com/pika-org/pika/issues/884
-#gcc12_cuda12_test:
+#gcc12_cuda12_build:
+#  needs: [gcc12_cuda12_spack_image]
+#  extends:
+#    - .variables_gcc12_cuda12_config
+#    - .build_template
+#
+#.gcc12_cuda12_test_commmon:
 #  needs: [gcc12_cuda12_build]
 #  extends:
 #    - .variables_gcc12_cuda12_config
 #    - .test_common_gpu_clariden_cuda
 #    - .test_template
+#
+#gcc12_cuda12_test_release:
+#  extends: [.gcc12_cuda12_test_commmon]
+#  image: $PERSIST_IMAGE_NAME_RELEASE
+#
+#gcc12_cuda12_test_debug:
+#  extends: [.gcc12_cuda12_test_commmon]
+#  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -11,15 +11,13 @@ include:
 .variables_gcc12_hip5_config:
   variables:
     ARCH: linux-ubuntu22.04-zen3
-    BUILD_TYPE: Debug
     COMPILER: gcc@12.2.0
     CXXSTD: 20
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
                  ^fmt@10.0.0 ^stdexec@git.nvhpc-23.09.rc4=main"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 
 gcc12_hip5_spack_compiler_image:
@@ -34,14 +32,14 @@ gcc12_hip5_spack_image:
     - .variables_gcc12_hip5_config
     - .dependencies_image_template
 
-gcc12_hip5_debug_build:
+gcc12_hip5_build:
   needs: [gcc12_hip5_spack_image]
   extends:
     - .variables_gcc12_hip5_config
     - .build_template
 
-gcc12_hip5_debug_test:
-  needs: [gcc12_hip5_debug_build]
+gcc12_hip5_test:
+  needs: [gcc12_hip5_build]
   extends:
     - .variables_gcc12_hip5_config
     - .test_common_gpu_clariden_hip

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -38,9 +38,17 @@ gcc12_hip5_build:
     - .variables_gcc12_hip5_config
     - .build_template
 
-gcc12_hip5_test:
+.gcc12_hip5_test_commmon:
   needs: [gcc12_hip5_build]
   extends:
     - .variables_gcc12_hip5_config
     - .test_common_gpu_clariden_hip
     - .test_template
+
+gcc12_hip5_test_release:
+  extends: [.gcc12_hip5_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc12_hip5_test_debug:
+  extends: [.gcc12_hip5_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -35,9 +35,17 @@ gcc12_build:
     - .variables_gcc12_config
     - .build_template
 
-gcc12_test:
+.gcc12_test_commmon:
   needs: [gcc12_build]
   extends:
     - .variables_gcc12_config
     - .test_common_mc
     - .test_template
+
+gcc12_test_release:
+  extends: [.gcc12_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc12_test_debug:
+  extends: [.gcc12_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -11,13 +11,12 @@ include:
 .variables_gcc12_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: gcc@12.1.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.79.0 \
                  ^hwloc@2.7.0"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc12_spack_compiler_image:
   extends:
@@ -30,14 +29,14 @@ gcc12_spack_image:
     - .variables_gcc12_config
     - .dependencies_image_template
 
-gcc12_debug_build:
+gcc12_build:
   needs: [gcc12_spack_image]
   extends:
     - .variables_gcc12_config
     - .build_template
 
-gcc12_debug_test:
-  needs: [gcc12_debug_build]
+gcc12_test:
+  needs: [gcc12_build]
   extends:
     - .variables_gcc12_config
     - .test_common_mc

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -11,15 +11,13 @@ include:
 .variables_gcc13_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: gcc@13.1.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
                  ^stdexec@git.nvhpc-23.09.rc4=main"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_STDEXEC=ON \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
+                  -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc13_spack_compiler_image:
   extends:
@@ -32,14 +30,14 @@ gcc13_spack_image:
     - .variables_gcc13_config
     - .dependencies_image_template
 
-gcc13_debug_build:
+gcc13_build:
   needs: [gcc13_spack_image]
   extends:
     - .variables_gcc13_config
     - .build_template
 
-gcc13_debug_test:
-  needs: [gcc13_debug_build]
+gcc13_test:
+  needs: [gcc13_build]
   extends:
     - .variables_gcc13_config
     - .test_common_mc

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -36,9 +36,17 @@ gcc13_build:
     - .variables_gcc13_config
     - .build_template
 
-gcc13_test:
+.gcc13_test_commmon:
   needs: [gcc13_build]
   extends:
     - .variables_gcc13_config
     - .test_common_mc
     - .test_template
+
+gcc13_test_release:
+  extends: [.gcc13_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc13_test_debug:
+  extends: [.gcc13_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -11,13 +11,11 @@ include:
 .variables_gcc9_cuda11_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: gcc@9.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
                  ^boost@1.75.0 ^hwloc@2.0.3 ^cuda@11.2.0 ^fmt@9"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_EXAMPLES_OPENMP=ON"
 
 gcc9_cuda11_spack_compiler_image:
@@ -31,14 +29,14 @@ gcc9_cuda11_spack_image:
     - .variables_gcc9_cuda11_config
     - .dependencies_image_template
 
-gcc9_cuda11_debug_build:
+gcc9_cuda11_build:
   needs: [gcc9_cuda11_spack_image]
   extends:
     - .variables_gcc9_cuda11_config
     - .build_template
 
-gcc9_cuda11_debug_test:
-  needs: [gcc9_cuda11_debug_build]
+gcc9_cuda11_test:
+  needs: [gcc9_cuda11_build]
   extends:
     - .variables_gcc9_cuda11_config
     - .test_common_gpu_clariden_cuda

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -35,9 +35,17 @@ gcc9_cuda11_build:
     - .variables_gcc9_cuda11_config
     - .build_template
 
-gcc9_cuda11_test:
+.gcc9_cuda11_test_commmon:
   needs: [gcc9_cuda11_build]
   extends:
     - .variables_gcc9_cuda11_config
     - .test_common_gpu_clariden_cuda
     - .test_template
+
+gcc9_cuda11_test_release:
+  extends: [.gcc9_cuda11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc9_cuda11_test_debug:
+  extends: [.gcc9_cuda11_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -36,9 +36,17 @@ gcc9_build:
     - .variables_gcc9_config
     - .build_template
 
-gcc9_test:
+.gcc9_test_commmon:
   needs: [gcc9_build]
   extends:
     - .variables_gcc9_config
     - .test_common_mc
     - .test_template
+
+gcc9_test_release:
+  extends: [.gcc9_test_commmon]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+gcc9_test_debug:
+  extends: [.gcc9_test_commmon]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -11,14 +11,13 @@ include:
 .variables_gcc9_config:
   variables:
     ARCH: linux-ubuntu22.04-broadwell
-    BUILD_TYPE: Debug
     COMPILER: gcc@9.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
                  +generic_coroutines ^boost@1.71.0 ^hwloc@1.11.5"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
-                  -DPIKA_WITH_MAX_CPU_COUNT=256 -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_BOOST_CONTEXT=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MAX_CPU_COUNT=256 \
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_BOOST_CONTEXT=ON \
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc9_spack_compiler_image:
   extends:
@@ -31,14 +30,14 @@ gcc9_spack_image:
     - .variables_gcc9_config
     - .dependencies_image_template
 
-gcc9_debug_build:
+gcc9_build:
   needs: [gcc9_spack_image]
   extends:
     - .variables_gcc9_config
     - .build_template
 
-gcc9_debug_test:
-  needs: [gcc9_debug_build]
+gcc9_test:
+  needs: [gcc9_build]
   extends:
     - .variables_gcc9_config
     - .test_common_mc

--- a/.gitlab/includes/performance_gcc13_pipeline.yml
+++ b/.gitlab/includes/performance_gcc13_pipeline.yml
@@ -16,7 +16,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=mimalloc cxxstd=$CXXSTD \
                  ^boost@1.83.0 ^hwloc@2.9.1"
-    CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIKA_WITH_CXX_STANDARD=$CXXSTD"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD"
 
 performance_gcc13_spack_compiler_image:
   extends:
@@ -35,14 +35,21 @@ performance_gcc13_release_build:
     - .variables_performance_gcc13_config
     - .build_template
 
-performance_gcc13_release_test:
+.performance_gcc13_test_common:
   extends:
     - .variables_performance_gcc13_config
     - .test_common_mc
     - .cmake_variables_common
   needs: [performance_gcc13_release_build]
-  image: $PERSIST_IMAGE_NAME
   script:
     - export MIMALLOC_EAGER_COMMIT_DELAY=0
     - export MIMALLOC_LARGE_OS_PAGES=1
     - "${SOURCE_DIR}/.gitlab/scripts/run_performance_benchmarks.sh"
+
+performance_gcc13_test_release:
+  extends: [.performance_gcc13_test_common]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+performance_gcc13_test_debug:
+  extends: [.performance_gcc13_test_common]
+  image: $PERSIST_IMAGE_NAME_DEBUG


### PR DESCRIPTION
- Use the matrix functionality to run both Debug and Release builds for each configuration.
- We are using 2 different jobs for the test stage (one release and one debug). 

The `image:` field of a gitlab CI job doesn't allow customization with a variable (build type for example). Since it's evaluated before running the script of the same job, a scripting logic to change the image name is not possible either. That's why we currently have 2 jobs for the test step (one for the release mode, the other for the debug mode) 