### PR TITLE
Disable recycling of threads when `PIKA_WITH_THREAD_STACK_MMAP` is disabled

### DIFF
--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -16,7 +16,8 @@ include:
     SPACK_SPEC: "pika@main arch=$ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.80.0 \
                  ^hwloc@2.8.0"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_UNITY_BUILD=OFF"
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_UNITY_BUILD=OFF \
+                  -DPIKA_WITH_THREAD_STACK_MMAP=OFF"
 
 clang15_spack_compiler_image:
   extends:

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -214,6 +214,7 @@ namespace pika::threads::detail {
         /// Only cleans up terminated tasks belonging to this thread
         bool cleanup_terminated(bool delete_all) override
         {
+#ifdef PIKA_HAVE_THREAD_STACK_MMAP
             using namespace pika::debug::detail;
             static auto cleanup = spq_deb<3>.make_timer(1, str<>("Cleanup"), "Global version");
             PIKA_DETAIL_DP(spq_deb<3>, timed(cleanup));
@@ -249,13 +250,22 @@ namespace pika::threads::detail {
             return numa_holder_[domain_num]
                 .thread_queue(static_cast<std::size_t>(q_index))
                 ->cleanup_terminated(local_num, delete_all);
+#else
+            PIKA_UNUSED(delete_all);
+            return true;
+#endif
         }
 
         // ------------------------------------------------------------
         /// Generic cleanup function called by scheduling loop
         bool cleanup_terminated(std::size_t /* thread_num */, bool delete_all) override
         {
+#ifdef PIKA_HAVE_THREAD_STACK_MMAP
             return cleanup_terminated(delete_all);
+#else
+            PIKA_UNUSED(delete_all);
+            return true;
+#endif
         }
 
         // ------------------------------------------------------------

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -407,6 +407,7 @@ namespace pika::threads::detail {
             std::lock_guard<mutex_type> lk(mtx_);
             return cleanup_terminated_locked(false);
 #else
+            PIKA_UNUSED(delete_all);
             return true;
 #endif
         }


### PR DESCRIPTION
When not using `mmap` for thread stacks we can rely on the allocator to do performant recycling instead of us manually recycling threads. In some situations it seems like not using `mmap` and relying on the allocator recycling memory is faster than us recycling threads. I'm leaving `mmap` as the default though as it's not clear if it's always faster to not use `mmap`.