### PR TITLE
Add release notes for 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 <!--- Distributed under the Boost Software License, Version 1.0. (See accompanying -->
 <!--- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
 
+## 0.22.2 (TBD)
+
+### Bugfixes
+
+- Fix incorrect worker thread numbers when using more than one thread pool. ([#1016](https://github.com/pika-org/pika/pull/1016))
+- Unrevert [#872](https://github.com/pika-org/pika/pull/872) with an indexing error fixed. ([#1017](https://github.com/pika-org/pika/pull/1017))
+
 ## 0.22.1 (2024-01-29)
 
 ### Bugfixes


### PR DESCRIPTION
Release date still TBD, but tentatively it will be on 2024-02-09.

#1016 and #1017 have been cherry-picked to the `release-0.22.X` branch: https://github.com/pika-org/pika/compare/0.22.1...release-0.22.X.