### PR TITLE
Disable more Jenkins configurations in CI

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -42,23 +42,11 @@ pipeline {
                 axes {
                     axis {
                         name 'configuration_name'
-                        values 'gcc-13', 'gcc-12', 'gcc-11', 'gcc-10-apex', 'gcc-9', 'gcc-cuda-11', 'gcc-cuda-12', 'clang-16', 'clang-15', 'clang-14-cuda', 'clang-13', 'clang-12', 'clang-11', 'cce', 'nvhpc'
+                        values 'cce', 'nvhpc'
                     }
                     axis {
                          name 'build_type'
                          values 'Debug', 'Release'
-                    }
-                }
-                excludes {
-                    exclude {
-                        axis {
-                            name 'build_type'
-                            values 'Debug'
-                        }
-                        axis {
-                            name 'configuration_name'
-                            notValues 'cce', 'nvhpc'
-                        }
                     }
                 }
                 stages {


### PR DESCRIPTION
Disable more jenkins configurations since they are now covered by CSCS CI. I'm leaving cce and nvhpc still since the nvhpc PR pipeline is not yet merged.