### PR TITLE
Use `-fno-omit-frame-pointer` in tsan CI configuration

### DIFF
--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -51,7 +51,7 @@ jobs:
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \
-                -DCMAKE_CXX_FLAGS="-fsanitize=thread -omit-frame-pointer" \
+                -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
                 -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
       - name: Build


### PR DESCRIPTION
I have no idea why I would've used this in #972. It should be `-fno-omit-frame-pointer`.