### PR TITLE
Store scheduler counter data on separate cache lines

### DIFF
--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool.hpp
@@ -318,7 +318,8 @@ namespace pika::threads::detail {
             bool tasks_active_;
         };
 
-        std::vector<scheduling_counter_data> counter_data_;
+        std::vector<pika::concurrency::detail::cache_aligned_data<scheduling_counter_data>>
+            counter_data_;
 
         std::atomic<long> thread_count_;
 


### PR DESCRIPTION
This doesn't make a measurable difference in performance, but the counters occasionally show up in `perf c2c` output and it makes sense to separate them to different cache lines.