### PR TITLE
Boost or BOOST cmake change

### DIFF
--- a/cmake/pika_setup_boost.cmake
+++ b/cmake/pika_setup_boost.cmake
@@ -54,9 +54,9 @@ if(NOT TARGET pika_dependencies_boost)
 
   # We are assuming that there is only one Boost Root
   if(NOT BOOST_ROOT AND "$ENV{BOOST_ROOT}")
-    set(BOOST_ROOT $ENV{BOOST_ROOT})
+    set(Boost_ROOT $ENV{BOOST_ROOT})
   elseif(NOT BOOST_ROOT)
-    string(REPLACE "/include" "" BOOST_ROOT "${Boost_INCLUDE_DIRS}")
+    string(REPLACE "/include" "" Boost_ROOT "${Boost_INCLUDE_DIRS}")
   endif()
 
   add_library(pika_dependencies_boost INTERFACE IMPORTED)


### PR DESCRIPTION
I can't remember why I have this patch in my branch, but the cmake policies changed to use Project name as opposed to PROJECT name in places and this shut up some warnings in my builds.  