### PR TITLE
Use `_GLIBCXX_DEBUG` in CI

### DIFF
--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -17,7 +17,8 @@ include:
                  ^boost@1.82.0 ^hwloc@2.9.1 \
                  ^stdexec@git.nvhpc-23.09.rc4=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+                  -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
+                  -DCMAKE_CXX_FLAGS='-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_DEBUG_BACKTRACE -D_GLIBCXX_ASSERTIONS'"
 
 gcc13_spack_compiler_image:
   extends:


### PR DESCRIPTION
Enables `_GLIBCXX_DEBUG` and related options in the GCC 13 CI configuration (debug and release): https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html#debug_mode.using.mode.