### PR TITLE
Fix data race in when polling for CUDA events

### DIFF
--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -185,7 +185,7 @@ namespace pika::cuda::experimental::detail {
             }
 
             using pika::threads::detail::polling_status;
-            return event_callback_vector.empty() ? polling_status::idle : polling_status::busy;
+            return get_number_of_active_events() == 0 ? polling_status::idle : polling_status::busy;
         }
 
         void add_to_event_callback_queue(event_callback_function_type&& f, whip::stream_t stream)
@@ -227,7 +227,10 @@ namespace pika::cuda::experimental::detail {
             return event_callback_queue.size_approx();
         }
 
-        std::size_t get_number_of_active_events() const noexcept { return active_events_counter; }
+        std::size_t get_number_of_active_events() const noexcept
+        {
+            return active_events_counter.load(std::memory_order_relaxed);
+        }
 
         void add_to_event_callback_vector(event_callback&& continuation)
         {


### PR DESCRIPTION
See commit message for description of the data race. The MPI polling already does the same as the fixed version on this PR, and does not have a data race.