### PR TITLE
Report lines of code to elastic

### DIFF
--- a/.gitlab/docker/Dockerfile.sloc_base
+++ b/.gitlab/docker/Dockerfile.sloc_base
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -yqq install --no-install-recommends \
+    curl \
+    jq \
+    moreutils \
+    npm \
+  && rm -Rf /var/lib/apt/lists/* && \
+  npm install --global sloc

--- a/.gitlab/includes/sloc.yml
+++ b/.gitlab/includes/sloc.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include:
+  - local: '.gitlab/includes/common_pipeline.yml'
+
+sloc_base_image:
+  extends: [.container-builder-cscs-zen2]
+  variables:
+    BASE_IMAGE: docker.io/ubuntu:22.04
+    DOCKERFILE: .gitlab/docker/Dockerfile.sloc_base
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE"]'
+  before_script:
+    - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
+    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE | sha256sum - | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/$ARCH/pika-sloc:$CONFIG_TAG
+    - echo -e "CONFIG_TAG=$CONFIG_TAG" >> sloc_base.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> sloc_base.env
+  artifacts:
+    reports:
+      dotenv: sloc_base.env
+
+sloc:
+  needs: [sloc_base_image]
+  extends: [.container-runner-eiger-mc-f7t]
+  image: $BASE_IMAGE
+  variables:
+    GIT_STRATEGY: fetch
+  script:
+    - ${CI_PROJECT_DIR}/.gitlab/scripts/sloc.sh ${CI_PROJECT_DIR}

--- a/.gitlab/pipelines_on_push.yml
+++ b/.gitlab/pipelines_on_push.yml
@@ -9,3 +9,4 @@ include:
   - local: '.gitlab/includes/clang14_cuda11_pipeline.yml'
   - local: '.gitlab/includes/performance_gcc13_pipeline.yml'
   #- local: '.gitlab/includes/gcc12_hip5_pipeline.yml' # Commented until end of maintenance 5th may
+  - local: '.gitlab/includes/sloc.yml'

--- a/.gitlab/scripts/sloc.sh
+++ b/.gitlab/scripts/sloc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set -euo pipefail
+
+source_directory="${1}"
+current_dir=$(dirname -- "${BASH_SOURCE[0]}")
+
+source "${current_dir}/utilities.sh"
+
+metadata_file=$(mktemp --tmpdir metadata.XXXXXXXXXX.json)
+create_metadata_file "${metadata_file}"
+
+result_file=$(mktemp --tmpdir "sloc.XXXXXXXXXX.json")
+echo '{}' >"${result_file}"
+
+# Count lines only for the core library, ignore tests and examples
+sloc_object=$(sloc --format json --exclude '(examples|tests)' "${source_directory}/libs/pika" |
+    # Remove file-specific line counts, leaving only the overall counts (by file type and total)
+    jq 'walk(if type == "object" then del(.files) else . end)')
+
+json_add_value_json "${result_file}" "sloc" "${sloc_object}"
+
+json_merge "${metadata_file}" "${result_file}" "${result_file}"
+submit_logstash "${result_file}"


### PR DESCRIPTION
This reports the number of lines of code to elastic using https://github.com/flosse/sloc. I filter out the line counts for individual files before sending the data. I also only send the data for the `lib/pika` directory, excluding tests and examples. What remains are the total lines of code in `libpika`, optionally categorized by filetype and type of line (source line, comment, empty line etc.).

The CI job runs on the CSCS CI infrastructure to be able to send data to elastic. The `sloc` tool now runs on a compute node, which is somewhat overkill. An alternative would be to run that step on rosa as well, but it leads to a slightly more complicated job description (since only whitelisted images are allowed to run on rosa, it would require running docker inside docker, which is awkward in the configuration file). If in the future it's possible to run this on rosa with fewer resources we should change it.