### PR TITLE
Avoid use of `std::invoke_result` in `tag_invoke_result` and variants

### DIFF
--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_fallback_invoke.hpp
@@ -103,6 +103,7 @@ namespace pika::functional::detail {
 
 # include <pika/config.hpp>
 # include <pika/functional/tag_invoke.hpp>
+# include <pika/type_support/type_identity.hpp>
 
 # include <type_traits>
 # include <utility>
@@ -196,11 +197,12 @@ namespace pika::functional::detail {
         is_nothrow_tag_fallback_invocable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
-    using tag_fallback_invoke_result =
-        std::invoke_result<decltype(tag_fallback_invoke_ns::tag_fallback_invoke), Tag, Args...>;
+    using tag_fallback_invoke_result_t = decltype(tag_fallback_invoke_ns::tag_fallback_invoke(
+        std::declval<Tag>(), std::declval<Args>()...));
 
     template <typename Tag, typename... Args>
-    using tag_fallback_invoke_result_t = typename tag_fallback_invoke_result<Tag, Args...>::type;
+    using tag_fallback_invoke_result =
+        pika::detail::type_identity<tag_fallback_invoke_result_t<Tag, Args...>>;
 
     ///////////////////////////////////////////////////////////////////////////////
     namespace tag_base_ns {

--- a/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/detail/tag_priority_invoke.hpp
@@ -105,6 +105,7 @@ namespace pika::functional::detail {
 # include <pika/config.hpp>
 # include <pika/functional/detail/tag_fallback_invoke.hpp>
 # include <pika/functional/tag_invoke.hpp>
+# include <pika/type_support/type_identity.hpp>
 
 # include <type_traits>
 # include <utility>
@@ -199,11 +200,12 @@ namespace pika::functional::detail {
         is_nothrow_tag_override_invocable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
-    using tag_override_invoke_result =
-        std::invoke_result<decltype(tag_override_invoke_ns::tag_override_invoke), Tag, Args...>;
+    using tag_override_invoke_result_t = decltype(tag_override_invoke_ns::tag_override_invoke(
+        std::declval<Tag>(), std::declval<Args>()...));
 
     template <typename Tag, typename... Args>
-    using tag_override_invoke_result_t = typename tag_override_invoke_result<Tag, Args...>::type;
+    using tag_override_invoke_result =
+        pika::detail::type_identity<tag_override_invoke_result_t<Tag, Args...>>;
 
     namespace tag_base_ns {
         // poison pill

--- a/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
+++ b/libs/pika/tag_invoke/include/pika/functional/tag_invoke.hpp
@@ -98,6 +98,7 @@ namespace pika::functional::detail {
 #else
 
 # include <pika/config.hpp>
+# include <pika/type_support/type_identity.hpp>
 
 # include <type_traits>
 # include <utility>
@@ -185,10 +186,11 @@ namespace pika::functional::detail {
         is_nothrow_tag_invocable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
-    using tag_invoke_result = std::invoke_result<decltype(tag_invoke_ns::tag_invoke), Tag, Args...>;
+    using tag_invoke_result_t =
+        decltype(tag_invoke_ns::tag_invoke(std::declval<Tag>(), std::declval<Args>()...));
 
     template <typename Tag, typename... Args>
-    using tag_invoke_result_t = typename tag_invoke_result<Tag, Args...>::type;
+    using tag_invoke_result = pika::detail::type_identity<tag_invoke_result_t<Tag, Args...>>;
 
     ///////////////////////////////////////////////////////////////////////////////
     namespace tag_base_ns {


### PR DESCRIPTION
This replaces the use of `std::invoke_result` to compute `tag_invoke_result*` with a direct use of `decltype`. At least with libstdc++ `std::invoke_result` results in three levels of template instantiations. Since we in these cases know that we are only making direct function calls, never member function calls, we don't need the more expensive `std::invoke_result`. This very slightly improves compile times in DLA-Future.