### PR TITLE
Add faster `invoke_result` for cases where we know we're not dealing with member functions

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -17,6 +17,7 @@
 # include <pika/execution_base/receiver.hpp>
 # include <pika/execution_base/sender.hpp>
 # include <pika/functional/bind_front.hpp>
+# include <pika/functional/detail/invoke_result_plain_function.hpp>
 # include <pika/functional/detail/tag_fallback_invoke.hpp>
 # include <pika/type_support/detail/with_result_of.hpp>
 # include <pika/type_support/pack.hpp>
@@ -56,7 +57,8 @@ namespace pika::schedule_from_detail {
                 Variant>;
 
         using scheduler_sender_type =
-            std::invoke_result_t<pika::execution::experimental::schedule_t, Scheduler>;
+            pika::detail::invoke_result_plain_function_t<pika::execution::experimental::schedule_t,
+                Scheduler>;
         template <template <typename...> class Variant>
         using scheduler_sender_error_types = typename pika::execution::experimental::sender_traits<
             scheduler_sender_type>::template error_types<Variant>;
@@ -125,7 +127,8 @@ namespace pika::schedule_from_detail {
             sender_operation_state_type sender_os;
 
             using scheduler_operation_state_type = pika::execution::experimental::connect_result_t<
-                std::invoke_result_t<pika::execution::experimental::schedule_t, Scheduler>,
+                pika::detail::invoke_result_plain_function_t<
+                    pika::execution::experimental::schedule_t, Scheduler>,
                 scheduler_sender_receiver>;
             std::optional<scheduler_operation_state_type> scheduler_op_state;
 

--- a/libs/pika/execution_base/include/pika/execution_base/completion_scheduler.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/completion_scheduler.hpp
@@ -10,6 +10,7 @@
 #if defined(PIKA_HAVE_STDEXEC)
 # include <pika/execution_base/sender.hpp>
 # include <pika/execution_base/stdexec_forward.hpp>
+# include <pika/functional/detail/invoke_result_plain_function.hpp>
 # include <pika/functional/tag_invoke.hpp>
 
 namespace pika::execution::experimental::detail {
@@ -20,9 +21,9 @@ namespace pika::execution::experimental::detail {
 
     template <typename CPO, typename Sender>
     struct has_completion_scheduler_impl<true, CPO, Sender>
-      : pika::execution::experimental::is_scheduler<
-            std::invoke_result_t<get_completion_scheduler_t<CPO>,
-                std::invoke_result_t<get_env_t, std::decay_t<Sender> const&>>>
+      : pika::execution::experimental::is_scheduler<pika::detail::invoke_result_plain_function_t<
+            get_completion_scheduler_t<CPO>,
+            pika::detail::invoke_result_plain_function_t<get_env_t, std::decay_t<Sender> const&>>>
     {
     };
 
@@ -30,7 +31,8 @@ namespace pika::execution::experimental::detail {
     struct has_completion_scheduler
       : has_completion_scheduler_impl<
             pika::functional::detail::is_tag_invocable_v<get_completion_scheduler_t<CPO>,
-                std::invoke_result_t<get_env_t, std::decay_t<Sender> const&>>,
+                pika::detail::invoke_result_plain_function_t<get_env_t,
+                    std::decay_t<Sender> const&>>,
             CPO, Sender>
     {
     };
@@ -64,16 +66,17 @@ namespace pika::execution::experimental {
         template <typename CPO, typename Sender>
         struct has_completion_scheduler_impl<true, CPO, Sender>
           : pika::execution::experimental::is_scheduler<
-                std::invoke_result_t<get_completion_scheduler_t<CPO>,
-                    std::invoke_result_t<get_env_t, std::decay_t<Sender> const&>>>
+                pika::detail::invoke_result_plain_function_t<get_completion_scheduler_t<CPO>,
+                    pika::detail::invoke_result_plain_function_t<get_env_t,
+                        std::decay_t<Sender> const&>>>
         {
         };
 
         template <typename CPO, typename Sender>
         struct has_completion_scheduler
-          : has_completion_scheduler_impl<
-                std::is_invocable_v<get_completion_scheduler_t<CPO>,
-                    std::invoke_result_t<get_env_t, std::decay_t<Sender> const&>>,
+          : has_completion_scheduler_impl<std::is_invocable_v<get_completion_scheduler_t<CPO>,
+                                              pika::detail::invoke_result_plain_function_t<
+                                                  get_env_t, std::decay_t<Sender> const&>>,
                 CPO, Sender>
         {
         };
@@ -93,10 +96,10 @@ namespace pika::execution::experimental {
             Ts...>
           : std::integral_constant<bool,
                 std::is_invocable_v<AlgorithmCPO,
-                    std::invoke_result_t<
+                    pika::detail::invoke_result_plain_function_t<
                         pika::execution::experimental::get_completion_scheduler_t<ReceiverCPO>,
-                        std::invoke_result_t<pika::execution::experimental::get_env_t,
-                            std::decay_t<Sender> const&>>,
+                        pika::detail::invoke_result_plain_function_t<
+                            pika::execution::experimental::get_env_t, std::decay_t<Sender> const&>>,
                     Sender, Ts...>>
         {
         };

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -42,6 +42,7 @@ namespace pika::execution::experimental {
 # include <pika/config/constexpr.hpp>
 # include <pika/execution_base/operation_state.hpp>
 # include <pika/execution_base/receiver.hpp>
+# include <pika/functional/detail/invoke_result_plain_function.hpp>
 # include <pika/functional/detail/tag_fallback_invoke.hpp>
 # include <pika/functional/tag_invoke.hpp>
 # include <pika/type_support/equality.hpp>
@@ -402,7 +403,7 @@ namespace pika::execution::experimental {
     inline constexpr bool is_scheduler_v = is_scheduler<Scheduler>::value;
 
     template <typename S, typename R>
-    using connect_result_t = std::invoke_result_t<connect_t, S, R>;
+    using connect_result_t = pika::detail::invoke_result_plain_function_t<connect_t, S, R>;
 
     struct empty_env
     {

--- a/libs/pika/functional/CMakeLists.txt
+++ b/libs/pika/functional/CMakeLists.txt
@@ -8,27 +8,28 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Default location is $PIKA_ROOT/libs/functional/include
 set(functional_headers
+    pika/functional/bind.hpp
+    pika/functional/bind_back.hpp
+    pika/functional/bind_front.hpp
     pika/functional/deferred_call.hpp
     pika/functional/detail/basic_function.hpp
     pika/functional/detail/empty_function.hpp
     pika/functional/detail/function_registration.hpp
+    pika/functional/detail/invoke_result_plain_function.hpp
     pika/functional/detail/reset_function.hpp
     pika/functional/detail/vtable/callable_vtable.hpp
     pika/functional/detail/vtable/copyable_vtable.hpp
     pika/functional/detail/vtable/function_vtable.hpp
     pika/functional/detail/vtable/vtable.hpp
-    pika/functional/bind.hpp
-    pika/functional/bind_back.hpp
-    pika/functional/bind_front.hpp
     pika/functional/first_argument.hpp
     pika/functional/function.hpp
     pika/functional/invoke.hpp
     pika/functional/one_shot.hpp
-    pika/functional/unique_function.hpp
     pika/functional/traits/get_function_address.hpp
     pika/functional/traits/get_function_annotation.hpp
     pika/functional/traits/is_action.hpp
     pika/functional/traits/is_bind_expression.hpp
+    pika/functional/unique_function.hpp
 )
 
 # Default location is $PIKA_ROOT/libs/functional/src

--- a/libs/pika/functional/include/pika/functional/detail/invoke_result_plain_function.hpp
+++ b/libs/pika/functional/include/pika/functional/detail/invoke_result_plain_function.hpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <utility>
+
+namespace pika::detail {
+    template <typename F, typename... Args>
+    using invoke_result_plain_function_t = decltype(std::declval<F>()(std::declval<Args>()...));
+}


### PR DESCRIPTION
In the spirit of #1058, add a `invoke_result_plain_function` type trait for use in cases where we know that the function is not a member function and we don't need the full `std::invoke_resutl`. This is true at least in cases where we're checking if a CPO is invocable. More generic cases where the callable comes from the user continue to use `std::invoke_result`.