### PR TITLE
Move CSCS CI to daint during the maintenance

### DIFF
--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang11_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@11.0.1
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.72.0 \
@@ -39,7 +39,7 @@ clang11_build:
   needs: [clang11_build]
   extends:
     - .variables_clang11_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang11_test_release:

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang12_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@12.0.1
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.79.0 \
@@ -43,7 +43,7 @@ clang12_build:
   needs: [clang12_build]
   extends:
     - .variables_clang12_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang12_test_release:

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang13_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@13.0.1
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} cxxflags=-stdlib=libc++ malloc=system \
@@ -41,7 +41,7 @@ clang13_build:
   needs: [clang13_build]
   extends:
     - .variables_clang13_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang13_test_release:

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -13,12 +13,14 @@ include:
     SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: clang@14.0.6
     CXXSTD: 17
-    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
-                 ^boost@1.79.0 ^cuda@11.5.0 +allow-unsupported-compilers ^hwloc@2.7.0"
+    GPU_TARGET: '60'
+    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system
+      cxxstd=$CXXSTD ^boost@1.79.0 ^cuda@11.5.0 +allow-unsupported-compilers ^hwloc@2.7.0"
     # PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE is OFF to test the fallback implementation of PIKA_FORWARD.
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=20 -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DCMAKE_CUDA_COMPILER=c++ \
-                  -DCMAKE_CUDA_ARCHITECTURES=80 -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
+                  -DCMAKE_CUDA_ARCHITECTURES=${GPU_TARGET} \
+                  -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF"
 
 clang14_cuda11_spack_compiler_image:
   extends:

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang14_cuda11_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen3
+    SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: clang@14.0.6
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
@@ -41,7 +41,7 @@ clang14_cuda11_build:
   needs: [clang14_cuda11_build]
   extends:
     - .variables_clang14_cuda11_config
-    - .test_common_gpu_clariden_cuda
+    - .test_common_gpu_daint_cuda
     - .test_template
 
 clang14_cuda11_test_release:

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang15_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@15.0.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.80.0 \
@@ -40,7 +40,7 @@ clang15_build:
   needs: [clang15_build]
   extends:
     - .variables_clang15_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang15_test_release:

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang16_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@16.0.2
     CXXSTD: 23
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.82.0 \
@@ -39,7 +39,7 @@ clang16_build:
   needs: [clang16_build]
   extends:
     - .variables_clang16_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang16_test_release:

--- a/.gitlab/includes/clang17_pipeline.yml
+++ b/.gitlab/includes/clang17_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_clang17_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: clang@17.0.4
     CXXSTD: 23
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.83.0 \
@@ -39,7 +39,7 @@ clang17_build:
   needs: [clang17_build]
   extends:
     - .variables_clang17_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 clang17_test_release:

--- a/.gitlab/includes/common_pipeline.yml
+++ b/.gitlab/includes/common_pipeline.yml
@@ -35,6 +35,14 @@ variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
 
+.test_common_daint_mc:
+  stage: test
+  extends:
+    - .test_common
+    - .container-runner-daint-mc
+  variables:
+    SLURM_PARTITION: normal
+
 .test_common_eiger_mc:
   stage: test
   extends:

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -19,7 +19,7 @@ clang14_debug_build_pika-ci-image:
 
 clang14_debug_test_pika-ci-image:
   stage: test
-  extends: .test_common_eiger_mc
+  extends: .test_common_daint_mc
   needs:
     - clang14_debug_build_pika-ci-image
   image: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc10_apex_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
@@ -39,7 +39,7 @@ gcc10_apex_build:
   needs: [gcc10_apex_build]
   extends:
     - .variables_gcc10_apex_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 gcc10_apex_test_release:

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc11_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: gcc@11.4.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.78.0 \
@@ -39,7 +39,7 @@ gcc11_build:
   needs: [gcc11_build]
   extends:
     - .variables_gcc11_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 gcc11_test_release:

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -10,10 +10,10 @@ include:
 
 .variables_gcc12_cuda12_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen3
+    SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: gcc@12.1.0
     CXXSTD: 17
-    GPU_TARGET: "80"
+    GPU_TARGET: "60"
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system \
                  cxxstd=$CXXSTD ^boost@1.82.0 ^hwloc@2.9.1 ^cuda@12.0.0 ^fmt@10.0.0"
     # PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE is OFF to test the fallback implementation of PIKA_FORWARD.
@@ -32,19 +32,19 @@ gcc12_cuda12_spack_image:
     - .variables_gcc12_cuda12_config
     - .dependencies_image_template_rosa
 
-# Test step currently commented as the cuda driver is too old on clariden:
-# https://github.com/pika-org/pika/issues/884
-#gcc12_cuda12_build:
-#  needs: [gcc12_cuda12_spack_image]
-#  extends:
-#    - .variables_gcc12_cuda12_config
-#    - .build_template_rosa
-#
+gcc12_cuda12_build:
+  needs: [gcc12_cuda12_spack_image]
+  extends:
+    - .variables_gcc12_cuda12_config
+    - .build_template_rosa
+
+## Test step currently commented as the cuda driver is too old on clariden:
+## https://github.com/pika-org/pika/issues/884
 #.gcc12_cuda12_test_commmon:
 #  needs: [gcc12_cuda12_build]
 #  extends:
 #    - .variables_gcc12_cuda12_config
-#    - .test_common_gpu_clariden_cuda
+#    - .test_common_gpu_daint_cuda
 #    - .test_template
 #
 #gcc12_cuda12_test_release:

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc12_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: gcc@12.1.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.79.0 \
@@ -39,7 +39,7 @@ gcc12_build:
   needs: [gcc12_build]
   extends:
     - .variables_gcc12_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 gcc12_test_release:

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc13_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: gcc@13.1.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
@@ -40,7 +40,7 @@ gcc13_build:
   needs: [gcc13_build]
   extends:
     - .variables_gcc13_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 gcc13_test_release:

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -13,8 +13,9 @@ include:
     SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: gcc@9.3.0
     CXXSTD: 17
-    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
-                 ^boost@1.75.0 ^hwloc@2.0.3 ^cuda@11.2.0 ^fmt@9"
+    GPU_TARGET: '60'
+    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system
+      cxxstd=$CXXSTD ^boost@1.75.0 ^hwloc@2.0.3 ^cuda@11.2.0 ^fmt@9"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_EXAMPLES_OPENMP=ON"
 

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc9_cuda11_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-broadwell
+    SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: gcc@9.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda malloc=system cxxstd=$CXXSTD \
@@ -39,7 +39,7 @@ gcc9_cuda11_build:
   needs: [gcc9_cuda11_build]
   extends:
     - .variables_gcc9_cuda11_config
-    - .test_common_gpu_clariden_cuda
+    - .test_common_gpu_daint_cuda
     - .test_template
 
 gcc9_cuda11_test_release:

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_gcc9_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     COMPILER: gcc@9.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
@@ -40,7 +40,7 @@ gcc9_build:
   needs: [gcc9_build]
   extends:
     - .variables_gcc9_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .test_template
 
 gcc9_test_release:

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -41,17 +41,19 @@ nvhpc23_9_build:
     - .variables_nvhpc23_9_config
     - .build_template_rosa
 
-.nvhpc23_9_test_commmon:
-  needs: [nvhpc23_9_build]
-  extends:
-    - .variables_nvhpc23_9_config
-    - .test_common_gpu_daint_cuda
-    - .test_template
-
-nvhpc23_9_test_release:
-  extends: [.nvhpc23_9_test_commmon]
-  image: $PERSIST_IMAGE_NAME_RELEASE
-
-nvhpc23_9_test_debug:
-  extends: [.nvhpc23_9_test_commmon]
-  image: $PERSIST_IMAGE_NAME_DEBUG
+# The test step is disabled until maintenance is over. Pulling the image on compute nodes is too
+# slow, and the image is too big.
+# .nvhpc23_9_test_commmon:
+#   needs: [nvhpc23_9_build]
+#   extends:
+#     - .variables_nvhpc23_9_config
+#     - .test_common_gpu_daint_cuda
+#     - .test_template
+#
+# nvhpc23_9_test_release:
+#   extends: [.nvhpc23_9_test_commmon]
+#   image: $PERSIST_IMAGE_NAME_RELEASE
+#
+# nvhpc23_9_test_debug:
+#   extends: [.nvhpc23_9_test_commmon]
+#   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -10,11 +10,11 @@ include:
 
 .variables_nvhpc23_9_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen3
+    SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: gcc@12.1.0
     NVHPC_COMPILER: nvhpc@23.9
     CXXSTD: 20
-    GPU_TARGET: '80'
+    GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.78.0%${NVHPC_COMPILER} ^hwloc@2.7.0 \
                  ^stdexec@git.nvhpc-23.09.rc4=main ^cuda@11.8%${NVHPC_COMPILER} \
@@ -43,7 +43,7 @@ nvhpc23_9_build:
   needs: [nvhpc23_9_build]
   extends:
     - .variables_nvhpc23_9_config
-    - .test_common_gpu_clariden_cuda
+    - .test_common_gpu_daint_cuda
     - .test_template
 
 nvhpc23_9_test_release:

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -21,6 +21,7 @@ include:
                  ^whip%${NVHPC_COMPILER}"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
+    PULL_ON_HOST_MACHINE: "YES"
 
 nvhpc23_9_spack_compiler_image:
   extends:

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -35,6 +35,7 @@ nvhpc23_9_spack_image:
     - .dependencies_image_template_rosa
 
 nvhpc23_9_build:
+  timeout: 2 hours
   needs: [nvhpc23_9_spack_image]
   extends:
     - .variables_nvhpc23_9_config

--- a/.gitlab/includes/performance_gcc13_pipeline.yml
+++ b/.gitlab/includes/performance_gcc13_pipeline.yml
@@ -10,7 +10,7 @@ include:
 
 .variables_performance_gcc13_config:
   variables:
-    SPACK_ARCH: linux-ubuntu22.04-zen2
+    SPACK_ARCH: linux-ubuntu22.04-broadwell
     BUILD_TYPE: Release
     COMPILER: gcc@13.1.0
     CXXSTD: 20
@@ -38,7 +38,7 @@ performance_gcc13_release_build:
 .performance_gcc13_test_common:
   extends:
     - .variables_performance_gcc13_config
-    - .test_common_eiger_mc
+    - .test_common_daint_mc
     - .cmake_variables_common
   needs: [performance_gcc13_release_build]
   script:

--- a/.gitlab/pipelines_on_push.yml
+++ b/.gitlab/pipelines_on_push.yml
@@ -8,4 +8,4 @@ include:
   - local: '.gitlab/includes/gcc13_pipeline.yml'
   - local: '.gitlab/includes/clang14_cuda11_pipeline.yml'
   - local: '.gitlab/includes/performance_gcc13_pipeline.yml'
-  - local: '.gitlab/includes/gcc12_hip5_pipeline.yml'
+  #- local: '.gitlab/includes/gcc12_hip5_pipeline.yml' # Commented until end of maintenance 5th may

--- a/libs/pika/runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/runtime/tests/unit/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
   string(
     CONCAT
       process_mask_flag_expected_output
-      "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\)), on pool \"default\"\n"
+      "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
       "   1: PU L#[0-9]+\\(P#1\\), Core L#[0-9]+\\(P#[0-9]+\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
       "All tests passed."
   )


### PR DESCRIPTION
The maintenance is ending on the 5th of may 2024, we move back the CI to daint for this period.