### PR TITLE
Add changelog to documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
                 --allow-remove-essential \
                 --allow-change-held-packages \
                 doxygen python3 python3-pip
-            pip install breathe sphinx sphinx-material
+            pip install breathe recommonmark sphinx sphinx-material
       - name: Build documentation
         run: |
             export PIKA_DOCS_DOXYGEN_OUTPUT_DIRECTORY=$PWD/build/docs/doxygen

--- a/RELEASE_PROCEDURE.rst
+++ b/RELEASE_PROCEDURE.rst
@@ -19,7 +19,7 @@ pika follows `Semantic Versioning <https://semver.org>`_.
    release. For patch releases: check out the corresponding
    ``release-major.minor.X`` branch.
 
-#. Write release notes in ``CHANGELOG.md``. Check for issues and pull requests
+#. Write release notes in ``docs/changelog.md``. Check for issues and pull requests
    for the release on the
    `pika planning board <https://github.com/orgs/pika-org/projects/1>`_. Check
    for items that do not have a release associated to them on the `Done` view.
@@ -50,7 +50,7 @@ pika follows `Semantic Versioning <https://semver.org>`_.
 
 #. Change ``PIKA_VERSION_TAG`` in ``CMakeLists.txt`` to an empty string.
 
-#. Add the release date to the caption of the current ``CHANGELOG.md`` section
+#. Add the release date to the caption of the current ``docs/changelog.md`` section
    and change the value of ``PIKA_VERSION_DATE`` in ``CMakeLists.txt``.
 
 #. Create a release on GitHub using the script ``tools/roll_release.sh``. This

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@
 <!--- Distributed under the Boost Software License, Version 1.0. (See accompanying -->
 <!--- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
 
+# Changelog
+
 ## 0.23.0 (2024-03-07)
 
 ### New features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ version = ""
 release = version
 
 # General sphinx settings
-extensions = ["breathe"]
+extensions = ["breathe", "recommonmark"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 source_suffix = [".rst"]
 language = "English"
@@ -60,6 +60,7 @@ html_theme_options = {
         {"href": "index", "internal": True, "title": "Overview"},
         {"href": "usage", "internal": True, "title": "Usage"},
         {"href": "api", "internal": True, "title": "API reference"},
+        {"href": "changelog", "internal": True, "title": "Changelog"},
     ],
     "heroes": {
         "index": "Concurrency and parallelism built on C++ std::execution",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,3 +58,4 @@ Pick your favourite meaning from the following:
 
    usage
    api
+   changelog

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ pkgs.mkShell.override { stdenv = pkgs.gcc11Stdenv; } {
     python311Packages.breathe
     python311Packages.sphinx
     python311Packages.sphinx-material
+    python311Packages.recommonmark
   ];
 
   hardeningDisable = [ "fortify" ];

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -31,7 +31,7 @@ if ! [[ "$CURRENT_BRANCH" =~ ^release-[0-9]+\.[0-9]+\.X$ ]]; then
     exit 1
 fi
 
-changelog_path="CHANGELOG.md"
+changelog_path="docs/changelog.md"
 
 if [ -z "${VERSION_TAG}" ]; then
     echo "You are about to tag and create a final release on GitHub."
@@ -66,7 +66,7 @@ else
     echo "If you intended to make a final release, remove the tag in the main CMakeLists.txt first."
 fi
 
-# Extract the changelog for this version from CHANGELOG.md
+# Extract the changelog for this version
 VERSION_DESCRIPTION=$(
     # Find the correct heading and print everything from there to the end of the file
     awk "/^## ${VERSION_FULL_NOTAG}/,EOF" ${changelog_path} |


### PR DESCRIPTION
This adds the current `CHANGELOG.md` to the documentation, at the same time moving it to `docs/changelog.md`. While the documentation is primarily written in restructuredText, I'm keeping the changelog as a markdown file because it's easier to do the checks for dates etc. we currently do in `roll_release.sh`. This requires another sphinx extension, `recommonmark`.