### PR TITLE
Mark `fmt::formatter` `format` member functions `const`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
@@ -176,7 +176,7 @@ template <>
 struct fmt::formatter<pika::cuda::experimental::cuda_pool> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::cuda::experimental::cuda_pool const& pool, FormatContext& ctx)
+    auto format(pika::cuda::experimental::cuda_pool const& pool, FormatContext& ctx) const
     {
         bool valid{pool.data};
         auto high_priority_streams =

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cublas_handle.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cublas_handle.hpp
@@ -60,7 +60,7 @@ template <>
 struct fmt::formatter<pika::cuda::experimental::cublas_handle> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::cuda::experimental::cublas_handle const& handle, FormatContext& ctx)
+    auto format(pika::cuda::experimental::cublas_handle const& handle, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(
             fmt::format("cublas_handle({})", fmt::ptr(handle.get())), ctx);

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cuda_stream.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cuda_stream.hpp
@@ -72,7 +72,7 @@ template <>
 struct fmt::formatter<pika::cuda::experimental::cuda_stream> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::cuda::experimental::cuda_stream const& stream, FormatContext& ctx)
+    auto format(pika::cuda::experimental::cuda_stream const& stream, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(
             fmt::format("cuda_stream({})", fmt::ptr(stream.get())), ctx);

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cusolver_handle.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cusolver_handle.hpp
@@ -60,7 +60,7 @@ template <>
 struct fmt::formatter<pika::cuda::experimental::cusolver_handle> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::cuda::experimental::cusolver_handle const& handle, FormatContext& ctx)
+    auto format(pika::cuda::experimental::cusolver_handle const& handle, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(
             fmt::format("cusolver_handle({})", fmt::ptr(handle.get())), ctx);

--- a/libs/pika/coroutines/include/pika/coroutines/thread_enums.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/thread_enums.hpp
@@ -244,7 +244,7 @@ template <>
 struct fmt::formatter<pika::threads::detail::thread_schedule_state> : fmt::formatter<char const*>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::thread_schedule_state const& t, FormatContext& ctx)
+    auto format(pika::threads::detail::thread_schedule_state const& t, FormatContext& ctx) const
     {
         return fmt::formatter<char const*>::format(
             pika::threads::detail::get_thread_state_name(t), ctx);
@@ -255,7 +255,7 @@ template <>
 struct fmt::formatter<pika::threads::detail::thread_restart_state> : fmt::formatter<char const*>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::thread_restart_state const& t, FormatContext& ctx)
+    auto format(pika::threads::detail::thread_restart_state const& t, FormatContext& ctx) const
     {
         return fmt::formatter<char const*>::format(
             pika::threads::detail::get_thread_state_ex_name(t), ctx);
@@ -266,7 +266,7 @@ template <>
 struct fmt::formatter<pika::execution::thread_priority> : fmt::formatter<char const*>
 {
     template <typename FormatContext>
-    auto format(pika::execution::thread_priority const& t, FormatContext& ctx)
+    auto format(pika::execution::thread_priority const& t, FormatContext& ctx) const
     {
         return fmt::formatter<char const*>::format(
             pika::execution::detail::get_thread_priority_name(t), ctx);
@@ -277,7 +277,7 @@ template <>
 struct fmt::formatter<pika::execution::thread_stacksize> : fmt::formatter<char const*>
 {
     template <typename FormatContext>
-    auto format(pika::execution::thread_stacksize const& t, FormatContext& ctx)
+    auto format(pika::execution::thread_stacksize const& t, FormatContext& ctx) const
     {
         return fmt::formatter<char const*>::format(
             pika::execution::detail::get_stack_size_enum_name(t), ctx);

--- a/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/thread_id_type.hpp
@@ -349,7 +349,7 @@ template <>
 struct fmt::formatter<pika::threads::detail::thread_id> : fmt::formatter<void*>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::thread_id id, FormatContext& ctx)
+    auto format(pika::threads::detail::thread_id id, FormatContext& ctx) const
     {
         return fmt::formatter<void*>::format(static_cast<void*>(id.get()), ctx);
     }
@@ -359,7 +359,7 @@ template <>
 struct fmt::formatter<pika::threads::detail::thread_id_ref> : fmt::formatter<void*>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::thread_id_ref id, FormatContext& ctx)
+    auto format(pika::threads::detail::thread_id_ref id, FormatContext& ctx) const
     {
         return fmt::formatter<void*>::format(static_cast<void*>(id.noref().get()), ctx);
     }

--- a/libs/pika/errors/include/pika/errors/error.hpp
+++ b/libs/pika/errors/include/pika/errors/error.hpp
@@ -167,7 +167,7 @@ template <>
 struct fmt::formatter<pika::error> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::error e, FormatContext& ctx)
+    auto format(pika::error e, FormatContext& ctx) const
     {
         int e_int = static_cast<int>(e);
         if (e_int >= static_cast<int>(pika::error::success) &&

--- a/libs/pika/execution_base/include/pika/execution_base/agent_ref.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/agent_ref.hpp
@@ -96,7 +96,7 @@ template <>
 struct fmt::formatter<pika::execution::detail::agent_ref> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::execution::detail::agent_ref const& a, FormatContext& ctx)
+    auto format(pika::execution::detail::agent_ref const& a, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(pika::execution::detail::format(a), ctx);
     }

--- a/libs/pika/logging/include/pika/logging/level.hpp
+++ b/libs/pika/logging/include/pika/logging/level.hpp
@@ -62,7 +62,7 @@ template <>
 struct fmt::formatter<pika::util::logging::level> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::util::logging::level const& value, FormatContext& ctx)
+    auto format(pika::util::logging::level const& value, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(pika::util::logging::levelname(value), ctx);
     }

--- a/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
+++ b/libs/pika/memory/include/pika/memory/intrusive_ptr.hpp
@@ -320,7 +320,7 @@ template <typename T>
 struct fmt::formatter<pika::memory::intrusive_ptr<T>> : fmt::formatter<void*>
 {
     template <typename FormatContext>
-    auto format(pika::memory::intrusive_ptr<T> p, FormatContext& ctx)
+    auto format(pika::memory::intrusive_ptr<T> p, FormatContext& ctx) const
     {
         return fmt::formatter<void*>::format(static_cast<void*>(p.get()), ctx);
     }

--- a/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_priority_queue_scheduler.hpp
@@ -1219,7 +1219,7 @@ struct fmt::formatter<pika::threads::detail::local_priority_queue_scheduler<Mute
     StagedQueuing, TerminatedQueuing>> : fmt::formatter<pika::threads::detail::scheduler_base>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::scheduler_base>::format(scheduler, ctx);
     }

--- a/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/local_queue_scheduler.hpp
@@ -863,7 +863,7 @@ struct fmt::formatter<pika::threads::detail::local_queue_scheduler<Mutex, Pendin
     StagedQueuing, TerminatedQueuing>> : fmt::formatter<pika::threads::detail::scheduler_base>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::scheduler_base>::format(scheduler, ctx);
     }

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -1340,7 +1340,7 @@ struct fmt::formatter<pika::threads::detail::shared_priority_queue_scheduler<Mut
   : fmt::formatter<pika::threads::detail::scheduler_base>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::scheduler_base>::format(scheduler, ctx);
     }

--- a/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_priority_queue_scheduler.hpp
@@ -73,7 +73,7 @@ struct fmt::formatter<pika::threads::detail::static_priority_queue_scheduler<Mut
     StagedQueuing, TerminatedQueuing>> : fmt::formatter<pika::threads::detail::scheduler_base>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::scheduler_base>::format(scheduler, ctx);
     }

--- a/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/static_queue_scheduler.hpp
@@ -135,7 +135,7 @@ struct fmt::formatter<pika::threads::detail::static_queue_scheduler<Mutex, Pendi
     StagedQueuing, TerminatedQueuing>> : fmt::formatter<pika::threads::detail::scheduler_base>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::scheduler_base>::format(scheduler, ctx);
     }

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -266,7 +266,7 @@ template <>
 struct fmt::formatter<pika::thread::id> : fmt::formatter<pika::threads::detail::thread_id>
 {
     template <typename FormatContext>
-    auto format(pika::thread::id const& id, FormatContext& ctx)
+    auto format(pika::thread::id const& id, FormatContext& ctx) const
     {
         return fmt::formatter<pika::threads::detail::thread_id>::format(id.native_handle(), ctx);
     }

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -381,7 +381,7 @@ template <>
 struct fmt::formatter<pika::threads::detail::scheduler_base> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx)
+    auto format(pika::threads::detail::scheduler_base const& scheduler, FormatContext& ctx) const
     {
         return fmt::formatter<std::string>::format(
             fmt::format(

--- a/libs/pika/threading_base/include/pika/threading_base/thread_description.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_description.hpp
@@ -255,7 +255,7 @@ template <>
 struct fmt::formatter<pika::detail::thread_description> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::detail::thread_description const& desc, FormatContext& ctx)
+    auto format(pika::detail::thread_description const& desc, FormatContext& ctx) const
     {
 #if defined(PIKA_HAVE_THREAD_DESCRIPTION)
         if (desc.kind() == pika::detail::thread_description::data_type_description)

--- a/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/thread_pool_base.hpp
@@ -389,7 +389,8 @@ template <>
 struct fmt::formatter<pika::threads::detail::thread_pool_base> : fmt::formatter<std::string>
 {
     template <typename FormatContext>
-    auto format(pika::threads::detail::thread_pool_base const& thread_pool, FormatContext& ctx)
+    auto
+    format(pika::threads::detail::thread_pool_base const& thread_pool, FormatContext& ctx) const
     {
         auto id = thread_pool.get_pool_id();
         return fmt::formatter<std::string>::format(


### PR DESCRIPTION
This is apparently required for `std::formatter` specializations, and the current fmt master branch has started requiring the same (https://github.com/fmtlib/fmt/commit/d70729215fba1d54862e407b626abf86ddf409bf).