### PR TITLE
Replace includes of `fmt/core.h` with `fmt/base.h`

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -20,7 +20,11 @@
 #include <pika/type_support/detail/with_result_of.hpp>
 #include <pika/type_support/pack.hpp>
 
-#include <fmt/core.h>
+#if __has_include(<fmt/base.h>)
+# include <fmt/base.h>
+#else
+# include <fmt/core.h>
+#endif
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 

--- a/libs/pika/logging/include/pika/logging/message.hpp
+++ b/libs/pika/logging/include/pika/logging/message.hpp
@@ -19,7 +19,6 @@
 #include <pika/config.hpp>
 #include <pika/type_support/unused.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/printf.h>

--- a/libs/pika/logging/src/format/formatter/high_precision_time.cpp
+++ b/libs/pika/logging/src/format/formatter/high_precision_time.cpp
@@ -18,7 +18,11 @@
 
 #include <pika/config.hpp>
 
-#include <fmt/core.h>
+#if __has_include(<fmt/base.h>)
+# include <fmt/base.h>
+#else
+# include <fmt/core.h>
+#endif
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 

--- a/libs/pika/logging/src/format/formatter/thread_id.cpp
+++ b/libs/pika/logging/src/format/formatter/thread_id.cpp
@@ -18,7 +18,6 @@
 
 #include <pika/config.hpp>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/printf.h>


### PR DESCRIPTION
Fix #1026.

Current fmt `master` has deprecated `fmt/core.h` in favour of `fmt/base.h` or `fmt/format.h` (https://github.com/fmtlib/fmt/blob/12acd7988b5eef3df060f321f61982221ec45d26/include/fmt/core.h). I've updated includes of `fmt/core.h` to use `fmt/base.h` if the latter is available (with `__has_include`). In cases where `fmt/format.h` is anyway included I've simply removed the `fmt/core.h` include.