### PR TITLE
Test APEX 2.6.5 in CI

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: 6cfcbc01679ebabe640f4462c8fc07626a543015
+  SPACK_COMMIT: 763279cd613f5ec7466bcb8359280dc87d2575a2
 
 .base_spack_image:
   timeout: 2 hours

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -14,7 +14,7 @@ include:
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
-                 ^apex@2.4.1~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
+                 ^apex@2.6.5 ~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/cmake/pika_add_test.cmake
+++ b/cmake/pika_add_test.cmake
@@ -9,8 +9,8 @@ if(PIKA_WITH_TESTS_VALGRIND)
 endif()
 
 function(pika_add_test category name)
-  set(options FAILURE_EXPECTED RUN_SERIAL TESTING PERFORMANCE_TESTING)
-  set(one_value_args COST EXECUTABLE RANKS THREADS TIMEOUT RUNWRAPPER)
+  set(options FAILURE_EXPECTED RUN_SERIAL TESTING PERFORMANCE_TESTING MPIWRAPPER)
+  set(one_value_args COST EXECUTABLE RANKS THREADS TIMEOUT WRAPPER)
   set(multi_value_args ARGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
@@ -59,7 +59,7 @@ function(pika_add_test category name)
 
   if(PIKA_WITH_PARALLEL_TESTS_BIND_NONE
      AND NOT run_serial
-     AND NOT "${name}_RUNWRAPPER"
+     AND NOT "${name}_MPIWRAPPER"
   )
     set(args ${args} "--pika:bind=none")
   endif()
@@ -70,7 +70,11 @@ function(pika_add_test category name)
 
   set(cmd ${_exe})
 
-  if(${name}_RUNWRAPPER)
+  if(${name}_WRAPPER)
+    list(PREPEND cmd "${${name}_WRAPPER}" ${_preflags_list_})
+  endif()
+
+  if(${name}_MPIWRAPPER)
     set(_preflags_list_ ${MPIEXEC_PREFLAGS})
     separate_arguments(_preflags_list_)
     list(PREPEND cmd "${MPIEXEC_EXECUTABLE}" "${MPIEXEC_NUMPROC_FLAG}" "${${name}_RANKS}"

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -13,17 +13,17 @@ set(tests # algorithm_transform_mpi
 set(mpi_ring_async_sender_receiver_PARAMETERS
     ARGS "--in-flight-limit=32" "--rounds=10" "--iterations=100" 
          "--pika:ignore-process-mask"
-    THREADS 4 RANKS 2 RUNWRAPPER mpi
+    THREADS 4 RANKS 2 MPIWRAPPER
 )
 
 set(mpi_async_storage_PARAMETERS
     ARGS "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1" 
          "--pika:ignore-process-mask"
-    THREADS 4 RANKS 2 RUNWRAPPER mpi
+    THREADS 4 RANKS 2 MPIWRAPPER
 )
 # cmake-format: on
 
-set(algorithm_transform_mpi_PARAMETERS RANKS 2 RUNWRAPPER mpi)
+set(algorithm_transform_mpi_PARAMETERS RANKS 2 MPIWRAPPER)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)
 
 foreach(test ${tests})

--- a/libs/pika/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/pika/threading_base/tests/unit/CMakeLists.txt
@@ -10,7 +10,9 @@ set(resume_suspended_same_thread_PARAMETERS THREADS 2)
 
 if(PIKA_WITH_APEX)
   list(APPEND tests annotation_check_senders)
-  set(annotation_check_senders_PARAMETERS THREADS 2)
+  set(annotation_check_senders_PARAMETERS THREADS 2 WRAPPER
+                                          "${PROJECT_SOURCE_DIR}/tools/sort-output.sh"
+  )
 endif()
 
 foreach(test ${tests})

--- a/tools/sort-output.sh
+++ b/tools/sort-output.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# This is a wrapper script used in testing which sorts the output of a given command. Sorting the
+# output makes it easier to check for the correct output if the output isn't always in the same
+# order. For testing we don't care about leading whitespace.
+
+$@ | sort --ignore-leading-blanks


### PR DESCRIPTION
Fixes #948. This also adds a little wrapper script around the APEX annotation test that sorts the output so that we can use later versions of APEX in unit tests to check for the correct output; later versions of APEX don't sort timers alphabetically anymore, but by time leading to the output potentially changing between runs.