### PR TITLE
Reenable precompiled headers in CircleCI ARM configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,9 +202,6 @@ jobs:
           name: Running CMake
           command: |
             cmake --version
-            # Enabling precompiled headers together with stdexec leads to
-            # compilation errors with some tests so we explicitly turn them off,
-            # see https://github.com/pika-org/pika/issues/514.
             cmake \
                 /pika/source \
                 -G "Ninja" \
@@ -215,7 +212,7 @@ jobs:
                 -DPIKA_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
                 -DPIKA_WITH_GIT_TAG="${CIRCLE_TAG}" \
                 -DPIKA_WITH_CXX_STANDARD=20 \
-                -DPIKA_WITH_PRECOMPILED_HEADERS=Off \
+                -DPIKA_WITH_PRECOMPILED_HEADERS=On \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_STDEXEC=ON \


### PR DESCRIPTION
Fixes #514. The issue reported in #514 seems to be no longer an issue.