### PR TITLE
Fix use `--pika:print-bind`, `--pika:bind=none`, and a non-full process mask on the process together

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
   docker:
-    - image: pikaorg/pika-ci-base:22
+    - image: pikaorg/pika-ci-base:23
 
 defaults: &defaults
   <<: *working_dir_default
@@ -470,6 +470,8 @@ jobs:
           name: Installing
           command: |
               ./bin/hello_world --pika:bind=none
+              ./bin/hello_world --pika:bind=none --pika:print-bind
+              hwloc-bind 0x3 ./bin/hello_world --pika:bind=none --pika:print-bind
               ninja -j2 install
           working_directory: /pika/build
           when: always

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "docker.io/pikaorg/pika-ci-base:22",
+  "image": "docker.io/pikaorg/pika-ci-base:23",
   "features": {},
   "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
   "extensions": [

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/address-undefined-leak
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:22
+      image: pikaorg/pika-ci-base:23
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:22
+    container: pikaorg/pika-ci-base:23
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:22
+    container: pikaorg/pika-ci-base:23
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/fetchcontent/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:22
+    container: pikaorg/pika-ci-base:23
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/tracy/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:22
+    container: pikaorg/pika-ci-base:23
 
     steps:
       - name: Check out Tracy

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/thread
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:22
+      image: pikaorg/pika-ci-base:23
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/valgrind
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:22
+    container: pikaorg/pika-ci-base:23
 
     strategy:
       matrix:

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -12,7 +12,7 @@ clang14_debug_build_pika-ci-image:
   extends: .container-builder
   needs: []   # To clear the dotenv artifacts
   variables:
-    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:22
+    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:23
     DOCKERFILE: .gitlab/docker/Dockerfile.dockerhub_build
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","BUILD_DIR","SOURCE_DIR"]'
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA


### PR DESCRIPTION
When using `--pika:print-bind` the runtime checks that the mask reported by hwloc and the mask supposedly used by pika are the same. When `--pika:bind=none` is used we store an empty mask for worker threads. In this case we also don't set bindings for the worker threads, because we assume that the process has no binding set. However, in the case that the full process already has a mask set (e.g. with `hwloc-bind` or slurm) the worker threads will inherit that mask even with `--pika:bind=none`. The worker threads then end up with a non-full process mask even if the user asked for a full process mask (no binding).

This fixes the issue by always setting a mask, even if the mask is empty/full. This also adds a simple `hello_world` test to the CircleCI configuration. I'm not adding this a CTest test since 1. I'm not quite sure how to do that cleanly and 2. I'd like to avoid making the `hwloc-bind` executable a dependency for tests. Ideas for better integration into the tests is welcome though.