### PR TITLE
Make sure `main` is never defined in `libpika.so`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ if(PIKA_WITH_PRECOMPILED_HEADERS)
   set(PIKA_WITH_PRECOMPILED_HEADERS_INTERNAL ON)
   # Only create the targets here. They will be set up later once all modules are known.
   add_library(pika_precompiled_headers OBJECT libs/src/dummy.cpp)
-  add_executable(pika_exe_precompiled_headers libs/src/dummy.cpp)
+  add_executable(pika_exe_precompiled_headers libs/src/dummy_main.cpp)
 
   set_target_properties(pika_precompiled_headers PROPERTIES FOLDER "Core")
   set_target_properties(pika_exe_precompiled_headers PROPERTIES FOLDER "Core")

--- a/libs/src/dummy_main.cpp
+++ b/libs/src/dummy_main.cpp
@@ -1,7 +1,9 @@
-//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2024 ETH Zurich
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // This file is intended for use in precompiled headers targets.
+
+int main() {}


### PR DESCRIPTION
When defining the `pika` CMake target we need a dummy cpp file since we don't otherwise have any source files for the `pika` target, only object files that are added later. For this we've so far reused a `dummy.cpp` file which has `main` defined. This means that `libpika.so` actually has `main` defined as well. Depending on where `main` is otherwise defined by an application using pika (another shared library or in the executable itself) the application may end up using the empty `main` defined in `libpika.so`. `main` should never have been in `libpika.so` in the first place, and this PR removes it from `libpika.so` by using an empty `dummy.cpp` file for `libpika.so` and a separate `dummy_main.cpp` with `main` defined for precompiled headers for executables (never exposed to consumers of pika).