### PR TITLE
Explicitly use macos-12 image in GitHub macos workflow

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -31,6 +31,7 @@ jobs:
           rm /usr/local/bin/python3*
 
           export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
+          brew pin xcbeautify
           brew upgrade
           brew update
           brew install boost cmake fmt hwloc ninja

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -19,7 +19,7 @@ jobs:
   build_and_test:
     name: github/macos/debug
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Pin the macos workflow to use the `macos-12` runner (which supposedly still uses intel CPUs) while `macos-latest` is gradually being rolled out to use `macos-14` (supposedly based on the M* CPUs). This also fixes an error which happens during `brew upgrade` where `xcbeautify` cannot be upgraded due to other conflicting packages.