### PR TITLE
Suppress harmless warnings about caching in documentation build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ breathe_domain_by_extension = {
 breathe_default_members = ("members",)
 breathe_show_include = False
 
+show_warning_types = True
 # https://github.com/sphinx-doc/sphinx/issues/12300
 suppress_warnings = ["config.cache"]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,9 @@ breathe_domain_by_extension = {
 breathe_default_members = ("members",)
 breathe_show_include = False
 
+# https://github.com/sphinx-doc/sphinx/issues/12300
+suppress_warnings = ["config.cache"]
+
 # HTML settings
 html_title = "pika"
 html_theme = "sphinx_material"


### PR DESCRIPTION
Suppresses the following warning, treated as error:
```
Warning, treated as error:
cannot cache unpickable configuration value: 'html_context' (because it contains a function, class, or module object)
```

More information in https://github.com/sphinx-doc/sphinx/issues/12300.