### PR TITLE
Reduce spinlock detection limits now that spinlocks do backoff

### DIFF
--- a/libs/pika/config/include/pika/config.hpp
+++ b/libs/pika/config/include/pika/config.hpp
@@ -54,12 +54,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// By default, enable minimal thread deadlock detection in debug builds only.
 #if !defined(PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT)
-#  define PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT 10000000
+#  define PIKA_SPINLOCK_DEADLOCK_DETECTION_LIMIT 1000000
 #endif
 
 /// Print a warning about potential deadlocks after this many iterations.
 #if !defined(PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT)
-#  define PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT 1000000
+#  define PIKA_SPINLOCK_DEADLOCK_WARNING_LIMIT 10000
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
After https://github.com/pika-org/pika/pull/927 `spin_k` and `yield_k` go through iterations much slower. This means that the spinlock deadlock warnings may not be printed in any reasonable time with the old limits. This reduces the error limit by an order of magnitude, and the warning limit by two orders of magnitude (since this is typically the interesting message, and it's harmless when printed). The limits can still be changed with configuration options as before, and the detection is still opt-in.