### PR TITLE
Minor debug cleanup

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -119,7 +119,6 @@ namespace pika::mpi::experimental::detail {
                 {
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
-                            using namespace pika::debug::detail;
                             using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;
 
                             PIKA_DETAIL_DP(mpi_tran<5>,
@@ -205,7 +204,6 @@ namespace pika::mpi::experimental::detail {
               , stream_{s}
               , op_state(ex::connect(PIKA_FORWARD(Sender_, sender), dispatch_mpi_receiver{*this}))
             {
-                using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(
                     mpi_tran<5>, debug(str<>("operation_state"), "stream", detail::stream_name(s)));
             }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -34,9 +34,8 @@ namespace pika::mpi::experimental::detail {
 
     // -----------------------------------------------------------------
     // by convention the title is 7 chars (for alignment)
-    using namespace pika::debug::detail;
     template <int Level>
-    inline constexpr print_threshold<Level, 0> mpi_tran("MPITRAN");
+    inline constexpr debug::detail::print_threshold<Level, 0> mpi_tran("MPITRAN");
 
     namespace ex = pika::execution::experimental;
 
@@ -118,7 +117,6 @@ namespace pika::mpi::experimental::detail {
     {
         detail::add_request_callback(
             [&op_state](int status) mutable {
-                using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(mpi_tran<5>,
                     debug(str<>(
                         "callback_void") /*, "stream", detail::stream_name(op_state.stream)*/));
@@ -135,7 +133,6 @@ namespace pika::mpi::experimental::detail {
     {
         detail::add_request_callback(
             [&op_state](int status) mutable {
-                using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("callback_nonvoid")));
                 PIKA_ASSERT(std::holds_alternative<Result>(op_state.result));
                 set_value_error_helper(status, PIKA_MOVE(op_state.receiver),
@@ -153,7 +150,6 @@ namespace pika::mpi::experimental::detail {
         op_state.completed = false;
         detail::add_request_callback(
             [&op_state](int status) mutable {
-                using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(mpi_tran<5>,
                     debug(str<>("callback_void_suspend_resume"), "status", status
                         /*, "stream", detail::stream_name(op_state.stream)*/));
@@ -176,7 +172,6 @@ namespace pika::mpi::experimental::detail {
     {
         detail::add_request_callback(
             [receiver = PIKA_MOVE(receiver)](int status) mutable {
-                using namespace pika::debug::detail;
                 PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("schedule_task_callback")));
                 if (status != MPI_SUCCESS)
                 {

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -46,7 +46,6 @@ namespace pika::mpi::experimental {
             transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
         {
             using namespace pika::mpi::experimental::detail;
-            using namespace pika::debug::detail;
             PIKA_DETAIL_DP(mpi_tran<5>,
                 debug(str<>("transform_mpi_t"), "tag_fallback_invoke", "stream",
                     detail::stream_name(s)));

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -42,9 +42,8 @@ namespace pika::mpi::experimental {
         // -----------------------------------------------------------------
         // by convention the title is 7 chars (for alignment)
         // a debug level of N shows messages with level 1..N
-        using namespace pika::debug::detail;
         template <int Level>
-        static print_threshold<Level, 0> mpi_debug("MPIPOLL");
+        static debug::detail::print_threshold<Level, 0> mpi_debug("MPIPOLL");
 
         constexpr std::uint32_t max_mpi_streams = detail::to_underlying(stream_type::max_stream);
         constexpr std::uint32_t max_poll_requests = 32;
@@ -204,6 +203,7 @@ namespace pika::mpi::experimental {
         // stream operator to display debug mpi_data
         PIKA_EXPORT std::ostream& operator<<(std::ostream& os, mpi_data const& info)
         {
+            using namespace pika::debug::detail;
             // clang-format off
             os << "R "
                << dec<3>(info.rank_) << "/"
@@ -220,6 +220,7 @@ namespace pika::mpi::experimental {
         // stream operator to display debug mpi_stream
         PIKA_EXPORT std::ostream& operator<<(std::ostream& os, mpi_stream const& stream)
         {
+            using namespace pika::debug::detail;
             // clang-format off
             os
                <<  "stream "    << stream.name_
@@ -232,7 +233,7 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT std::ostream& operator<<(std::ostream& os, MPI_Request const& req)
         {
             // clang-format off
-            os <<  "req " << hex<8>(req);
+            os <<  "req " << debug::detail::hex<8>(req);
             // clang-format on
             return os;
         }
@@ -451,7 +452,7 @@ namespace pika::mpi::experimental {
                     {
                         // for debugging, create a timer : debug info every N seconds
                         static auto poll_deb =
-                            mpi_debug<5>.make_timer(2, str<>("Poll - lock failed"));
+                            mpi_debug<5>.make_timer(2, debug::detail::str<>("Poll - lock failed"));
                         PIKA_DETAIL_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                     }
                     return polling_status::idle;
@@ -460,7 +461,8 @@ namespace pika::mpi::experimental {
                 if constexpr (mpi_debug<5>.is_enabled())
                 {
                     // for debugging, create a timer : debug info every N seconds
-                    static auto poll_deb = mpi_debug<5>.make_timer(2, str<>("Poll - lock success"));
+                    static auto poll_deb =
+                        mpi_debug<5>.make_timer(2, debug::detail::str<>("Poll - lock success"));
                     PIKA_DETAIL_DP(mpi_debug<5>, timed(poll_deb, mpi_data_));
                 }
 
@@ -560,7 +562,8 @@ namespace pika::mpi::experimental {
             // output a debug heartbeat every N seconds
             if constexpr (mpi_debug<4>.is_enabled())
             {
-                static auto poll_deb = mpi_debug<4>.make_timer(1, str<>("Poll - success"));
+                static auto poll_deb =
+                    mpi_debug<4>.make_timer(1, debug::detail::str<>("Poll - success"));
                 PIKA_DETAIL_DP(mpi_debug<4>, timed(poll_deb, mpi_data_));
             }
 
@@ -699,7 +702,6 @@ namespace pika::mpi::experimental {
             // if we have a single rank - disable pool
             if (detail::mpi_data_.size_ == 1) { flags &= ~1; }
         }
-        using namespace pika::debug::detail;
         PIKA_DETAIL_DP(detail::mpi_debug<6>,
             debug(str<>("completion mode"), bin<8>(flags), detail::mode_string(flags)));
         // override the variable used to control completion mode and pool flags
@@ -748,7 +750,6 @@ namespace pika::mpi::experimental {
     // but only one thread per rank needs to do so
     void init(bool init_mpi, bool init_errorhandler)
     {
-        using namespace pika::debug::detail;
         if (init_mpi)
         {
             int required = MPI_THREAD_MULTIPLE;
@@ -820,7 +821,6 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     void finalize(std::string const& pool_name)
     {
-        using namespace pika::debug::detail;
         if (detail::mpi_data_.error_handler_initialized_)
         {
             PIKA_ASSERT(detail::pika_mpi_errhandler != 0);

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<pika::counting_semaphore<>> limiter;
 // a debug level of zero disables messages with a priority>0
 // a debug level of N shows messages with priority<N
 template <int Level>
-static pika::debug::detail::print_threshold<Level, 0> msr_deb("MPI_SR_");
+static print_threshold<Level, 0> msr_deb("MPI_SR_");
 
 // ------------------------------------------------------------
 // caution: message_buffers will be constructed in-place in a buffer

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -55,6 +55,8 @@ using pika::program_options::options_description;
 using pika::program_options::value;
 using pika::program_options::variables_map;
 
+using namespace pika::debug::detail;
+
 namespace ex = pika::execution::experimental;
 namespace mpi = pika::mpi::experimental;
 namespace tt = pika::this_thread::experimental;
@@ -69,9 +71,8 @@ std::unique_ptr<pika::counting_semaphore<>> limiter;
 // ------------------------------------------------------------
 // a debug level of zero disables messages with a priority>0
 // a debug level of N shows messages with priority<N
-using namespace pika::debug::detail;
 template <int Level>
-static print_threshold<Level, 0> msr_deb("MPI_SR_");
+static pika::debug::detail::print_threshold<Level, 0> msr_deb("MPI_SR_");
 
 // ------------------------------------------------------------
 // caution: message_buffers will be constructed in-place in a buffer
@@ -136,7 +137,6 @@ void msg_info(
 {
     if (output)
     {
-        using namespace pika::debug::detail;
         int other = (mtype == msg_type::send) ? next_rank(rank, size) : prev_rank(rank, size);
         const char* msg = (mtype == msg_type::send) ? "send" : "recv";
         std::stringstream temp;
@@ -424,7 +424,6 @@ int pika_main(pika::program_options::variables_map& vm)
         while (counter > 0) { pika::this_thread::yield(); }
         if (output)
         {
-            using namespace pika::debug::detail;
             // clang-format off
             msr_deb<0>.debug(str<>("User Messages")
                 , "Rank", dec<3>(rank), "of", dec<3>(size)

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -16,17 +16,19 @@
 // gcc and clang both provide this header
 #if __has_include(<cxxabi.h>)
 # include <cxxabi.h>
-using cxxabi_supported__ = std::true_type;
+namespace pika::debug::detail {
+    using cxxabi_supported__ = std::true_type;
+    using abi::__cxa_demangle;
+}    // namespace pika::debug::detail
 #else
-using cxxabi_supported__ = std::false_type;
-// create some dummy function to make the compiler happy in the true_type instantiation
-namespace abi {
+namespace pika::debug::detail {
+    using cxxabi_supported__ = std::false_type;
     template <typename... Ts>
     char* __cxa_demangle(Ts... ts)
     {
         return nullptr;
     }
-}    // namespace abi
+}    // namespace pika::debug::detail
 #endif
 
 // --------------------------------------------------------------------
@@ -43,7 +45,7 @@ namespace pika::debug::detail {
     struct demangle_helper<T, std::true_type>
     {
         demangle_helper()
-          : demangled_{abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr), std::free}
+          : demangled_{__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr), std::free}
         {
         }
 

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -10,6 +10,7 @@
 #include <pika/config.hpp>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <typeinfo>
 
 // gcc and clang both provide this header

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -8,37 +8,40 @@
 #pragma once
 
 #include <pika/config.hpp>
-#include <cstdlib>
+#include <memory>
 #include <string>
-#include <type_traits>
 #include <typeinfo>
 
-// --------------------------------------------------------------------
-// Always present regardless of compiler : used by serialization code
+// gcc and clang both provide this header
+#if __has_include(<cxxabi.h>)
+# include <cxxabi.h>
+using cxxabi_supported__ = std::true_type;
+#else
+using cxxabi_supported__ = std::false_type;
+// create some dummy function to make the compiler happy in the true_type instantiation
+namespace abi {
+    template <typename... Ts>
+    char* __cxa_demangle(Ts... ts)
+    {
+        return nullptr;
+    }
+}    // namespace abi
+#endif
+
 // --------------------------------------------------------------------
 namespace pika::debug::detail {
-    template <typename T>
+    // default : use built-in typeid to get the best info we can
+    template <typename T, typename Enabled = std::false_type>
     struct demangle_helper
     {
         char const* type_id() const { return typeid(T).name(); }
     };
-}    // namespace pika::debug::detail
 
-#if defined(__GNUG__)
-
-# include <cxxabi.h>
-# include <memory>
-# include <stdlib.h>
-
-// --------------------------------------------------------------------
-// if available : demangle an arbitrary c++ type using gnu utility
-// --------------------------------------------------------------------
-namespace pika::debug::detail {
+    // if available : demangle an arbitrary c++ type using gnu utility
     template <typename T>
-    class cxxabi_demangle_helper
+    struct demangle_helper<T, std::true_type>
     {
-    public:
-        cxxabi_demangle_helper()
+        demangle_helper()
           : demangled_{abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr), std::free}
         {
         }
@@ -46,65 +49,35 @@ namespace pika::debug::detail {
         char const* type_id() const { return demangled_ ? demangled_.get() : typeid(T).name(); }
 
     private:
-        std::unique_ptr<char, void (*)(void*)> demangled_;
+        std::unique_ptr<char, decltype(&std::free)> demangled_;
     };
+
+    template <typename T>
+    using cxx_type_id = demangle_helper<T, cxxabi_supported__>;
 }    // namespace pika::debug::detail
 
-#else
-
-namespace pika::debug::detail {
-    template <typename T>
-    using cxxabi_demangle_helper = demangle_helper<T>;
-}    // namespace pika::debug::detail
-
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-namespace pika::debug::detail {
-    template <typename T>
-    struct type_id
-    {
-        static demangle_helper<T> typeid_;
-    };
-
-    template <typename T>
-    demangle_helper<T> type_id<T>::typeid_ = demangle_helper<T>();
-
-#if defined(__GNUG__)
-    template <typename T>
-    struct cxx_type_id
-    {
-        static cxxabi_demangle_helper<T> typeid_;
-    };
-
-    template <typename T>
-    cxxabi_demangle_helper<T> cxx_type_id<T>::typeid_ = cxxabi_demangle_helper<T>();
-#else
-    template <typename T>
-    using cxx_type_id = type_id<T>;
-#endif
-
-    // --------------------------------------------------------------------
-    // print type information
-    // usage : std::cout << print_type<args...>("separator")
-    // separator is appended if the number of types > 1
-    // --------------------------------------------------------------------
-    template <typename T = void>
+// --------------------------------------------------------------------
+// print type information
+// usage : std::cout << debug::print_type<args...>("separator")
+// separator is appended if the number of types > 1
+// --------------------------------------------------------------------
+namespace pika::debug {
+    template <typename T = void>    // print a single type
     inline std::string print_type(const char* = "")
     {
-        return std::string(cxx_type_id<T>::typeid_.type_id());
+        return std::string(detail::cxx_type_id<T>().type_id());
     }
 
-    template <>
-    inline std::string print_type<>(const char*)
+    template <>    // fallback for an empty type
+    inline std::string print_type<>(char const*)
     {
-        return "void";
+        return "<>";
     }
 
-    template <typename T, typename... Args>
+    template <typename T, typename... Args>    // print a list of types
     inline std::enable_if_t<sizeof...(Args) != 0, std::string> print_type(const char* delim = "")
     {
-        std::string temp(cxx_type_id<T>::typeid_.type_id());
+        std::string temp(print_type<T>());
         return temp + delim + print_type<Args...>(delim);
     }
-}    // namespace pika::debug::detail
+}    // namespace pika::debug

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -18,13 +18,13 @@
 # include <cxxabi.h>
 namespace pika::debug::detail {
     using cxxabi_supported__ = std::true_type;
-    using abi::__cxa_demangle;
+    constexpr auto demangle = abi::__cxa_demangle;
 }    // namespace pika::debug::detail
 #else
 namespace pika::debug::detail {
     using cxxabi_supported__ = std::false_type;
     template <typename... Ts>
-    char* __cxa_demangle(Ts... ts)
+    char* demangle(Ts... ts)
     {
         return nullptr;
     }
@@ -45,7 +45,7 @@ namespace pika::debug::detail {
     struct demangle_helper<T, std::true_type>
     {
         demangle_helper()
-          : demangled_{__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr), std::free}
+          : demangled_{demangle(typeid(T).name(), nullptr, nullptr, nullptr), std::free}
         {
         }
 

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -24,7 +24,7 @@ namespace pika::debug::detail {
 namespace pika::debug::detail {
     using cxxabi_supported__ = std::false_type;
     template <typename... Ts>
-    char* demangle(Ts... ts)
+    constexpr char* demangle(Ts... ts)
     {
         return nullptr;
     }
@@ -52,7 +52,8 @@ namespace pika::debug::detail {
         char const* type_id() const { return demangled_ ? demangled_.get() : typeid(T).name(); }
 
     private:
-        std::unique_ptr<char, decltype(&std::free)> demangled_;
+        // would prefer decltype(&std::free) here but clang overloads it for host/device code
+        std::unique_ptr<char, void (*)(void*)> demangled_;
     };
 
     template <typename T>

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -57,7 +57,11 @@
 // when debugging is disabled
 #define PIKA_DETAIL_DP_LAZY(printer, Expr) printer.eval([&] { return Expr; })
 #define PIKA_DETAIL_DP(printer, Expr)                                                              \
-    if constexpr (printer.is_enabled()) { printer.Expr; };
+ if constexpr (printer.is_enabled())                                                               \
+ {                                                                                                 \
+  using namespace pika::debug::detail;                                                             \
+  printer.Expr;                                                                                    \
+ };
 
 #define PIKA_DETAIL_NS_DEBUG pika::debug::detail
 

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -57,11 +57,11 @@
 // when debugging is disabled
 #define PIKA_DETAIL_DP_LAZY(printer, Expr) printer.eval([&] { return Expr; })
 #define PIKA_DETAIL_DP(printer, Expr)                                                              \
- if constexpr (printer.is_enabled())                                                               \
- {                                                                                                 \
-  using namespace pika::debug::detail;                                                             \
-  printer.Expr;                                                                                    \
- };
+    if constexpr (printer.is_enabled())                                                            \
+    {                                                                                              \
+        using namespace pika::debug::detail;                                                       \
+        printer.Expr;                                                                              \
+    };
 
 #define PIKA_DETAIL_NS_DEBUG pika::debug::detail
 

--- a/tools/clang-reformat.sh
+++ b/tools/clang-reformat.sh
@@ -12,6 +12,6 @@ for file in $(git ls-files | grep -E "\.(cpp|hpp|cu)(\.in)?$"); do
     # to allow for per-directory clang format files, we cd into the dir first
     DIR=$(dirname "$file")
     pushd ${DIR} >/dev/null
-    clang-format -i $(basename -- ${file})
+    clang-format-16 -i $(basename -- ${file})
     popd >/dev/null
 done


### PR DESCRIPTION
part 1 : Simplifies the debug helper code by removing ifdefs and using `__has_include` for c++ name demmangling
part 2 : declutter some of the mpi code for example by moving a namespace check into a macro so it doesn't need to be used in many places.
pushing this PR because it is in my incoming MPI change PR and can be reviewed separately

Note that removing the debug code and replacing it with `fmt::` is a next step. 