### PR TITLE
Reenable `condition_variable2` test on ARM CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,7 +570,6 @@ jobs:
               -j2 \
               --timeout 500 \
               -T test \
-              -E "tests.unit.modules.threading.condition_variable2" \
               --no-compress-output \
               --output-on-failure
       - run:


### PR DESCRIPTION
The test seems to no longer be failing the same way it was before. Going to test this on `main` for a while and revert if needed.