### PR TITLE
Fix build with `PIKA_HAVE_THREAD_DEADLOCK_DETECTION_ENABLED`

### DIFF
--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -16,7 +16,8 @@ include:
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.78.0 \
                  ^hwloc@2.7.0"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MAX_CPU_COUNT=256 \
-                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
+                  -DPIKA_WITH_THREAD_DEBUG_INFO=ON"
 
 gcc11_spack_compiler_image:
   extends:

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -31,6 +31,7 @@
 #include <pika/runtime/runtime_handlers.hpp>
 #include <pika/runtime/shutdown_function.hpp>
 #include <pika/runtime/startup_function.hpp>
+#include <pika/schedulers/deadlock_detection.hpp>
 #include <pika/string_util/classification.hpp>
 #include <pika/string_util/split.hpp>
 #include <pika/threading/thread.hpp>
@@ -123,7 +124,7 @@ namespace pika {
             else { pika::util::disable_lock_detection(); }
 #endif
 #ifdef PIKA_HAVE_THREAD_DEADLOCK_DETECTION
-            threads::detail::set_deadlock_detection_enabled(
+            pika::threads::detail::set_deadlock_detection_enabled(
                 cmdline.rtcfg_.enable_deadlock_detection());
 #endif
 #ifdef PIKA_HAVE_SPINLOCK_DEADLOCK_DETECTION


### PR DESCRIPTION
Also enabled a CI configuration which ensures that this configuration keeps building in the future.