### PR TITLE
More MPI polling improvements

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -68,18 +68,13 @@ namespace pika::mpi::experimental::detail {
     // return a scheduler on the mpi pool, with or without stack
     inline auto mpi_pool_scheduler(execution::thread_priority p, bool stack = true)
     {
-        if (stack)
+        ex::thread_pool_scheduler sched{&resource::get_thread_pool(get_pool_name())};
+        if (!stack)
         {
-            return ex::with_priority(
-                ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p);
+            sched = ex::with_stacksize(std::move(sched), execution::thread_stacksize::nostack);
         }
-        else
-        {
-            return ex::with_stacksize(
-                ex::with_priority(
-                    ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p),
-                execution::thread_stacksize::nostack);
-        }
+        sched = ex::with_priority(std::move(sched), p);
+        return sched;
     }
 
     // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -66,16 +66,18 @@ namespace pika::mpi::experimental::detail {
 
     // -----------------------------------------------------------------
     // return a scheduler on the mpi pool, with or without stack
-    inline auto mpi_pool_scheduler(bool stack = true)
+    inline auto mpi_pool_scheduler(execution::thread_priority p, bool stack = true)
     {
         if (stack)
         {
-            return ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())};
+            return ex::with_priority(
+                ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p);
         }
         else
         {
             return ex::with_stacksize(
-                ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())},
+                ex::with_priority(
+                    ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p),
                 execution::thread_stacksize::nostack);
         }
     }
@@ -84,10 +86,6 @@ namespace pika::mpi::experimental::detail {
     // return a scheduler on the default pool with added priority if requested
     inline auto default_pool_scheduler(execution::thread_priority p)
     {
-        if (p == execution::thread_priority::normal)
-        {
-            return ex::thread_pool_scheduler{&resource::get_thread_pool("default")};
-        }
         return ex::with_priority(
             ex::thread_pool_scheduler{&resource::get_thread_pool("default")}, p);
     }
@@ -168,10 +166,11 @@ namespace pika::mpi::experimental::detail {
     // adds a request callback to the mpi polling code which will call
     // set_value/error on the receiver
     template <typename Receiver>
-    void schedule_task_callback(MPI_Request request, Receiver&& receiver)
+    void
+    schedule_task_callback(MPI_Request request, execution::thread_priority p, Receiver&& receiver)
     {
         detail::add_request_callback(
-            [receiver = PIKA_MOVE(receiver)](int status) mutable {
+            [receiver = PIKA_MOVE(receiver), p](int status) mutable {
                 PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("schedule_task_callback")));
                 if (status != MPI_SUCCESS)
                 {
@@ -181,8 +180,7 @@ namespace pika::mpi::experimental::detail {
                 else
                 {
                     // pass the result onto a new task and invoke the continuation
-                    auto snd0 = ex::just(status) |
-                        ex::transfer(default_pool_scheduler(execution::thread_priority::high)) |
+                    auto snd0 = ex::just(status) | ex::transfer(default_pool_scheduler(p)) |
                         ex::then([receiver = PIKA_MOVE(receiver)](int status) mutable {
                             PIKA_DETAIL_DP(
                                 mpi_tran<5>, debug(str<>("set_value_error_helper"), status));

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -145,7 +145,7 @@ namespace pika::mpi::experimental::detail {
     template <typename OperationState>
     void resume_request_callback(MPI_Request request, OperationState& op_state)
     {
-        op_state.completed = false;
+        PIKA_ASSERT(op_state.completed == false);
         detail::add_request_callback(
             [&op_state](int status) mutable {
                 PIKA_DETAIL_DP(mpi_tran<5>,

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -142,10 +142,6 @@ namespace pika::mpi::experimental {
             ///
             /// * continuation : the polling thread will call the continuation directly
             ///
-            /// * mpix_continuation : the continuation of the mpi_request is passed into the mpi
-            /// library using mpix extensions and is triggered by the polling thread directly
-            /// by the mpi library (during MPI_Test)
-            ///
             /// * unspecified : reserved for development purposes or for customization by an
             /// application using pika
             yield_while = 0x00,       // 00 ... 15

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -115,9 +115,11 @@ namespace pika::mpi::experimental {
             /// from the polling thread onto a new one
             completion_inline = 0x04,
 
-            /// this bit enables the use of a high priority task flag when a
-            /// completion is handled so that the continuation is executed quickly
-            /// if transferred to a new task, or resumed from sleep.
+            /// this bit enables the use of a high priority task flag
+            /// 1) requests are boosted to high priority if they are passed the the mpi-pool
+            ///    to ensure they execute before other polling tasks (reduce latency)
+            /// 2) completions are boosted to high priority when sent to the main thread pool
+            ///    so that the continuation is executed as quickly as possible
             high_priority = 0x08,
 
             /// 2 bits control the handler method,
@@ -140,8 +142,8 @@ namespace pika::mpi::experimental {
                 flags & detail::to_underlying(handler_mode::method_mask));
         }
 
-        // 1 bit defines high priority mode for completion
-        inline bool use_HP_completion(int mode)
+        // 1 bit defines high priority boost mode for pool transfers
+        inline bool use_priority_boost(int mode)
         {
             return static_cast<bool>((mode & detail::to_underlying(handler_mode::high_priority)) ==
                 detail::to_underlying(handler_mode::high_priority));

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -104,28 +104,28 @@ namespace pika::mpi::experimental {
         enum class handler_mode : std::uint32_t
         {
             /// enable the use of a dedicated pool for polling mpi messages.
-            use_pool = 0x01,
+            use_pool = 0b0000'0001,    // 1
 
             /// this bit enables the inline invocation of the mpi request, when set
             /// the calling thread performs the mpi operation, when unset, a transfer
             /// is made so that the invocation happens on a new task that
             /// would normally be on a dedicated pool if/when it exists
-            request_inline = 0x02,
+            request_inline = 0b0000'0010,    // 2
 
             /// this bit enables the inline execution of the completion handler for the
             /// request, when unset a transfer is made to move the completion handler
             /// from the polling thread onto a new one
-            completion_inline = 0x04,
+            completion_inline = 0b0000'0100,    // 4
 
             /// this bit enables the use of a high priority task flag
             /// 1) requests are boosted to high priority if they are passed the the mpi-pool
             ///    to ensure they execute before other polling tasks (reduce latency)
             /// 2) completions are boosted to high priority when sent to the main thread pool
             ///    so that the continuation is executed as quickly as possible
-            high_priority = 0x08,
+            high_priority = 0b0000'1000,    // 8
 
             /// 3 bits control the handler method,
-            method_mask = 0x70,
+            method_mask = 0b0111'0000,    // 70
 
             /// Methods supported for dispatching continuations:
             ///
@@ -144,18 +144,18 @@ namespace pika::mpi::experimental {
             ///
             /// * unspecified : reserved for development purposes or for customization by an
             /// application using pika
-            yield_while = 0x00,       // 00 ... 15
-            suspend_resume = 0x10,    // 16 ... 31
-            new_task = 0x20,          // 32 ... 47
-            continuation = 0x30,      // 48 ... 63
-            unspecified = 0x40,       // 64
+            yield_while = 0b0000'0000,       // 0x00, 00 ... 15
+            suspend_resume = 0b0001'0000,    // 0x10, 16 ... 31
+            new_task = 0b0010'0000,          // 0x20, 32 ... 47
+            continuation = 0b0011'0000,      // 0x30, 48 ... 63
+            unspecified = 0b0100'0000,       // 0x40, 64 ...
 
             /// Default flags are to invoke inline, but transfer completion using a dedicated pool
             default_mode = use_pool | request_inline | high_priority | new_task,
         };
 
         /// 2 bits define continuation mode
-        inline handler_mode get_handler_mode(int flags)
+        inline handler_mode get_handler_mode(std::underlying_type_t<handler_mode> flags)
         {
             return static_cast<handler_mode>(
                 flags & detail::to_underlying(handler_mode::method_mask));

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -78,9 +78,9 @@ namespace pika::mpi::experimental {
             PIKA_ASSERT(pool_exists() == need_pool);
 #endif
 
-            using execution::thread_priority;
-            thread_priority p =
-                use_HP_completion(mode) ? thread_priority::high : thread_priority::normal;
+            execution::thread_priority p = use_priority_boost(mode) ?
+                execution::thread_priority::boost :
+                execution::thread_priority::normal;
             if (inline_req)
             {
                 return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f), s} |
@@ -104,7 +104,7 @@ namespace pika::mpi::experimental {
             }
             else
             {
-                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler());
+                auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(p));
                 return dispatch_mpi_sender<decltype(snd0), F>{
                            PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s} |
                     let_value([=](MPI_Request request) -> unique_any_sender<> {

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -42,13 +42,10 @@ namespace pika::mpi::experimental {
             PIKA_CONCEPT_REQUIRES_(
                 pika::execution::experimental::is_sender_v<std::decay_t<Sender>>)>
         friend PIKA_FORCEINLINE pika::execution::experimental::unique_any_sender<>
-        tag_fallback_invoke(
-            transform_mpi_t, Sender&& sender, F&& f, stream_type s = stream_type::automatic)
+        tag_fallback_invoke(transform_mpi_t, Sender&& sender, F&& f)
         {
             using namespace pika::mpi::experimental::detail;
-            PIKA_DETAIL_DP(mpi_tran<5>,
-                debug(str<>("transform_mpi_t"), "tag_fallback_invoke", "stream",
-                    detail::stream_name(s)));
+            PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("transform_mpi_t"), "tag_fallback_invoke"));
 
             using execution::thread_priority;
             using pika::execution::experimental::just;
@@ -83,7 +80,7 @@ namespace pika::mpi::experimental {
                 execution::thread_priority::normal;
             if (inline_req || !pool_exists())
             {
-                return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f), s} |
+                return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f)} |
                     let_value([=](MPI_Request request) -> unique_any_sender<> {
                         if (inline_com)
                         {
@@ -112,8 +109,7 @@ namespace pika::mpi::experimental {
             else
             {
                 auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(p));
-                return dispatch_mpi_sender<decltype(snd0), F>{
-                           PIKA_MOVE(snd0), PIKA_FORWARD(F, f), s} |
+                return dispatch_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
                     let_value([=](MPI_Request request) -> unique_any_sender<> {
                         if (inline_com)
                         {
@@ -138,11 +134,10 @@ namespace pika::mpi::experimental {
         // tag invoke overload for mpi_transform
         //
         template <typename F>
-        friend constexpr PIKA_FORCEINLINE auto
-        tag_fallback_invoke(transform_mpi_t, F&& f, stream_type s = stream_type::automatic)
+        friend constexpr PIKA_FORCEINLINE auto tag_fallback_invoke(transform_mpi_t, F&& f)
         {
-            return pika::execution::experimental::detail::partial_algorithm<transform_mpi_t, F,
-                stream_type>{PIKA_FORWARD(F, f), /*p, */ s};
+            return pika::execution::experimental::detail::partial_algorithm<transform_mpi_t, F>{
+                PIKA_FORWARD(F, f)};
         }
 
     } transform_mpi{};

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -136,7 +136,7 @@ namespace pika::mpi::experimental::detail {
                             case handler_mode::yield_while:
                             {
                                 pika::util::yield_while(
-                                    [&request]() { return !detail::poll_request(request); });
+                                    [request]() { return !detail::poll_request(request); });
 #ifdef PIKA_HAVE_APEX
                                 apex::scoped_timer apex_invoke("pika::mpi::trigger");
 #endif

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -120,6 +120,9 @@ namespace pika::mpi::experimental::detail {
 
                     // which polling/testing mode are we using
                     handler_mode mode = get_handler_mode(r.op_state.mode_flags);
+                    execution::thread_priority p = use_priority_boost(r.op_state.mode_flags) ?
+                        execution::thread_priority::boost :
+                        execution::thread_priority::normal;
 
                     PIKA_DETAIL_DP(mpi_tran<5>,
                         debug(str<>("trigger_mpi_recv"), "set_value_t", "req", ptr(request),
@@ -146,7 +149,7 @@ namespace pika::mpi::experimental::detail {
                                 // The callback will call set_value/set_error inside a new task
                                 // and execution will continue on that thread
                                 detail::schedule_task_callback(
-                                    request, PIKA_MOVE(r.op_state.receiver));
+                                    request, p, PIKA_MOVE(r.op_state.receiver));
                                 break;
                             }
                             case handler_mode::continuation:
@@ -163,10 +166,10 @@ namespace pika::mpi::experimental::detail {
                                 // the callback will resume _this_ thread
                                 std::unique_lock l{r.op_state.mutex};
                                 resume_request_callback(request, r.op_state);
-                                if (use_HP_completion(r.op_state.mode_flags))
+                                if (use_priority_boost(r.op_state.mode_flags))
                                 {
                                     threads::detail::thread_data::scoped_thread_priority
-                                        set_restore(execution::thread_priority::high);
+                                        set_restore(p);
                                     r.op_state.cond_var.wait(
                                         l, [&]() { return r.op_state.completed; });
                                 }

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -82,7 +82,7 @@ namespace pika::mpi::experimental::detail {
             int mode_flags;
             int status;
             // these vars are needed by suspend/resume mode
-            bool completed;
+            bool completed{false};
             pika::detail::spinlock mutex;
             pika::condition_variable cond_var;
 

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -459,7 +459,7 @@ void init_resource_partitioner_handler(
     if (vm["no-mpi-pool"].as<bool>()) { pool_mode = mpix::pool_create_mode::force_no_create; }
 
     msr_deb<2>.debug(str<>("init RP"), "create_pool");
-    mpix::create_pool("", mpix::pool_create_mode::pika_decides);
+    mpix::create_pool("", pool_mode);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains a number of improvements to the mpi polling and continuation handling
1) If a request is not being handled inline, then it must be transferred to the polling pool - but if the polling pool has been disabled, then this extra transfer can be elided. We remove some unwanted transfers
2) If the polling pool is enabled and no other thread can participate in the handling of requests/continuations, then the polling loop can be simplified to remove some locks and queues as they are unnecessary
3) Remove all stream based operations (they will be reinstated in a later PR)
4) Consistently handle high priority boosts for tasks that are transferred/injected to the polling loop or back to the work queues. 
