### PR TITLE
Fix builds with newest stdexec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
                 -DPIKA_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
                 -DPIKA_WITH_GIT_TAG="${CIRCLE_TAG}" \
                 -DPIKA_WITH_CXX_STANDARD=20 \
-                -DPIKA_WITH_PRECOMPILED_HEADERS=On \
+                -DPIKA_WITH_PRECOMPILED_HEADERS=Off \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_STDEXEC=ON \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
   docker:
-    - image: pikaorg/pika-ci-base:23
+    - image: pikaorg/pika-ci-base:25
 
 defaults: &defaults
   <<: *working_dir_default

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "docker.io/pikaorg/pika-ci-base:23",
+  "image": "docker.io/pikaorg/pika-ci-base:25",
   "features": {},
   "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
   "extensions": [

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/address-undefined-leak
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:23
+      image: pikaorg/pika-ci-base:25
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:23
+    container: pikaorg/pika-ci-base:25
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:23
+    container: pikaorg/pika-ci-base:25
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/fetchcontent/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:23
+    container: pikaorg/pika-ci-base:25
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/tracy/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:23
+    container: pikaorg/pika-ci-base:25
 
     steps:
       - name: Check out Tracy

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/thread
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:23
+      image: pikaorg/pika-ci-base:25
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/valgrind
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:23
+    container: pikaorg/pika-ci-base:25
 
     strategy:
       matrix:

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} cxxflags=-stdlib=libc++ malloc=system \
                  cxxstd=$CXXSTD +stdexec ^boost@1.79.0 ^hwloc@2.6.0 ^fmt cxxflags=-stdlib=libc++ \
-                 ^stdexec@git.nvhpc-23.09.rc4=main"
+                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
                   -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -11,7 +11,7 @@ clang14_debug_build_pika-ci-image:
   extends: .container-builder
   needs: []   # To clear the dotenv artifacts
   variables:
-    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:23
+    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:25
     DOCKERFILE: .gitlab/docker/Dockerfile.dockerhub_build
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","BUILD_DIR","SOURCE_DIR"]'
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
-                 ^fmt@10.0.0 ^stdexec@git.nvhpc-23.09.rc4=main"
+                 ^fmt@10.0.0 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
-                 ^fmt@10.0.0 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
+                 ^fmt@10.0.0 ^stdexec@git.d64da3a6188ec2c1492fdeb8590717acad8d5d02=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.nvhpc-23.09.rc4=main"
+                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DCMAKE_CXX_FLAGS='-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_DEBUG_BACKTRACE -D_GLIBCXX_ASSERTIONS'"

--- a/.gitlab/includes/gcc13_santis_pipeline.yml
+++ b/.gitlab/includes/gcc13_santis_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.nvhpc-23.09.rc4=main"
+                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -17,7 +17,7 @@ include:
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.78.0%${NVHPC_COMPILER} ^hwloc@2.7.0 \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main ^cuda@11.8%${NVHPC_COMPILER} \
+                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main ^cuda@12.4%${NVHPC_COMPILER} \
                  ^whip%${NVHPC_COMPILER}"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -17,7 +17,7 @@ include:
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.78.0%${NVHPC_COMPILER} ^hwloc@2.7.0 \
-                 ^stdexec@git.nvhpc-23.09.rc4=main ^cuda@11.8%${NVHPC_COMPILER} \
+                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main ^cuda@11.8%${NVHPC_COMPILER} \
                  ^whip%${NVHPC_COMPILER}"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"

--- a/cmake/pika_add_config_test.cmake
+++ b/cmake/pika_add_config_test.cmake
@@ -472,3 +472,12 @@ function(pika_check_for_cxx_lambda_capture_decltype)
     FILE ${ARGN}
   )
 endfunction()
+
+# ##################################################################################################
+function(pika_check_for_stdexec_sender_receiver_concepts)
+  pika_add_config_test(
+    PIKA_WITH_STDEXEC_SENDER_RECEIVER_CONCEPTS
+    SOURCE cmake/tests/stdexec_sender_receiver_concepts.cpp
+    FILE ${ARGN}
+  )
+endfunction()

--- a/cmake/pika_perform_cxx_feature_tests.cmake
+++ b/cmake/pika_perform_cxx_feature_tests.cmake
@@ -51,4 +51,8 @@ function(pika_perform_cxx_feature_tests)
   )
 
   pika_check_for_cxx_lambda_capture_decltype(DEFINITIONS PIKA_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE)
+
+  pika_check_for_stdexec_sender_receiver_concepts(
+    DEFINITIONS PIKA_HAVE_STDEXEC_SENDER_RECEIVER_CONCEPTS
+  )
 endfunction()

--- a/cmake/tests/stdexec_sender_receiver_concepts.cpp
+++ b/cmake/tests/stdexec_sender_receiver_concepts.cpp
@@ -1,0 +1,13 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdexec/execution.hpp>
+
+int main()
+{
+    using sender_concept = stdexec::sender_t;
+    using receiver_concept = stdexec::receiver_t;
+}

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,8 +72,8 @@ pika optionally depends on:
   default user-level thread implementations in pika. This can be enabled with
   ``PIKA_WITH_BOOST_CONTEXT=ON``.
 * `stdexec <https://github.com/NVIDIA/stdexec>`_. stdexec support can be enabled with
-  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `nvhpc-23.09.rc4
-  <https://github.com/NVIDIA/stdexec/tree/nvhpc-23.09.rc4>`_).  The
+  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `b39a506096900de4074ee556867a3805bd8351bd
+  <https://github.com/NVIDIA/stdexec/tree/b39a506096900de4074ee556867a3805bd8351bd>`_).  The
   integration is experimental. See :ref:`pika_stdexec` for more information about the integration.
 
 If you are using `nix <https://nixos.org>`_ you can also use the ``shell.nix`` file provided at the

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -106,7 +106,7 @@ namespace pika::cuda::experimental {
             };
 
         public:
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             PIKA_EXPORT explicit cuda_scheduler_sender(cuda_scheduler scheduler);
             cuda_scheduler_sender(cuda_scheduler_sender&&) = default;

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -37,7 +37,7 @@ namespace pika::cuda::experimental {
         template <typename Receiver, typename F>
         struct then_on_host_receiver_impl<Receiver, F>::then_on_host_receiver_type
         {
-            using is_receiver = void;
+            PIKA_STDEXEC_RECEIVER_CONCEPT
 
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
@@ -127,7 +127,7 @@ namespace pika::cuda::experimental {
         template <typename Sender, typename F>
         struct then_on_host_sender_impl<Sender, F>::then_on_host_sender_type
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             std::decay_t<Sender> sender;
             std::decay_t<F> f;

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -129,7 +129,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
     template <typename Sender, typename F>
     struct then_with_cuda_stream_sender_impl<Sender, F>::then_with_cuda_stream_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
@@ -218,7 +218,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
 
             struct then_with_cuda_stream_receiver
             {
-                using is_receiver = void;
+                PIKA_STDEXEC_RECEIVER_CONCEPT
                 using then_with_cuda_stream_receiver_tag = void;
 
                 operation_state& op_state;

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -30,6 +30,8 @@ __global__ void dummy_kernel() {}
 template <typename T>
 struct const_reference_cuda_sender
 {
+    PIKA_STDEXEC_SENDER_CONCEPT
+
     std::reference_wrapper<std::decay_t<T>> x;
     cu::cuda_scheduler sched;
 
@@ -86,6 +88,8 @@ struct const_reference_cuda_sender
 
 struct const_reference_error_cuda_sender
 {
+    PIKA_STDEXEC_SENDER_CONCEPT
+
     cu::cuda_scheduler sched;
 
     PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -52,7 +52,7 @@ namespace pika::mpi::experimental::detail {
     template <typename Sender, typename F>
     struct dispatch_mpi_sender_impl<Sender, F>::dispatch_mpi_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::decay_t<Sender> sender;
         std::decay_t<F> f;
@@ -89,7 +89,7 @@ namespace pika::mpi::experimental::detail {
             // invokes the mpi call, and sets a callback on the polling handler
             struct dispatch_mpi_receiver
             {
-                using is_receiver = void;
+                PIKA_STDEXEC_RECEIVER_CONCEPT
 
                 operation_state& op_state;
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -53,7 +53,7 @@ namespace pika::mpi::experimental::detail {
     template <typename Sender>
     struct trigger_mpi_sender_impl<Sender>::trigger_mpi_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
         std::decay_t<Sender> sender;
         int completion_mode_flags_;
 
@@ -91,7 +91,7 @@ namespace pika::mpi::experimental::detail {
             // invokes the mpi call, and sets a callback on the polling handler
             struct trigger_mpi_receiver
             {
-                using is_receiver = void;
+                PIKA_STDEXEC_RECEIVER_CONCEPT
                 operation_state& op_state;
 
                 template <typename Error>

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -39,7 +39,7 @@ namespace pika::drop_op_state_detail {
     template <typename OpState>
     struct drop_op_state_receiver_impl<OpState>::drop_op_state_receiver_type
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         OpState* op_state = nullptr;
 
@@ -164,7 +164,7 @@ namespace pika::drop_op_state_detail {
     template <typename Sender>
     struct drop_op_state_sender_impl<Sender>::drop_op_state_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::decay_t<Sender> sender;
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -120,7 +120,7 @@ namespace pika::drop_value_detail {
                 r.sender, drop_value_receiver<Receiver>{PIKA_FORWARD(Receiver, receiver)});
         }
 
-        friend constexpr decltype(auto) tag_invoke(
+        friend decltype(auto) tag_invoke(
             pika::execution::experimental::get_env_t, drop_value_sender_type const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -34,7 +34,7 @@ namespace pika::drop_value_detail {
     template <typename Receiver>
     struct drop_value_receiver_impl<Receiver>::drop_value_receiver_type
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
@@ -78,7 +78,7 @@ namespace pika::drop_value_detail {
     template <typename Sender>
     struct drop_value_sender_impl<Sender>::drop_value_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
 

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -98,7 +98,7 @@ namespace pika {
         template <typename OpState>
         struct require_started_receiver_impl<OpState>::require_started_receiver_type
         {
-            using is_receiver = void;
+            PIKA_STDEXEC_RECEIVER_CONCEPT
 
             OpState* op_state = nullptr;
 
@@ -223,7 +223,7 @@ namespace pika {
         template <typename Sender>
         struct require_started_sender_impl<Sender>::require_started_sender_type
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             std::optional<std::decay_t<Sender>> sender{std::nullopt};
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -111,7 +111,7 @@ namespace pika::split_tuple_detail {
 
         struct split_tuple_receiver
         {
-            using is_receiver = void;
+            PIKA_STDEXEC_RECEIVER_CONCEPT
 
             shared_state& state;
 
@@ -371,7 +371,7 @@ namespace pika::split_tuple_detail {
     template <typename Sender, typename Allocator, std::size_t Index>
     struct split_tuple_sender_impl<Sender, Allocator, Index>::split_tuple_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         using allocator_type = Allocator;
         using shared_state_type = shared_state<Sender, Allocator>;

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -53,7 +53,7 @@ namespace pika::sync_wait_detail {
     template <typename Sender>
     struct sync_wait_receiver_impl<Sender>::sync_wait_receiver_type
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
 #if defined(PIKA_HAVE_STDEXEC)
         // value and error_types of the predecessor sender

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -37,7 +37,7 @@ namespace pika::unpack_detail {
     template <typename Receiver>
     struct unpack_receiver_impl<Receiver>::unpack_receiver_type
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
 
@@ -148,7 +148,7 @@ namespace pika::unpack_detail {
     template <typename Sender>
     struct unpack_sender_impl<Sender>::unpack_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         PIKA_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
 

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -47,7 +47,7 @@ namespace pika::when_all_vector_detail {
     template <typename Sender>
     struct when_all_vector_sender_impl<Sender>::when_all_vector_sender_type
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         using senders_type = std::vector<Sender>;
         senders_type senders;
@@ -143,7 +143,7 @@ namespace pika::when_all_vector_detail {
         {
             struct when_all_vector_receiver
             {
-                using is_receiver = void;
+                PIKA_STDEXEC_RECEIVER_CONCEPT
 
                 operation_state& op_state;
                 std::size_t const i;

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/execution/algorithms/execute.hpp>
+#include <pika/execution_base/sender.hpp>
 #include <pika/testing.hpp>
 
 #include <cstddef>
@@ -18,7 +19,7 @@ static std::size_t tag_invoke_execute_calls = 0;
 template <typename Scheduler>
 struct sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<>>;

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -18,6 +18,8 @@ static std::size_t tag_invoke_execute_calls = 0;
 template <typename Scheduler>
 struct sender
 {
+    using is_sender = void;
+
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<>>;
 

--- a/libs/pika/execution/tests/unit/algorithm_let_error.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_error.cpp
@@ -229,7 +229,7 @@ int main()
         PIKA_TEST(!let_error_callback_called);
     }
 
-    test_adl_isolation(ex::let_error(ex::just(), my_namespace::my_type{}));
+    test_adl_isolation(ex::let_error(error_sender<>{}, my_namespace::my_let_error_type{}));
 
     return 0;
 }

--- a/libs/pika/execution/tests/unit/algorithm_let_value.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_let_value.cpp
@@ -208,7 +208,7 @@ int main()
         PIKA_TEST(!let_value_callback_called);
     }
 
-    test_adl_isolation(ex::let_value(ex::just(), my_namespace::my_type{}));
+    test_adl_isolation(ex::let_value(ex::just(), my_namespace::my_let_value_type{}));
 
     return 0;
 }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -36,6 +36,8 @@ struct scheduler_schedule_from
 
     struct sender
     {
+        using is_sender = void;
+
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
         std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
@@ -76,6 +78,24 @@ struct scheduler_schedule_from
         {
             return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
         }
+
+        struct env
+        {
+            std::reference_wrapper<std::atomic<bool>> schedule_called;
+            std::reference_wrapper<std::atomic<bool>> execute_called;
+            std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
+
+            friend scheduler_schedule_from tag_invoke(
+                ex::get_completion_scheduler_t<ex::set_value_t>, env const& e) noexcept
+            {
+                return {e.schedule_called, e.execute_called, e.tag_invoke_overload_called};
+            }
+        };
+
+        friend env tag_invoke(ex::get_env_t, sender const& s) noexcept
+        {
+            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+        }
     };
 
     friend sender tag_invoke(pika::execution::experimental::schedule_t, scheduler_schedule_from s)
@@ -113,6 +133,8 @@ struct scheduler_transfer
 
     struct sender
     {
+        using is_sender = void;
+
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
         std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
@@ -150,6 +172,24 @@ struct scheduler_transfer
             pika::execution::experimental::get_completion_scheduler_t<
                 pika::execution::experimental::set_value_t>,
             sender const& s) noexcept
+        {
+            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+        }
+
+        struct env
+        {
+            std::reference_wrapper<std::atomic<bool>> schedule_called;
+            std::reference_wrapper<std::atomic<bool>> execute_called;
+            std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
+
+            friend scheduler_transfer tag_invoke(
+                ex::get_completion_scheduler_t<ex::set_value_t>, env const& e) noexcept
+            {
+                return {e.schedule_called, e.execute_called, e.tag_invoke_overload_called};
+            }
+        };
+
+        friend env tag_invoke(ex::get_env_t, sender const& s) noexcept
         {
             return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
         }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -36,7 +36,7 @@ struct scheduler_schedule_from
 
     struct sender
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
@@ -133,7 +133,7 @@ struct scheduler_transfer
 
     struct sender
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -514,7 +514,7 @@ namespace pika::execution::experimental::detail {
         storage_type storage{};
 
     public:
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
         template <typename Receiver,
             typename = std::enable_if_t<!std::is_same_v<std::decay_t<Receiver>, any_receiver>>>
         explicit any_receiver(Receiver&& receiver)
@@ -738,7 +738,7 @@ namespace pika::execution::experimental {
         storage_type storage{};
 
     public:
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
         unique_any_sender() = default;
 
         template <typename Sender,
@@ -848,7 +848,7 @@ namespace pika::execution::experimental {
         friend unique_any_sender<Ts...>;
 
     public:
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
         any_sender() = default;
 
         template <typename Sender,

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -506,8 +506,6 @@ namespace pika::execution::experimental::detail {
     template <typename... Ts>
     class any_receiver
     {
-        using is_receiver = void;
-
         using base_type = detail::any_receiver_base<Ts...>;
         template <typename Receiver>
         using impl_type = detail::any_receiver_impl<Receiver, Ts...>;
@@ -516,6 +514,7 @@ namespace pika::execution::experimental::detail {
         storage_type storage{};
 
     public:
+        using is_receiver = void;
         template <typename Receiver,
             typename = std::enable_if_t<!std::is_same_v<std::decay_t<Receiver>, any_receiver>>>
         explicit any_receiver(Receiver&& receiver)

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -30,6 +30,12 @@ namespace pika::execution::experimental {
         static constexpr bool value = is_receiver_of_v<Receiver, Completions>;
     };
 }    // namespace pika::execution::experimental
+
+# if defined(PIKA_HAVE_STDEXEC_SENDER_RECEIVER_CONCEPTS)
+#  define PIKA_STDEXEC_RECEIVER_CONCEPT                                                            \
+      using is_receiver = void;                                                                    \
+      using receiver_concept = stdexec::receiver_t;
+# endif
 #else
 # include <pika/config/constexpr.hpp>
 # include <pika/functional/tag_invoke.hpp>
@@ -220,3 +226,7 @@ namespace pika::execution::experimental::detail {
     template <typename CPO>
     inline constexpr bool is_receiver_cpo_v = is_receiver_cpo<CPO>::value;
 }    // namespace pika::execution::experimental::detail
+
+#if !defined(PIKA_STDEXEC_RECEIVER_CONCEPT)
+# define PIKA_STDEXEC_RECEIVER_CONCEPT using is_receiver = void;
+#endif

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -38,6 +38,12 @@ namespace pika::execution::experimental {
         static constexpr bool value = is_sender_to_v<Sender, Receiver>;
     };
 }    // namespace pika::execution::experimental
+
+# if defined(PIKA_HAVE_STDEXEC_SENDER_RECEIVER_CONCEPTS)
+#  define PIKA_STDEXEC_SENDER_CONCEPT                                                              \
+      using is_sender = void;                                                                      \
+      using sender_concept = stdexec::sender_t;
+# endif
 #else
 # include <pika/config/constexpr.hpp>
 # include <pika/execution_base/operation_state.hpp>
@@ -427,3 +433,7 @@ namespace pika::execution::detail {
     {
     };
 }    // namespace pika::execution::detail
+
+#if !defined(PIKA_STDEXEC_SENDER_CONCEPT)
+# define PIKA_STDEXEC_SENDER_CONCEPT using is_sender = void;
+#endif

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -20,7 +20,7 @@
 
 struct void_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <typename...> class Tuple, template <typename...> class Variant>
     using value_types = Variant<Tuple<>>;
@@ -54,7 +54,7 @@ struct void_sender
 template <typename... Ts>
 struct error_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <typename...> class Tuple, template <typename...> class Variant>
     using value_types = Variant<Tuple<Ts...>>;
@@ -96,7 +96,7 @@ struct error_sender
 template <typename... Ts>
 struct const_reference_error_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<Ts...>>;
@@ -132,7 +132,7 @@ struct const_reference_error_sender
 template <typename F>
 struct callback_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::decay_t<F> f;
     std::atomic<bool>& set_value_called;
@@ -169,7 +169,7 @@ struct callback_receiver
 template <typename F>
 struct error_callback_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::decay_t<F> f;
     std::atomic<bool>& set_error_called;
@@ -233,7 +233,7 @@ void check_exception_ptr(std::exception_ptr eptr)
 
 struct custom_sender_tag_invoke
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::atomic<bool>& tag_invoke_overload_called;
 
@@ -264,7 +264,7 @@ struct custom_sender_tag_invoke
 
 struct custom_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
@@ -305,7 +305,7 @@ struct custom_sender
 template <typename T>
 struct custom_typed_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::decay_t<T> x;
 
@@ -357,7 +357,7 @@ struct custom_sender2 : custom_sender
 template <typename T>
 struct const_reference_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::reference_wrapper<std::decay_t<T>> x;
 
@@ -452,7 +452,7 @@ struct scheduler
 
     struct sender
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
@@ -533,7 +533,7 @@ struct scheduler2
 
     struct sender
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         std::reference_wrapper<std::atomic<bool>> schedule_called;
         std::reference_wrapper<std::atomic<bool>> execute_called;
@@ -637,7 +637,7 @@ namespace my_namespace {
     {
         struct sender
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             template <template <class...> class Tuple, template <class...> class Variant>
             using value_types = Variant<Tuple<>>;
@@ -706,7 +706,7 @@ namespace my_namespace {
     template <typename... Ts>
     struct my_sender
     {
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         template <template <typename...> class Tuple, template <typename...> class Variant>
         using value_types = Variant<Tuple<Ts...>>;

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -633,6 +633,16 @@ namespace my_namespace {
         void operator()(std::exception_ptr) const {}
     };
 
+    struct my_let_value_type
+    {
+        auto operator()() const { return pika::execution::experimental::just(); }
+    };
+
+    struct my_let_error_type
+    {
+        auto operator()(std::exception_ptr) const { return pika::execution::experimental::just(); }
+    };
+
     struct my_scheduler
     {
         struct sender

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -41,6 +41,8 @@ struct custom_type_non_copyable
 template <typename... Ts>
 struct non_copyable_sender
 {
+    using is_sender = void;
+
     std::tuple<std::decay_t<Ts>...> ts;
 
     template <template <class...> class Tuple, template <class...> class Variant>
@@ -97,6 +99,8 @@ struct non_copyable_sender
 template <typename... Ts>
 struct sender
 {
+    using is_sender = void;
+
     std::tuple<std::decay_t<Ts>...> ts;
 
     template <template <class...> class Tuple, template <class...> class Variant>
@@ -209,6 +213,8 @@ struct large_sender : sender<Ts...>
 
 struct error_receiver
 {
+    using is_receiver = void;
+
     std::atomic<bool>& set_error_called;
 
     friend void tag_invoke(pika::execution::experimental::set_error_t, error_receiver&& r,

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -41,7 +41,7 @@ struct custom_type_non_copyable
 template <typename... Ts>
 struct non_copyable_sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::tuple<std::decay_t<Ts>...> ts;
 
@@ -99,7 +99,7 @@ struct non_copyable_sender
 template <typename... Ts>
 struct sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     std::tuple<std::decay_t<Ts>...> ts;
 
@@ -213,7 +213,7 @@ struct large_sender : sender<Ts...>
 
 struct error_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::atomic<bool>& set_error_called;
 

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -22,6 +22,8 @@ bool value_called = false;
 namespace mylib {
     struct receiver_1
     {
+        using is_receiver = void;
+
         friend void tag_invoke(ex::set_stopped_t, receiver_1&&) noexcept { done_called = true; }
 
         friend void tag_invoke(ex::set_error_t, receiver_1&&, std::exception_ptr) noexcept
@@ -39,6 +41,8 @@ namespace mylib {
 
     struct receiver_2
     {
+        using is_receiver = void;
+
         friend void tag_invoke(ex::set_stopped_t, receiver_2&&) noexcept { done_called = true; }
 
         friend void tag_invoke(ex::set_error_t, receiver_2&&, int) noexcept { error_called = true; }
@@ -51,6 +55,8 @@ namespace mylib {
 
     struct receiver_3
     {
+        using is_receiver = void;
+
         friend void tag_invoke(ex::set_stopped_t, receiver_3&&) noexcept { done_called = true; }
 
         friend void tag_invoke(ex::set_error_t, receiver_3&&, std::exception_ptr) noexcept
@@ -113,6 +119,8 @@ namespace mylib {
 
     struct non_receiver_4
     {
+        using is_receiver = void;
+
         friend void tag_invoke(ex::set_stopped_t, non_receiver_4&&) noexcept { done_called = true; }
 
         friend void tag_invoke(ex::set_error_t, non_receiver_4&&, std::exception_ptr) noexcept

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -22,7 +22,7 @@ bool value_called = false;
 namespace mylib {
     struct receiver_1
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         friend void tag_invoke(ex::set_stopped_t, receiver_1&&) noexcept { done_called = true; }
 
@@ -41,7 +41,7 @@ namespace mylib {
 
     struct receiver_2
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         friend void tag_invoke(ex::set_stopped_t, receiver_2&&) noexcept { done_called = true; }
 
@@ -55,7 +55,7 @@ namespace mylib {
 
     struct receiver_3
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         friend void tag_invoke(ex::set_stopped_t, receiver_3&&) noexcept { done_called = true; }
 
@@ -119,7 +119,7 @@ namespace mylib {
 
     struct non_receiver_4
     {
-        using is_receiver = void;
+        PIKA_STDEXEC_RECEIVER_CONCEPT
 
         friend void tag_invoke(ex::set_stopped_t, non_receiver_4&&) noexcept { done_called = true; }
 

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -21,7 +21,7 @@ static std::size_t tag_invoke_schedule_calls = 0;
 template <typename Scheduler>
 struct sender
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<>>;

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -21,6 +21,8 @@ static std::size_t tag_invoke_schedule_calls = 0;
 template <typename Scheduler>
 struct sender
 {
+    using is_sender = void;
+
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<>>;
 

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -68,7 +68,7 @@ struct non_sender_7
 
 struct receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     friend void tag_invoke(ex::set_error_t, receiver&&, std::exception_ptr) noexcept {}
 
@@ -86,7 +86,7 @@ struct receiver
 
 struct sender_1
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<int>>;
@@ -117,7 +117,7 @@ struct sender_1
 
 struct sender_2
 {
-    using is_sender = void;
+    PIKA_STDEXEC_SENDER_CONCEPT
 
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<int>>;
@@ -150,7 +150,7 @@ static std::size_t void_receiver_set_value_calls = 0;
 
 struct void_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     friend void tag_invoke(ex::set_error_t, void_receiver&&, std::exception_ptr) noexcept {}
 

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -68,6 +68,8 @@ struct non_sender_7
 
 struct receiver
 {
+    using is_receiver = void;
+
     friend void tag_invoke(ex::set_error_t, receiver&&, std::exception_ptr) noexcept {}
 
     friend void tag_invoke(ex::set_stopped_t, receiver&&) noexcept {}
@@ -84,6 +86,8 @@ struct receiver
 
 struct sender_1
 {
+    using is_sender = void;
+
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<int>>;
 
@@ -113,6 +117,8 @@ struct sender_1
 
 struct sender_2
 {
+    using is_sender = void;
+
     template <template <class...> class Tuple, template <class...> class Variant>
     using value_types = Variant<Tuple<int>>;
 
@@ -144,6 +150,8 @@ static std::size_t void_receiver_set_value_calls = 0;
 
 struct void_receiver
 {
+    using is_receiver = void;
+
     friend void tag_invoke(ex::set_error_t, void_receiver&&, std::exception_ptr) noexcept {}
 
     friend void tag_invoke(ex::set_stopped_t, void_receiver&&) noexcept {}

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -69,7 +69,7 @@ namespace pika::execution::experimental {
 
         struct sender
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             template <template <typename...> class Tuple, template <typename...> class Variant>
             using value_types = Variant<Tuple<>>;

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -179,7 +179,7 @@ namespace pika::execution::experimental {
         template <typename Scheduler>
         struct sender
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
 

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -88,8 +88,10 @@ namespace pika::thread_pool_bulk_detail {
             using type = pika::util::detail::transform_t<Tuple, std::decay>;
         };
 
+        // PIKA_STDEXEC_SENDER_CONCEPT
+
 #if defined(PIKA_HAVE_STDEXEC)
-        using is_sender = void;
+        PIKA_STDEXEC_SENDER_CONCEPT
 
         template <template <typename...> class Tuple, template <typename...> class Variant>
         using value_types = pika::util::detail::transform_t<
@@ -130,7 +132,7 @@ namespace pika::thread_pool_bulk_detail {
         {
             struct bulk_receiver
             {
-                using is_receiver = void;
+                PIKA_STDEXEC_RECEIVER_CONCEPT
 
                 operation_state* op_state;
 

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -498,7 +498,7 @@ namespace pika::thread_pool_bulk_detail {
                 s.scheduler, s.sender, s.shape, s.f, PIKA_FORWARD(Receiver, receiver)};
         }
 
-        friend constexpr auto tag_invoke(
+        friend auto tag_invoke(
             pika::execution::experimental::get_env_t, thread_pool_bulk_sender const& s) noexcept
         {
             return pika::execution::experimental::get_env(s.sender);

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -1245,9 +1245,9 @@ void test_completion_scheduler()
     }
 
     {
-        auto sender =
-            ex::bulk(ex::then(ex::transfer_just(ex::std_thread_scheduler{}, 42), [](int) {}), 10,
-                [](int, int) {});
+        auto sender = ex::bulk(
+            ex::then(ex::transfer_just(ex::std_thread_scheduler{}, 42), [](int x) { return x; }),
+            10, [](int, int) {});
         auto completion_scheduler =
             ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(sender));
         static_assert(

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -49,6 +49,8 @@ void test_execute()
 
 struct check_context_receiver
 {
+    using is_receiver = void;
+
     std::thread::id parent_id;
     std::mutex& mtx;
     std::condition_variable& cond;
@@ -208,6 +210,8 @@ void test_sender_receiver_then_arguments()
 template <typename F>
 struct callback_receiver
 {
+    using is_receiver = void;
+
     std::decay_t<F> f;
     std::mutex& mtx;
     std::condition_variable& cond;

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -49,7 +49,7 @@ void test_execute()
 
 struct check_context_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::thread::id parent_id;
     std::mutex& mtx;
@@ -210,7 +210,7 @@ void test_sender_receiver_then_arguments()
 template <typename F>
 struct callback_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::decay_t<F> f;
     std::mutex& mtx;

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1359,9 +1359,9 @@ void test_completion_scheduler()
     }
 
     {
-        auto sender =
-            ex::bulk(ex::then(ex::transfer_just(ex::thread_pool_scheduler{}, 42), [](int) {}), 10,
-                [](int, int) {});
+        auto sender = ex::bulk(
+            ex::then(ex::transfer_just(ex::thread_pool_scheduler{}, 42), [](int x) { return x; }),
+            10, [](int, int) {});
         auto completion_scheduler =
             ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(sender));
         static_assert(

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -56,7 +56,7 @@ void test_execute()
 
 struct check_context_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     pika::thread::id parent_id;
     pika::mutex& mtx;
@@ -218,7 +218,7 @@ void test_sender_receiver_then_arguments()
 template <typename F>
 struct callback_receiver
 {
-    using is_receiver = void;
+    PIKA_STDEXEC_RECEIVER_CONCEPT
 
     std::decay_t<F> f;
     pika::mutex& mtx;

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -56,6 +56,8 @@ void test_execute()
 
 struct check_context_receiver
 {
+    using is_receiver = void;
+
     pika::thread::id parent_id;
     pika::mutex& mtx;
     pika::condition_variable& cond;
@@ -216,6 +218,8 @@ void test_sender_receiver_then_arguments()
 template <typename F>
 struct callback_receiver
 {
+    using is_receiver = void;
+
     std::decay_t<F> f;
     pika::mutex& mtx;
     pika::condition_variable& cond;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -393,6 +393,8 @@ namespace pika::execution::experimental {
         template <async_rw_mutex_access_type AccessType>
         struct sender
         {
+            using is_sender = void;
+
             shared_state_weak_ptr_type prev_state;
             shared_state_ptr_type state;
 
@@ -583,6 +585,8 @@ namespace pika::execution::experimental {
         template <async_rw_mutex_access_type AccessType>
         struct sender
         {
+            using is_sender = void;
+
             shared_state_weak_ptr_type prev_state;
             shared_state_ptr_type state;
 

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -393,7 +393,7 @@ namespace pika::execution::experimental {
         template <async_rw_mutex_access_type AccessType>
         struct sender
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             shared_state_weak_ptr_type prev_state;
             shared_state_ptr_type state;
@@ -585,7 +585,7 @@ namespace pika::execution::experimental {
         template <async_rw_mutex_access_type AccessType>
         struct sender
         {
-            using is_sender = void;
+            PIKA_STDEXEC_SENDER_CONCEPT
 
             shared_state_weak_ptr_type prev_state;
             shared_state_ptr_type state;


### PR DESCRIPTION
Opts in to the newer stdexec sender/receiver concepts (with `using sender_concept = stdexec::sender_t` etc.). Also fixes a number of compilation failures resulting from stricter checks etc. in stdexec.