### PR TITLE
Enable MPI support in valgrind and sanitizer CI configurations

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -43,6 +43,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DPIKA_WITH_MALLOC=system \
+                -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -33,6 +33,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ccache-linux-sanitizers-address-undefined-leak
+      - name: Switch OpenMPI to MPICH
+        shell: bash
+        run: |
+            apt-get update
+            apt-get remove --yes mpi-default-dev
+            apt-get autoremove --yes
+            apt-get install --no-install-recommends --yes libmpich-dev
       - name: Configure
         shell: bash
         run: |
@@ -52,7 +59,7 @@ jobs:
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \
-                -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" \
+                -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer -Wno-error=ignored-optimization-argument" \
                 -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
       - name: Build
@@ -65,11 +72,6 @@ jobs:
         if: always()
         shell: bash
         run: |
-            # We are certain that we want to run mpiexec as root despite warnings as that is the
-            # only user available in the container. Mistakes will only affect the current step.
-            export OMPI_ALLOW_RUN_AS_ROOT=1
-            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
             # Newer GitHub actions runners increased the number of bits used for address space
             # layout randomization to a higher number such that thread sanitizer breaks. Newer
             # versions of LLVM (17 and newer) should fix this again.

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -65,6 +65,11 @@ jobs:
         if: always()
         shell: bash
         run: |
+            # We are certain that we want to run mpiexec as root despite warnings as that is the
+            # only user available in the container. Mistakes will only affect the current step.
+            export OMPI_ALLOW_RUN_AS_ROOT=1
+            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
             # Newer GitHub actions runners increased the number of bits used for address space
             # layout randomization to a higher number such that thread sanitizer breaks. Newer
             # versions of LLVM (17 and newer) should fix this again.

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -43,6 +43,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DPIKA_WITH_MALLOC=system \
+                -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -33,6 +33,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ccache-linux-sanitizers-thread
+      - name: Switch OpenMPI to MPICH
+        shell: bash
+        run: |
+            apt-get update
+            apt-get remove --yes mpi-default-dev
+            apt-get autoremove --yes
+            apt-get install --no-install-recommends --yes libmpich-dev
       - name: Configure
         shell: bash
         run: |
@@ -52,7 +59,7 @@ jobs:
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \
-                -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
+                -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -Wno-error=ignored-optimization-argument" \
                 -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On
       - name: Build
@@ -65,11 +72,6 @@ jobs:
         if: always()
         shell: bash
         run: |
-            # We are certain that we want to run mpiexec as root despite warnings as that is the
-            # only user available in the container. Mistakes will only affect the current step.
-            export OMPI_ALLOW_RUN_AS_ROOT=1
-            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
             # Newer GitHub actions runners increased the number of bits used for address space
             # layout randomization to a higher number such that thread sanitizer breaks. Newer
             # versions of LLVM (17 and newer) should fix this again.

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -65,6 +65,11 @@ jobs:
         if: always()
         shell: bash
         run: |
+            # We are certain that we want to run mpiexec as root despite warnings as that is the
+            # only user available in the container. Mistakes will only affect the current step.
+            export OMPI_ALLOW_RUN_AS_ROOT=1
+            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
             # Newer GitHub actions runners increased the number of bits used for address space
             # layout randomization to a higher number such that thread sanitizer breaks. Newer
             # versions of LLVM (17 and newer) should fix this again.

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -45,6 +45,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 -DCMAKE_CXX_FLAGS="-gdwarf-4" \
                 -DPIKA_WITH_MALLOC=system \
+                -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_EXAMPLES=ON \
                 -DPIKA_WITH_TESTS=ON \
                 -DPIKA_WITH_TESTS_EXAMPLES=ON \

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Test
         shell: bash
         run: |
+            # We are certain that we want to run mpiexec as root despite warnings as that is the
+            # only user available in the container. Mistakes will only affect the current step.
+            export OMPI_ALLOW_RUN_AS_ROOT=1
+            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
             cd build
             ctest \
               -j $(nproc) \

--- a/tools/tsan.supp
+++ b/tools/tsan.supp
@@ -12,3 +12,6 @@ race:pika::concurrency::detail::ConcurrentQueue*
 
 # https://github.com/pika-org/pika/issues/989
 race:pika::experimental::base_channel_mpsc
+
+# Used in mpi_ring_async_sender_receiver
+race:boost::lockfree::stack*

--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -25,3 +25,21 @@
    fun:_Z17test_command_linev
    fun:main
 }
+
+# OpenMPI
+{
+   ORTE init
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:orte_init
+}
+
+{
+   ORTE event loop
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:event_base_loop
+}


### PR DESCRIPTION
Enables MPI support in valgrind and sanitizer CI configurations. Since OpenMPI seems to be unhappy running under thread sanitizer, I've switched OpenMPI to MPICH in all the sanitizer configurations. I think it probably makes sense to keep testing both OpenMPI and MPICH in different configurations (so far we've had no MPICH CI configuration). Uninstalling OpenMPI and installing MPICH in the CI job takes ~10 seconds, so at the moment I'm not bothering with a separate container image.

I've had to suppress memory leaks in ORTE (OpenMPI) and data races in `boost::lockfree::stack` (used in one of the tests, same issue as https://github.com/pika-org/pika/issues/990).