### PR TITLE
Reenable HIP CI builds in CSCS CI

### DIFF
--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -38,17 +38,18 @@ gcc12_hip5_build:
     - .variables_gcc12_hip5_config
     - .build_template_rosa
 
-.gcc12_hip5_test_commmon:
-  needs: [gcc12_hip5_build]
-  extends:
-    - .variables_gcc12_hip5_config
-    - .test_common_gpu_clariden_hip
-    - .test_template
+# Disabled until AMD GPU runners come back online
+# .gcc12_hip5_test_commmon:
+#   needs: [gcc12_hip5_build]
+#   extends:
+#     - .variables_gcc12_hip5_config
+#     - .test_common_gpu_clariden_hip
+#     - .test_template
 
-gcc12_hip5_test_release:
-  extends: [.gcc12_hip5_test_commmon]
-  image: $PERSIST_IMAGE_NAME_RELEASE
+# gcc12_hip5_test_release:
+#   extends: [.gcc12_hip5_test_commmon]
+#   image: $PERSIST_IMAGE_NAME_RELEASE
 
-gcc12_hip5_test_debug:
-  extends: [.gcc12_hip5_test_commmon]
-  image: $PERSIST_IMAGE_NAME_DEBUG
+# gcc12_hip5_test_debug:
+#   extends: [.gcc12_hip5_test_commmon]
+#   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/pipelines_on_push.yml
+++ b/.gitlab/pipelines_on_push.yml
@@ -8,5 +8,5 @@ include:
   - local: '.gitlab/includes/gcc13_pipeline.yml'
   - local: '.gitlab/includes/clang14_cuda11_pipeline.yml'
   - local: '.gitlab/includes/performance_gcc13_pipeline.yml'
-  #- local: '.gitlab/includes/gcc12_hip5_pipeline.yml' # Commented until end of maintenance 5th may
+  - local: '.gitlab/includes/gcc12_hip5_pipeline.yml'
   - local: '.gitlab/includes/sloc.yml'


### PR DESCRIPTION
Tests remain disabled due to clariden still being unavailable, but we can already test that builds work.