### PR TITLE
Use Boost 1.85.0 in CI

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get -yqq install --no-install-recommends \
     git \
     gnupg2 \
     jq \
+    libcurl4-openssl-dev \
+    libssl-dev \
     libtool \
     locales \
     m4 \

--- a/.gitlab/includes/clang18_pipeline.yml
+++ b/.gitlab/includes/clang18_pipeline.yml
@@ -13,7 +13,7 @@ include:
     SPACK_ARCH: linux-ubuntu22.04-zen2
     COMPILER: clang@18.1.1
     CXXSTD: 23
-    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.84.0 \
+    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.85.0 \
                  ^hwloc@2.9.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: d9ef0fcdc1d8d696ddf33fb91e640ddcbf69ec3f
+  SPACK_COMMIT: 7f3dd38ccc106142846f29f76b928fa58e0e3164
 
 .base_spack_image:
   timeout: 2 hours


### PR DESCRIPTION
Use Boost 1.85.0 in clang 18 CI configuration. Also updates the spack commit used in CI to include the upstream change have spdlog as a dependency.