### PR TITLE
Blacklist two more tests in address sanitizer CI configuration

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan_blacklist.txt
+++ b/.github/workflows/linux_asan_ubsan_lsan_blacklist.txt
@@ -1,1 +1,3 @@
+tests.unit.modules.resource_partitioner.cross_pool_injection
+tests.unit.modules.resource_partitioner.suspend_thread
 tests.unit.modules.thread_manager.thread_num


### PR DESCRIPTION
`cross_pool_injection` and `suspend_thread` tests have been failing more frequently lately. They need looking into, but I'm blacklisting them for now to make progress with other PRs.