### PR TITLE
Remove unnecessary breaks from `mpi_polling.hpp`

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -162,11 +162,11 @@ namespace pika::mpi::experimental {
         {
             switch (get_handler_mode(flags))
             {
-            case handler_mode::yield_while: return "yield_while"; break;
-            case handler_mode::new_task: return "new_task"; break;
-            case handler_mode::continuation: return "continuation"; break;
-            case handler_mode::suspend_resume: return "suspend_resume"; break;
-            case handler_mode::unspecified: return "unspecified"; break;
+            case handler_mode::yield_while: return "yield_while";
+            case handler_mode::new_task: return "new_task";
+            case handler_mode::continuation: return "continuation";
+            case handler_mode::suspend_resume: return "suspend_resume";
+            case handler_mode::unspecified: return "unspecified";
             default: return "invalid";
             }
         }


### PR DESCRIPTION
nvc++ warns about unreachable statements. Since the breaks are preceded by returns the breaks are not needed.