### PR TITLE
Downgrade `set_thread_state` warnings to info messages

### DIFF
--- a/libs/pika/threading_base/src/set_thread_state.cpp
+++ b/libs/pika/threading_base/src/set_thread_state.cpp
@@ -43,7 +43,7 @@ namespace pika::threads::detail {
         if (current_state.state() == previous_state.state() && current_state != previous_state)
         {
             // NOLINTNEXTLINE(bugprone-branch-clone)
-            PIKA_LOG(warn,
+            PIKA_LOG(info,
                 "set_active_state: thread is still active, however it was non-active since the "
                 "original set_state request was issued, aborting state change, thread({}), "
                 "description({}), new state({})",
@@ -92,7 +92,7 @@ namespace pika::threads::detail {
             if (new_state == previous_state_val)
             {
                 // NOLINTNEXTLINE(bugprone-branch-clone)
-                PIKA_LOG(warn,
+                PIKA_LOG(info,
                     "set_thread_state: old thread state is the same as new thread state, aborting "
                     "state change, thread({}), description({}), new state({})",
                     thrd, get_thread_id_data(thrd)->get_description(),
@@ -113,7 +113,7 @@ namespace pika::threads::detail {
                 {
                     // schedule a new thread to set the state
                     // NOLINTNEXTLINE(bugprone-branch-clone)
-                    PIKA_LOG(warn,
+                    PIKA_LOG(info,
                         "set_thread_state: thread is currently active, scheduling "
                         "new thread, thread({}), description({}), new state({})",
                         thrd, get_thread_id_data(thrd)->get_description(),
@@ -136,7 +136,7 @@ namespace pika::threads::detail {
                     ++k;
 
                     // NOLINTNEXTLINE(bugprone-branch-clone)
-                    PIKA_LOG(warn,
+                    PIKA_LOG(info,
                         "set_thread_state: thread is currently active, but not "
                         "scheduling new thread because retry_on_active = false, "
                         "thread({}), description({}), new state({})",
@@ -153,7 +153,7 @@ namespace pika::threads::detail {
             case thread_schedule_state::terminated:
             {
                 // NOLINTNEXTLINE(bugprone-branch-clone)
-                PIKA_LOG(warn,
+                PIKA_LOG(info,
                     "set_thread_state: thread is terminated, aborting state "
                     "change, thread({}), description({}), new state({})",
                     thrd, get_thread_id_data(thrd)->get_description(),
@@ -216,7 +216,7 @@ namespace pika::threads::detail {
 
             // state has changed since we fetched it from the thread, retry
             // NOLINTNEXTLINE(bugprone-branch-clone)
-            PIKA_LOG(warn,
+            PIKA_LOG(info,
                 "set_thread_state: state has been changed since it was fetched, retrying, "
                 "thread({}), description({}), new state({}), old state({})",
                 thrd, get_thread_id_data(thrd)->get_description(), get_thread_state_name(new_state),


### PR DESCRIPTION
`set_thread_state` reports events that can occur under normal circumstances as warnings. This downgrades those messages to info messages.