### PR TITLE
Access receiver by reference in `split`, `split_tuple`, and `ensure_started` visitors

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -45,7 +45,7 @@ namespace pika::ensure_started_detail {
     template <typename Receiver>
     struct error_visitor
     {
-        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        std::decay_t<Receiver>& receiver;
 
         template <typename Error>
         void operator()(Error&& error)
@@ -58,7 +58,7 @@ namespace pika::ensure_started_detail {
     template <typename Receiver>
     struct value_visitor
     {
-        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        std::decay_t<Receiver>& receiver;
 
         void operator()(std::monostate) { PIKA_UNREACHABLE; }
 
@@ -216,7 +216,7 @@ namespace pika::ensure_started_detail {
             template <typename Receiver>
             struct stopped_error_value_visitor
             {
-                PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+                std::decay_t<Receiver>& receiver;
 
                 template <typename T,
                     typename =
@@ -234,8 +234,7 @@ namespace pika::ensure_started_detail {
 
                 void operator()(error_type&& error)
                 {
-                    pika::detail::visit(
-                        error_visitor<Receiver>{PIKA_MOVE(receiver)}, PIKA_MOVE(error));
+                    pika::detail::visit(error_visitor<Receiver>{receiver}, PIKA_MOVE(error));
                 }
 
                 template <typename T,
@@ -244,8 +243,7 @@ namespace pika::ensure_started_detail {
                         std::is_same_v<std::decay_t<T>, value_type>>>
                 void operator()(T&& t)
                 {
-                    pika::detail::visit(
-                        value_visitor<Receiver>{PIKA_MOVE(receiver)}, PIKA_FORWARD(T, t));
+                    pika::detail::visit(value_visitor<Receiver>{receiver}, PIKA_FORWARD(T, t));
                 }
             };
 
@@ -319,8 +317,7 @@ namespace pika::ensure_started_detail {
                     // TODO: Should this preserve the scheduler? It does not
                     // if we call set_* inline.
                     pika::detail::visit(
-                        stopped_error_value_visitor<Receiver>{PIKA_FORWARD(Receiver, receiver)},
-                        PIKA_MOVE(v));
+                        stopped_error_value_visitor<Receiver>{receiver}, PIKA_MOVE(v));
                 }
                 else
                 {
@@ -336,8 +333,7 @@ namespace pika::ensure_started_detail {
                         // directly again.
                         l.unlock();
                         pika::detail::visit(
-                            stopped_error_value_visitor<Receiver>{PIKA_FORWARD(Receiver, receiver)},
-                            PIKA_MOVE(v));
+                            stopped_error_value_visitor<Receiver>{receiver}, PIKA_MOVE(v));
                     }
                     else
                     {
@@ -348,8 +344,7 @@ namespace pika::ensure_started_detail {
                         continuation.emplace(
                             [this, receiver = PIKA_FORWARD(Receiver, receiver)]() mutable {
                                 pika::detail::visit(
-                                    stopped_error_value_visitor<Receiver>{PIKA_MOVE(receiver)},
-                                    PIKA_MOVE(v));
+                                    stopped_error_value_visitor<Receiver>{receiver}, PIKA_MOVE(v));
                             });
                     }
                 }

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -42,7 +42,7 @@ namespace pika::split_tuple_detail {
     template <typename Receiver>
     struct error_visitor
     {
-        PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+        std::decay_t<Receiver>& receiver;
 
         template <typename Error>
         void operator()(Error const& error)
@@ -210,8 +210,7 @@ namespace pika::split_tuple_detail {
 
             void operator()(error_type const& error)
             {
-                pika::detail::visit(
-                    error_visitor<Receiver>{PIKA_FORWARD(Receiver, receiver)}, error);
+                pika::detail::visit(error_visitor<Receiver>{receiver}, error);
             }
 
             void operator()(value_type& t)
@@ -325,12 +324,11 @@ namespace pika::split_tuple_detail {
                     // to the vector and the vector is not threadsafe in
                     // itself. The continuation will be called later
                     // when set_error/set_stopped/set_value is called.
-                    continuations[Index] = [this,
-                                               receiver =
-                                                   PIKA_FORWARD(Receiver, receiver)]() mutable {
-                        pika::detail::visit(
-                            stopped_error_value_visitor<Index, Receiver>{PIKA_MOVE(receiver)}, v);
-                    };
+                    continuations[Index] =
+                        [this, receiver = PIKA_FORWARD(Receiver, receiver)]() mutable {
+                            pika::detail::visit(
+                                stopped_error_value_visitor<Index, Receiver>{receiver}, v);
+                        };
                 }
             }
         }


### PR DESCRIPTION
Avoids some unnecessary move constructions. Could further be refactored to simply pass a reference to the operation state and access the receiver through that, but leaving that for a separate PR.