### PR TITLE
Minor logging fixes

### DIFF
--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -273,12 +273,13 @@ namespace PIKA_DETAIL_NS_DEBUG {
 #else
         char** env = environ;
 #endif
-        std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
-        for (char** current = env; *current; current++)
+        std::vector<std::string_view> env_strings{"_PROCID=", "_WORLD_RANK=", "_RANK="};
+
+        for (auto s : env_strings)
         {
-            auto e = std::string(*current);
-            for (auto s : env_strings)
+            for (char** current = env; *current; current++)
             {
+                auto e = std::string(*current);
                 auto pos = e.find(s);
                 if (pos != std::string::npos)
                 {

--- a/libs/pika/init_runtime/CMakeLists.txt
+++ b/libs/pika/init_runtime/CMakeLists.txt
@@ -15,6 +15,10 @@ set(init_runtime_headers
 
 set(init_runtime_sources init_logging.cpp init_runtime.cpp scoped_finalize.cpp)
 
+if(PIKA_WITH_MPI)
+  list(APPEND init_runtime_additional_module_dependencies pika_mpi_base)
+endif()
+
 include(pika_add_module)
 pika_add_module(
   pika init_runtime
@@ -33,5 +37,6 @@ pika_add_module(
     pika_schedulers
     pika_threading_base
     pika_timing
+    ${init_runtime_additional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -76,7 +76,7 @@ namespace pika::detail {
     {
         static void format_id(spdlog::memory_buf_t& dest, std::size_t i)
         {
-            if (i != std::size_t(-1)) { dest.append(fmt::format("{:04x}", i)); }
+            if (i != std::size_t(-1)) { dest.append(fmt::format("{:04}", i)); }
             else { dest.append(std::string_view("----")); }
         }
 


### PR DESCRIPTION
This fixes some minor issues with the logging output related to hostnames and ranks:
- The hostname was printed twice in multi-rank runs.
- The thread and pool indices were printed as hexadecimal which in my opinion doesn't make much sense; they're now printed as decimal.
- The MPI rank is retrieved with `MPI_Comm_rank` first, if MPI is initialized.
- If the MPI rank can't be retrieved with `MPI_Comm_rank`, the way environment variables are checked is slightly changed to prioritize environment variable names that are more likely to contain the rank.