### PR TITLE
Add support for MPI continuations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages
 /out
 .vs
 /spack-*
+*.user

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -152,7 +152,7 @@ namespace pika::mpi::experimental::detail {
                                     std::make_exception_ptr(mpi_exception(status)));
                                 return;
                             }
-                            // early poll just in case the request completed immmediately
+                            // early poll just in case the request completed immediately
                             if (poll_request(request))
                             {
 #ifdef PIKA_HAVE_APEX

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -152,9 +152,8 @@ namespace pika::mpi::experimental::detail {
                                     std::make_exception_ptr(mpi_exception(status)));
                                 return;
                             }
-
-                            PIKA_DETAIL_DP(mpi_tran<7>, debug(str<>("poll_request"), ptr(request)));
-                            if (0 && poll_request(request))
+                            // early poll just in case the request completed immmediately
+                            if (poll_request(request))
                             {
 #ifdef PIKA_HAVE_APEX
                                 apex::scoped_timer apex_invoke("pika::mpi::trigger");

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -153,7 +153,8 @@ namespace pika::mpi::experimental::detail {
                                 return;
                             }
 
-                            if (poll_request(request))
+                            PIKA_DETAIL_DP(mpi_tran<7>, debug(str<>("poll_request"), ptr(request)));
+                            if (0 && poll_request(request))
                             {
 #ifdef PIKA_HAVE_APEX
                                 apex::scoped_timer apex_invoke("pika::mpi::trigger");

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -161,15 +161,9 @@ namespace pika::mpi::experimental::detail {
                                 PIKA_DETAIL_DP(mpi_tran<7>,
                                     debug(
                                         str<>("dispatch_mpi_recv"), "eager poll ok", ptr(request)));
-                                // calls set_value(request), or set_error(mpi_exception(status))
-                                set_value_error_helper(
-                                    status, PIKA_MOVE(r.op_state.receiver), MPI_REQUEST_NULL);
+                                ex::set_value(PIKA_MOVE(r.op_state.receiver), MPI_REQUEST_NULL);
                             }
-                            else
-                            {
-                                set_value_error_helper(
-                                    status, PIKA_MOVE(r.op_state.receiver), request);
-                            }
+                            else { ex::set_value(PIKA_MOVE(r.op_state.receiver), request); }
                         },
                         [&](std::exception_ptr ep) {
                             ex::set_error(PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -35,7 +35,7 @@ namespace pika::mpi::experimental::detail {
     // -----------------------------------------------------------------
     // by convention the title is 7 chars (for alignment)
     template <int Level>
-    inline constexpr debug::detail::print_threshold<Level, 9> mpi_tran("MPITRAN");
+    inline constexpr debug::detail::print_threshold<Level, 0> mpi_tran("MPITRAN");
 
     namespace ex = pika::execution::experimental;
 
@@ -168,7 +168,6 @@ namespace pika::mpi::experimental::detail {
         {
             std::lock_guard lk(op_state.mutex);
             op_state.completed = true;
-            detail::complete_mpix();
         }
         op_state.cond_var.notify_one();
         return MPI_SUCCESS;

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -134,9 +134,9 @@ namespace pika::mpi::experimental::detail {
                 {
                     // pass the result onto a new task and invoke the continuation
                     auto snd0 = ex::transfer_just(default_pool_scheduler(p)) |
-                        ex::then([receiver = PIKA_MOVE(receiver)]() mutable {
+                        ex::then([receiver = PIKA_FORWARD(Receiver, receiver)]() mutable {
                             PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("set_value")));
-                            ex::set_value(PIKA_FORWARD(Receiver, receiver));
+                            ex::set_value(PIKA_MOVE(receiver));
                         });
                     ex::start_detached(PIKA_MOVE(snd0));
                 }
@@ -160,7 +160,7 @@ namespace pika::mpi::experimental::detail {
     }
 
     // -----------------------------------------------------------------
-    // handler_method::mpix_continuation
+    // handler_method::mpix_continuation - signature is
     /// typedef int (MPIX_Continue_cb_function)(int rc, void *cb_data);
     template <typename OperationState>
     int mpix_callback([[maybe_unused]] int rc, void* cb_data)

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -18,6 +18,7 @@
 #include <pika/execution/algorithms/just.hpp>
 #include <pika/execution/algorithms/then.hpp>
 #include <pika/execution/algorithms/transfer.hpp>
+#include <pika/execution/algorithms/transfer_just.hpp>
 #include <pika/execution_base/any_sender.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
@@ -37,20 +38,8 @@ namespace pika::mpi::experimental::detail {
     template <int Level>
     inline constexpr debug::detail::print_threshold<Level, 0> mpi_tran("MPITRAN");
 
-    namespace ex = pika::execution::experimental;
-
     // -----------------------------------------------------------------
-    template <typename T>
-    struct any_sender_helper
-    {
-        using type = ex::unique_any_sender<T>;
-    };
-
-    template <>
-    struct any_sender_helper<void>
-    {
-        using type = ex::unique_any_sender<>;
-    };
+    namespace ex = pika::execution::experimental;
 
     // -----------------------------------------------------------------
     // is func(Ts..., MPI_Request) invocable
@@ -103,49 +92,17 @@ namespace pika::mpi::experimental::detail {
     }
 
     // -----------------------------------------------------------------
-    // adds a request callback to the mpi polling code which will call
-    // the set_value/set_error helper using the void return signature
-    template <typename OperationState>
-    void set_value_request_callback_void(MPI_Request request, OperationState& op_state)
-    {
-        detail::add_request_callback(
-            [&op_state](int status) mutable {
-                PIKA_DETAIL_DP(mpi_tran<5>,
-                    debug(str<>(
-                        "callback_void") /*, "stream", detail::stream_name(op_state.stream)*/));
-                set_value_error_helper(status, PIKA_MOVE(op_state.receiver));
-            },
-            request);
-    }
-
-    // -----------------------------------------------------------------
-    // adds a request callback to the mpi polling code which will call
-    // the set_value/set_error helper with a valid return value
-    template <typename Result, typename OperationState>
-    void set_value_request_callback_non_void(MPI_Request request, OperationState& op_state)
-    {
-        detail::add_request_callback(
-            [&op_state](int status) mutable {
-                PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("callback_nonvoid")));
-                PIKA_ASSERT(std::holds_alternative<Result>(op_state.result));
-                set_value_error_helper(status, PIKA_MOVE(op_state.receiver),
-                    PIKA_MOVE(std::get<Result>(op_state.result)));
-            },
-            request);
-    }
-
-    // -----------------------------------------------------------------
+    // handler_method::suspend_resume
     // adds a request callback to the mpi polling code which will call
     // notify_one to wake up a suspended task
     template <typename OperationState>
-    void resume_request_callback(MPI_Request request, OperationState& op_state)
+    void add_suspend_resume_request_callback(MPI_Request request, OperationState& op_state)
     {
         PIKA_ASSERT(op_state.completed == false);
         detail::add_request_callback(
             [&op_state](int status) mutable {
-                PIKA_DETAIL_DP(mpi_tran<5>,
-                    debug(str<>("callback_void_suspend_resume"), "status", status
-                        /*, "stream", detail::stream_name(op_state.stream)*/));
+                PIKA_DETAIL_DP(
+                    mpi_tran<5>, debug(str<>("callback_void_suspend_resume"), "status", status));
                 // wake up the suspended thread
                 {
                     std::lock_guard lk(op_state.mutex);
@@ -158,6 +115,52 @@ namespace pika::mpi::experimental::detail {
     }
 
     // -----------------------------------------------------------------
+    // handler_method::new_task
+    // adds a request callback to the mpi polling code which will call
+    // set_value/error on the receiver
+    template <typename Receiver>
+    void add_new_task_request_callback(
+        MPI_Request request, execution::thread_priority p, Receiver&& receiver)
+    {
+        detail::add_request_callback(
+            [receiver = PIKA_MOVE(receiver), p](int status) mutable {
+                PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("schedule_task_callback")));
+                if (status != MPI_SUCCESS)
+                {
+                    ex::set_error(PIKA_FORWARD(Receiver, receiver),
+                        std::make_exception_ptr(mpi_exception(status)));
+                }
+                else
+                {
+                    // pass the result onto a new task and invoke the continuation
+                    auto snd0 = ex::transfer_just(default_pool_scheduler(p)) |
+                        ex::then([receiver = PIKA_MOVE(receiver)]() mutable {
+                            PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("set_value")));
+                            ex::set_value(PIKA_FORWARD(Receiver, receiver));
+                        });
+                    ex::start_detached(PIKA_MOVE(snd0));
+                }
+            },
+            request);
+    }
+
+    // -----------------------------------------------------------------
+    // handler_method::continuation
+    // adds a request callback to the mpi polling code which will call
+    // the set_value/set_error helper using the void return signature
+    template <typename OperationState>
+    void add_continuation_request_callback(MPI_Request request, OperationState& op_state)
+    {
+        detail::add_request_callback(
+            [&op_state](int status) mutable {
+                PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("callback_void")));
+                set_value_error_helper(status, PIKA_MOVE(op_state.receiver));
+            },
+            request);
+    }
+
+    // -----------------------------------------------------------------
+    // handler_method::mpix_continuation
     /// typedef int (MPIX_Continue_cb_function)(int rc, void *cb_data);
     template <typename OperationState>
     static int mpix_callback([[maybe_unused]] int rc, void* cb_data)
@@ -171,36 +174,6 @@ namespace pika::mpi::experimental::detail {
         }
         op_state.cond_var.notify_one();
         return MPI_SUCCESS;
-    }
-
-    // -----------------------------------------------------------------
-    // adds a request callback to the mpi polling code which will call
-    // set_value/error on the receiver
-    template <typename Receiver>
-    void
-    schedule_task_callback(MPI_Request request, execution::thread_priority p, Receiver&& receiver)
-    {
-        detail::add_request_callback(
-            [receiver = PIKA_MOVE(receiver), p](int status) mutable {
-                PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("schedule_task_callback")));
-                if (status != MPI_SUCCESS)
-                {
-                    ex::set_error(PIKA_FORWARD(Receiver, receiver),
-                        std::make_exception_ptr(mpi_exception(status)));
-                }
-                else
-                {
-                    // pass the result onto a new task and invoke the continuation
-                    auto snd0 = ex::just(status) | ex::transfer(default_pool_scheduler(p)) |
-                        ex::then([receiver = PIKA_MOVE(receiver)](int status) mutable {
-                            PIKA_DETAIL_DP(
-                                mpi_tran<5>, debug(str<>("set_value_error_helper"), status));
-                            set_value_error_helper(status, PIKA_MOVE(receiver));
-                        });
-                    ex::start_detached(PIKA_MOVE(snd0));
-                }
-            },
-            request);
     }
 
 }    // namespace pika::mpi::experimental::detail

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -204,8 +204,7 @@ namespace pika::mpi::experimental {
 
     // initialize the pika::mpi background request handler
     // All ranks should call this function (but only one thread per rank needs to do so)
-    PIKA_EXPORT void init(bool init_mpi = false, bool init_errorhandler = false,
-        pool_create_mode pool_mode = pool_create_mode::pika_decides);
+    PIKA_EXPORT void init(bool init_mpi = false, bool init_errorhandler = false);
 
     // -----------------------------------------------------------------
     PIKA_EXPORT void finalize(std::string const& pool_name = "");

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -170,7 +170,7 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT int comm_world_size();
 
         /// mpix extensions in openmpi to support mpi continuations
-        typedef int(MPIX_Continue_cb_function)(int rc, void* cb_data);
+        using MPIX_Continue_cb_function = int(int rc, void* cb_data);
         PIKA_EXPORT void register_mpix_continuation(
             MPI_Request*, MPIX_Continue_cb_function*, void*);
         /// called after each completed continuation to restart/re-enable continuation support

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -173,7 +173,7 @@ namespace pika::mpi::experimental {
         typedef int(MPIX_Continue_cb_function)(int rc, void* cb_data);
         PIKA_EXPORT void register_mpix_continuation(
             MPI_Request*, MPIX_Continue_cb_function*, void*);
-        /// called after each completed continuation to restart/reenable continuation support
+        /// called after each completed continuation to restart/re-enable continuation support
         PIKA_EXPORT void restart_mpix();
     }    // namespace detail
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -112,17 +112,18 @@ namespace pika::mpi::experimental {
             ///
             /// * unspecified : reserved for development purposes or for customization by an
             /// application using pika
-            yield_while = 0b0000'0000,       // 0x00, 00 ... 15
-            suspend_resume = 0b0001'0000,    // 0x10, 16 ... 31
-            new_task = 0b0010'0000,          // 0x20, 32 ... 47
-            continuation = 0b0011'0000,      // 0x30, 48 ... 63
-            unspecified = 0b0100'0000,       // 0x40, 64 ...
+            yield_while = 0b0000'0000,          // 0x00, 00 ... 15
+            suspend_resume = 0b0001'0000,       // 0x10, 16 ... 31
+            new_task = 0b0010'0000,             // 0x20, 32 ... 47
+            continuation = 0b0011'0000,         // 0x30, 48 ... 63
+            mpix_continuation = 0b0100'0000,    // 0x40, 64 ... 79
+            unspecified = 0b0101'0000,          // 0x50, 80 ...
 
             /// Default flags are to invoke inline, but transfer completion using a dedicated pool
             default_mode = use_pool | request_inline | high_priority | new_task,
         };
 
-        /// 2 bits define continuation mode
+        /// 3 bits define continuation mode
         inline handler_method get_handler_method(std::underlying_type_t<handler_method> flags)
         {
             return static_cast<handler_method>(
@@ -167,6 +168,7 @@ namespace pika::mpi::experimental {
             case handler_method::new_task: return "new_task";
             case handler_method::continuation: return "continuation";
             case handler_method::suspend_resume: return "suspend_resume";
+            case handler_method::mpix_continuation: return "mpi_continuation";
             case handler_method::unspecified: return "unspecified";
             default: return "invalid";
             }
@@ -174,6 +176,13 @@ namespace pika::mpi::experimental {
 
         /// utility : needed by static checks when debugging
         PIKA_EXPORT int comm_world_size();
+
+        typedef int(MPIX_Continue_cb_function)(int rc, void* cb_data);
+        PIKA_EXPORT void register_mpix_continuation(
+            MPI_Request*, MPIX_Continue_cb_function*, void*);
+
+        PIKA_EXPORT void restart_mpix();
+        PIKA_EXPORT void complete_mpix();
 
     }    // namespace detail
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -202,6 +202,12 @@ namespace pika::mpi::experimental {
 
     PIKA_EXPORT void register_polling();
 
+    PIKA_EXPORT int get_preferred_thread_mode();
+
+    /// when true pika::mpi can disable the pool, or change the thread mode
+    /// otherwise, the flags passed by the user to completion mode etc are honoured
+    PIKA_EXPORT void enable_optimizations(bool enable);
+
     // initialize the pika::mpi background request handler
     // All ranks should call this function (but only one thread per rank needs to do so)
     PIKA_EXPORT void init(bool init_mpi = false, bool init_errorhandler = false);

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -69,7 +69,7 @@ namespace pika::mpi::experimental {
         // -----------------------------------------------------------------
         // handling of requests and continuations
         /// flags that control how mpi continuations are handled
-        enum class handler_mode : std::uint32_t
+        enum class handler_method : std::uint32_t
         {
             /// enable the use of a dedicated pool for polling mpi messages.
             use_pool = 0b0000'0001,    // 1
@@ -123,50 +123,51 @@ namespace pika::mpi::experimental {
         };
 
         /// 2 bits define continuation mode
-        inline handler_mode get_handler_mode(std::underlying_type_t<handler_mode> flags)
+        inline handler_method get_handler_method(std::underlying_type_t<handler_method> flags)
         {
-            return static_cast<handler_mode>(
-                flags & pika::detail::to_underlying(handler_mode::method_mask));
+            return static_cast<handler_method>(
+                flags & pika::detail::to_underlying(handler_method::method_mask));
         }
 
         /// 1 bit defines high priority boost mode for pool transfers
         inline bool use_priority_boost(int mode)
         {
             return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_mode::high_priority)) ==
-                pika::detail::to_underlying(handler_mode::high_priority));
+                (mode & pika::detail::to_underlying(handler_method::high_priority)) ==
+                pika::detail::to_underlying(handler_method::high_priority));
         }
         /// 1 bit defines inline or transfer completion
         inline bool use_inline_completion(int mode)
         {
             return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_mode::completion_inline)) ==
-                pika::detail::to_underlying(handler_mode::completion_inline));
+                (mode & pika::detail::to_underlying(handler_method::completion_inline)) ==
+                pika::detail::to_underlying(handler_method::completion_inline));
         }
         /// 1 bit defines inline or transfer mpi invocation
         inline bool use_inline_request(int mode)
         {
             return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_mode::request_inline)) ==
-                pika::detail::to_underlying(handler_mode::request_inline));
+                (mode & pika::detail::to_underlying(handler_method::request_inline)) ==
+                pika::detail::to_underlying(handler_method::request_inline));
         }
         /// 1 bit defines whether we use a pool or not
         inline bool use_pool(int mode)
         {
-            return static_cast<bool>((mode & pika::detail::to_underlying(handler_mode::use_pool)) ==
-                pika::detail::to_underlying(handler_mode::use_pool));
+            return static_cast<bool>(
+                (mode & pika::detail::to_underlying(handler_method::use_pool)) ==
+                pika::detail::to_underlying(handler_method::use_pool));
         }
 
         /// used for debugging to show mode type in messages, should be removed
         inline const char* mode_string(int flags)
         {
-            switch (get_handler_mode(flags))
+            switch (get_handler_method(flags))
             {
-            case handler_mode::yield_while: return "yield_while";
-            case handler_mode::new_task: return "new_task";
-            case handler_mode::continuation: return "continuation";
-            case handler_mode::suspend_resume: return "suspend_resume";
-            case handler_mode::unspecified: return "unspecified";
+            case handler_method::yield_while: return "yield_while";
+            case handler_method::new_task: return "new_task";
+            case handler_method::continuation: return "continuation";
+            case handler_method::suspend_resume: return "suspend_resume";
+            case handler_method::unspecified: return "unspecified";
             default: return "invalid";
             }
         }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -177,13 +177,12 @@ namespace pika::mpi::experimental {
         /// utility : needed by static checks when debugging
         PIKA_EXPORT int comm_world_size();
 
+        /// mpix extensions in openmpi to support mpi continuations
         typedef int(MPIX_Continue_cb_function)(int rc, void* cb_data);
         PIKA_EXPORT void register_mpix_continuation(
             MPI_Request*, MPIX_Continue_cb_function*, void*);
-
+        /// called after each completed continuation to restart/reenable continuation support
         PIKA_EXPORT void restart_mpix();
-        PIKA_EXPORT void complete_mpix();
-
     }    // namespace detail
 
     /// return the total number of mpi requests currently in queues

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -133,30 +133,22 @@ namespace pika::mpi::experimental {
         /// 1 bit defines high priority boost mode for pool transfers
         inline bool use_priority_boost(int mode)
         {
-            return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_method::high_priority)) ==
-                pika::detail::to_underlying(handler_method::high_priority));
+            return (mode & pika::detail::to_underlying(handler_method::high_priority)) != 0;
         }
         /// 1 bit defines inline or transfer completion
         inline bool use_inline_completion(int mode)
         {
-            return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_method::completion_inline)) ==
-                pika::detail::to_underlying(handler_method::completion_inline));
+            return (mode & pika::detail::to_underlying(handler_method::completion_inline)) != 0;
         }
         /// 1 bit defines inline or transfer mpi invocation
         inline bool use_inline_request(int mode)
         {
-            return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_method::request_inline)) ==
-                pika::detail::to_underlying(handler_method::request_inline));
+            return (mode & pika::detail::to_underlying(handler_method::request_inline)) != 0;
         }
         /// 1 bit defines whether we use a pool or not
         inline bool use_pool(int mode)
         {
-            return static_cast<bool>(
-                (mode & pika::detail::to_underlying(handler_method::use_pool)) ==
-                pika::detail::to_underlying(handler_method::use_pool));
+            return (mode & pika::detail::to_underlying(handler_method::use_pool)) != 0;
         }
 
         /// used for debugging to show mode type in messages, should be removed
@@ -168,7 +160,7 @@ namespace pika::mpi::experimental {
             case handler_method::new_task: return "new_task";
             case handler_method::continuation: return "continuation";
             case handler_method::suspend_resume: return "suspend_resume";
-            case handler_method::mpix_continuation: return "mpi_continuation";
+            case handler_method::mpix_continuation: return "mpix_continuation";
             case handler_method::unspecified: return "unspecified";
             default: return "invalid";
             }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -81,10 +81,12 @@ namespace pika::mpi::experimental {
                 if (!inline_com)
                 {
                     if (request == MPI_REQUEST_NULL)
+                    {
                         return transfer_just(default_pool_scheduler(p));
+                    }
                     return transfer_just(default_pool_scheduler(p), request) | trigger_mpi(mode);
                 }
-                if (request == MPI_REQUEST_NULL) return just();
+                if (request == MPI_REQUEST_NULL) { return just(); }
                 return just(request) | trigger_mpi(mode);
             };
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -54,9 +54,8 @@ namespace pika::mpi::experimental {
             using pika::execution::experimental::transfer_just;
             using pika::execution::experimental::unique_any_sender;
 
-            // get the mpi completion mode
+            // get mpi completion mode settings
             auto mode = get_completion_mode();
-
             bool inline_com = use_inline_completion(mode);
             bool inline_req = use_inline_request(mode);
 
@@ -65,10 +64,9 @@ namespace pika::mpi::experimental {
             // the pool should exist if the completion mode needs it
             int cwsize = detail::comm_world_size();
             bool need_pool = (cwsize > 1 && use_pool(mode));
-
             if (pool_exists() != need_pool)
             {
-                PIKA_DETAIL_DP(mpi_tran<1>,
+                PIKA_DETAIL_DP(mpi_tran<0>,
                     error(str<>("transform_mpi"), "mode", mode, "pool_exists()", pool_exists(),
                         "need_pool", need_pool));
             }
@@ -78,48 +76,28 @@ namespace pika::mpi::experimental {
             execution::thread_priority p = use_priority_boost(mode) ?
                 execution::thread_priority::boost :
                 execution::thread_priority::normal;
-            if (inline_req || !pool_exists())
+
+            auto completion_snd = [=](MPI_Request request) -> unique_any_sender<> {
+                if (!inline_com)
+                {
+                    if (request == MPI_REQUEST_NULL)
+                        return transfer_just(default_pool_scheduler(p));
+                    return transfer_just(default_pool_scheduler(p), request) | trigger_mpi(mode);
+                }
+                if (request == MPI_REQUEST_NULL) return just();
+                return just(request) | trigger_mpi(mode);
+            };
+
+            if (inline_req)
             {
                 return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f)} |
-                    let_value([=](MPI_Request request) -> unique_any_sender<> {
-                        if (inline_com || !pool_exists())
-                        {
-                            if (request == MPI_REQUEST_NULL)
-                                return just();
-                            else
-                                return just(request) | trigger_mpi(mode);
-                        }
-                        else
-                        {    // do not transfer if there is no pool
-                            if (request == MPI_REQUEST_NULL)
-                                return transfer_just(default_pool_scheduler(p));
-                            else
-                                return transfer_just(default_pool_scheduler(p), request) |
-                                    trigger_mpi(mode);
-                        }
-                    });
+                    let_value(completion_snd);
             }
             else
             {
                 auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(p));
                 return dispatch_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
-                    let_value([=](MPI_Request request) -> unique_any_sender<> {
-                        if (inline_com)
-                        {
-                            if (request == MPI_REQUEST_NULL)
-                                return just();
-                            else
-                                return just(request) | trigger_mpi(mode);
-                        }
-                        else
-                        {
-                            if (request == MPI_REQUEST_NULL)
-                                return transfer_just(default_pool_scheduler(p));
-                            else
-                                return transfer_just(default_pool_scheduler(p), request) |
-                                    trigger_mpi(mode);
-                        }
-                    });
+                    let_value(completion_snd);
             }
         }
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -119,7 +119,7 @@ namespace pika::mpi::experimental::detail {
                     }
 
                     // which polling/testing mode are we using
-                    handler_mode mode = get_handler_mode(r.op_state.mode_flags);
+                    handler_method mode = get_handler_method(r.op_state.mode_flags);
                     execution::thread_priority p = use_priority_boost(r.op_state.mode_flags) ?
                         execution::thread_priority::boost :
                         execution::thread_priority::normal;
@@ -133,7 +133,7 @@ namespace pika::mpi::experimental::detail {
                         [&]() mutable {
                             switch (mode)
                             {
-                            case handler_mode::yield_while:
+                            case handler_method::yield_while:
                             {
                                 pika::util::yield_while(
                                     [request]() { return !detail::poll_request(request); });
@@ -144,7 +144,7 @@ namespace pika::mpi::experimental::detail {
                                 ex::set_value(PIKA_MOVE(r.op_state.receiver));
                                 break;
                             }
-                            case handler_mode::new_task:
+                            case handler_method::new_task:
                             {
                                 // The callback will call set_value/set_error inside a new task
                                 // and execution will continue on that thread
@@ -152,14 +152,14 @@ namespace pika::mpi::experimental::detail {
                                     request, p, PIKA_MOVE(r.op_state.receiver));
                                 break;
                             }
-                            case handler_mode::continuation:
+                            case handler_method::continuation:
                             {
                                 // The callback will call set_value/set_error
                                 // execution will continue on the callback thread
                                 detail::set_value_request_callback_void<>(request, r.op_state);
                                 break;
                             }
-                            case handler_mode::suspend_resume:
+                            case handler_method::suspend_resume:
                             {
                                 // suspend is invalid except on a pika thread
                                 PIKA_ASSERT(pika::threads::detail::get_self_id());

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -715,7 +715,7 @@ namespace pika::mpi::experimental {
     {
         auto mode = get_completion_mode();
         // enable pika polling on the mpi pool if the handling mode needs it
-        if (detail::get_handler_mode(mode) != detail::handler_mode::yield_while)
+        if (detail::get_handler_method(mode) != detail::handler_method::yield_while)
         {
             PIKA_DETAIL_DP(detail::mpi_debug<1>,
                 debug(str<>("enabling polling"), get_pool_name(), detail::mode_string(mode)));

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -727,7 +727,7 @@ namespace pika::mpi::experimental {
     // initialize the pika::mpi background request handler
     // All ranks should call this function,
     // but only one thread per rank needs to do so
-    void init(bool init_mpi, bool init_errorhandler, pool_create_mode /*pool_mode*/)
+    void init(bool init_mpi, bool init_errorhandler)
     {
         // don't allow polling code to run until init has completed
         std::lock_guard<detail::mutex_type> lk(detail::mpi_data_.polling_vector_mtx_);

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -658,9 +658,12 @@ namespace pika::mpi::experimental {
 #if defined(PIKA_DEBUG)
             ++get_register_polling_count();
 #endif
-            PIKA_DETAIL_DP(detail::mpi_debug<0>,
-                debug(str<>("polling_enabled"), "pool =", pool.get_pool_name(), ", mode",
-                    mode_string(get_completion_mode()), get_completion_mode()));
+            if (detail::mpi_data_.rank_ == 0)
+            {
+                PIKA_DETAIL_DP(detail::mpi_debug<1>,
+                    debug(str<>("polling_enabled"), "pool =", pool.get_pool_name(), ", mode",
+                        mode_string(get_completion_mode()), get_completion_mode()));
+            }
             auto* sched = pool.get_scheduler();
             sched->set_mpi_polling_functions(&detail::poll, &get_work_count);
         }
@@ -870,7 +873,7 @@ namespace pika::mpi::experimental {
             MPIX_RESULT_CHECK(MPIX_Continue_init(MPIX_CONT_POLL_ONLY, MPI_UNDEFINED, MPI_INFO_NULL,
                 &detail::mpi_data_.mpix_continuations_request));
 
-            PIKA_DETAIL_DP(detail::mpi_debug<0>,
+            PIKA_DETAIL_DP(detail::mpi_debug<1>,
                 debug(str<>("MPIX"), "Enable", "Pool", get_pool_name(), "Mode",
                     detail::mode_string(mode), ptr(detail::mpi_data_.mpix_continuations_request)));
             // it is now safe to use the mpix request, {memory_order = not a critical code path}

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -40,7 +40,6 @@
 
 #if __has_include(<mpi-ext.h>)
 # include <mpi-ext.h>
-
 # ifndef OMPI_HAVE_MPI_EXT_CONTINUE
 #  pragma warning "MPIX Continuations not found"
 # endif
@@ -60,7 +59,7 @@ namespace pika::mpi::experimental {
         // by convention the title is 7 chars (for alignment)
         // a debug level of N shows messages with level 1..N
         template <int Level>
-        static debug::detail::print_threshold<Level, 9> mpi_debug("MPIPOLL");
+        static debug::detail::print_threshold<Level, 0> mpi_debug("MPIPOLL");
 
         constexpr std::uint32_t max_poll_requests = 32;
 
@@ -146,8 +145,7 @@ namespace pika::mpi::experimental {
             mutex_type polling_vector_mtx_;
 
             // MPI continuations support (Experimental mpi extension)
-            MPI_Request mpi_continuations_request{MPI_REQUEST_NULL};
-            std::atomic<int> mpix_counter{0};
+            MPI_Request mpix_continuations_request{MPI_REQUEST_NULL};
             std::mutex mpix_lock;
         };
 
@@ -251,7 +249,7 @@ namespace pika::mpi::experimental {
             // clang-format on
         }
 
-        // -------------------------------------------------------------
+// -------------------------------------------------------------
 #if defined(PIKA_DEBUG)
         std::atomic<std::uint32_t>& get_register_polling_count()
         {
@@ -278,7 +276,8 @@ namespace pika::mpi::experimental {
         // function that converts an MPI error into an exception
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
-            PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("pika_MPI_Handler")));
+            PIKA_DETAIL_DP(
+                mpi_debug<5>, debug(str<>("pika_MPI_Handler"), error_message(*errorcode)));
             throw mpi_exception(*errorcode, error_message(*errorcode));
         }
 
@@ -334,31 +333,25 @@ namespace pika::mpi::experimental {
             mpi_data_.callbacks_.resize(pos);
         }
 
-        // -------------------------------------------------------------
-        // Background progress function for MPI async operations
-        // Checks for completed MPI_Requests and readies sender when complete
-        pika::threads::detail::polling_status poll_multithreaded()
+#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
+        pika::threads::detail::polling_status try_mpix_polling()
         {
             using pika::threads::detail::polling_status;
-
-            // ---------------
-            // if mpi continuations are available, poll here and bypass main routine
-#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
-            if (detail::mpi_data_.mpi_continuations_request != MPI_REQUEST_NULL)
+            if (detail::mpi_data_.mpix_continuations_request != MPI_REQUEST_NULL)
             {
                 std::unique_lock lk(detail::mpi_data_.mpix_lock, std::try_to_lock);
                 if (!lk.owns_lock()) { return polling_status::busy; }
 
                 int flag = 0;
                 MPIX_RESULT_CHECK(MPI_Test(
-                    &detail::mpi_data_.mpi_continuations_request, &flag, MPI_STATUS_IGNORE));
+                    &detail::mpi_data_.mpix_continuations_request, &flag, MPI_STATUS_IGNORE));
 
                 // for debugging, create a timer : debug info every N seconds
                 static auto mpix_deb =
                     mpi_debug<1>.make_timer(2, debug::detail::str<>("MPIX"), "poll");
                 PIKA_DETAIL_DP(mpi_debug<1>,
                     timed(
-                        mpix_deb, ptr(detail::mpi_data_.mpi_continuations_request), "Flag", flag));
+                        mpix_deb, ptr(detail::mpi_data_.mpix_continuations_request), "Flag", flag));
 
                 if (flag != 0)
                 {
@@ -368,14 +361,18 @@ namespace pika::mpi::experimental {
                 else
                     return pika::threads::detail::polling_status::idle;
             }
-            // don't allow code to escape this block if mpix_continuation mode is 'on'
-            else if (pika::mpi::experimental::detail::get_handler_method(
-                         mpi::experimental::get_completion_mode()) ==
-                detail::handler_method::mpix_continuation)
-            {
-                return polling_status::idle;
-            }
+            //
+            throw mpi_exception(0, "Invalid use of mpix polling with NULL request");
+            return polling_status::idle;
+        }
 #endif
+
+        // -------------------------------------------------------------
+        // Background progress function for MPI async operations
+        // Checks for completed MPI_Requests and readies sender when complete
+        pika::threads::detail::polling_status poll_multithreaded()
+        {
+            using pika::threads::detail::polling_status;
 
             // ---------------
             // If a thread is already polling and found a completion,
@@ -630,6 +627,16 @@ namespace pika::mpi::experimental {
         // -------------------------------------------------------------
         pika::threads::detail::polling_status poll()
         {
+            // ---------------
+            // if mpi continuations are available, poll here and bypass main routine
+#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
+            if (get_handler_method(get_completion_mode()) == handler_method::mpix_continuation)
+            {
+                using pika::threads::detail::polling_status;
+                return try_mpix_polling();
+            }
+#endif
+
             if (detail::use_pool(detail::task_completion_flags_) &&
                 !detail::use_inline_request(detail::task_completion_flags_))
             {
@@ -647,7 +654,7 @@ namespace pika::mpi::experimental {
             if (detail::mpi_data_.rank_ == 0)
             {
                 PIKA_DETAIL_DP(detail::mpi_debug<1>,
-                    debug(str<>("register_polling"), pool.get_pool_name(), "mode",
+                    debug(str<>("register_polling"), "pool", pool.get_pool_name(), "mode",
                         get_completion_mode()));
             }
             auto* sched = pool.get_scheduler();
@@ -679,38 +686,32 @@ namespace pika::mpi::experimental {
 
         int comm_world_size() { return detail::mpi_data_.size_; }
 
+#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
         void register_mpix_continuation(
             MPI_Request* request, MPIX_Continue_cb_function* cb_func, void* op_state)
         {
-#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
             // @TODO we don't strictly need defer complete flag, but for debugging ...
             PIKA_DETAIL_DP(
-                mpi_debug<0>, debug(str<>("MPIX"), "register continuation", ptr(request)));
+                mpi_debug<2>, debug(str<>("MPIX"), "register continuation", ptr(request)));
             MPIX_RESULT_CHECK(MPIX_Continue(request, cb_func, op_state,
                 /*MPIX_CONT_DEFER_COMPLETE | */ MPIX_CONT_INVOKE_FAILED, MPI_STATUSES_IGNORE,
-                detail::mpi_data_.mpi_continuations_request));
-            //
-            // restart_mpix();
-
-#endif
-        }
-
-        void complete_mpix()
-        {
-            detail::mpi_data_.mpix_counter--;
-            PIKA_DETAIL_DP(
-                mpi_debug<0>, debug(str<>("MPIX"), "counter", detail::mpi_data_.mpix_counter));
+                detail::mpi_data_.mpix_continuations_request));
         }
 
         void restart_mpix()
         {
             {
-                PIKA_DETAIL_DP(mpi_debug<0>,
+                PIKA_DETAIL_DP(mpi_debug<2>,
                     debug(str<>("MPIX"), "MPI_Start",
-                        ptr(detail::mpi_data_.mpi_continuations_request)));
-                MPIX_RESULT_CHECK(MPI_Start(&detail::mpi_data_.mpi_continuations_request));
+                        ptr(detail::mpi_data_.mpix_continuations_request)));
+                MPIX_RESULT_CHECK(MPI_Start(&detail::mpi_data_.mpix_continuations_request));
             }
         }
+#else
+        void register_mpix_continuation(MPI_Request*, MPIX_Continue_cb_function*, void*) {}
+        void restart_mpix() {}
+#endif
+
     }    // namespace detail
 
     // -------------------------------------------------------------
@@ -807,7 +808,8 @@ namespace pika::mpi::experimental {
         if (detail::get_handler_method(mode) != detail::handler_method::yield_while)
         {
             PIKA_DETAIL_DP(detail::mpi_debug<1>,
-                debug(str<>("enabling polling"), get_pool_name(), detail::mode_string(mode)));
+                debug(
+                    str<>("enabling polling"), "pool", get_pool_name(), detail::mode_string(mode)));
             detail::register_polling(pika::resource::get_thread_pool(get_pool_name()));
         }
     }
@@ -842,8 +844,7 @@ namespace pika::mpi::experimental {
             else { PIKA_DETAIL_DP(detail::mpi_debug<1>, error(str<>("mpi not initialized"))); }
         }
 
-        PIKA_DETAIL_DP(
-            detail::mpi_debug<1>, debug(str<>("pika::mpi::experimental::init"), detail::mpi_data_));
+        PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("init"), detail::mpi_data_));
 
         // --------------------------------------
         // install error handler (convert mpi errors into exceptoions
@@ -853,22 +854,24 @@ namespace pika::mpi::experimental {
             detail::mpi_data_.error_handler_initialized_ = true;
         }
 
+        // --------------------------------------
+        // if we are using experimental mpix_continuations, setup internals
 #ifdef OMPI_HAVE_MPI_EXT_CONTINUE
         auto mode = get_completion_mode();
-        if (pika::mpi::experimental::detail::get_handler_method(mode) ==
-            detail::handler_method::mpix_continuation)
+        if (detail::get_handler_method(mode) == detail::handler_method::mpix_continuation)
         {
             std::unique_lock lk(detail::mpi_data_.mpix_lock);
             MPIX_RESULT_CHECK(MPIX_Continue_init(
-                0, MPI_UNDEFINED, MPI_INFO_NULL, &detail::mpi_data_.mpi_continuations_request));
+                0, MPI_UNDEFINED, MPI_INFO_NULL, &detail::mpi_data_.mpix_continuations_request));
             detail::restart_mpix();
-            //            MPIX_RESULT_CHECK(MPI_Start(&detail::mpi_data_.mpi_continuations_request));
             PIKA_DETAIL_DP(detail::mpi_debug<0>,
                 debug(str<>("MPIX"), "Enable", "Pool", get_pool_name(), "Mode",
-                    mpi::experimental::detail::mode_string(mode),
-                    ptr(detail::mpi_data_.mpi_continuations_request)));
+                    detail::mode_string(mode), ptr(detail::mpi_data_.mpix_continuations_request)));
         }
 #endif
+
+        // --------------------------------------
+        // throttling is disabled, but left for future use
         static bool defaults_set = false;
         if (!defaults_set)
         {

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -40,10 +40,9 @@
 
 #if __has_include(<mpi-ext.h>)
 # include <mpi-ext.h>
-# ifndef OMPI_HAVE_MPI_EXT_CONTINUE
-#  pragma warning "MPIX Continuations not found in <mpi-ext.h>"
-# endif
+#endif
 
+#ifdef OMPI_HAVE_MPI_EXT_CONTINUE
 static inline void PIKA_MPI_EXT_CONTINUATION_RESULT_CHECK(int code)
 {
     if (code != MPI_SUCCESS)

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -523,8 +523,7 @@ int main(int argc, char* argv[])
     po::store(po::command_line_parser(argc, argv).options(cmdline).allow_unregistered().run(), vm);
     po::notify(vm);
 
-    if (vm["mpi-optimizations"].as<bool>()) { mpix::enable_optimizations(true); }
-    else { mpix::enable_optimizations(false); }
+    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
 
     // -----------------
     // Init MPI

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -318,12 +318,12 @@ int call_mpi_irecv(void* buf, int count, MPI_Datatype datatype, int source, int 
 // this is called on a pika thread after the runtime starts up
 int pika_main(pika::program_options::variables_map& vm)
 {
-    // setup polling on default pool, enable exceptions and init mpi internals
+    // Do not initialize mpi (we do that ourselves), do install an error handler
     mpix::init(false, true);
+    // Setup mpi polling on default pool, enable exceptions and init mpi internals
     mpix::register_polling();
     //
     std::int32_t rank, size;
-    //
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 


### PR DESCRIPTION
Some cleanups to the main mpi polling routines and API - quite a lot of redundant use removed and some minor api changes to make things clearer.

And ...  support for mpi-continuations using the openmpi extension. 

we check for the extension using
```
#if __has_include(<mpi-ext.h>)
# include <mpi-ext.h>
# ifndef OMPI_HAVE_MPI_EXT_CONTINUE
#  pragma warning "MPIX Continuations not found in <mpi-ext.h>"
# endif
``` 
so code is only enabled if `OMPI_HAVE_MPI_EXT_CONTINUE` is found in `<mpi-ext.h>` 

Some optimizations are added to handle single/multiple threaded polling
