### PR TITLE
Enable upstream spack binary cache in CI

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -53,4 +53,6 @@ RUN spack external find --exclude python --scope site \
     && spack compiler find --scope site \
     && ([[ "${USE_SPACK_BUILDCACHE}" != "true" ]] \
         || (spack mirror add ${SPACK_BUILDCACHE} https://binaries.spack.io/${SPACK_BUILDCACHE} \
-            && spack buildcache keys --install --trust))
+            && spack mirror add develop https://binaries.spack.io/develop \
+            && spack buildcache keys --install --trust \
+            && spack mirror rm develop))

--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -3,6 +3,8 @@ FROM $BASE_IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+SHELL ["/bin/bash", "-c"]
+
 # Install utility packages
 RUN apt-get update && apt-get -yqq install --no-install-recommends \
     build-essential \

--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -45,4 +45,10 @@ RUN mkdir -p $SPACK_ROOT \
 
 ENV PATH $SPACK_ROOT/bin:/root/.local/bin:$PATH
 
-RUN spack external find --exclude python --scope site && spack compiler find --scope site
+ARG SPACK_BUILDCACHE
+ARG USE_SPACK_BUILDCACHE
+RUN spack external find --exclude python --scope site \
+    && spack compiler find --scope site \
+    && ([[ "${USE_SPACK_BUILDCACHE}" != "true" ]] \
+        || (spack mirror add ${SPACK_BUILDCACHE} https://binaries.spack.io/${SPACK_BUILDCACHE} \
+            && spack buildcache keys --install --trust))

--- a/.gitlab/docker/Dockerfile.spack_compiler
+++ b/.gitlab/docker/Dockerfile.spack_compiler
@@ -1,8 +1,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-SHELL ["/bin/bash", "-c"]
-
 # Disable host compatibility to be able to compile for other architectures than the one from the
 # CSCS CI's .container-builder
 # Allow installing deprecated packages (needed for apex)

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -23,6 +23,8 @@ variables:
     - echo -e "ARCH=$ARCH" >> base.env
     - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> base.env
   variables:
+    # TODO: Temporary
+    CSCS_REBUILD_POLICY: "always"
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_BUILDCACHE","SPACK_COMMIT","USE_SPACK_BUILDCACHE", "SPACK_REPO"]'

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,14 +8,16 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: develop-2024-09-15
+  SPACK_COMMIT: develop-2024-09-22
+  SPACK_BUILDCACHE: $SPACK_COMMIT
+  USE_SPACK_BUILDCACHE: true
 
 .base_spack_image:
   timeout: 1 hours
   before_script:
     - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
-    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT-$SPACK_REPO | sha256sum - | head -c 16`
+    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_BUILDCACHE-$SPACK_COMMIT-$USE_SPACK_BUILDCACHE-$SPACK_REPO | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/$ARCH/pika-spack-base:$CONFIG_TAG
     - echo -e "CONFIG_TAG=$CONFIG_TAG" >> base.env
     - echo -e "ARCH=$ARCH" >> base.env
@@ -23,7 +25,7 @@ variables:
   variables:
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
-    DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_COMMIT","SPACK_REPO"]'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_BUILDCACHE","SPACK_COMMIT","USE_SPACK_BUILDCACHE", "SPACK_REPO"]'
   artifacts:
     reports:
       dotenv: base.env


### PR DESCRIPTION
Related to https://github.com/pika-org/pika/issues/789, but does not fully cover the issue. This may be enough though. This simply uses the upstream cache to download packages, but does not populate a cache.

This seems to work well for pulling dependencies to build the compilers, but does not pull dependencies built with the spack-built compiler. At least the compiler build step is slightly faster with the cache, so I think this is still an improvement.

There's a new variable `SPACK_BUILDCACHE` which is currently just set to `SPACK_COMMIT`. If `SPACK_COMMIT` is an arbitrary hash, there won't be a corresponding cache, and in that case one might want to set `SPACK_BUILDCACHE` to something else explicitly. I've also updated `SPACK_COMMIT` to a `develop-X-Y-Z` tag which does have a build cache, so they can be the same.