### PR TITLE
Fix codacy URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,10 +48,10 @@ To get started using pika see the `documentation <https://pikacpp.org>`_.
      :target: https://github.com/pika-org/pika/actions/workflows/macos_debug.yml
      :alt: macOS CI (Debug)
 
-.. |codacy| image:: https://api.codacy.com/project/badge/Grade/e03f57f1c4cd40e7b514e552a723c125
-     :target: https://www.codacy.com/gh/pika-org/pika
+.. |codacy| image:: https://app.codacy.com/project/badge/Grade/e03f57f1c4cd40e7b514e552a723c125
+     :target: https://app.codacy.com/gh/pika-org/pika
      :alt: Codacy
 
-.. |codacy_coverage| image:: https://api.codacy.com/project/badge/Coverage/e03f57f1c4cd40e7b514e552a723c125
-     :target: https://www.codacy.com/gh/pika-org/pika
+.. |codacy_coverage| image:: https://app.codacy.com/project/badge/Coverage/e03f57f1c4cd40e7b514e552a723c125
+     :target: https://app.codacy.com/gh/pika-org/pika
      :alt: Codacy coverage


### PR DESCRIPTION
Clicking on the codacy score would result in a 404 not found. Updating the codacy URL so that the site is reachable. This does NOT fix  #1131 since it looks like there is no report on https://app.codacy.com/gh/pika-org/pika/coverage/dashboard. There is an error in the [upload coverage report](https://app.codacy.com/gh/pika-org/pika/coverage/dashboard) step which I haven't investigated yet.
Issue opened here: https://github.com/codacy/codacy-coverage-reporter/issues/504