### PR TITLE
Use low CPU frequency in performance CI pipeline

### DIFF
--- a/.gitlab/includes/performance_gcc13_pipeline.yml
+++ b/.gitlab/includes/performance_gcc13_pipeline.yml
@@ -41,6 +41,8 @@ performance_gcc13_release_build:
     - .variables_performance_gcc13_config
     - .test_common_daint_mc
     - .cmake_variables_common
+  variables:
+    SLURM_CPU_FREQ_REQ: "Low"
   needs: [performance_gcc13_release_build]
   script:
     - export MIMALLOC_EAGER_COMMIT_DELAY=0


### PR DESCRIPTION
Testing what effect this has on performance. The hope is to have less variance, but given that we don't pass/fail PRs based on these results, it may not be necessary to set this.