### PR TITLE
Print scheduler in suspension unit tests

### DIFF
--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -11,6 +11,8 @@
 #include <pika/threading_base/thread_pool_base.hpp>
 #include <pika/threading_base/thread_queue_init_parameters.hpp>
 
+#include <fmt/format.h>
+
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -71,4 +73,19 @@ namespace pika::resource {
         abp_priority_lifo = 6,
         shared_priority = 7,
     };
+
+    namespace detail {
+        PIKA_EXPORT char const* get_scheduling_policy_name(scheduling_policy p) noexcept;
+    }
 }    // namespace pika::resource
+
+template <>
+struct fmt::formatter<pika::resource::scheduling_policy> : fmt::formatter<char const*>
+{
+    template <typename FormatContext>
+    auto format(pika::resource::scheduling_policy p, FormatContext& ctx) const
+    {
+        return fmt::formatter<char const*>::format(
+            pika::resource::detail::get_scheduling_policy_name(p), ctx);
+    }
+};

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -213,5 +213,22 @@ namespace pika::resource {
             return ::pika::resource::partitioner(rpmode, rtcfg, affinity_data);
         }
 
+        char const* get_scheduling_policy_name(scheduling_policy p) noexcept
+        {
+            switch (p)
+            {
+            case scheduling_policy::user_defined: return "user_defined";
+            case scheduling_policy::unspecified: return "unspecified";
+            case scheduling_policy::local: return "local";
+            case scheduling_policy::local_priority_fifo: return "local_priority_fifo";
+            case scheduling_policy::local_priority_lifo: return "local_priority_lifo";
+            case scheduling_policy::static_: return "static";
+            case scheduling_policy::static_priority: return "static_priority";
+            case scheduling_policy::abp_priority_fifo: return "abp_priority_fifo";
+            case scheduling_policy::abp_priority_lifo: return "abp_priority_lifo";
+            case scheduling_policy::shared_priority: return "shared_priority";
+            default: return "unknown";
+            }
+        }
     }    // namespace detail
 }    // namespace pika::resource

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -21,6 +21,9 @@
 #include <pika/testing.hpp>
 #include <pika/thread.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -245,6 +248,8 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
     init_args.rp_callback =
         pika::util::detail::bind_back(init_resource_partitioner_handler, scheduler);

--- a/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -16,8 +16,12 @@
 #include <pika/threading_base/scheduler_mode.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -57,6 +61,8 @@ int pika_main()
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
 
     using ::pika::threads::scheduler_mode;

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -20,9 +20,13 @@
 #include <pika/threading_base/thread_helpers.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -117,6 +121,8 @@ int pika_main()
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     using ::pika::threads::scheduler_mode;
 
     pika::init_params init_args;

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -16,8 +16,12 @@
 #include <pika/threading_base/thread_helpers.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <atomic>
 #include <cstddef>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
@@ -28,6 +32,8 @@ namespace ex = pika::execution::experimental;
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
 
     init_args.cfg = {"pika.os_threads=" +

--- a/libs/pika/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -14,7 +14,11 @@
 #include <pika/testing.hpp>
 #include <pika/thread.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <cstddef>
+#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,6 +27,8 @@ namespace ex = pika::execution::experimental;
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
 
     init_args.cfg = {"pika.os_threads=" +

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -17,8 +17,12 @@
 #include <pika/threading_base/scheduler_mode.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -196,6 +200,8 @@ int pika_main()
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     using ::pika::threads::scheduler_mode;
     pika::init_params init_args;
     init_args.cfg = {"pika.os_threads=" + std::to_string(max_threads)};

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -17,8 +17,12 @@
 #include <pika/threading_base/scheduler_mode.hpp>
 #include <pika/threading_base/thread_pool_base.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -163,6 +167,8 @@ int pika_main()
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
 
     using ::pika::threads::scheduler_mode;

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -17,6 +17,9 @@
 #include <pika/thread.hpp>
 #include <pika/threading_base/scheduler_mode.hpp>
 
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
 #include <chrono>
 #include <cstddef>
 #include <cstdlib>
@@ -103,6 +106,8 @@ int pika_main(int argc, char* argv[])
 
 void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy scheduler)
 {
+    fmt::print(std::cerr, "Testing scheduler: {}\n", scheduler);
+
     pika::init_params init_args;
 
     using ::pika::threads::scheduler_mode;


### PR DESCRIPTION
Also adds a `fmt::formatter` specialization for `pika::resource::scheduling_policy` to be able to print the scheduler.

I'm adding this to aid in understanding if a particular scheduler is more likely to fail in CI.