### PR TITLE
Fix typo in CI job names

### DIFF
--- a/.gitlab/includes/clang11_pipeline.yml
+++ b/.gitlab/includes/clang11_pipeline.yml
@@ -35,7 +35,7 @@ clang11_build:
     - .variables_clang11_config
     - .build_template_rosa
 
-.clang11_test_commmon:
+.clang11_test_common:
   needs: [clang11_build]
   extends:
     - .variables_clang11_config
@@ -43,9 +43,9 @@ clang11_build:
     - .test_template
 
 clang11_test_release:
-  extends: [.clang11_test_commmon]
+  extends: [.clang11_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang11_test_debug:
-  extends: [.clang11_test_commmon]
+  extends: [.clang11_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang12_pipeline.yml
+++ b/.gitlab/includes/clang12_pipeline.yml
@@ -39,7 +39,7 @@ clang12_build:
     - .variables_clang12_config
     - .build_template_rosa
 
-.clang12_test_commmon:
+.clang12_test_common:
   needs: [clang12_build]
   extends:
     - .variables_clang12_config
@@ -47,9 +47,9 @@ clang12_build:
     - .test_template
 
 clang12_test_release:
-  extends: [.clang12_test_commmon]
+  extends: [.clang12_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang12_test_debug:
-  extends: [.clang12_test_commmon]
+  extends: [.clang12_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -38,7 +38,7 @@ clang13_build:
     - .variables_clang13_config
     - .build_template_rosa
 
-.clang13_test_commmon:
+.clang13_test_common:
   needs: [clang13_build]
   extends:
     - .variables_clang13_config
@@ -46,9 +46,9 @@ clang13_build:
     - .test_template
 
 clang13_test_release:
-  extends: [.clang13_test_commmon]
+  extends: [.clang13_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang13_test_debug:
-  extends: [.clang13_test_commmon]
+  extends: [.clang13_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -39,7 +39,7 @@ clang14_cuda11_build:
     - .variables_clang14_cuda11_config
     - .build_template_rosa
 
-.clang14_cuda11_test_commmon:
+.clang14_cuda11_test_common:
   needs: [clang14_cuda11_build]
   extends:
     - .variables_clang14_cuda11_config
@@ -47,9 +47,9 @@ clang14_cuda11_build:
     - .test_template
 
 clang14_cuda11_test_release:
-  extends: [.clang14_cuda11_test_commmon]
+  extends: [.clang14_cuda11_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang14_cuda11_test_debug:
-  extends: [.clang14_cuda11_test_commmon]
+  extends: [.clang14_cuda11_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -36,7 +36,7 @@ clang15_build:
     - .variables_clang15_config
     - .build_template_rosa
 
-.clang15_test_commmon:
+.clang15_test_common:
   needs: [clang15_build]
   extends:
     - .variables_clang15_config
@@ -44,9 +44,9 @@ clang15_build:
     - .test_template
 
 clang15_test_release:
-  extends: [.clang15_test_commmon]
+  extends: [.clang15_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang15_test_debug:
-  extends: [.clang15_test_commmon]
+  extends: [.clang15_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang16_pipeline.yml
+++ b/.gitlab/includes/clang16_pipeline.yml
@@ -35,7 +35,7 @@ clang16_build:
     - .variables_clang16_config
     - .build_template_rosa
 
-.clang16_test_commmon:
+.clang16_test_common:
   needs: [clang16_build]
   extends:
     - .variables_clang16_config
@@ -43,9 +43,9 @@ clang16_build:
     - .test_template
 
 clang16_test_release:
-  extends: [.clang16_test_commmon]
+  extends: [.clang16_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang16_test_debug:
-  extends: [.clang16_test_commmon]
+  extends: [.clang16_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang17_pipeline.yml
+++ b/.gitlab/includes/clang17_pipeline.yml
@@ -35,7 +35,7 @@ clang17_build:
     - .variables_clang17_config
     - .build_template_rosa
 
-.clang17_test_commmon:
+.clang17_test_common:
   needs: [clang17_build]
   extends:
     - .variables_clang17_config
@@ -43,9 +43,9 @@ clang17_build:
     - .test_template
 
 clang17_test_release:
-  extends: [.clang17_test_commmon]
+  extends: [.clang17_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang17_test_debug:
-  extends: [.clang17_test_commmon]
+  extends: [.clang17_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/clang18_pipeline.yml
+++ b/.gitlab/includes/clang18_pipeline.yml
@@ -35,7 +35,7 @@ clang18_build:
     - .variables_clang18_config
     - .build_template_rosa
 
-.clang18_test_commmon:
+.clang18_test_common:
   needs: [clang18_build]
   extends:
     - .variables_clang18_config
@@ -43,9 +43,9 @@ clang18_build:
     - .test_template
 
 clang18_test_release:
-  extends: [.clang18_test_commmon]
+  extends: [.clang18_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 clang18_test_debug:
-  extends: [.clang18_test_commmon]
+  extends: [.clang18_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -35,7 +35,7 @@ gcc10_apex_build:
     - .variables_gcc10_apex_config
     - .build_template_rosa
 
-.gcc10_apex_test_commmon:
+.gcc10_apex_test_common:
   needs: [gcc10_apex_build]
   extends:
     - .variables_gcc10_apex_config
@@ -43,9 +43,9 @@ gcc10_apex_build:
     - .test_template
 
 gcc10_apex_test_release:
-  extends: [.gcc10_apex_test_commmon]
+  extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc10_apex_test_debug:
-  extends: [.gcc10_apex_test_commmon]
+  extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -36,7 +36,7 @@ gcc11_build:
     - .build_template_rosa
     - .variables_gcc11_config
 
-.gcc11_test_commmon:
+.gcc11_test_common:
   needs: [gcc11_build]
   extends:
     - .variables_gcc11_config
@@ -44,9 +44,9 @@ gcc11_build:
     - .test_template
 
 gcc11_test_release:
-  extends: [.gcc11_test_commmon]
+  extends: [.gcc11_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc11_test_debug:
-  extends: [.gcc11_test_commmon]
+  extends: [.gcc11_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -40,7 +40,7 @@ gcc12_cuda12_build:
 
 ## Test step currently commented as the cuda driver is too old on clariden:
 ## https://github.com/pika-org/pika/issues/884
-#.gcc12_cuda12_test_commmon:
+#.gcc12_cuda12_test_common:
 #  needs: [gcc12_cuda12_build]
 #  extends:
 #    - .variables_gcc12_cuda12_config
@@ -48,9 +48,9 @@ gcc12_cuda12_build:
 #    - .test_template
 #
 #gcc12_cuda12_test_release:
-#  extends: [.gcc12_cuda12_test_commmon]
+#  extends: [.gcc12_cuda12_test_common]
 #  image: $PERSIST_IMAGE_NAME_RELEASE
 #
 #gcc12_cuda12_test_debug:
-#  extends: [.gcc12_cuda12_test_commmon]
+#  extends: [.gcc12_cuda12_test_common]
 #  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -39,7 +39,7 @@ gcc12_hip5_build:
     - .build_template_rosa
 
 # Disabled until AMD GPU runners come back online
-# .gcc12_hip5_test_commmon:
+# .gcc12_hip5_test_common:
 #   needs: [gcc12_hip5_build]
 #   extends:
 #     - .variables_gcc12_hip5_config
@@ -47,9 +47,9 @@ gcc12_hip5_build:
 #     - .test_template
 
 # gcc12_hip5_test_release:
-#   extends: [.gcc12_hip5_test_commmon]
+#   extends: [.gcc12_hip5_test_common]
 #   image: $PERSIST_IMAGE_NAME_RELEASE
 
 # gcc12_hip5_test_debug:
-#   extends: [.gcc12_hip5_test_commmon]
+#   extends: [.gcc12_hip5_test_common]
 #   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -35,7 +35,7 @@ gcc12_build:
     - .variables_gcc12_config
     - .build_template_rosa
 
-.gcc12_test_commmon:
+.gcc12_test_common:
   needs: [gcc12_build]
   extends:
     - .variables_gcc12_config
@@ -43,9 +43,9 @@ gcc12_build:
     - .test_template
 
 gcc12_test_release:
-  extends: [.gcc12_test_commmon]
+  extends: [.gcc12_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc12_test_debug:
-  extends: [.gcc12_test_commmon]
+  extends: [.gcc12_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -39,7 +39,7 @@ gcc13_build:
     - .variables_gcc13_config
     - .build_template_rosa
 
-.gcc13_test_commmon:
+.gcc13_test_common:
   needs: [gcc13_build]
   extends:
     - .variables_gcc13_config
@@ -47,9 +47,9 @@ gcc13_build:
     - .test_template
 
 gcc13_test_release:
-  extends: [.gcc13_test_commmon]
+  extends: [.gcc13_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc13_test_debug:
-  extends: [.gcc13_test_commmon]
+  extends: [.gcc13_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc9_cuda11_pipeline.yml
+++ b/.gitlab/includes/gcc9_cuda11_pipeline.yml
@@ -36,7 +36,7 @@ gcc9_cuda11_build:
     - .variables_gcc9_cuda11_config
     - .build_template_rosa
 
-.gcc9_cuda11_test_commmon:
+.gcc9_cuda11_test_common:
   needs: [gcc9_cuda11_build]
   extends:
     - .variables_gcc9_cuda11_config
@@ -44,9 +44,9 @@ gcc9_cuda11_build:
     - .test_template
 
 gcc9_cuda11_test_release:
-  extends: [.gcc9_cuda11_test_commmon]
+  extends: [.gcc9_cuda11_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc9_cuda11_test_debug:
-  extends: [.gcc9_cuda11_test_commmon]
+  extends: [.gcc9_cuda11_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/gcc9_pipeline.yml
+++ b/.gitlab/includes/gcc9_pipeline.yml
@@ -36,7 +36,7 @@ gcc9_build:
     - .variables_gcc9_config
     - .build_template_rosa
 
-.gcc9_test_commmon:
+.gcc9_test_common:
   needs: [gcc9_build]
   extends:
     - .variables_gcc9_config
@@ -44,9 +44,9 @@ gcc9_build:
     - .test_template
 
 gcc9_test_release:
-  extends: [.gcc9_test_commmon]
+  extends: [.gcc9_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
 
 gcc9_test_debug:
-  extends: [.gcc9_test_commmon]
+  extends: [.gcc9_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -43,7 +43,7 @@ nvhpc23_9_build:
 
 # The test step is disabled until maintenance is over. Pulling the image on compute nodes is too
 # slow, and the image is too big.
-# .nvhpc23_9_test_commmon:
+# .nvhpc23_9_test_common:
 #   needs: [nvhpc23_9_build]
 #   extends:
 #     - .variables_nvhpc23_9_config
@@ -51,9 +51,9 @@ nvhpc23_9_build:
 #     - .test_template
 #
 # nvhpc23_9_test_release:
-#   extends: [.nvhpc23_9_test_commmon]
+#   extends: [.nvhpc23_9_test_common]
 #   image: $PERSIST_IMAGE_NAME_RELEASE
 #
 # nvhpc23_9_test_debug:
-#   extends: [.nvhpc23_9_test_commmon]
+#   extends: [.nvhpc23_9_test_common]
 #   image: $PERSIST_IMAGE_NAME_DEBUG


### PR DESCRIPTION
Changes `commmon` to `common`.