### PR TITLE
Test `mpi_ring_async_sender_receiver` with all MPI completion modes

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -190,6 +190,7 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     /// Get the polling transfer mode for continuations.
     PIKA_EXPORT std::size_t get_completion_mode();
+    PIKA_EXPORT void set_completion_mode(std::size_t mode);
 
     PIKA_EXPORT bool create_pool(
         std::string const& = "", pool_create_mode = pool_create_mode::pika_decides);

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -604,11 +604,6 @@ namespace pika::mpi::experimental {
                         debug(
                             str<>("CB invoke"), ptr(mpi_data_.callbacks_[index].request_), status));
 
-                    // Invoke callback (PIKA_MOVE doesn't compile here)
-                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
-
-                    pika::threads::detail::decrement_global_activity_count();
-
                     // Remove the request from our vector to prevent retesting
                     mpi_data_.requests_[index] = MPI_REQUEST_NULL;
 
@@ -616,6 +611,11 @@ namespace pika::mpi::experimental {
                     // if invoked code checks in_flight value
                     --mpi_data_.all_in_flight_;
                     --mpi_data_.active_requests_size_;
+
+                    // Invoke callback (PIKA_MOVE doesn't compile here)
+                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
+
+                    pika::threads::detail::decrement_global_activity_count();
                 }
             } while (event_handled == true);
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -742,6 +742,7 @@ namespace pika::mpi::experimental {
 
     // -----------------------------------------------------------------
     std::size_t get_completion_mode() { return detail::completion_flags_; }
+    void set_completion_mode(std::size_t mode) { detail::completion_flags_ = mode; }
 
     // -----------------------------------------------------------------
     bool create_pool(std::string const& pool_name, pool_create_mode mode)

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -115,12 +115,6 @@ namespace pika::mpi::experimental {
             int size_ = -1;
             std::size_t max_polling_requests = get_polling_default();
 
-            // requests vector holds the requests that are checked; this
-            // represents the number of active requests in the vector, not the
-            // size of the vector
-            std::atomic<std::uint32_t> active_requests_size_{0};
-            // requests queue holds the requests recently added
-            std::atomic<std::uint32_t> request_queue_size_{0};
             // The sum of messages in queue + vector
             std::atomic<std::uint32_t> all_in_flight_{0};
             // for debugging of code creating/destroying polling handlers
@@ -169,8 +163,6 @@ namespace pika::mpi::experimental {
             os << "R "
                << dec<3>(info.rank_) << "/"
                << dec<3>(info.size_)
-               << " vector "    << dec<4>(info.active_requests_size_)
-               << " queued "    << dec<4>(info.request_queue_size_)
                << " in_flight " << dec<4>(info.all_in_flight_)
                << " vec_cb "    << dec<4>(info.callbacks_.size())
                << " vec_rq "    << dec<4>(info.requests_.size());
@@ -221,11 +213,9 @@ namespace pika::mpi::experimental {
         void add_to_request_callback_queue(request_callback&& req_callback)
         {
             pika::threads::detail::increment_global_activity_count();
-
-            // access data before moving it
-            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
-            ++mpi_data_.request_queue_size_;
             ++mpi_data_.all_in_flight_;
+            //
+            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
             PIKA_DETAIL_DP(
                 mpi_debug<5>, debug(str<>("CB queued"), ptr(req_callback.request_), mpi_data_));
         }
@@ -240,7 +230,6 @@ namespace pika::mpi::experimental {
             mpi_data_.requests_.push_back(req_callback.request_);
             mpi_data_.callbacks_.push_back(
                 {PIKA_MOVE(req_callback.callback_function_), MPI_SUCCESS, req_callback.request_});
-            ++(mpi_data_.active_requests_size_);
 
             // clang-format off
             PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("CB queue => vector"),
@@ -398,9 +387,9 @@ namespace pika::mpi::experimental {
                     debug(str<>("Ready CB invoke"), ptr(ready_callback_.request_),
                         ready_callback_.err_));
 
-                // Invoke callback (PIKA_MOVE doesn't compile here)
-                PIKA_INVOKE(std::move(ready_callback_.cb_), ready_callback_.err_);
-
+                // decrement before invoking callback : race if invoked code checks in_flight
+                --mpi_data_.all_in_flight_;
+                PIKA_INVOKE(PIKA_MOVE(ready_callback_.cb_), ready_callback_.err_);
                 pika::threads::detail::decrement_global_activity_count();
             }
 
@@ -446,7 +435,6 @@ namespace pika::mpi::experimental {
                     while (mpi_data_.request_callback_queue_.try_dequeue(req_callback))
                     {
                         add_to_request_callback_vector(PIKA_MOVE(req_callback));
-                        --mpi_data_.request_queue_size_;
                     }
 
                     std::uint32_t vsize = mpi_data_.requests_.size();
@@ -489,11 +477,6 @@ namespace pika::mpi::experimental {
                                                            MPI_SUCCESS});
                                     // Remove the request from our vector to prevent retesting
                                     mpi_data_.requests_[req_init + index] = MPI_REQUEST_NULL;
-
-                                    // decrement before invoking callback to avoid race
-                                    // if invoked code checks in_flight value
-                                    --mpi_data_.all_in_flight_;
-                                    --mpi_data_.active_requests_size_;
                                 }
                             }
                             vsize -= req_size;
@@ -514,11 +497,6 @@ namespace pika::mpi::experimental {
                                     mpi_data_.callbacks_[index].request_, status});
                             // Remove the request from our vector to prevent retesting
                             mpi_data_.requests_[index] = MPI_REQUEST_NULL;
-
-                            // decrement before invoking callback to avoid race
-                            // if invoked code checks in_flight value
-                            --mpi_data_.all_in_flight_;
-                            --mpi_data_.active_requests_size_;
                         }
                     }
                 } while (event_handled == true);
@@ -544,9 +522,9 @@ namespace pika::mpi::experimental {
                 PIKA_DETAIL_DP(mpi_debug<5>,
                     debug(str<>("CB invoke"), ptr(ready_callback_.request_), ready_callback_.err_));
 
-                // Invoke callback (PIKA_MOVE doesn't compile here)
-                PIKA_INVOKE(std::move(ready_callback_.cb_), ready_callback_.err_);
-
+                // decrement before invoking callback : race if invoked code checks in_flight
+                --mpi_data_.all_in_flight_;
+                PIKA_INVOKE(PIKA_MOVE(ready_callback_.cb_), ready_callback_.err_);
                 pika::threads::detail::decrement_global_activity_count();
             }
 
@@ -581,15 +559,11 @@ namespace pika::mpi::experimental {
             do {
                 event_handled = false;
 
-                // Move requests in the queue (that have not yet been polled for)
-                // into the polling vector ...
-                // Number in_flight does not change during this section as one
-                // is moved off the queue and into the vector
+                // Move unpolled requests in the queue into the polling vector ...
                 request_callback req_callback;
                 while (mpi_data_.request_callback_queue_.try_dequeue(req_callback))
                 {
                     add_to_request_callback_vector(PIKA_MOVE(req_callback));
-                    --mpi_data_.request_queue_size_;
                 }
 
                 int rindex, flag;
@@ -607,14 +581,9 @@ namespace pika::mpi::experimental {
                     // Remove the request from our vector to prevent retesting
                     mpi_data_.requests_[index] = MPI_REQUEST_NULL;
 
-                    // decrement before invoking callback to avoid race
-                    // if invoked code checks in_flight value
+                    // decrement before invoking callback : race if invoked code checks in_flight
                     --mpi_data_.all_in_flight_;
-                    --mpi_data_.active_requests_size_;
-
-                    // Invoke callback (PIKA_MOVE doesn't compile here)
-                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
-
+                    PIKA_INVOKE(PIKA_MOVE(mpi_data_.callbacks_[index].cb_), status);
                     pika::threads::detail::decrement_global_activity_count();
                 }
             } while (event_handled == true);
@@ -682,8 +651,8 @@ namespace pika::mpi::experimental {
             {
                 std::unique_lock<detail::mutex_type> lk(detail::mpi_data_.polling_vector_mtx_);
                 bool request_queue_empty =
-                    detail::mpi_data_.request_callback_queue_.size_approx() == 0;
-                bool requests_empty = detail::mpi_data_.all_in_flight_ == 0;
+                    (detail::mpi_data_.request_callback_queue_.size_approx() == 0);
+                bool requests_empty = (detail::mpi_data_.all_in_flight_ == 0);
                 lk.unlock();
                 PIKA_ASSERT_MSG(request_queue_empty,
                     "MPI request polling was disabled while there are unprocessed MPI requests. "
@@ -729,10 +698,7 @@ namespace pika::mpi::experimental {
     }    // namespace detail
 
     // -------------------------------------------------------------
-    size_t get_work_count()
-    {
-        return detail::mpi_data_.active_requests_size_ + detail::mpi_data_.request_queue_size_;
-    }
+    size_t get_work_count() { return detail::mpi_data_.all_in_flight_; }
 
     // -------------------------------------------------------------
     void set_max_polling_size(std::size_t p) { detail::mpi_data_.max_polling_requests = p; }

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -32,7 +32,6 @@ foreach(test ${tests})
 
   source_group("Source Files" FILES ${sources})
 
-  # add example executable
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
@@ -41,6 +40,18 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/AsyncMPI"
   )
 
+  foreach(polling_mode RANGE 0 63 1)
+    pika_add_pseudo_target(${test}_mode_${polling_mode}_test)
+    pika_add_pseudo_dependencies(${test}_mode_${polling_mode}_test ${test}_test)
+    pika_add_unit_test(
+      "modules.async_mpi"
+      ${test}_mode_${polling_mode}
+      ${${test}_PARAMETERS}
+      EXECUTABLE
+      ${test}_test
+      ARGS
+      "--pika:mpi-completion-mode=${polling_mode}"
+    )
+  endforeach()
   pika_add_unit_test("modules.async_mpi" ${test} ${${test}_PARAMETERS})
-
 endforeach()

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -21,6 +21,7 @@
 //
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
@@ -427,7 +428,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
 
         // the user queue should always be empty by now since our counter tracks it
-        PIKA_ASSERT(mpix::get_work_count() == 0);
+        PIKA_TEST_EQ(mpix::get_work_count(), static_cast<std::size_t>(0));
 
         double elapsed = t.elapsed();
 

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -308,15 +308,6 @@ struct message_receiver
 };
 
 // ------------------------------------------------------------
-int call_mpi_irecv(void* buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
-    MPI_Request* request)
-{
-    int res = MPI_Irecv(buf, count, datatype, source, tag, comm, request);
-    msr_deb<6>.debug(str<>("MPI_Irecv"), dec<5>(count));
-    return res;
-}
-
-// ------------------------------------------------------------
 // this is called on a pika thread after the runtime starts up
 int pika_main(pika::program_options::variables_map& vm)
 {

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -459,8 +459,7 @@ void init_resource_partitioner_handler(
     auto pool_mode = mpix::pool_create_mode::pika_decides;
     if (vm["no-mpi-pool"].as<bool>()) { pool_mode = mpix::pool_create_mode::force_no_create; }
 
-    if (vm["mpi-optimizations"].as<bool>()) { mpix::enable_optimizations(true); }
-    else { mpix::enable_optimizations(false); }
+    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
     std::cout << "init_resource_partitioner_handler enable optimizations "
               << vm["mpi-optimizations"].as<bool>() << std::endl;
 
@@ -523,8 +522,6 @@ int main(int argc, char* argv[])
     po::variables_map vm;
     po::store(po::command_line_parser(argc, argv).options(cmdline).allow_unregistered().run(), vm);
     po::notify(vm);
-
-    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
 
     // -----------------
     // Init MPI

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -8,6 +8,7 @@
 #include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/debugging/print.hpp>
 #include <pika/execution.hpp>
+#include <pika/execution_base/this_thread.hpp>
 #include <pika/init.hpp>
 #include <pika/mpi.hpp>
 #include <pika/program_options.hpp>
@@ -416,7 +417,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
 
         // don't exit until all messages are drained
-        while (counter > 0) { pika::this_thread::yield(); }
+        pika::util::yield_while([&] { return counter > 0; });
         if (output)
         {
             // clang-format off

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -394,6 +394,21 @@ namespace pika::detail {
         }
     }
 
+#if defined(PIKA_HAVE_MPI)
+    std::size_t handle_mpi_completion_mode(
+        detail::manage_config& cfgmap, pika::program_options::variables_map& vm)
+    {
+        std::size_t completion_mode = cfgmap.get_value<std::size_t>("pika.mpi.completion_mode", 0);
+
+        if (vm.count("pika:mpi-completion-mode"))
+        {
+            completion_mode = vm["pika:mpi-completion-mode"].as<std::size_t>();
+        }
+
+        return completion_mode;
+    }
+#endif
+
     ///////////////////////////////////////////////////////////////////////////
     void command_line_handling::handle_arguments(detail::manage_config& cfgmap,
         pika::program_options::variables_map& vm, std::vector<std::string>& ini_config)
@@ -531,6 +546,11 @@ namespace pika::detail {
             ini_config.emplace_back("pika.thread_queue.high_priority_queues!=" +
                 std::to_string(num_high_priority_queues));
         }
+
+#if defined(PIKA_HAVE_MPI)
+        std::size_t const mpi_completion_mode = detail::handle_mpi_completion_mode(cfgmap, vm);
+        ini_config.emplace_back("pika.mpi.completion_mode=" + std::to_string(mpi_completion_mode));
+#endif
 
         update_logging_settings(vm, ini_config);
 

--- a/libs/pika/command_line_handling/src/parse_command_line.cpp
+++ b/libs/pika/command_line_handling/src/parse_command_line.cpp
@@ -338,6 +338,11 @@ namespace pika::detail {
                 "allowed values: 0 - no NUMA sensitivity, 1 - allow only for "
                 "boundary cores to steal across NUMA domains, 2 - "
                 "no cross boundary stealing is allowed (default value: 0)")
+#if defined(PIKA_HAVE_MPI)
+            ("pika:mpi-completion-mode", value<std::size_t>(),
+                "the pika MPI polling completion mode (only available if MPI "
+                "built with MPI support)")
+#endif
         ;
 
         options_description config_options("pika configuration options");

--- a/libs/pika/init_runtime/CMakeLists.txt
+++ b/libs/pika/init_runtime/CMakeLists.txt
@@ -14,7 +14,7 @@ set(init_runtime_headers
 set(init_runtime_sources init_logging.cpp init_runtime.cpp scoped_finalize.cpp)
 
 if(PIKA_WITH_MPI)
-  list(APPEND init_runtime_additional_module_dependencies pika_mpi_base)
+  list(APPEND init_runtime_additional_module_dependencies pika_mpi_base pika_async_mpi)
 endif()
 
 include(pika_add_module)

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -41,6 +41,10 @@
 #include <pika/util/get_entry_as.hpp>
 #include <pika/version.hpp>
 
+#if defined(PIKA_HAVE_MPI)
+# include <pika/async_mpi/mpi_polling.hpp>
+#endif
+
 #if defined(PIKA_HAVE_HIP)
 # include <hip/hip_runtime.h>
 # include <whip.hpp>
@@ -134,6 +138,10 @@ namespace pika {
                 cmdline.rtcfg_.get_spinlock_deadlock_detection_limit());
             pika::util::detail::set_spinlock_deadlock_warning_limit(
                 cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
+#endif
+#ifdef PIKA_HAVE_MPI
+            pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
+                cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
             init_logging(cmdline.rtcfg_);
         }

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -189,6 +189,11 @@ namespace pika::util {
             "${PIKA_THREAD_QUEUE_INIT_THREADS_COUNT:" PIKA_PP_STRINGIZE(
                 PIKA_PP_EXPAND(PIKA_THREAD_QUEUE_INIT_THREADS_COUNT)) "}",
 
+#if defined(PIKA_HAVE_MPI)
+            "[pika.mpi]",
+            "completion_mode = ${PIKA_MPI_COMPLETION_MODE:0}",
+#endif
+
             "[pika.commandline]",
 
             // allow for unknown options to be passed through

--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -33,6 +33,7 @@
    match-leak-kinds: definite
    ...
    fun:orte_init
+   ...
 }
 
 {


### PR DESCRIPTION
Fixes #1142, except for testing the MPI continuations modes. Those will be enabled separately (https://github.com/pika-org/pika/issues/1150).

This:
- Adds a `--pika:mpi-completion-mode` flag for setting the mode via command line options. This isn't intended as the primary way to change the mode for users, but is mostly there for the unit test. CMake's `ENVIRONMENT` property on tests allows setting an environment variable. I originally intended to use this, but the variables are not exported so sub-processes don't see the value, and since the tests are run through `mpirun`/`mpiexec` the variable isn't applied.
- Decrements MPI counters before calling the user-provided callback. This fixes a race in the test checking for zero MPI requests in flight. The assertion is also changed to use `PIKA_TEST_EQ` so that it's run with all build types and prints the failing value if it fails.
- Adds a `--recv-before-send` flag to the unit test, and makes send-before-recv the default, to avoid deadlocks when requests are done inline. Sends will never block indefinitely, so doing the sends first avoids hangs.
- Some minor additional cleanup in the test (see individual commit messages for descriptions).