### PR TITLE
Add task yield benchmark

### DIFF
--- a/.gitlab/scripts/run_performance_benchmarks.sh
+++ b/.gitlab/scripts/run_performance_benchmarks.sh
@@ -24,6 +24,8 @@ pika_targets=(
 "task_latency_test"
 "task_latency_test"
 "task_latency_test"
+"task_yield_test"
+"task_yield_test"
 "condition_variable_overhead_test"
 )
 pika_test_options=(
@@ -65,6 +67,16 @@ pika_test_options=(
 
 "--repetitions=1000000
 --nostack
+--pika:threads=2
+--perftest-json"
+
+"--repetitions=100
+--num-yields=100000
+--pika:threads=1
+--perftest-json"
+
+"--repetitions=100
+--num-yields=100000
 --pika:threads=2
 --perftest-json"
 

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -22,6 +22,7 @@ set(benchmarks
     task_overhead
     task_overhead_report
     task_size
+    task_yield
 )
 
 if(NOT PIKA_WITH_SANITIZERS)

--- a/tests/performance/local/task_yield.cpp
+++ b/tests/performance/local/task_yield.cpp
@@ -1,0 +1,105 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/config.hpp>
+#include <pika/execution.hpp>
+#include <pika/init.hpp>
+#include <pika/modules/timing.hpp>
+#include <pika/runtime.hpp>
+#include <pika/testing/performance.hpp>
+#include <pika/thread.hpp>
+
+#include <fmt/format.h>
+#include <fmt/printf.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <utility>
+
+namespace ex = pika::execution::experimental;
+namespace po = pika::program_options;
+namespace tt = pika::this_thread::experimental;
+
+template <typename Scheduler>
+double test_yield(Scheduler&& sched, std::size_t num_yields)
+{
+    return tt::sync_wait(ex::schedule(std::forward<Scheduler>(sched)) | ex::then([num_yields]() {
+        pika::chrono::detail::high_resolution_timer timer;
+        for (std::size_t i = 0; i < num_yields; ++i) { pika::this_thread::yield(); }
+        return timer.elapsed();
+    }));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int pika_main(po::variables_map& vm)
+{
+    auto const num_yields = vm["num-yields"].as<std::uint64_t>();
+    auto const repetitions = vm["repetitions"].as<std::uint64_t>();
+    auto const perftest_json = vm["perftest-json"].as<bool>();
+
+    double time_avg_s = 0.0;
+    double time_min_s = std::numeric_limits<double>::max();
+    double time_max_s = std::numeric_limits<double>::min();
+
+    for (std::uint64_t i = 0; i < repetitions; ++i)
+    {
+        auto sched = ex::thread_pool_scheduler();
+        sched = ex::with_hint(std::move(sched),
+            pika::execution::thread_schedule_hint(pika::get_worker_thread_num() + 1));
+
+        double time_s = test_yield(sched, num_yields);
+
+        time_avg_s += time_s;
+        time_max_s = (std::max)(time_max_s, time_s);
+        time_min_s = (std::min)(time_min_s, time_s);
+    }
+
+    time_avg_s /= repetitions;
+
+    double const time_avg_us = time_avg_s * 1e6 / num_yields;
+    double const time_min_us = time_min_s * 1e6 / num_yields;
+    double const time_max_us = time_max_s * 1e6 / num_yields;
+
+    if (perftest_json)
+    {
+        pika::util::detail::json_perf_times t;
+        t.add(fmt::format("task_yield - {} threads - {}", pika::get_num_worker_threads(),
+                  "thread_pool_scheduler"),
+            time_avg_us);
+        std::cout << t;
+    }
+    else
+    {
+        fmt::print("repetitions,time_avg_us,time_min_us,time_max_us\n");
+        fmt::print("{},{},{},{}\n", repetitions, time_avg_us, time_min_us, time_max_us);
+    }
+
+    pika::finalize();
+    return EXIT_SUCCESS;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    po::options_description cmdline("usage: " PIKA_APPLICATION_STRING " [options]");
+
+    // clang-format off
+    cmdline.add_options()
+        ("num-yields", po::value<std::uint64_t>()->default_value(100000), "number of yields per repetition")
+        ("repetitions", po::value<std::uint64_t>()->default_value(10), "number of repetitions of the benchmark")
+        ("perftest-json", po::bool_switch(), "print final task size in json format for use with performance CI")
+        // clang-format on
+        ;
+
+    // Initialize and run pika.
+    pika::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return pika::init(pika_main, argc, argv, init_args);
+}


### PR DESCRIPTION
The added benchmark simply times how long a yield and reschedule takes, i.e. two context switches and adding and removing the task from a queue.

This also adds the benchmark to CI with both `--pika:threads=1` and `--pika:threads=2`. The one-thread version runs significantly faster, probably due to less contention from other threads trying to steal tasks. Running with more than one worker thread and the static scheduler gives roughly the same timings as a single worker thread with the default scheduler.