### PR TITLE
Explicitly disable building tests and documentation for fmt in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,8 @@ jobs:
               cmake \
                 -GNinja \
                 -DBUILD_SHARED_LIBS=ON \
+                -DFMT_DOC=OFF \
+                -DFMT_TEST=OFF \
                 -DCMAKE_INSTALL_PREFIX=$HOME/project/install/fmt . && \
               ninja install)
             export CMAKE_PREFIX_PATH=$HOME/project/install/fmt:${CMAKE_PREFIX_PATH}


### PR DESCRIPTION
Tests are currently built in CI. This disables building fmt tests.