### PR TITLE
Run coverage on PRs

### DIFF
--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -7,9 +7,13 @@
 name: Linux CI (Coverage)
 
 on:
+  merge_group:
+  pull_request:
   push:
     branches:
+      # Development and release branches
       - main
+      - release**
 
 jobs:
   build:

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -58,7 +58,7 @@ jobs:
         continue-on-error: true
         run: |
             ctest -j2 --timeout 120 --output-on-failure
-      - name: Upload coverage report
+      - name: Generate coverage report
         shell: bash
         working-directory: build
         run: |
@@ -69,7 +69,9 @@ jobs:
                 --llvm \
                 --ignore-not-existing \
                 --keep-only "*libs/pika/*/{src,include}/*"
-            bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-                --project-token ${{ secrets.CODACY_PIKA_PROJECT_TOKEN }} \
-                --language CPP \
-                --coverage-reports lcov.info
+      - name: Upload coverage report to GH artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build/lcov.info
+          if-no-files-found: error

--- a/.github/workflows/linux_coverage_upload.yml
+++ b/.github/workflows/linux_coverage_upload.yml
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Coverage upload)
+
+on:
+  workflow_run:
+    workflows: ["Linux CI (Coverage)"]
+    types:
+      - completed
+
+jobs:
+  build:
+    name: github/linux/coverage/upload
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download coverage report from GH artifacts
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: coverage-report
+          workflow: linux_coverage.yml
+          allow_forks: true
+          workflow_conclusion: success
+      - name: Upload coverage report
+        shell: bash
+        working-directory: build
+        run: |
+            curl --output codacy-coverage-reporter-linux --location https://artifacts.codacy.com/bin/codacy-coverage-reporter/13.16.8/codacy-coverage-reporter-linux
+            echo "85d98fccfa4350aa65e709557540c74ca6fea493f690c602a991f8f14d2082d8  codacy-coverage-reporter-linux" | sha256sum --check
+            chmod +x codacy-coverage-reporter-linux
+            ./codacy-coverage-reporter-linux \
+                report \
+                --project-token ${{ secrets.CODACY_PIKA_PROJECT_TOKEN }} \
+                --commit-uuid ${{ github.event.workflow_run.head_sha }} \
+                --language CPP \
+                --coverage-reports lcov.info


### PR DESCRIPTION
We currently only run the coverage workflow on `main`. This enables it for pull requests and the `release-*` branches as well.

Since PRs don't have access to secrets this uses a `workflow_run` workflow, which does have access to secrets, to upload the coverage report. The PR itself simply generates the coverage report and stores it in GitHub artifacts and then the `workflow_run` workflow downloads the file and pushes it to codacy.