### PR TITLE
Attempt to fix integer overflow snyk warning

### DIFF
--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -206,11 +206,15 @@ namespace pika::detail {
                 // got the section name. It might be hierarchical, so split it up, and
                 // for each elem, check if we have it.  If not, create it, and add
                 std::string sec_name(line.substr(1, line.size() - 2));
+
                 std::string::size_type pos = 0;
-                for (std::string::size_type pos1 = sec_name.find_first_of('.');
-                     std::string::npos != pos1; pos1 = sec_name.find_first_of('.', pos = pos1 + 1))
+                std::string::size_type pos1 = sec_name.find_first_of('.');
+
+                while (pos1 != std::string::npos)
                 {
                     current = current->add_section_if_new(sec_name.substr(pos, pos1 - pos));
+                    pos = pos1 + 1;
+                    pos1 = sec_name.find_first_of('.', pos);
                 }
 
                 current = current->add_section_if_new(sec_name.substr(pos));

--- a/libs/pika/ini/tests/unit/CMakeLists.txt
+++ b/libs/pika/ini/tests/unit/CMakeLists.txt
@@ -1,5 +1,25 @@
-# Copyright (c) 2020-2021 The STE||AR-Group
+# Copyright (c)   2024 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(runtime_config_tests parse)
+
+foreach(test ${runtime_config_tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  pika_add_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources}
+    NOLIBS
+    DEPENDENCIES pika
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/Modules/Ini"
+  )
+
+  pika_add_unit_test("modules.ini" ${test})
+
+endforeach()

--- a/libs/pika/ini/tests/unit/parse.cpp
+++ b/libs/pika/ini/tests/unit/parse.cpp
@@ -1,0 +1,23 @@
+//  Copyright (c)   2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/runtime_configuration/runtime_configuration.hpp>
+#include <pika/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> config = {
+        "[system]", "pid=42", "[pika.stacks]", "small_stack_size=64"};
+    pika::detail::section sec;
+    sec.parse("<static defaults>", config, false, false, false);
+
+    PIKA_TEST(sec.has_section("system"));
+    PIKA_TEST(sec.has_section("pika.stacks"));
+    PIKA_TEST(!sec.has_section("pika.thread_queue"));
+}


### PR DESCRIPTION
snyk emits a warning when using the operator- in `std::string::substr`
https://app.snyk.io/org/aurianer/project/d4ed2629-64fe-44d9-abaa-66f15e7df793#issue-f1446f1e-dfef-4c06-837b-1f64300d28ce
this is an attempt to fix the warning