### PR TITLE
Allow compiling libpika as a static library

### DIFF
--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -16,7 +16,7 @@ include:
     SPACK_SPEC: "pika@main +apex arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
                  ^apex@2.6.5 ~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DBUILD_SHARED_LIBS=OFF"
 
 gcc10_apex_spack_compiler_image:
   extends:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,12 @@ unset(PIKA_ENABLED_MODULES CACHE)
 include(pika_compiler_flags_targets)
 
 # ##################################################################################################
+# Use shared libraries by default
+pika_option(
+  BUILD_SHARED_LIBS BOOL "Build using shared libraries (default: ON)" ON CATEGORY "Build Targets"
+)
+
+# ##################################################################################################
 # Setup platform for which pika should be compiled.
 #
 include(pika_set_platform)

--- a/cmake/pika_add_library.cmake
+++ b/cmake/pika_add_library.cmake
@@ -12,7 +12,6 @@ function(pika_add_library name)
       INTERNAL_FLAGS
       NOLIBS
       NOEXPORT
-      STATIC
       OBJECT
       NONAMEPREFIX
       UNITY_BUILD
@@ -28,13 +27,6 @@ function(pika_add_library name)
   )
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPILER_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
-
-  if(${name}_OBJECT AND ${name}_STATIC)
-    pika_error(
-      "Trying to create ${name} library with both STATIC and OBJECT.\
- Only one can be used at the same time."
-    )
-  endif()
 
   if(NOT ${name}_SOURCE_ROOT)
     set(${name}_SOURCE_ROOT ".")
@@ -95,7 +87,7 @@ function(pika_add_library name)
     # cmake-format: on
 
     # install PDB if needed
-    if(MSVC AND NOT ${name}_STATIC)
+    if(MSVC AND BUILD_SHARED_LIBS)
       # cmake-format: off
       set(_target_flags
           ${_target_flags}
@@ -112,12 +104,9 @@ function(pika_add_library name)
     set(_target_flags ${_target_flags} NONAMEPREFIX)
   endif()
 
-  if(${name}_STATIC)
-    set(${name}_linktype STATIC)
-  elseif(${name}_OBJECT)
+  set(${name}_linktype)
+  if(${name}_OBJECT)
     set(${name}_linktype OBJECT)
-  else()
-    set(${name}_linktype SHARED)
   endif()
 
   if(PIKA_WITH_HIP)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 set(pika_libs pika)
 
 foreach(lib ${pika_libs})
-  add_library(${lib} SHARED src/dummy.cpp ${pika_natvis_files_SOURCES})
+  add_library(${lib} src/dummy.cpp ${pika_natvis_files_SOURCES})
   set_target_properties(
     ${lib}
     PROPERTIES VERSION ${PIKA_VERSION}

--- a/testing/performance_testing/CMakeLists.txt
+++ b/testing/performance_testing/CMakeLists.txt
@@ -7,7 +7,7 @@
 set(performance_testing_sources performance.cpp)
 list(TRANSFORM performance_testing_sources PREPEND src/ OUTPUT_VARIABLE performance_testing_sources)
 
-add_library(pika_performance_testing SHARED ${performance_testing_sources})
+add_library(pika_performance_testing ${performance_testing_sources})
 target_include_directories(pika_performance_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(pika_performance_testing PRIVATE pika_private_flags)
 target_link_libraries(pika_performance_testing PUBLIC pika::pika)

--- a/testing/testing/CMakeLists.txt
+++ b/testing/testing/CMakeLists.txt
@@ -7,7 +7,7 @@
 set(testing_sources testing.cpp)
 list(TRANSFORM testing_sources PREPEND src/ OUTPUT_VARIABLE testing_sources)
 
-add_library(pika_testing SHARED ${testing_sources})
+add_library(pika_testing ${testing_sources})
 target_include_directories(pika_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(pika_testing PRIVATE pika_private_flags)
 target_link_libraries(pika_testing PUBLIC pika::pika)


### PR DESCRIPTION
Fixes #491.

With this change, all libraries follow `BUILD_SHARED_LIBS` to decide whether they'll be static or shared. Object libraries are still used internally. One CI configuration has `BUILD_SHARED_LIBS` disabled, otherwise `BUILD_SHARED_LIBS` is enabled by default.