### PR TITLE
Remove stray `tag_invoke` deletion in unpack test

### DIFF
--- a/libs/pika/execution/tests/unit/algorithm_unpack.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_unpack.cpp
@@ -36,8 +36,6 @@ namespace test {
     }
 }    // namespace test
 
-void tag_invoke() = delete;
-
 int main()
 {
 #if defined(PIKA_HAVE_STDEXEC)


### PR DESCRIPTION
This was likely used for testing at some point, but is not supposed to be there permanently.