### PR TITLE
Add link to cppreference.com execution documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,11 @@ pika follows `semver <https://semver.org>`__. pika is currently at a 0.X version
 minor versions may break the API. pika gives no guarantees about ABI stability. The ABI may change
 even in patch versions.
 
-The API reference is a work in progress. The following headers are part of the public API. Any other
+The API reference is a work in progress. While the reference is being expanded, the
+:ref:`std_execution_more_resources` section contains useful links to high level overviews and low
+level API descriptions of ``std::execution``.
+
+The following headers are part of the public API. Any other
 headers are internal implementation details.
 
 .. contents::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -277,6 +277,9 @@ More resources
 .. |stdexec_resources| replace:: list of presentations, blog posts etc. about the ``std::execution`` model
 .. _stdexec_resources: https://github.com/NVIDIA/stdexec#resources
 
+.. |cppreference_execution| replace:: documentation about ``std::execution``
+.. _cppreference_execution: https://en.cppreference.com/w/cpp/experimental/execution
+
 The `P2300 proposal <https://wg21.link/p2300>`__ is the source of truth for ``std::execution``
 functionality. The reference implementation of P2300, stdexec, maintains a |stdexec_resources|_.  In
 addition to the above, other implementations of the ``std::execution`` model exist, with useful
@@ -286,7 +289,7 @@ documentation and examples:
 - `libunifex <https://github.com/facebookexperimental/libunifex/blob/main/doc/overview.md>`__
 
 Even though the implementations differ, the concepts are transferable between implementations and
-useful for learning.
+useful for learning. cppreference.com also contains early |cppreference_execution|_.
 
 pika has been presented at the following events and slides of the presentations are public:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -271,6 +271,8 @@ of the proposed sender algorithms which is why we recommend that you enable ``PI
 whenever possible. We plan to deprecate and remove the P2300 implementation in pika in favour of
 stdexec and/or standard library implementations.
 
+.. _std_execution_more_resources:
+
 More resources
 ==============
 


### PR DESCRIPTION
Also links to "More resources" in "API reference" section.