### PR TITLE
Add documentation for `split_tuple`

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -7,7 +7,9 @@ GENERATE_RTF           = NO
 GENERATE_HTML          = NO
 QUIET                  = NO
 OUTPUT_DIRECTORY       = "$(PIKA_DOCS_DOXYGEN_OUTPUT_DIRECTORY)"
-INPUT                  = "$(PIKA_DOCS_DOXYGEN_INPUT_ROOT)/libs/pika/init_runtime" "$(PIKA_DOCS_DOXYGEN_INPUT_ROOT)/libs/pika/runtime"
+INPUT                  = "$(PIKA_DOCS_DOXYGEN_INPUT_ROOT)/libs/pika/init_runtime" \
+                         "$(PIKA_DOCS_DOXYGEN_INPUT_ROOT)/libs/pika/runtime" \
+                         "$(PIKA_DOCS_DOXYGEN_INPUT_ROOT)/libs/pika/execution"
 FILE_PATTERNS          = *.cpp *.hpp *.cu
 RECURSIVE              = YES
 EXCLUDE_PATTERNS       = */test */detail

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,3 +64,16 @@ The ``pika/init.hpp`` header provides functionality to manage the pika runtime.
 
 .. doxygenstruct:: pika::init_params
    :members:
+
+.. _header_pika_execution:
+
+``pika/execution.hpp``
+======================
+
+The ``pika/execution.hpp`` header provides functionality related to ``std::execution``.
+
+.. doxygenvariable:: pika::execution::experimental::split_tuple
+
+.. literalinclude:: ../examples/documentation/split_tuple_documentation.cpp
+   :language: c++
+   :start-at: #include

--- a/examples/documentation/CMakeLists.txt
+++ b/examples/documentation/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(example_programs hello_world_documentation init_hpp_documentation)
+set(example_programs hello_world_documentation init_hpp_documentation split_tuple_documentation)
 
 foreach(example_program ${example_programs})
   set(sources ${example_program}.cpp)

--- a/examples/documentation/split_tuple_documentation.cpp
+++ b/examples/documentation/split_tuple_documentation.cpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/execution.hpp>
+#include <pika/init.hpp>
+
+#include <fmt/printf.h>
+
+#include <chrono>
+#include <thread>
+#include <tuple>
+#include <utility>
+
+int main(int argc, char* argv[])
+{
+    namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
+
+    pika::start(argc, argv);
+    ex::thread_pool_scheduler sched{};
+
+    // split_tuple can be used to process the result and its square through
+    // senders, without having to pass both around together
+    auto [snd, snd_squared] = ex::schedule(sched) | ex::then([]() { return 42; }) |
+        ex::then([](int x) { return std::tuple(x, x * x); }) | ex::split_tuple();
+
+    // snd and snd_squared will be ready at the same time, but can be used independently
+    auto snd_print =
+        std::move(snd) | ex::transfer(sched) | ex::then([](int x) { fmt::print("x is {}\n", x); });
+    auto snd_process = std::move(snd_squared) | ex::transfer(sched) | ex::then([](int x_squared) {
+        fmt::print("Performing expensive operations on x * x\n");
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        return x_squared / 2;
+    });
+
+    auto x_squared_processed =
+        tt::sync_wait(ex::when_all(std::move(snd_print), std::move(snd_process)));
+    fmt::print("The final result is {}\n", x_squared_processed);
+
+    pika::finalize();
+    pika::stop();
+
+    return 0;
+}

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -527,15 +527,7 @@ namespace pika::split_tuple_detail {
 }    // namespace pika::split_tuple_detail
 
 namespace pika::execution::experimental {
-    /// \brief Splits a sender of a tuple into a tuple of senders.
-    ///
-    /// Sender adaptor that takes a sender that sends a single, non-empty, tuple
-    /// and returns a new tuple of the same size as the one sent by the input
-    /// sender which contains one sender for each element in the input sender
-    /// tuple. Each output sender signals completion whenever the input sender
-    /// would have signalled completion.
-    inline constexpr struct split_tuple_t final
-      : pika::functional::detail::tag_fallback<split_tuple_t>
+    struct split_tuple_t final : pika::functional::detail::tag_fallback<split_tuple_t>
     {
     private:
         template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
@@ -561,5 +553,14 @@ namespace pika::execution::experimental {
         {
             return detail::partial_algorithm<split_tuple_t, Allocator>{allocator};
         }
-    } split_tuple{};
+    };
+
+    /// \brief Splits a sender of a tuple into a tuple of senders.
+    ///
+    /// Sender adaptor that takes a sender that sends a single, non-empty, tuple and returns a new
+    /// tuple of the same size as the one sent by the input sender which contains one sender for
+    /// each element in the input sender tuple. Each output sender signals completion whenever the
+    /// input sender would have signalled completion. The predecessor sender must complete with
+    /// exactly one tuple of at least one type.
+    inline constexpr split_tuple_t split_tuple{};
 }    // namespace pika::execution::experimental


### PR DESCRIPTION
Adds `split_tuple` to the API reference under `pika/execution.hpp`. Includes the doxygen docstring and a small example program that uses `split_tuple`.

I'm starting to document the `pika::execution` functionality that is not available in P2300 or stdexec, since documentation for what is in P2300 can be looked up elsewhere.