### PR TITLE
Add a bypass scheduler to improve mpi continuations

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -125,7 +125,7 @@ namespace pika::mpi::experimental::detail {
                             apex::scoped_timer apex_post("pika::mpi::post");
 #endif
                             // init a request
-                            MPI_Request request;
+                            MPI_Request request{MPI_REQUEST_NULL};
                             int status = MPI_SUCCESS;
                             // execute the mpi function call, passing in the request object
                             if constexpr (std::is_void_v<invoke_result_type>)

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -190,6 +190,7 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     /// Get the polling transfer mode for continuations.
     PIKA_EXPORT std::size_t get_completion_mode();
+    PIKA_EXPORT void set_completion_mode(std::size_t mode);
 
     PIKA_EXPORT bool create_pool(
         std::string const& = "", pool_create_mode = pool_create_mode::pika_decides);

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -224,6 +224,7 @@ namespace pika::mpi::experimental {
           : pool_name_(pool_name)
         {
             mpi::experimental::init(false, init_errorhandler);
+            mpi::experimental::register_polling();
         }
 
         ~enable_user_polling() { mpi::experimental::finalize(pool_name_); }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -23,6 +23,7 @@
 #include <pika/execution_base/any_sender.hpp>
 #include <pika/execution_base/receiver.hpp>
 #include <pika/execution_base/sender.hpp>
+#include <pika/executors/thread_pool_scheduler_queue_bypass.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
 #include <pika/mpi_base/mpi.hpp>
@@ -50,14 +51,15 @@ namespace pika::mpi::experimental {
             using execution::thread_priority;
             using pika::execution::experimental::just;
             using pika::execution::experimental::let_value;
+            using pika::execution::experimental::thread_pool_scheduler_queue_bypass;
             using pika::execution::experimental::transfer;
             using pika::execution::experimental::transfer_just;
             using pika::execution::experimental::unique_any_sender;
 
             // get mpi completion mode settings
             auto mode = get_completion_mode();
-            bool inline_com = use_inline_completion(mode);
-            bool inline_req = use_inline_request(mode);
+            bool completions_inline = use_inline_completion(mode);
+            bool requests_inline = use_inline_request(mode);
 
 #ifdef PIKA_DEBUG
             // ----------------------------------------------------------
@@ -77,29 +79,40 @@ namespace pika::mpi::experimental {
                 execution::thread_priority::boost :
                 execution::thread_priority::normal;
 
+            auto dgb = []() {
+                PIKA_DETAIL_DP(mpi_tran<0>, debug(str<>("transform_mpi"), "complete"));
+            };
+
             auto completion_snd = [=](MPI_Request request) -> unique_any_sender<> {
-                if (!inline_com)
+                if (!completions_inline)    // not inline : a transfer is required
                 {
                     if (request == MPI_REQUEST_NULL)
                     {
                         return transfer_just(default_pool_scheduler(p));
                     }
-                    return transfer_just(default_pool_scheduler(p), request) | trigger_mpi(mode);
+                    return just(request) | trigger_mpi(mode) | transfer(default_pool_scheduler(p));
                 }
+                // inline, can we skip any steps?
                 if (request == MPI_REQUEST_NULL) { return just(); }
-                return just(request) | trigger_mpi(mode);
+                if (inline_ready(mode))    // the completion mode does not requre a transfer
+                {
+                    return just(request) | trigger_mpi(mode);    //
+                }
+                return just(request) | trigger_mpi(mode) |
+                    transfer(ex::with_annotation(
+                        ex::thread_pool_scheduler_queue_bypass{}, "transform_mpi"));
             };
 
-            if (inline_req)
+            if (requests_inline)
             {
-                return dispatch_mpi_sender<Sender, F>{PIKA_MOVE(sender), PIKA_FORWARD(F, f)} |
-                    let_value(completion_snd);
+                return dispatch_mpi(PIKA_MOVE(sender), PIKA_FORWARD(F, f)) |
+                    let_value(completion_snd) | ex::then(dgb);
             }
             else
             {
                 auto snd0 = PIKA_FORWARD(Sender, sender) | transfer(mpi_pool_scheduler(p));
-                return dispatch_mpi_sender<decltype(snd0), F>{PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
-                    let_value(completion_snd);
+                return dispatch_mpi(PIKA_MOVE(snd0), PIKA_FORWARD(F, f)) |
+                    let_value(completion_snd) | ex::then(dgb);
             }
         }
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -604,11 +604,6 @@ namespace pika::mpi::experimental {
                         debug(
                             str<>("CB invoke"), ptr(mpi_data_.callbacks_[index].request_), status));
 
-                    // Invoke callback (PIKA_MOVE doesn't compile here)
-                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
-
-                    pika::threads::detail::decrement_global_activity_count();
-
                     // Remove the request from our vector to prevent retesting
                     mpi_data_.requests_[index] = MPI_REQUEST_NULL;
 
@@ -616,6 +611,11 @@ namespace pika::mpi::experimental {
                     // if invoked code checks in_flight value
                     --mpi_data_.all_in_flight_;
                     --mpi_data_.active_requests_size_;
+
+                    // Invoke callback (PIKA_MOVE doesn't compile here)
+                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
+
+                    pika::threads::detail::decrement_global_activity_count();
                 }
             } while (event_handled == true);
 

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -742,6 +742,7 @@ namespace pika::mpi::experimental {
 
     // -----------------------------------------------------------------
     std::size_t get_completion_mode() { return detail::completion_flags_; }
+    void set_completion_mode(std::size_t mode) { detail::completion_flags_ = mode; }
 
     // -----------------------------------------------------------------
     bool create_pool(std::string const& pool_name, pool_create_mode mode)

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -833,13 +833,6 @@ namespace pika::mpi::experimental {
             MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
             MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
         }
-        if (init_mpi)
-        {
-            int provided, required = MPI_THREAD_MULTIPLE;
-            pika::util::mpi_environment::init(nullptr, nullptr, required, required, provided);
-            MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
-            MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
-        }
         else
         {
             int is_initialized = 0;

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -203,7 +203,7 @@ namespace pika::mpi::experimental {
         std::size_t get_completion_mode_default()
         {
             // inline continuations are default
-            return pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE", 1);
+            return pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE", 0);
         }
 
         // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -115,12 +115,6 @@ namespace pika::mpi::experimental {
             int size_ = -1;
             std::size_t max_polling_requests = get_polling_default();
 
-            // requests vector holds the requests that are checked; this
-            // represents the number of active requests in the vector, not the
-            // size of the vector
-            std::atomic<std::uint32_t> active_requests_size_{0};
-            // requests queue holds the requests recently added
-            std::atomic<std::uint32_t> request_queue_size_{0};
             // The sum of messages in queue + vector
             std::atomic<std::uint32_t> all_in_flight_{0};
             // for debugging of code creating/destroying polling handlers
@@ -169,8 +163,6 @@ namespace pika::mpi::experimental {
             os << "R "
                << dec<3>(info.rank_) << "/"
                << dec<3>(info.size_)
-               << " vector "    << dec<4>(info.active_requests_size_)
-               << " queued "    << dec<4>(info.request_queue_size_)
                << " in_flight " << dec<4>(info.all_in_flight_)
                << " vec_cb "    << dec<4>(info.callbacks_.size())
                << " vec_rq "    << dec<4>(info.requests_.size());
@@ -221,11 +213,9 @@ namespace pika::mpi::experimental {
         void add_to_request_callback_queue(request_callback&& req_callback)
         {
             pika::threads::detail::increment_global_activity_count();
-
-            // access data before moving it
-            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
-            ++mpi_data_.request_queue_size_;
             ++mpi_data_.all_in_flight_;
+            //
+            mpi_data_.request_callback_queue_.enqueue(PIKA_MOVE(req_callback));
             PIKA_DETAIL_DP(
                 mpi_debug<5>, debug(str<>("CB queued"), ptr(req_callback.request_), mpi_data_));
         }
@@ -240,7 +230,6 @@ namespace pika::mpi::experimental {
             mpi_data_.requests_.push_back(req_callback.request_);
             mpi_data_.callbacks_.push_back(
                 {PIKA_MOVE(req_callback.callback_function_), MPI_SUCCESS, req_callback.request_});
-            ++(mpi_data_.active_requests_size_);
 
             // clang-format off
             PIKA_DETAIL_DP(mpi_debug<5>, debug(str<>("CB queue => vector"),
@@ -398,9 +387,9 @@ namespace pika::mpi::experimental {
                     debug(str<>("Ready CB invoke"), ptr(ready_callback_.request_),
                         ready_callback_.err_));
 
-                // Invoke callback (PIKA_MOVE doesn't compile here)
-                PIKA_INVOKE(std::move(ready_callback_.cb_), ready_callback_.err_);
-
+                // decrement before invoking callback : race if invoked code checks in_flight
+                --mpi_data_.all_in_flight_;
+                PIKA_INVOKE(PIKA_MOVE(ready_callback_.cb_), ready_callback_.err_);
                 pika::threads::detail::decrement_global_activity_count();
             }
 
@@ -446,7 +435,6 @@ namespace pika::mpi::experimental {
                     while (mpi_data_.request_callback_queue_.try_dequeue(req_callback))
                     {
                         add_to_request_callback_vector(PIKA_MOVE(req_callback));
-                        --mpi_data_.request_queue_size_;
                     }
 
                     std::uint32_t vsize = mpi_data_.requests_.size();
@@ -489,11 +477,6 @@ namespace pika::mpi::experimental {
                                                            MPI_SUCCESS});
                                     // Remove the request from our vector to prevent retesting
                                     mpi_data_.requests_[req_init + index] = MPI_REQUEST_NULL;
-
-                                    // decrement before invoking callback to avoid race
-                                    // if invoked code checks in_flight value
-                                    --mpi_data_.all_in_flight_;
-                                    --mpi_data_.active_requests_size_;
                                 }
                             }
                             vsize -= req_size;
@@ -514,11 +497,6 @@ namespace pika::mpi::experimental {
                                     mpi_data_.callbacks_[index].request_, status});
                             // Remove the request from our vector to prevent retesting
                             mpi_data_.requests_[index] = MPI_REQUEST_NULL;
-
-                            // decrement before invoking callback to avoid race
-                            // if invoked code checks in_flight value
-                            --mpi_data_.all_in_flight_;
-                            --mpi_data_.active_requests_size_;
                         }
                     }
                 } while (event_handled == true);
@@ -544,9 +522,9 @@ namespace pika::mpi::experimental {
                 PIKA_DETAIL_DP(mpi_debug<5>,
                     debug(str<>("CB invoke"), ptr(ready_callback_.request_), ready_callback_.err_));
 
-                // Invoke callback (PIKA_MOVE doesn't compile here)
-                PIKA_INVOKE(std::move(ready_callback_.cb_), ready_callback_.err_);
-
+                // decrement before invoking callback : race if invoked code checks in_flight
+                --mpi_data_.all_in_flight_;
+                PIKA_INVOKE(PIKA_MOVE(ready_callback_.cb_), ready_callback_.err_);
                 pika::threads::detail::decrement_global_activity_count();
             }
 
@@ -581,15 +559,11 @@ namespace pika::mpi::experimental {
             do {
                 event_handled = false;
 
-                // Move requests in the queue (that have not yet been polled for)
-                // into the polling vector ...
-                // Number in_flight does not change during this section as one
-                // is moved off the queue and into the vector
+                // Move unpolled requests in the queue into the polling vector ...
                 request_callback req_callback;
                 while (mpi_data_.request_callback_queue_.try_dequeue(req_callback))
                 {
                     add_to_request_callback_vector(PIKA_MOVE(req_callback));
-                    --mpi_data_.request_queue_size_;
                 }
 
                 int rindex, flag;
@@ -607,14 +581,9 @@ namespace pika::mpi::experimental {
                     // Remove the request from our vector to prevent retesting
                     mpi_data_.requests_[index] = MPI_REQUEST_NULL;
 
-                    // decrement before invoking callback to avoid race
-                    // if invoked code checks in_flight value
+                    // decrement before invoking callback : race if invoked code checks in_flight
                     --mpi_data_.all_in_flight_;
-                    --mpi_data_.active_requests_size_;
-
-                    // Invoke callback (PIKA_MOVE doesn't compile here)
-                    PIKA_INVOKE(std::move(mpi_data_.callbacks_[index].cb_), status);
-
+                    PIKA_INVOKE(PIKA_MOVE(mpi_data_.callbacks_[index].cb_), status);
                     pika::threads::detail::decrement_global_activity_count();
                 }
             } while (event_handled == true);
@@ -682,8 +651,8 @@ namespace pika::mpi::experimental {
             {
                 std::unique_lock<detail::mutex_type> lk(detail::mpi_data_.polling_vector_mtx_);
                 bool request_queue_empty =
-                    detail::mpi_data_.request_callback_queue_.size_approx() == 0;
-                bool requests_empty = detail::mpi_data_.all_in_flight_ == 0;
+                    (detail::mpi_data_.request_callback_queue_.size_approx() == 0);
+                bool requests_empty = (detail::mpi_data_.all_in_flight_ == 0);
                 lk.unlock();
                 PIKA_ASSERT_MSG(request_queue_empty,
                     "MPI request polling was disabled while there are unprocessed MPI requests. "
@@ -729,10 +698,7 @@ namespace pika::mpi::experimental {
     }    // namespace detail
 
     // -------------------------------------------------------------
-    size_t get_work_count()
-    {
-        return detail::mpi_data_.active_requests_size_ + detail::mpi_data_.request_queue_size_;
-    }
+    size_t get_work_count() { return detail::mpi_data_.all_in_flight_; }
 
     // -------------------------------------------------------------
     void set_max_polling_size(std::size_t p) { detail::mpi_data_.max_polling_requests = p; }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -905,7 +905,10 @@ namespace pika::mpi::experimental {
         PIKA_DETAIL_DP(detail::mpi_debug<5>,
             debug(str<>("Clearing mode"), detail::mpi_data_, "disable_user_polling"));
 
-        if (pool_name.empty()) { detail::unregister_polling(pika::resource::get_thread_pool(0)); }
+        if (pool_name.empty())
+        {
+            detail::unregister_polling(pika::resource::get_thread_pool(get_pool_name()));
+        }
         else { detail::unregister_polling(pika::resource::get_thread_pool(pool_name)); }
     }
 }    // namespace pika::mpi::experimental

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,11 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests #
-    algorithm_transform_mpi #
-    mpi_ring_async_sender_receiver #
-    # mpi_async_storage
-)
+set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver)
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,8 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests # algorithm_transform_mpi
-    mpi_ring_async_sender_receiver
+set(tests #
+    algorithm_transform_mpi #
+    mpi_ring_async_sender_receiver #
     # mpi_async_storage
 )
 
@@ -23,7 +24,7 @@ set(mpi_async_storage_PARAMETERS
 )
 # cmake-format: on
 
-set(algorithm_transform_mpi_PARAMETERS RANKS 2 MPIWRAPPER)
+set(algorithm_transform_mpi_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)
 
 foreach(test ${tests})

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -32,7 +32,6 @@ foreach(test ${tests})
 
   source_group("Source Files" FILES ${sources})
 
-  # add example executable
   pika_add_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
@@ -41,6 +40,18 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/AsyncMPI"
   )
 
+  foreach(polling_mode RANGE 0 63 1)
+    pika_add_pseudo_target(${test}_mode_${polling_mode}_test)
+    pika_add_pseudo_dependencies(${test}_mode_${polling_mode}_test ${test}_test)
+    pika_add_unit_test(
+      "modules.async_mpi"
+      ${test}_mode_${polling_mode}
+      ${${test}_PARAMETERS}
+      EXECUTABLE
+      ${test}_test
+      ARGS
+      "--pika:mpi-completion-mode=${polling_mode}"
+    )
+  endforeach()
   pika_add_unit_test("modules.async_mpi" ${test} ${${test}_PARAMETERS})
-
 endforeach()

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -6,11 +6,10 @@
 
 #include <pika/exception.hpp>
 #include <pika/execution.hpp>
+#include <pika/execution_base/tests/algorithm_test_utils.hpp>
 #include <pika/init.hpp>
 #include <pika/mpi.hpp>
 #include <pika/testing.hpp>
-
-#include "algorithm_test_utils.hpp"
 
 #include <atomic>
 #include <cstdlib>
@@ -46,16 +45,15 @@ int pika_main()
         {
             // Use the custom error handler from the async_mpi module which throws
             // exceptions on error returned
-            mpi::enable_user_polling enable_polling("", true);
+            mpi::enable_user_polling enable_polling(mpi::get_pool_name(), true);
             // Success path
             {
                 // MPI function pointer
                 int data = 0, count = 1;
                 if (rank == 0) { data = 42; }
                 auto s = mpi::transform_mpi(ex::just(&data, count, datatype, 0, comm), MPI_Ibcast);
-                auto result = tt::sync_wait(PIKA_MOVE(s));
-                if (rank != 0) { PIKA_TEST_EQ(data, 42); }
-                if (rank == 0) { PIKA_TEST(result == MPI_SUCCESS); }
+                tt::sync_wait(PIKA_MOVE(s));
+                PIKA_TEST_EQ(data, 42);
             }
 
             {
@@ -67,9 +65,8 @@ int pika_main()
                         MPI_Request* request) {
                         return MPI_Ibcast(data, count, datatype, i, comm, request);
                     });
-                auto result = tt::sync_wait(PIKA_MOVE(s));
-                if (rank != 0) { PIKA_TEST_EQ(data, 42); }
-                if (rank == 0) { PIKA_TEST(result == MPI_SUCCESS); }
+                tt::sync_wait(PIKA_MOVE(s));
+                PIKA_TEST_EQ(data, 42);
             }
 
             {
@@ -82,7 +79,7 @@ int pika_main()
                         MPI_Ibcast(data, count, datatype, i, comm, request);
                     });
                 tt::sync_wait(PIKA_MOVE(s));
-                if (rank != 0) { PIKA_TEST_EQ(data, 42); }
+                PIKA_TEST_EQ(data, 42);
             }
 
             // transform_mpi should be able to handle reference types (by copying
@@ -95,7 +92,7 @@ int pika_main()
                         MPI_Ibcast(&data, count, datatype, 0, comm, request);
                     });
                 tt::sync_wait(PIKA_MOVE(s));
-                if (rank != 0) { PIKA_TEST_EQ(data, 42); }
+                PIKA_TEST_EQ(data, 42);
             }
 
             {
@@ -104,7 +101,7 @@ int pika_main()
                 custom_type<int> c{tag_invoke_overload_called, 0};
                 if (rank == 0) { c.x = 3; }
                 auto s = mpi::transform_mpi(c);
-                tt::sync_wait(s);
+                tt::sync_wait(std::move(s));
                 if (rank == 0) { PIKA_TEST_EQ(c.x, 3); }
                 PIKA_TEST(tag_invoke_overload_called);
             }
@@ -114,10 +111,9 @@ int pika_main()
                 // MPI function pointer
                 int data = 0, count = 1;
                 if (rank == 0) { data = 42; }
-                auto result = tt::sync_wait(
+                tt::sync_wait(
                     ex::just(&data, count, datatype, 0, comm) | mpi::transform_mpi(MPI_Ibcast));
                 if (rank != 0) { PIKA_TEST_EQ(data, 42); }
-                if (rank == 0) { PIKA_TEST(result == MPI_SUCCESS); }
             }
 
             // Failure path
@@ -191,19 +187,18 @@ int pika_main()
                 }
                 catch (pika::exception const& e)
                 {
-                    PIKA_TEST_EQ(e.get_error(), pika::error::invalid_status);
-
-                    // Different MPI implementations print different error
-                    // messages. We handle MPICH and OpenMPI explicitly and
-                    // hope that for the rest it's enough to check that a
-                    // pika::exception was thrown with invalid_status.
-#if defined(MPICH)
-                    PIKA_TEST(std::string(e.what()).find(std::string("Invalid datatype")) !=
-                        std::string::npos);
-#elif defined(OPEN_MPI)
-                    PIKA_TEST(std::string(e.what()).find(std::string("MPI_ERR_TYPE")) !=
-                        std::string::npos);
-#endif
+                    // Different MPI implementations print different error messages.
+                    bool err_ok = (e.get_error() == pika::error::bad_function_call) ||
+                        (e.get_error() == pika::error::invalid_status);
+                    PIKA_TEST_MSG(err_ok, "Returned error code was not in expected list");
+                    std::vector<std::string> err_msgs = {
+                        "null datatype", "Invalid datatype", "MPI_ERR_TYPE"};
+                    bool msg_ok = false;
+                    for (const auto& msg : err_msgs)
+                    {
+                        msg_ok |= (std::string(e.what()).find(msg) != std::string::npos);
+                    }
+                    PIKA_TEST_MSG(msg_ok, "Error message did not contain expected string");
                     exception_thrown = true;
                 }
                 PIKA_TEST(exception_thrown);
@@ -234,19 +229,33 @@ int pika_main()
         }
     }
 
-    test_adl_isolation(mpi::transform_mpi(my_namespace::my_sender{}, [](MPI_Request) {}));
+    test_adl_isolation(mpi::transform_mpi(my_namespace::my_sender{}, [](MPI_Request*) {}));
 
     pika::finalize();
     return EXIT_SUCCESS;
 }
 
+//----------------------------------------------------------------------------
+void init_resource_partitioner_handler(
+    pika::resource::partitioner&, pika::program_options::variables_map const& /*vm*/)
+{
+    namespace mpix = pika::mpi::experimental;
+    mpix::create_pool("", mpix::pool_create_mode::pika_decides);
+}
+
+//----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     MPI_Init(&argc, &argv);
 
-    auto result = pika::init(pika_main, argc, argv);
+    // Set runtime initialization callback to init thread_pools
+    pika::init_params init_args;
+    init_args.rp_callback = &init_resource_partitioner_handler;
+
+    // Start runtime and collect runtime exit status
+    auto result = pika::init(pika_main, argc, argv, init_args);
+    PIKA_TEST_EQ(result, 0);
 
     MPI_Finalize();
-
     return result;
 }

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -16,6 +16,7 @@
 #include <mpi.h>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace ex = pika::execution::experimental;
 namespace mpi = pika::mpi::experimental;

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -114,7 +114,7 @@ int pika_main()
                 if (rank == 0) { data = 42; }
                 tt::sync_wait(
                     ex::just(&data, count, datatype, 0, comm) | mpi::transform_mpi(MPI_Ibcast));
-                if (rank != 0) { PIKA_TEST_EQ(data, 42); }
+                PIKA_TEST_EQ(data, 42);
             }
 
             // Failure path
@@ -189,8 +189,7 @@ int pika_main()
                 catch (pika::exception const& e)
                 {
                     // Different MPI implementations print different error messages.
-                    bool err_ok = (e.get_error() == pika::error::bad_function_call) ||
-                        (e.get_error() == pika::error::invalid_status);
+                    bool err_ok = (e.get_error() == pika::error::bad_function_call);
                     PIKA_TEST_MSG(err_ok, "Returned error code was not in expected list");
                     std::vector<std::string> err_msgs = {
                         "null datatype", "Invalid datatype", "MPI_ERR_TYPE"};

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -21,6 +21,7 @@
 //
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
@@ -427,7 +428,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
 
         // the user queue should always be empty by now since our counter tracks it
-        PIKA_ASSERT(mpix::get_work_count() == 0);
+        PIKA_TEST_EQ(mpix::get_work_count(), static_cast<std::size_t>(0));
 
         double elapsed = t.elapsed();
 

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -328,6 +328,7 @@ struct message_receiver
 // this is called on a pika thread after the runtime starts up
 int pika_main(pika::program_options::variables_map& vm)
 {
+    [[maybe_unused]] pika::scoped_annotation annotate("mpi_ring_test");
     // Do not initialize mpi (we do that ourselves), do install an error handler
     mpix::init(false, true);
     // Setup mpi polling on default pool, enable exceptions and init mpi internals

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -308,15 +308,6 @@ struct message_receiver
 };
 
 // ------------------------------------------------------------
-int call_mpi_irecv(void* buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm,
-    MPI_Request* request)
-{
-    int res = MPI_Irecv(buf, count, datatype, source, tag, comm, request);
-    msr_deb<6>.debug(str<>("MPI_Irecv"), dec<5>(count));
-    return res;
-}
-
-// ------------------------------------------------------------
 // this is called on a pika thread after the runtime starts up
 int pika_main(pika::program_options::variables_map& vm)
 {

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -487,8 +487,6 @@ void init_resource_partitioner_handler(
     if (vm["no-mpi-pool"].as<bool>()) { pool_mode = mpix::pool_create_mode::force_no_create; }
 
     mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
-    std::cout << "init_resource_partitioner_handler enable optimizations "
-              << vm["mpi-optimizations"].as<bool>() << std::endl;
 
     msr_deb<2>.debug(str<>("init RP"), "create_pool");
     mpix::create_pool("", pool_mode);

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -459,8 +459,7 @@ void init_resource_partitioner_handler(
     auto pool_mode = mpix::pool_create_mode::pika_decides;
     if (vm["no-mpi-pool"].as<bool>()) { pool_mode = mpix::pool_create_mode::force_no_create; }
 
-    if (vm["mpi-optimizations"].as<bool>()) { mpix::enable_optimizations(true); }
-    else { mpix::enable_optimizations(false); }
+    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
     std::cout << "init_resource_partitioner_handler enable optimizations "
               << vm["mpi-optimizations"].as<bool>() << std::endl;
 
@@ -523,8 +522,6 @@ int main(int argc, char* argv[])
     po::variables_map vm;
     po::store(po::command_line_parser(argc, argv).options(cmdline).allow_unregistered().run(), vm);
     po::notify(vm);
-
-    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
 
     // -----------------
     // Init MPI

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -8,6 +8,7 @@
 #include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/debugging/print.hpp>
 #include <pika/execution.hpp>
+#include <pika/execution_base/this_thread.hpp>
 #include <pika/init.hpp>
 #include <pika/mpi.hpp>
 #include <pika/program_options.hpp>
@@ -416,7 +417,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
 
         // don't exit until all messages are drained
-        while (counter > 0) { pika::this_thread::yield(); }
+        pika::util::yield_while([&] { return counter > 0; });
         if (output)
         {
             // clang-format off

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -7,6 +7,7 @@
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
 #include <pika/command_line_handling/command_line_handling.hpp>
+#include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/command_line_handling/parse_command_line.hpp>
 #include <pika/debugging/attach_debugger.hpp>
 #include <pika/functional/detail/reset_function.hpp>
@@ -398,7 +399,9 @@ namespace pika::detail {
     std::size_t handle_mpi_completion_mode(
         detail::manage_config& cfgmap, pika::program_options::variables_map& vm)
     {
-        std::size_t completion_mode = cfgmap.get_value<std::size_t>("pika.mpi.completion_mode", 0);
+        int def_val = pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE", 0);
+        std::size_t completion_mode =
+            cfgmap.get_value<std::size_t>("pika.mpi.completion_mode", def_val);
 
         if (vm.count("pika:mpi-completion-mode"))
         {

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -394,6 +394,21 @@ namespace pika::detail {
         }
     }
 
+#if defined(PIKA_HAVE_MPI)
+    std::size_t handle_mpi_completion_mode(
+        detail::manage_config& cfgmap, pika::program_options::variables_map& vm)
+    {
+        std::size_t completion_mode = cfgmap.get_value<std::size_t>("pika.mpi.completion_mode", 0);
+
+        if (vm.count("pika:mpi-completion-mode"))
+        {
+            completion_mode = vm["pika:mpi-completion-mode"].as<std::size_t>();
+        }
+
+        return completion_mode;
+    }
+#endif
+
     ///////////////////////////////////////////////////////////////////////////
     void command_line_handling::handle_arguments(detail::manage_config& cfgmap,
         pika::program_options::variables_map& vm, std::vector<std::string>& ini_config)
@@ -531,6 +546,11 @@ namespace pika::detail {
             ini_config.emplace_back("pika.thread_queue.high_priority_queues!=" +
                 std::to_string(num_high_priority_queues));
         }
+
+#if defined(PIKA_HAVE_MPI)
+        std::size_t const mpi_completion_mode = detail::handle_mpi_completion_mode(cfgmap, vm);
+        ini_config.emplace_back("pika.mpi.completion_mode=" + std::to_string(mpi_completion_mode));
+#endif
 
         update_logging_settings(vm, ini_config);
 

--- a/libs/pika/command_line_handling/src/parse_command_line.cpp
+++ b/libs/pika/command_line_handling/src/parse_command_line.cpp
@@ -338,6 +338,11 @@ namespace pika::detail {
                 "allowed values: 0 - no NUMA sensitivity, 1 - allow only for "
                 "boundary cores to steal across NUMA domains, 2 - "
                 "no cross boundary stealing is allowed (default value: 0)")
+#if defined(PIKA_HAVE_MPI)
+            ("pika:mpi-completion-mode", value<std::size_t>(),
+                "the pika MPI polling completion mode (only available if MPI "
+                "built with MPI support)")
+#endif
         ;
 
         options_description config_options("pika configuration options");

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -286,7 +286,7 @@ namespace pika::execution::experimental {
 #endif
         /// \endcond
 
-    private:
+    protected:
         /// \cond NOINTERNAL
         char const* get_fallback_annotation() const
         {
@@ -312,6 +312,7 @@ namespace pika::execution::experimental {
             return "<unknown>";
         }
 
+    protected:
         pika::threads::detail::thread_pool_base* pool_ =
             pika::threads::detail::get_self_or_default_pool();
         pika::execution::thread_priority priority_ = pika::execution::thread_priority::normal;

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_queue_bypass.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_queue_bypass.hpp
@@ -1,0 +1,419 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <pika/config.hpp>
+#include <pika/assert.hpp>
+#include <pika/coroutines/thread_enums.hpp>
+#include <pika/errors/try_catch_exception_ptr.hpp>
+#include <pika/execution/algorithms/execute.hpp>
+#include <pika/execution/algorithms/schedule_from.hpp>
+#include <pika/execution_base/receiver.hpp>
+#include <pika/execution_base/sender.hpp>
+#include <pika/execution_base/this_thread.hpp>
+#include <pika/executors/thread_pool_scheduler_queue_bypass.hpp>
+#include <pika/threading_base/annotated_function.hpp>
+#include <pika/threading_base/register_thread.hpp>
+#include <pika/threading_base/thread_data.hpp>
+#include <pika/threading_base/thread_description.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace pika { namespace execution { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////
+    using namespace pika::threads::detail;
+    class switch_status_background
+    {
+    public:
+        switch_status_background(thread_id_ref_type const& t, thread_state prev_state)
+          : thread_(t)
+          , prev_state_(prev_state)
+          , next_thread_id_(nullptr)
+          , need_restore_state_(get_thread_id_data(thread_)->set_state_tagged(
+                thread_schedule_state::active, prev_state_, orig_state_, std::memory_order_relaxed))
+        {
+        }
+
+        ~switch_status_background()
+        {
+            if (need_restore_state_) { store_state(prev_state_); }
+        }
+
+        bool is_valid() const { return need_restore_state_; }
+
+        // allow to change the state the thread will be switched to after
+        // execution
+        thread_state operator=(thread_result_type&& new_state)
+        {
+            prev_state_ =
+                thread_state(new_state.first, prev_state_.state_ex(), prev_state_.tag() + 1);
+            next_thread_id_ = PIKA_MOVE(new_state.second);
+            return prev_state_;
+        }
+
+        // Get the state this thread was in before execution (usually pending),
+        // this helps making sure no other worker-thread is started to execute this
+        // pika-thread in the meantime.
+        thread_schedule_state get_previous() const { return prev_state_.state(); }
+
+        // This restores the previous state, while making sure that the
+        // original state has not been changed since we started executing this
+        // thread. The function returns true if the state has been set, false
+        // otherwise.
+        bool store_state(thread_state& newstate)
+        {
+            disable_restore();
+            if (get_thread_id_data(thread_)->restore_state(
+                    prev_state_, orig_state_, std::memory_order_relaxed, std::memory_order_relaxed))
+            {
+                newstate = prev_state_;
+                return true;
+            }
+            return false;
+        }
+
+        // disable default handling in destructor
+        void disable_restore() { need_restore_state_ = false; }
+
+        thread_id_ref_type const& get_next_thread() const { return next_thread_id_; }
+
+        thread_id_ref_type move_next_thread() { return PIKA_MOVE(next_thread_id_); }
+
+    private:
+        thread_id_ref_type const& thread_;
+        thread_state prev_state_;
+        thread_state orig_state_;
+        thread_id_ref_type next_thread_id_;
+        bool need_restore_state_;
+    };
+
+    struct thread_pool_scheduler_queue_bypass : thread_pool_scheduler
+    {
+        using thread_pool_scheduler::get_fallback_annotation;
+        using thread_pool_scheduler::thread_pool_scheduler;
+        using thread_pool_scheduler::operator==;
+        using thread_pool_scheduler::operator!=;
+
+        // support with_priority property
+        friend thread_pool_scheduler_queue_bypass tag_invoke(
+            pika::execution::experimental::with_priority_t,
+            thread_pool_scheduler_queue_bypass const& scheduler,
+            pika::execution::thread_priority priority)
+        {
+            auto sched_with_priority = scheduler;
+            sched_with_priority.priority_ = priority;
+            return sched_with_priority;
+        }
+
+        friend pika::execution::thread_priority tag_invoke(
+            pika::execution::experimental::get_priority_t,
+            thread_pool_scheduler_queue_bypass const& scheduler)
+        {
+            return scheduler.priority_;
+        }
+
+        // support with_stacksize property
+        friend thread_pool_scheduler_queue_bypass tag_invoke(
+            pika::execution::experimental::with_stacksize_t,
+            thread_pool_scheduler_queue_bypass const& scheduler,
+            pika::execution::thread_stacksize stacksize)
+        {
+            auto sched_with_stacksize = scheduler;
+            sched_with_stacksize.stacksize_ = stacksize;
+            return sched_with_stacksize;
+        }
+
+        friend pika::execution::thread_stacksize tag_invoke(
+            pika::execution::experimental::get_stacksize_t,
+            thread_pool_scheduler_queue_bypass const& scheduler)
+        {
+            return scheduler.stacksize_;
+        }
+
+        // support with_hint property
+        friend thread_pool_scheduler_queue_bypass tag_invoke(
+            pika::execution::experimental::with_hint_t,
+            thread_pool_scheduler_queue_bypass const& scheduler,
+            pika::execution::thread_schedule_hint hint)
+        {
+            auto sched_with_hint = scheduler;
+            sched_with_hint.schedulehint_ = hint;
+            return sched_with_hint;
+        }
+
+        friend pika::execution::thread_schedule_hint tag_invoke(
+            pika::execution::experimental::get_hint_t,
+            thread_pool_scheduler_queue_bypass const& scheduler)
+        {
+            return scheduler.schedulehint_;
+        }
+
+        // support with_annotation property
+        friend constexpr thread_pool_scheduler_queue_bypass tag_invoke(
+            pika::execution::experimental::with_annotation_t,
+            thread_pool_scheduler_queue_bypass const& scheduler, char const* annotation)
+        {
+            auto sched_with_annotation = scheduler;
+            sched_with_annotation.annotation_ = annotation;
+            return sched_with_annotation;
+        }
+
+        friend thread_pool_scheduler_queue_bypass tag_invoke(
+            pika::execution::experimental::with_annotation_t,
+            thread_pool_scheduler_queue_bypass const& scheduler, std::string annotation)
+        {
+            auto sched_with_annotation = scheduler;
+            sched_with_annotation.annotation_ =
+                pika::detail::store_function_annotation(PIKA_MOVE(annotation));
+            return sched_with_annotation;
+        }
+
+        // support get_annotation property
+        friend constexpr char const* tag_invoke(pika::execution::experimental::get_annotation_t,
+            thread_pool_scheduler_queue_bypass const& scheduler) noexcept
+        {
+            return scheduler.annotation_;
+        }
+
+        template <typename F>
+        void execute(F&& f, char const* fallback_annotation) const
+        {
+#if 0
+            pika::detail::thread_description desc(f, fallback_annotation);
+            threads::detail::thread_init_data data(
+                threads::detail::make_thread_function_nullary(
+                    PIKA_FORWARD(F, f)),
+                desc, priority_, schedulehint_, stacksize_);
+            threads::detail::register_work(data, pool_);
+#else
+            using namespace pika::threads::detail;
+            using namespace pika::detail;
+            // which thread index are we
+            const std::int16_t thread_num = get_local_thread_num_tss();
+            thread_description desc(f, fallback_annotation);
+
+            // create thread using pending_do_not_scheduleto bypass queue insertion
+            thread_init_data data(make_thread_function_nullary(PIKA_FORWARD(F, f)), desc, priority_,
+                thread_schedule_hint(thread_num), stacksize_,
+                thread_schedule_state::pending_do_not_schedule, true /* run_now */
+            );
+            data.scheduler_base = pool_->get_scheduler();
+
+            // threads::detail::register_work(data, pool_);
+            thread_id_ref_type id = invalid_thread_id;
+            pika::error_code ec = throws;
+            data.scheduler_base->create_thread(data, &id, ec);
+            data.initial_state = thread_schedule_state::pending;
+
+            thread_data* threaddata = get_thread_id_data(id);
+            thread_state state = threaddata->get_state(std::memory_order_relaxed);
+
+            switch_status_background thrd_stat(id, state);
+
+            if (PIKA_LIKELY(thrd_stat.is_valid() &&
+                    thrd_stat.get_previous() == thread_schedule_state::pending))
+            {
+                pika::execution::this_thread::detail::agent_storage* context_storage =
+                    pika::execution::this_thread::detail::get_agent_storage();
+
+                // invoke thread callable
+                thrd_stat = (*threaddata)(context_storage);
+
+                thread_id_ref_type next = thrd_stat.move_next_thread();
+                if (next != nullptr && next != id)
+                {
+                    thread_id_ref_type next_thrd;
+                    if (next_thrd == nullptr) { next_thrd = PIKA_MOVE(next); }
+                    else
+                    {
+                        auto* scheduler = get_thread_id_data(next)->get_scheduler_base();
+                        scheduler->schedule_thread(PIKA_MOVE(next),
+                            execution::thread_schedule_hint(static_cast<std::int16_t>(thread_num)),
+                            true);
+                        scheduler->do_some_work(thread_num);
+                    }
+                }
+                thrd_stat.store_state(state);
+                //
+                switch (state.state())
+                {
+                case thread_schedule_state::pending_boost:
+                    // might happen? reset to pending and schedule it
+                    threaddata->set_state(thread_schedule_state::pending);
+                    // fallthrough
+                case thread_schedule_state::pending:
+                    data.scheduler_base->schedule_thread(id, thread_schedule_hint(thread_num),
+                        false /*allow_fallback*/, execution::thread_priority::high);
+                    break;
+                case thread_schedule_state::terminated:
+                    // thread goes into terminated items and gets cleaned up
+                case thread_schedule_state::suspended:
+                    // thread sits in thread map until resumed
+                    return;
+                default: throw std::runtime_error("fix this thread state type");
+                }
+            }
+#endif
+        }
+
+        template <typename F>
+        friend void tag_invoke(execute_t, thread_pool_scheduler_queue_bypass const& sched, F&& f)
+        {
+            sched.execute(PIKA_FORWARD(F, f), sched.get_fallback_annotation());
+        }
+        /*
+        template <typename Scheduler, typename Receiver>
+        struct operation_state
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            char const* fallback_annotation;
+
+            template <typename Scheduler_, typename Receiver_>
+            operation_state(Scheduler_&& scheduler, Receiver_&& receiver,
+                char const* fallback_annotation)
+              : scheduler(PIKA_FORWARD(Scheduler_, scheduler))
+              , receiver(PIKA_FORWARD(Receiver_, receiver))
+              , fallback_annotation(fallback_annotation)
+            {
+                PIKA_ASSERT(fallback_annotation != nullptr);
+            }
+
+            operation_state(operation_state&&) = delete;
+            operation_state(operation_state const&) = delete;
+            operation_state& operator=(operation_state&&) = delete;
+            operation_state& operator=(operation_state const&) = delete;
+
+            friend void tag_invoke(start_t, operation_state& os) noexcept
+            {
+                pika::detail::try_catch_exception_ptr(
+                    [&]() {
+                        os.scheduler.execute(
+                            [receiver = PIKA_MOVE(os.receiver)]() mutable {
+                                pika::execution::experimental::set_value(
+                                    PIKA_MOVE(receiver));
+                            },
+                            os.fallback_annotation);
+                    },
+                    [&](std::exception_ptr ep) {
+                        pika::execution::experimental::set_error(
+                            PIKA_MOVE(os.receiver), PIKA_MOVE(ep));
+                    });
+            }
+        };
+
+        template <typename Scheduler>
+        struct sender
+        {
+            PIKA_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+
+            // We explicitly get the fallback annotation when constructing the
+            // sender so that if the scheduler has no annotation, the annotation
+            // is instead taken from the context creating the sender, not from
+            // the context when the task is actually spawned (if different).
+            char const* fallback_annotation =
+                scheduler.get_fallback_annotation();
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<>>;
+
+            template <template <typename...> class Variant>
+            using error_types = Variant<std::exception_ptr>;
+
+            static constexpr bool sends_done = false;
+
+            using completion_signatures =
+                pika::execution::experimental::completion_signatures<
+                    pika::execution::experimental::set_value_t(),
+                    pika::execution::experimental::set_error_t(
+                        std::exception_ptr)>;
+
+            template <typename Receiver>
+            friend operation_state<Scheduler, Receiver> tag_invoke(
+                connect_t, sender&& s, Receiver&& receiver)
+            {
+                return {PIKA_MOVE(s.scheduler),
+                    PIKA_FORWARD(Receiver, receiver), s.fallback_annotation};
+            }
+
+            template <typename Receiver>
+            friend operation_state<Scheduler, Receiver> tag_invoke(
+                connect_t, sender& s, Receiver&& receiver)
+            {
+                return {s.scheduler, PIKA_FORWARD(Receiver, receiver),
+                    s.fallback_annotation};
+            }
+
+            template <typename CPO,
+                PIKA_CONCEPT_REQUIRES_(std::is_same_v<CPO,
+                    pika::execution::experimental::set_value_t>)>
+            friend constexpr auto tag_invoke(
+                pika::execution::experimental::get_completion_scheduler_t<CPO>,
+                sender const& s) noexcept
+            {
+                return s.scheduler;
+            }
+        };
+*/
+        friend sender<thread_pool_scheduler_queue_bypass> tag_invoke(
+            schedule_t, thread_pool_scheduler_queue_bypass&& sched)
+        {
+            return {PIKA_MOVE(sched)};
+        }
+
+        friend sender<thread_pool_scheduler_queue_bypass> tag_invoke(
+            schedule_t, thread_pool_scheduler_queue_bypass const& sched)
+        {
+            return {sched};
+        }
+
+        // We customize schedule_from to customize transfer. We want transfer to
+        // take the annotation from the calling context of transfer if needed
+        // and available. If we don't customize schedule_from the schedule
+        // customization will be called much later by the schedule_from default
+        // implementation, and the annotation may no longer come from the
+        // calling context  of transfer.
+        //
+        // This updates the annotation of the scheduler with
+        // get_fallback_annotation. If scheduler already has an annotation it
+        // will simply set the same annotation. However, if scheduler doesn't
+        // have an annotation set it will get it from the context calling
+        // transfer if available, and otherwise fall back to the default
+        // annotation. Once the scheduler annotation has been updated we
+        // construct a sender from the default schedule_from implementation.
+        //
+        // TODO: Can we simply dispatch to the default implementation? This is
+        // disabled with the P2300 reference implementation because we don't
+        // want to use implementation details of it.
+#if !defined(PIKA_HAVE_P2300_REFERENCE_IMPLEMENTATION)
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend auto tag_invoke(schedule_from_t, thread_pool_scheduler_queue_bypass&& scheduler,
+            Sender&& predecessor_sender)
+        {
+            return schedule_from_detail::schedule_from_sender<Sender,
+                thread_pool_scheduler_queue_bypass>{PIKA_FORWARD(Sender, predecessor_sender),
+                with_annotation(PIKA_MOVE(scheduler), scheduler.get_fallback_annotation())};
+        }
+
+        template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
+        friend auto tag_invoke(schedule_from_t, thread_pool_scheduler_queue_bypass const& scheduler,
+            Sender&& predecessor_sender)
+        {
+            return schedule_from_detail::schedule_from_sender<Sender,
+                thread_pool_scheduler_queue_bypass>{PIKA_FORWARD(Sender, predecessor_sender),
+                with_annotation(scheduler, scheduler.get_fallback_annotation())};
+        }
+#endif
+        /// \endcond
+    };
+}}}    // namespace pika::execution::experimental

--- a/libs/pika/init_runtime/CMakeLists.txt
+++ b/libs/pika/init_runtime/CMakeLists.txt
@@ -14,7 +14,7 @@ set(init_runtime_headers
 set(init_runtime_sources init_logging.cpp init_runtime.cpp scoped_finalize.cpp)
 
 if(PIKA_WITH_MPI)
-  list(APPEND init_runtime_additional_module_dependencies pika_mpi_base)
+  list(APPEND init_runtime_additional_module_dependencies pika_mpi_base pika_async_mpi)
 endif()
 
 include(pika_add_module)

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -41,6 +41,10 @@
 #include <pika/util/get_entry_as.hpp>
 #include <pika/version.hpp>
 
+#if defined(PIKA_HAVE_MPI)
+# include <pika/async_mpi/mpi_polling.hpp>
+#endif
+
 #if defined(PIKA_HAVE_HIP)
 # include <hip/hip_runtime.h>
 # include <whip.hpp>
@@ -134,6 +138,10 @@ namespace pika {
                 cmdline.rtcfg_.get_spinlock_deadlock_detection_limit());
             pika::util::detail::set_spinlock_deadlock_warning_limit(
                 cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
+#endif
+#ifdef PIKA_HAVE_MPI
+            pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
+                cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
             init_logging(cmdline.rtcfg_);
         }

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -189,6 +189,11 @@ namespace pika::util {
             "${PIKA_THREAD_QUEUE_INIT_THREADS_COUNT:" PIKA_PP_STRINGIZE(
                 PIKA_PP_EXPAND(PIKA_THREAD_QUEUE_INIT_THREADS_COUNT)) "}",
 
+#if defined(PIKA_HAVE_MPI)
+            "[pika.mpi]",
+            "completion_mode = ${PIKA_MPI_COMPLETION_MODE:0}",
+#endif
+
             "[pika.commandline]",
 
             // allow for unknown options to be passed through

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -598,8 +598,10 @@ namespace pika::threads::detail {
                     "execution::thread_priority::high");
                 return true;
             }
+#ifdef PIKA_DEBUG
             // if we're out of work in the main queues,
             debug_queues("get_next_thread");
+#endif
             return false;
         }
 
@@ -623,8 +625,10 @@ namespace pika::threads::detail {
                     "execution::thread_priority::low");
                 return true;
             }
+#ifdef PIKA_DEBUG
             // if we're out of work in the main queues,
             debug_queues("get_next_thread");
+#endif
             return false;
         }
 
@@ -679,7 +683,9 @@ namespace pika::threads::detail {
             count += owns_hp_queue() ? hp_queue_->get_queue_length() : 0;
             count += owns_np_queue() ? np_queue_->get_queue_length() : 0;
             count += owns_lp_queue() ? lp_queue_->get_queue_length() : 0;
+#ifdef PIKA_DEBUG
             debug_queues("get_queue_length");
+#endif
             return count;
         }
 

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
@@ -185,6 +185,9 @@ namespace pika::threads::detail {
 
             PIKA_ASSERT(data.stacksize != execution::thread_stacksize::current);
 
+            bool schedule_now =
+                data.initial_state == threads::detail::thread_schedule_state::pending;
+
             if (data.run_now)
             {
                 threads::detail::thread_id_ref_type tid;
@@ -192,7 +195,7 @@ namespace pika::threads::detail {
                 holder_->add_to_thread_map(tid.noref());
 
                 // push the new thread in the pending queue thread
-                if (data.initial_state == threads::detail::thread_schedule_state::pending)
+                if (schedule_now)
                 {
                     // return the thread_id_ref of the newly created thread
                     if (id) { *id = tid; }

--- a/libs/pika/threading_base/include/pika/threading_base/print.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/print.hpp
@@ -8,9 +8,12 @@
 
 #include <pika/config.hpp>
 #include <pika/debugging/print.hpp>
-#include <pika/threading_base/thread_data.hpp>
 
 #include <iosfwd>
+
+namespace pika::threads::detail {
+    class thread_data;    // forward declaration only
+}
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
@@ -51,9 +54,9 @@ namespace pika::debug::detail {
     };
 
     template <>
-    struct threadinfo<threads::detail::thread_id_ref_type*>
+    struct threadinfo<threads::detail::thread_id_ref*>
     {
-        constexpr explicit threadinfo(threads::detail::thread_id_ref_type const* v)
+        constexpr explicit threadinfo(threads::detail::thread_id_ref const* v)
           : data(v)
         {
         }
@@ -75,5 +78,19 @@ namespace pika::debug::detail {
 
         PIKA_EXPORT friend std::ostream& operator<<(std::ostream& os, threadinfo const& d);
     };
+
+    template <>
+    struct threadinfo<std::size_t*>
+    {
+        constexpr explicit threadinfo(std::size_t const* v)
+          : data(*v)
+        {
+        }
+
+        std::size_t const data;
+
+        PIKA_EXPORT friend std::ostream& operator<<(std::ostream& os, threadinfo const& d);
+    };
+
 }    // namespace pika::debug::detail
 /// \endcond

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -24,8 +24,11 @@ namespace pika::debug::detail {
 
     std::ostream& operator<<(std::ostream& os, threadinfo<threads::detail::thread_data*> const& d)
     {
-        os << ptr(d.data) << " \"" << ((d.data != nullptr) ? d.data->get_description() : "nullptr")
-           << "\"";
+        os << ptr(d.data)                                                                       //
+           << " \"" << ((d.data != nullptr) ? d.data->get_description() : "nullptr") << "\""    //
+           << " state:" << ((d.data != nullptr) ? get_thread_state_name(d.data->get_state()) : "")
+           << " state ex:"
+           << ((d.data != nullptr) ? get_thread_state_ex_name(d.data->get_state().state_ex()) : "");
         return os;
     }
 
@@ -53,6 +56,12 @@ namespace pika::debug::detail {
 #else
         os << "??? " << /*hex<8,uintptr_t>*/ (std::uintptr_t(&d.data));
 #endif
+        return os;
+    }
+
+    std::ostream& operator<<(std::ostream& os, threadinfo<std::size_t*> const& d)
+    {
+        os << d.data;
         return os;
     }
 

--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -33,6 +33,7 @@
    match-leak-kinds: definite
    ...
    fun:orte_init
+   ...
 }
 
 {


### PR DESCRIPTION
I would like this to go through testing ASAP, so I'm pushing it, but it can be can be considered a draft PR for now
Relies on #1151 and #1180 

Here, we add a stdexec style scheduler that executes a task/function - it behaves like the main pika scheduling loop - by takinf the function, wrapping it in a task, then switching context to it immediately, so that if the task later tries to suspend, then there are no problems and the task goes ontoo the queues as usual. 

It is an error to call this on a pika thread and is only supported by certain modes of the mpi continuations