### PR TITLE
Suppress another OpenMPI/`orte_init` leak reported by valgrind in MPI tests

### DIFF
--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -37,6 +37,17 @@
 }
 
 {
+   ORTE init
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:hwloc_topology_load
+   ...
+   fun:orte_init
+}
+
+{
    ORTE event loop
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
Suppresses for example leaks like these:
```
==4005== 
==4005== HEAP SUMMARY:
==4005==     in use at exit: 150,473 bytes in 456 blocks
==4005==   total heap usage: 25,629 allocs, 25,173 frees, 5,781,499 bytes allocated
==4005== 
==4005== 40 bytes in 1 blocks are possibly lost in loss record 128 of 265
==4005==    at 0x4845828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==4005==    by 0x4C396F1: hwloc_alloc_setup_object (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==4005==    by 0x4C71CB6: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==4005==    by 0x4C6AB08: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==4005==    by 0x4C67055: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==4005==    by 0x4C42B7A: hwloc_topology_load (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==4005==    by 0x7933C58: ???
==4005==    by 0x795888B: ???
==4005==    by 0x78E9802: ???
==4005==    by 0x48A42B2: pmix_server_init (in /usr/lib/x86_64-linux-gnu/libopen-rte.so.40.30.3)
==4005==    by 0x522BF08: ???
==4005==    by 0x48F1179: orte_init (in /usr/lib/x86_64-linux-gnu/libopen-rte.so.40.30.3)
==4005== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: possible
   fun:malloc
   fun:hwloc_alloc_setup_object
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   fun:hwloc_topology_load
   obj:*
   obj:*
   obj:*
   fun:pmix_server_init
   obj:*
   fun:orte_init
}
==4005== LEAK SUMMARY:
==4005==    definitely lost: 0 bytes in 0 blocks
==4005==    indirectly lost: 21,838 bytes in 312 blocks
==4005==      possibly lost: 40 bytes in 1 blocks
==4005==    still reachable: 113,807 bytes in 121 blocks
==4005==         suppressed: 14,788 bytes in 22 blocks
==4005== Reachable blocks (those to which a pointer was found) are not shown.
==4005== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4005== 
==4005== For lists of detected and suppressed errors, rerun with: -s
==4005== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 20 from 20)

```