### PR TITLE
Use static libraries on a CI configuration without APEX enabled

### DIFF
--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -16,7 +16,7 @@ include:
     SPACK_SPEC: "pika@main +apex arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
                  ^apex@2.6.5 ~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DBUILD_SHARED_LIBS=OFF"
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
 gcc10_apex_spack_compiler_image:
   extends:

--- a/.gitlab/includes/gcc11_pipeline.yml
+++ b/.gitlab/includes/gcc11_pipeline.yml
@@ -17,7 +17,7 @@ include:
                  ^hwloc@2.7.0"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MAX_CPU_COUNT=256 \
                   -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
-                  -DPIKA_WITH_THREAD_DEBUG_INFO=ON"
+                  -DPIKA_WITH_THREAD_DEBUG_INFO=ON -DBUILD_SHARED_LIBS=OFF"
 
 gcc11_spack_compiler_image:
   extends:


### PR DESCRIPTION
I suspect that something related to static libraries are causing problems on the APEX CI configuration: https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/479009878135925/5304355110917878/-/jobs/7312229099#L133. This PR moves `BUILD_SHARED_LIBS=OFF` to another CI configuration to see if that's the case.