### PR TITLE
Update stdexec commit used in CI to `e99073de4c4b924804f54d7f52bc4e9fbcf53b92`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
   docker:
-    - image: pikaorg/pika-ci-base:26
+    - image: pikaorg/pika-ci-base:27
 
 defaults: &defaults
   <<: *working_dir_default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ setup_arm64_machine: &setup_arm64_machine
 
 docker_default: &docker_default
   docker:
-    - image: pikaorg/pika-ci-base:25
+    - image: pikaorg/pika-ci-base:26
 
 defaults: &defaults
   <<: *working_dir_default

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "docker.io/pikaorg/pika-ci-base:25",
+  "image": "docker.io/pikaorg/pika-ci-base:26",
   "features": {},
   "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
   "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "docker.io/pikaorg/pika-ci-base:26",
+  "image": "docker.io/pikaorg/pika-ci-base:27",
   "features": {},
   "onCreateCommand": "cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DPIKA_WITH_MALLOC=system -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON -DPIKA_WITH_TESTS_EXAMPLES=ON -DPIKA_WITH_TESTS_HEADERS=ON -DPIKA_WITH_TESTS_MAX_THREADS=2 -DPIKA_WITH_COMPILER_WARNINGS=ON -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON && cmake --build build --target pika",
   "extensions": [

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/address-undefined-leak
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:25
+      image: pikaorg/pika-ci-base:26
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/address-undefined-leak
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:26
+      image: pikaorg/pika-ci-base:27
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:25
+    container: pikaorg/pika-ci-base:26
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_coverage.yml
+++ b/.github/workflows/linux_coverage.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/coverage
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:26
+    container: pikaorg/pika-ci-base:27
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:26
+    container: pikaorg/pika-ci-base:27
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/debug/fast
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:25
+    container: pikaorg/pika-ci-base:26
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/fetchcontent/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:25
+    container: pikaorg/pika-ci-base:26
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/fetchcontent/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:26
+    container: pikaorg/pika-ci-base:27
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/tracy/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:25
+    container: pikaorg/pika-ci-base:26
 
     steps:
       - name: Check out Tracy

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -20,7 +20,7 @@ jobs:
     name: github/linux/tracy/fast
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:26
+    container: pikaorg/pika-ci-base:27
 
     steps:
       - name: Check out Tracy

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/thread
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:25
+      image: pikaorg/pika-ci-base:26
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -21,7 +21,7 @@ jobs:
     name: github/linux/sanitizers/thread
     runs-on: ubuntu-latest
     container:
-      image: pikaorg/pika-ci-base:26
+      image: pikaorg/pika-ci-base:27
       # --privileged is enabled for sysctl further down.
       options: --privileged
 

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/valgrind
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:26
+    container: pikaorg/pika-ci-base:27
 
     strategy:
       matrix:

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: github/linux/valgrind
     runs-on: ubuntu-latest
-    container: pikaorg/pika-ci-base:25
+    container: pikaorg/pika-ci-base:26
 
     strategy:
       matrix:

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -16,7 +16,7 @@ include:
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} cxxflags=-stdlib=libc++ malloc=system \
                  cxxstd=$CXXSTD +stdexec ^boost@1.79.0 ^hwloc@2.6.0 ^fmt cxxflags=-stdlib=libc++ \
                  ^spdlog cxxflags=-stdlib=libc++ \
-                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
                   -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/clang13_pipeline.yml
+++ b/.gitlab/includes/clang13_pipeline.yml
@@ -16,7 +16,7 @@ include:
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} cxxflags=-stdlib=libc++ malloc=system \
                  cxxstd=$CXXSTD +stdexec ^boost@1.79.0 ^hwloc@2.6.0 ^fmt cxxflags=-stdlib=libc++ \
                  ^spdlog cxxflags=-stdlib=libc++ \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
+                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
                   -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: develop-2024-07-21
+  SPACK_COMMIT: develop-2024-08-18
 
 .base_spack_image:
   timeout: 1 hours

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: 7f3dd38ccc106142846f29f76b928fa58e0e3164
+  SPACK_COMMIT: develop-2024-07-21
 
 .base_spack_image:
   timeout: 1 hours

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -11,7 +11,7 @@ clang14_debug_build_pika-ci-image:
   extends: .container-builder
   needs: []   # To clear the dotenv artifacts
   variables:
-    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:26
+    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:27
     DOCKERFILE: .gitlab/docker/Dockerfile.dockerhub_build
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","BUILD_DIR","SOURCE_DIR"]'
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA

--- a/.gitlab/includes/dockerhub_pipeline.yml
+++ b/.gitlab/includes/dockerhub_pipeline.yml
@@ -11,7 +11,7 @@ clang14_debug_build_pika-ci-image:
   extends: .container-builder
   needs: []   # To clear the dotenv artifacts
   variables:
-    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:25
+    BASE_IMAGE: docker.io/pikaorg/pika-ci-base:26
     DOCKERFILE: .gitlab/docker/Dockerfile.dockerhub_build
     DOCKER_BUILD_ARGS: '["BASE_IMAGE","BUILD_DIR","SOURCE_DIR"]'
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-debug-cpu-clang14:$CI_COMMIT_SHORT_SHA

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
-                 ^fmt@10.0.0 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main \
+                 ^fmt@10.0.0 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main \
                  ^ninja@1.11.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -16,7 +16,8 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
-                 ^fmt@10.0.0 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
+                 ^fmt@10.0.0 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main \
+                 ^ninja@1.11.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 

--- a/.gitlab/includes/gcc12_hip5_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip5_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.79.0 ^hwloc@2.6.0 ^hip@5.5 ^llvm~gold \
-                 ^fmt@10.0.0 ^stdexec@git.d64da3a6188ec2c1492fdeb8590717acad8d5d02=main"
+                 ^fmt@10.0.0 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main \
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main \
                  ^spdlog cxxflags=-D_GLIBCXX_DEBUG cxxflags=-D_GLIBCXX_DEBUG_PEDANTIC \
                  cxxflags=-D_GLIBCXX_DEBUG_BACKTRACE cxxflags=-D_GLIBCXX_ASSERTIONS'"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main \
+                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main \
                  ^spdlog cxxflags=-D_GLIBCXX_DEBUG cxxflags=-D_GLIBCXX_DEBUG_PEDANTIC \
                  cxxflags=-D_GLIBCXX_DEBUG_BACKTRACE cxxflags=-D_GLIBCXX_ASSERTIONS'"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -17,7 +17,8 @@ include:
                  ^boost@1.82.0 ^hwloc@2.9.1 \
                  ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main \
                  ^spdlog cxxflags=-D_GLIBCXX_DEBUG cxxflags=-D_GLIBCXX_DEBUG_PEDANTIC \
-                 cxxflags=-D_GLIBCXX_DEBUG_BACKTRACE cxxflags=-D_GLIBCXX_ASSERTIONS'"
+                 cxxflags=-D_GLIBCXX_DEBUG_BACKTRACE cxxflags=-D_GLIBCXX_ASSERTIONS' \
+                 ^fmt@11.0.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DCMAKE_CXX_FLAGS='-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_DEBUG_BACKTRACE -D_GLIBCXX_ASSERTIONS'"

--- a/.gitlab/includes/gcc13_santis_pipeline.yml
+++ b/.gitlab/includes/gcc13_santis_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/.gitlab/includes/gcc13_santis_pipeline.yml
+++ b/.gitlab/includes/gcc13_santis_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
+                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/.gitlab/includes/gcc14_pipeline.yml
+++ b/.gitlab/includes/gcc14_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main"
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/.gitlab/includes/gcc14_pipeline.yml
+++ b/.gitlab/includes/gcc14_pipeline.yml
@@ -15,7 +15,8 @@ include:
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
                  ^boost@1.82.0 ^hwloc@2.9.1 \
-                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main"
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main \
+                 ^fmt@11.0.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_STDEXEC=ON -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -17,7 +17,7 @@ include:
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.78.0%${NVHPC_COMPILER} ^hwloc@2.7.0 \
-                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main ^cuda@12.4%${NVHPC_COMPILER} \
+                 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main ^cuda@12.4%${NVHPC_COMPILER} \
                  ^whip%${NVHPC_COMPILER}"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/nvhpc23_9_pipeline.yml
+++ b/.gitlab/includes/nvhpc23_9_pipeline.yml
@@ -17,7 +17,7 @@ include:
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.78.0%${NVHPC_COMPILER} ^hwloc@2.7.0 \
-                 ^stdexec@git.b39a506096900de4074ee556867a3805bd8351bd=main ^cuda@12.4%${NVHPC_COMPILER} \
+                 ^stdexec@git.e99073de4c4b924804f54d7f52bc4e9fbcf53b92=main ^cuda@12.4%${NVHPC_COMPILER} \
                  ^whip%${NVHPC_COMPILER}"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"

--- a/.gitlab/includes/nvhpc24_7_pipeline.yml
+++ b/.gitlab/includes/nvhpc24_7_pipeline.yml
@@ -8,11 +8,11 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
   - local: '.gitlab/includes/common_spack_pipeline.yml'
 
-.variables_nvhpc23_9_config:
+.variables_nvhpc24_7_config:
   variables:
     SPACK_ARCH: linux-ubuntu22.04-haswell
-    COMPILER: gcc@12.1.0
-    NVHPC_COMPILER: nvhpc@23.9
+    COMPILER: gcc@14.2.0
+    NVHPC_COMPILER: nvhpc@24.7
     CXXSTD: 20
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${NVHPC_COMPILER} +stdexec +mpi +cuda cuda_arch=${GPU_TARGET} \
@@ -23,37 +23,37 @@ include:
                   -DPIKA_WITH_MPI=ON -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
     PULL_ON_HOST_MACHINE: "YES"
 
-nvhpc23_9_spack_compiler_image:
+nvhpc24_7_spack_compiler_image:
   extends:
-    - .variables_nvhpc23_9_config
+    - .variables_nvhpc24_7_config
     - .compiler_image_template_rosa
 
-nvhpc23_9_spack_image:
-  needs: [nvhpc23_9_spack_compiler_image]
+nvhpc24_7_spack_image:
+  needs: [nvhpc24_7_spack_compiler_image]
   extends:
-    - .variables_nvhpc23_9_config
+    - .variables_nvhpc24_7_config
     - .dependencies_image_template_rosa
 
-nvhpc23_9_build:
+nvhpc24_7_build:
   timeout: 2 hours
-  needs: [nvhpc23_9_spack_image]
+  needs: [nvhpc24_7_spack_image]
   extends:
-    - .variables_nvhpc23_9_config
+    - .variables_nvhpc24_7_config
     - .build_template_rosa
 
 # The test step is disabled until maintenance is over. Pulling the image on compute nodes is too
 # slow, and the image is too big.
-# .nvhpc23_9_test_common:
-#   needs: [nvhpc23_9_build]
+# .nvhpc24_7_test_common:
+#   needs: [nvhpc24_7_build]
 #   extends:
-#     - .variables_nvhpc23_9_config
+#     - .variables_nvhpc24_7_config
 #     - .test_common_gpu_daint_cuda
 #     - .test_template
 #
-# nvhpc23_9_test_release:
-#   extends: [.nvhpc23_9_test_common]
+# nvhpc24_7_test_release:
+#   extends: [.nvhpc24_7_test_common]
 #   image: $PERSIST_IMAGE_NAME_RELEASE
 #
-# nvhpc23_9_test_debug:
-#   extends: [.nvhpc23_9_test_common]
+# nvhpc24_7_test_debug:
+#   extends: [.nvhpc24_7_test_common]
 #   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/pipelines_on_merge.yml
+++ b/.gitlab/pipelines_on_merge.yml
@@ -22,4 +22,4 @@ include:
   - local: '.gitlab/includes/clang16_pipeline.yml'
   - local: '.gitlab/includes/clang17_pipeline.yml'
   - local: '.gitlab/includes/clang18_pipeline.yml'
-  - local: '.gitlab/includes/nvhpc23_9_pipeline.yml'
+  - local: '.gitlab/includes/nvhpc24_7_pipeline.yml'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,8 +72,8 @@ pika optionally depends on:
   default user-level thread implementations in pika. This can be enabled with
   ``PIKA_WITH_BOOST_CONTEXT=ON``.
 * `stdexec <https://github.com/NVIDIA/stdexec>`__. stdexec support can be enabled with
-  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `b39a506096900de4074ee556867a3805bd8351bd
-  <https://github.com/NVIDIA/stdexec/tree/b39a506096900de4074ee556867a3805bd8351bd>`__).  The
+  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `e99073de4c4b924804f54d7f52bc4e9fbcf53b92
+  <https://github.com/NVIDIA/stdexec/tree/e99073de4c4b924804f54d7f52bc4e9fbcf53b92>`__).  The
   integration is experimental. See :ref:`pika_stdexec` for more information about the integration.
 
 If you are using `nix <https://nixos.org>`__ you can also use the ``shell.nix`` file provided at the

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,8 +72,8 @@ pika optionally depends on:
   default user-level thread implementations in pika. This can be enabled with
   ``PIKA_WITH_BOOST_CONTEXT=ON``.
 * `stdexec <https://github.com/NVIDIA/stdexec>`__. stdexec support can be enabled with
-  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `e99073de4c4b924804f54d7f52bc4e9fbcf53b92
-  <https://github.com/NVIDIA/stdexec/tree/e99073de4c4b924804f54d7f52bc4e9fbcf53b92>`__).  The
+  ``PIKA_WITH_STDEXEC=ON`` (currently tested with commit `8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd
+  <https://github.com/NVIDIA/stdexec/tree/8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd>`__).  The
   integration is experimental. See :ref:`pika_stdexec` for more information about the integration.
 
 If you are using `nix <https://nixos.org>`__ you can also use the ``shell.nix`` file provided at the

--- a/examples/documentation/when_all_vector_documentation.cpp
+++ b/examples/documentation/when_all_vector_documentation.cpp
@@ -8,6 +8,7 @@
 #include <pika/init.hpp>
 
 #include <fmt/printf.h>
+#include <fmt/ranges.h>
 
 #include <cstddef>
 #include <random>

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_on_host.hpp
@@ -154,7 +154,7 @@ namespace pika::cuda::experimental {
                         detail::result_type_signature_helper_t<std::invoke_result_t<F, Ts...>>>;
 
             using completion_signatures =
-                pika::execution::experimental::make_completion_signatures<Sender,
+                pika::execution::experimental::transform_completion_signatures_of<Sender,
                     pika::execution::experimental::empty_env,
                     pika::execution::experimental::completion_signatures<
                         pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -159,7 +159,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                         cuda_stream const&, std::add_lvalue_reference_t<std::decay_t<Ts>>...>>>;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
+            pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/async_cuda/tests/performance/synchronize.cu
+++ b/libs/pika/async_cuda/tests/performance/synchronize.cu
@@ -118,9 +118,9 @@ int pika_main(pika::program_options::variables_map& vm)
                   << '\n';
     }
 
-// The compilation of this loop unrolling with llvm-amdgpu's
-// Clang 5.3.3 is hanging.
-#if !defined(PIKA_HAVE_HIP)
+// The compilation of this loop unrolling with llvm-amdgpu's Clang 5.3.3 is hanging. NVHPC 24.7 also
+// fails to compile this when unrolling the full loop.
+#if !defined(PIKA_HAVE_HIP) && !defined(PIKA_NVHPC_VERSION)
     {
         cu::enable_user_polling poll("default");
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -174,7 +174,7 @@ namespace pika::drop_op_state_detail {
             pika::execution::experimental::set_value_t(std::decay_t<Ts>&&...)>;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
+            pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -88,7 +88,7 @@ namespace pika::drop_value_detail {
             pika::execution::experimental::set_value_t()>;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<Sender,
+            pika::execution::experimental::transform_completion_signatures_of<Sender,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<>, empty_set_value>;
 #else

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -233,8 +233,8 @@ namespace pika {
 
 #if defined(PIKA_HAVE_STDEXEC)
             using completion_signatures =
-                pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
-                    pika::execution::experimental::empty_env>;
+                pika::execution::experimental::transform_completion_signatures_of<
+                    std::decay_t<Sender>, pika::execution::experimental::empty_env>;
 #else
             template <template <typename...> class Tuple, template <typename...> class Variant>
             using value_types = typename pika::execution::experimental::sender_traits<

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -399,7 +399,7 @@ namespace pika::split_tuple_detail {
                 typename add_const_lvalue_reference<T>::type)>;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<Sender,
+            pika::execution::experimental::transform_completion_signatures_of<Sender,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -154,7 +154,7 @@ namespace pika::unpack_detail {
 
 #if defined(PIKA_HAVE_STDEXEC)
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<std::decay_t<Sender>,
+            pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -98,7 +98,7 @@ namespace pika::when_all_vector_detail {
         static constexpr bool sends_done = false;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<Sender,
+            pika::execution::experimental::transform_completion_signatures_of<Sender,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -100,7 +100,10 @@ sender<scheduler_2> tag_invoke(ex::schedule_t, scheduler_2)
 int main()
 {
     static_assert(!ex::is_scheduler_v<non_scheduler_1>, "non_scheduler_1 is not a scheduler");
+    // stdexec static_asserts that a member schedule must return a sender
+#if !defined(PIKA_HAVE_STDEXEC)
     static_assert(!ex::is_scheduler_v<non_scheduler_2>, "non_scheduler_2 is not a scheduler");
+#endif
     static_assert(!ex::is_scheduler_v<non_scheduler_3>, "non_scheduler_3 is not a scheduler");
     static_assert(ex::is_scheduler_v<scheduler_1>, "scheduler_1 is a scheduler");
     static_assert(ex::is_scheduler_v<scheduler_2>, "scheduler_2 is a scheduler");

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -106,7 +106,7 @@ namespace pika::thread_pool_bulk_detail {
                 std::exception_ptr>>;
 
         using completion_signatures =
-            pika::execution::experimental::make_completion_signatures<Sender,
+            pika::execution::experimental::transform_completion_signatures_of<Sender,
                 pika::execution::experimental::empty_env,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>>;


### PR DESCRIPTION
stdexec now `static_assert`s if a scheduler has a `schedule` member that doesn't return a sender, so we can't check with `is_scheduler_v` those types of non-schedulers (as one test does).

`make_completion_signatures` is also buggy in the new commit, so I've moved uses of `make_completion_signatures` over to the new `transform_completion_signatures_of` (the former was renamed to the latter in P2300R8).