### PR TITLE
Add missing includes

### DIFF
--- a/libs/pika/include/include/pika/execution.hpp
+++ b/libs/pika/include/include/pika/execution.hpp
@@ -7,4 +7,5 @@
 #pragma once
 
 #include <pika/modules/execution.hpp>
+#include <pika/modules/execution_base.hpp>
 #include <pika/modules/executors.hpp>

--- a/tests/performance/local/condition_variable_overhead.cpp
+++ b/tests/performance/local/condition_variable_overhead.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/config.hpp>
+#include <pika/condition_variable.hpp>
 #include <pika/execution.hpp>
 #include <pika/init.hpp>
 #include <pika/modules/timing.hpp>


### PR DESCRIPTION
Adds `pika/condition_variable.hpp` to the condition variable overhead test and the `execution_base` module header explicitly to `pika/execution.hpp`.