### PR TITLE
Separate x86 and ARM CSCS CI pipelines to be completely independent

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -16,9 +16,9 @@ variables:
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/$ARCH/pika-spack-base:$CONFIG_TAG
-    - arch_upper=`echo $ARCH | tr '[:lower:]' '[:upper:]'`
     - echo -e "CONFIG_TAG=$CONFIG_TAG" >> base.env
-    - echo -e "BASE_IMAGE_$arch_upper=$PERSIST_IMAGE_NAME" >> base.env
+    - echo -e "ARCH=$ARCH" >> base.env
+    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> base.env
   variables:
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
@@ -34,24 +34,7 @@ base_spack_image_aarch64:
 base_spack_image_x86_64:
   extends: [.container-builder-cscs-zen2, .base_spack_image]
 
-make_multiarch_image:
-  needs:
-    - job: base_spack_image_aarch64
-      optional: true
-    - job: base_spack_image_x86_64
-  extends: .make-multiarch-image
-  after_script:
-    - echo -e "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> multiarch.env
-  variables:
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/pika-spack-base:${CONFIG_TAG}
-    PERSIST_IMAGE_NAME_AARCH64: $BASE_IMAGE_AARCH64
-    PERSIST_IMAGE_NAME_X86_64: $BASE_IMAGE_X86_64
-  artifacts:
-    reports:
-      dotenv: multiarch.env
-
 .compiler_image_template:
-  needs: [make_multiarch_image]
   before_script:
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - compiler=${COMPILER}${NVHPC_COMPILER:+-}${NVHPC_COMPILER}
@@ -68,9 +51,11 @@ make_multiarch_image:
       dotenv: compiler.env
 
 .compiler_image_template_santis:
+  needs: [base_spack_image_aarch64]
   extends: [.container-builder-cscs-gh200, .compiler_image_template]
 
 .compiler_image_template_rosa:
+  needs: [base_spack_image_x86_64]
   extends: [.container-builder-cscs-zen2, .compiler_image_template]
 
 .dependencies_image_template:

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -14,7 +14,7 @@ variables:
   timeout: 2 hours
   before_script:
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
-    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT | sha256sum - | head -c 16`
+    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT-$SPACK_REPO | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/$ARCH/pika-spack-base:$CONFIG_TAG
     - echo -e "CONFIG_TAG=$CONFIG_TAG" >> base.env
     - echo -e "ARCH=$ARCH" >> base.env
@@ -22,7 +22,7 @@ variables:
   variables:
     BASE_IMAGE: docker.io/ubuntu:22.04
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_base
-    DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_COMMIT"]'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE","SPACK_COMMIT","SPACK_REPO"]'
   artifacts:
     reports:
       dotenv: base.env


### PR DESCRIPTION
Also sets `SPACK_REPO` as a build argument in the spack base image stage (the default in the Dockerfile was the same as the value we were setting in the configuration, so no change is expected from this change).