### PR TITLE
Make `orte_init` memcheck suppressions more generic

### DIFF
--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -40,11 +40,9 @@
    ORTE init
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:malloc
-   ...
-   fun:hwloc_topology_load
    ...
    fun:orte_init
+   ...
 }
 
 {


### PR DESCRIPTION
There are more `orte_init` leaks in the style of https://github.com/pika-org/pika/pull/1201 reported in the MPI tests. This makes the suppression more generic.