### PR TITLE
Add documentation for `when_all_vector`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -80,3 +80,9 @@ The ``pika/execution.hpp`` header provides functionality related to ``std::execu
 .. literalinclude:: ../examples/documentation/split_tuple_documentation.cpp
    :language: c++
    :start-at: #include
+
+.. doxygenvariable:: pika::execution::experimental::when_all_vector
+
+.. literalinclude:: ../examples/documentation/when_all_vector_documentation.cpp
+   :language: c++
+   :start-at: #include

--- a/examples/documentation/CMakeLists.txt
+++ b/examples/documentation/CMakeLists.txt
@@ -4,7 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(example_programs hello_world_documentation init_hpp_documentation split_tuple_documentation)
+set(example_programs hello_world_documentation init_hpp_documentation split_tuple_documentation
+                     when_all_vector_documentation
+)
 
 foreach(example_program ${example_programs})
   set(sources ${example_program}.cpp)

--- a/examples/documentation/when_all_vector_documentation.cpp
+++ b/examples/documentation/when_all_vector_documentation.cpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/execution.hpp>
+#include <pika/init.hpp>
+
+#include <fmt/printf.h>
+
+#include <cstddef>
+#include <random>
+#include <utility>
+#include <vector>
+
+std::size_t get_n() { return 13; }
+std::size_t calculate(std::size_t i) { return (std::rand() % 4) * i * i; }
+
+int main(int argc, char* argv[])
+{
+    namespace ex = pika::execution::experimental;
+    namespace tt = pika::this_thread::experimental;
+
+    pika::start(argc, argv);
+    ex::thread_pool_scheduler sched{};
+
+    // when_all_vector is like when_all, but for a dynamic number of senders
+    // through a vector of senders
+    auto const n = get_n();
+    std::vector<ex::unique_any_sender<std::size_t>> snds;
+    snds.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        snds.push_back(ex::transfer_just(sched, i) | ex::then(calculate));
+    }
+    auto snds_print =
+        ex::when_all_vector(std::move(snds)) | ex::then([](std::vector<std::size_t> results) {
+            fmt::print("Results are: {}\n", fmt::join(results, ", "));
+        });
+    tt::sync_wait(std::move(snds_print));
+
+    // when_all_vector will send no value on completion if the input vector
+    // contains senders sending no value
+    std::vector<ex::unique_any_sender<>> snds_nothing;
+    snds_nothing.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        snds_nothing.push_back(ex::transfer_just(sched, i) |
+            ex::then([](auto i) { fmt::print("{}: {}\n", i, calculate(i)); }));
+    }
+    auto snds_nothing_done = ex::when_all_vector(std::move(snds_nothing)) |
+        ex::then([]() { fmt::print("Done printing all results\n"); });
+    tt::sync_wait(std::move(snds_nothing_done));
+
+    pika::finalize();
+    pika::stop();
+
+    return 0;
+}

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -389,8 +389,7 @@ namespace pika::when_all_vector_detail {
 }    // namespace pika::when_all_vector_detail
 
 namespace pika::execution::experimental {
-    inline constexpr struct when_all_vector_t final
-      : pika::functional::detail::tag_fallback<when_all_vector_t>
+    struct when_all_vector_t final : pika::functional::detail::tag_fallback<when_all_vector_t>
     {
     private:
         template <typename Sender, PIKA_CONCEPT_REQUIRES_(is_sender_v<Sender>)>
@@ -406,5 +405,16 @@ namespace pika::execution::experimental {
         {
             return when_all_vector_detail::when_all_vector_sender<Sender>{senders};
         }
-    } when_all_vector{};
+    };
+
+    /// \brief Returns a sender that completes when all senders in the input vector have completed.
+    ///
+    /// Sender adaptor that takes a vector of senders and returns a sender that sends a vector of
+    /// the values sent by the input senders. The vector sent has the same size as the input vector.
+    /// An empty vector of senders completes immediately on start. When the input vector of senders
+    /// contains senders that send no value the output sender sends no value instead of a vector.
+    /// The senders in the input vector must send at most a single type.
+    ///
+    /// Added in 0.2.0.
+    inline constexpr when_all_vector_t when_all_vector{};
 }    // namespace pika::execution::experimental


### PR DESCRIPTION
I should note that writing this highlighted to me the design decision to make `when_all_vector` require that senders send exactly zero or one values. This need not be the case in general, and we can consider changing `when_all_vector` or adding a new algorithm to instead send a `vector<tuple<Ts...>>` or even `vector<variant<tuple<T1s...>, tuple<T2s...>, ...>>` as more generic versions of the current implementation. This is similar to how there's a `sync_wait` and `sync_wait_with_variant` in P2300. I will not change the behaviour here, just highlight the possibility for the future.