### PR TITLE
Add GCC 12 and HIP 6 CI configuration

### DIFF
--- a/.gitlab/includes/gcc12_hip6_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip6_pipeline.yml
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include:
+  - local: '.gitlab/includes/common_pipeline.yml'
+  - local: '.gitlab/includes/common_spack_pipeline.yml'
+
+.variables_gcc12_hip6_config:
+  variables:
+    SPACK_ARCH: linux-ubuntu22.04-zen3
+    COMPILER: gcc@12
+    CXXSTD: 23
+    GPU_TARGET: 'gfx90a'
+    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
+                 malloc=system cxxstd=$CXXSTD ^boost@1.85.0 ^hwloc@2.9.1 ^hip@6.1.0 ^llvm~gold \
+                 ^fmt@10.2.1 ^stdexec@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
+                  -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
+
+gcc12_hip6_spack_compiler_image:
+  extends:
+    - .variables_gcc12_hip6_config
+    - .compiler_image_template_rosa
+
+gcc12_hip6_spack_image:
+  timeout: 4 hours
+  needs: [gcc12_hip6_spack_compiler_image]
+  extends:
+    - .variables_gcc12_hip6_config
+    - .dependencies_image_template_rosa
+
+gcc12_hip6_build:
+  needs: [gcc12_hip6_spack_image]
+  extends:
+    - .variables_gcc12_hip6_config
+    - .build_template_rosa
+
+# Disabled until AMD GPU runners come back online
+# .gcc12_hip6_test_common:
+#   needs: [gcc12_hip6_build]
+#   extends:
+#     - .variables_gcc12_hip6_config
+#     - .test_common_gpu_clariden_hip
+#     - .test_template
+
+# gcc12_hip6_test_release:
+#   extends: [.gcc12_hip6_test_common]
+#   image: $PERSIST_IMAGE_NAME_RELEASE
+
+# gcc12_hip6_test_debug:
+#   extends: [.gcc12_hip6_test_common]
+#   image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/pipelines_on_merge.yml
+++ b/.gitlab/pipelines_on_merge.yml
@@ -13,6 +13,7 @@ include:
   - local: '.gitlab/includes/gcc11_pipeline.yml'
   - local: '.gitlab/includes/gcc12_pipeline.yml'
   - local: '.gitlab/includes/gcc12_cuda12_pipeline.yml'
+  - local: '.gitlab/includes/gcc12_hip5_pipeline.yml'
   - local: '.gitlab/includes/gcc13_santis_pipeline.yml'
   - local: '.gitlab/includes/gcc14_pipeline.yml'
   - local: '.gitlab/includes/clang11_pipeline.yml'

--- a/.gitlab/pipelines_on_push.yml
+++ b/.gitlab/pipelines_on_push.yml
@@ -7,5 +7,5 @@
 include:
   - local: '.gitlab/includes/gcc13_pipeline.yml'
   - local: '.gitlab/includes/clang14_cuda11_pipeline.yml'
-  - local: '.gitlab/includes/gcc12_hip5_pipeline.yml'
+  - local: '.gitlab/includes/gcc12_hip6_pipeline.yml'
   - local: '.gitlab/includes/sloc.yml'

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/custom_lapack_api.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/custom_lapack_api.hpp
@@ -36,6 +36,8 @@
 # define CUSOLVER_STATUS_INVALID_VALUE rocblas_status_invalid_value
 # define CUSOLVER_STATUS_CONTINUE rocblas_status_continue
 # define CUSOLVER_STATUS_CHECK_NUMERICS_FAIL rocblas_status_check_numerics_fail
+# define CUSOLVER_STATUS_EXCLUDED_FROM_BUILD rocblas_status_excluded_from_build
+# define CUSOLVER_STATUS_ARCH_MISMATCH rocblas_status_arch_mismatch
 
 #elif defined(PIKA_HAVE_CUDA)
 

--- a/libs/pika/async_cuda_base/src/cublas_exception.cpp
+++ b/libs/pika/async_cuda_base/src/cublas_exception.cpp
@@ -43,6 +43,10 @@ namespace pika::cuda::experimental {
             case rocblas_status_size_increased: return "rocblas_status_size_increased";
             case rocblas_status_size_query_mismatch: return "rocblas_status_size_query_mismatch";
             case rocblas_status_size_unchanged: return "rocblas_status_size_unchanged";
+# if ROCBLAS_VERSION_MAJOR >= 4
+            case rocblas_status_excluded_from_build: return "rocblas_status_excluded_from_build";
+            case rocblas_status_arch_mismatch: return "rocblas_status_arch_mismatch";
+# endif
 #endif
             }
             return "<unknown>";

--- a/libs/pika/async_cuda_base/src/cusolver_exception.cpp
+++ b/libs/pika/async_cuda_base/src/cusolver_exception.cpp
@@ -66,6 +66,10 @@ namespace pika::cuda::experimental {
             case CUSOLVER_STATUS_SIZE_UNCHANGED: return "CUSOLVER_STATUS_SIZE_UNCHANGED";
             case CUSOLVER_STATUS_CONTINUE: return "CUSOLVER_STATUS_CONTINUE";
             case CUSOLVER_STATUS_CHECK_NUMERICS_FAIL: return "CUSOLVER_STATUS_CHECK_NUMERICS_FAIL";
+#  if ROCBLAS_VERSION_MAJOR >= 4
+            case CUSOLVER_STATUS_EXCLUDED_FROM_BUILD: return "CUSOLVER_STATUS_EXCLUDED_FROM_BUILD";
+            case CUSOLVER_STATUS_ARCH_MISMATCH: return "CUSOLVER_STATUS_ARCH_MISMATCH";
+#  endif
 # endif
             }
             return "<unknown>";

--- a/libs/pika/program_options/tests/unit/variable_map.cpp
+++ b/libs/pika/program_options/tests/unit/variable_map.cpp
@@ -4,6 +4,10 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include <pika/program_options/detail/utf8_codecvt_facet.hpp>
 #include <pika/program_options/errors.hpp>
 #include <pika/program_options/option.hpp>
@@ -17,6 +21,9 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif
 
 using namespace pika::program_options;
 using namespace std;


### PR DESCRIPTION
Fixes #1164. The newly added GCC 12/HIP 6 configuration is now run on pushes and replaces the old GCC 12/HIP 5 which is still run on merges.

GCC (libstdc++) 13 and newer are incompatible with HIP for now: https://github.com/spack/spack/pull/46291.