### PR TITLE
Use sockets, not NUMA nodes, when dealing with CPU masks

### DIFF
--- a/libs/pika/affinity/src/affinity_data.cpp
+++ b/libs/pika/affinity/src/affinity_data.cpp
@@ -161,12 +161,12 @@ namespace pika::detail {
             // pu_num.
             return topo.get_core_affinity_mask(pu_num);
         }
-        if (0 == std::string("numa").find(affinity_domain_))
+        if (0 == std::string("socket").find(affinity_domain_))
         {
-            // The affinity domain is 'numa', return a bit mask corresponding
-            // to all processing units of the NUMA domain containing the
+            // The affinity domain is 'socket', return a bit mask corresponding
+            // to all processing units of the socket containing the
             // given pu_num.
-            return topo.get_numa_node_affinity_mask(pu_num);
+            return topo.get_socket_affinity_mask(pu_num);
         }
 
         // The affinity domain is 'machine', return a bit mask corresponding

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -769,7 +769,7 @@ namespace pika::mpi::experimental {
         auto& rp = resource::get_partitioner();
         rp.create_thread_pool(
             get_pool_name(), pika::resource::scheduling_policy::static_priority, smode);
-        rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], get_pool_name());
+        rp.add_resource(rp.sockets()[0].cores()[0].pus()[0], get_pool_name());
         PIKA_DETAIL_DP(detail::mpi_debug<1>,
             debug(str<>("pool created"), "name", get_pool_name(), "mode flags", bin<8>(flags)));
         return true;

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -471,7 +471,7 @@ void init_resource_partitioner_handler(
     // communication related tasks
     rp.create_thread_pool(
         mpi::get_pool_name(), pika::resource::scheduling_policy::local_priority_fifo, mode);
-    rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], mpi::get_pool_name());
+    rp.add_resource(rp.sockets()[0].cores()[0].pus()[0], mpi::get_pool_name());
 }
 
 //----------------------------------------------------------------------------

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -350,12 +350,12 @@ namespace pika::detail {
         {
             if (0 != std::string("pu").find(affinity_domain_) &&
                 0 != std::string("core").find(affinity_domain_) &&
-                0 != std::string("numa").find(affinity_domain_) &&
+                0 != std::string("socket").find(affinity_domain_) &&
                 0 != std::string("machine").find(affinity_domain_))
             {
                 throw pika::detail::command_line_error(
                     "Invalid command line option --pika:affinity, value must be one of: pu, core, "
-                    "numa, or machine.");
+                    "socket, or machine.");
             }
         }
     }

--- a/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -216,7 +216,7 @@ void init_resource_partitioner_handler(
         rp.create_thread_pool(pool_name, pika::resource::scheduling_policy::shared_priority, deft);
         // add N pus to network pool
         int count = 0;
-        for (pika::resource::numa_domain const& d : rp.numa_domains())
+        for (pika::resource::socket const& d : rp.sockets())
         {
             for (pika::resource::core const& c : d.cores())
             {

--- a/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/pika/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -201,7 +201,7 @@ void init_resource_partitioner_handler(
         rp.create_thread_pool(pool_name, pika::resource::scheduling_policy::shared_priority, deft);
         // add N pus to network pool
         int count = 0;
-        for (pika::resource::numa_domain const& d : rp.numa_domains())
+        for (pika::resource::socket const& d : rp.sockets())
         {
             for (pika::resource::core const& c : d.cores())
             {

--- a/libs/pika/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
+++ b/libs/pika/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // This example creates a resource partitioner, a custom thread pool, and adds
-// processing units from a single NUMA domain to the custom thread pool. It is
+// processing units from a single socket to the custom thread pool. It is
 // intended for inclusion in the documentation.
 
 //[body
@@ -26,16 +26,16 @@ void init_resource_partitioner_handler(
 {
     rp.create_thread_pool("my-thread-pool");
 
-    bool one_numa_domain = rp.numa_domains().size() == 1;
+    bool one_socket = rp.sockets().size() == 1;
     bool skipped_first_pu = false;
 
-    pika::resource::numa_domain const& d = rp.numa_domains()[0];
+    pika::resource::socket const& d = rp.sockets()[0];
 
     for (pika::resource::core const& c : d.cores())
     {
         for (pika::resource::pu const& p : c.pus())
         {
-            if (one_numa_domain && !skipped_first_pu)
+            if (one_socket && !skipped_first_pu)
             {
                 skipped_first_pu = true;
                 continue;

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -93,7 +93,7 @@ namespace pika::resource::detail {
         void create_thread_pool(std::string const& name, scheduler_function scheduler_creation);
 
         // Functions to add processing units to thread pools via
-        // the pu/core/numa_domain API
+        // the pu/core/socket API
         void add_resource(
             pika::resource::pu const& p, std::string const& pool_name, std::size_t num_threads = 1)
         {
@@ -107,9 +107,9 @@ namespace pika::resource::detail {
             const pika::resource::core& c, std::string const& pool_name, bool exclusive = true);
         void add_resource(const std::vector<pika::resource::core>& cv, std::string const& pool_name,
             bool exclusive = true);
-        void add_resource(const pika::resource::numa_domain& nd, std::string const& pool_name,
-            bool exclusive = true);
-        void add_resource(const std::vector<pika::resource::numa_domain>& ndv,
+        void add_resource(
+            const pika::resource::socket& nd, std::string const& pool_name, bool exclusive = true);
+        void add_resource(const std::vector<pika::resource::socket>& ndv,
             std::string const& pool_name, bool exclusive = true);
 
         pika::detail::affinity_data const& get_affinity_data() const { return affinity_data_; }
@@ -151,7 +151,7 @@ namespace pika::resource::detail {
 
         scheduler_function get_pool_creator(size_t index) const;
 
-        std::vector<numa_domain> const& numa_domains() const { return numa_domains_; }
+        std::vector<socket> const& sockets() const { return sockets_; }
 
         std::size_t assign_cores(std::size_t first_core);
 
@@ -218,7 +218,7 @@ namespace pika::resource::detail {
 
         // contains the internal topology back-end used to add resources to
         // initial_thread_pools
-        std::vector<numa_domain> numa_domains_;
+        std::vector<socket> sockets_;
 
         // store policy flags determining the general behavior of the
         // resource_partitioner

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
@@ -39,11 +39,11 @@ namespace pika::resource {
 
     private:
         friend class core;
-        friend class numa_domain;
+        friend class socket;
         friend class resource::detail::partitioner;
 
         std::vector<pu> pus_sharing_core();
-        std::vector<pu> pus_sharing_numa_domain();
+        std::vector<pu> pus_sharing_socket();
 
         std::size_t id_;
         core* core_;
@@ -63,9 +63,9 @@ namespace pika::resource {
         static constexpr const std::size_t invalid_core_id = std::size_t(-1);
 
     public:
-        explicit core(std::size_t id = invalid_core_id, numa_domain* domain = nullptr)
+        explicit core(std::size_t id = invalid_core_id, socket* socket = nullptr)
           : id_(id)
-          , domain_(domain)
+          , socket_(socket)
         {
         }
 
@@ -73,23 +73,23 @@ namespace pika::resource {
         std::size_t id() const { return id_; }
 
     private:
-        std::vector<core> cores_sharing_numa_domain();
+        std::vector<core> cores_sharing_socket();
 
         friend class pu;
-        friend class numa_domain;
+        friend class socket;
         friend class resource::detail::partitioner;
 
         std::size_t id_;
-        numa_domain* domain_;
+        socket* socket_;
         std::vector<pu> pus_;
     };
 
-    class numa_domain
+    class socket
     {
-        static constexpr const std::size_t invalid_numa_domain_id = std::size_t(-1);
+        static constexpr const std::size_t invalid_socket_id = std::size_t(-1);
 
     public:
-        explicit numa_domain(std::size_t id = invalid_numa_domain_id)
+        explicit socket(std::size_t id = invalid_socket_id)
           : id_(id)
         {
         }
@@ -140,7 +140,7 @@ namespace pika::resource {
 
         ///////////////////////////////////////////////////////////////////////
         // Functions to add processing units to thread pools via
-        // the pu/core/numa_domain API
+        // the pu/core/socket API
         void add_resource(
             pika::resource::pu const& p, std::string const& pool_name, std::size_t num_threads = 1)
         {
@@ -154,13 +154,13 @@ namespace pika::resource {
             pika::resource::core const& c, std::string const& pool_name, bool exclusive = true);
         PIKA_EXPORT void add_resource(std::vector<pika::resource::core>& cv,
             std::string const& pool_name, bool exclusive = true);
-        PIKA_EXPORT void add_resource(pika::resource::numa_domain const& nd,
-            std::string const& pool_name, bool exclusive = true);
-        PIKA_EXPORT void add_resource(std::vector<pika::resource::numa_domain> const& ndv,
+        PIKA_EXPORT void add_resource(
+            pika::resource::socket const& nd, std::string const& pool_name, bool exclusive = true);
+        PIKA_EXPORT void add_resource(std::vector<pika::resource::socket> const& ndv,
             std::string const& pool_name, bool exclusive = true);
 
-        // Access all available NUMA domains
-        PIKA_EXPORT std::vector<numa_domain> const& numa_domains() const;
+        // Access all available sockets
+        PIKA_EXPORT std::vector<socket> const& sockets() const;
 
         // Returns the threads requested at startup --pika:threads=cores
         // for example will return the number actually created

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 namespace pika::resource {
-    class numa_domain;
+    class socket;
     class core;
     class pu;
 

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -31,12 +31,12 @@ namespace pika::resource {
         return result;
     }
 
-    std::vector<pu> pu::pus_sharing_numa_domain()
+    std::vector<pu> pu::pus_sharing_socket()
     {
         std::vector<pu> result;
-        result.reserve(core_->domain_->cores_.size());
+        result.reserve(core_->socket_->cores_.size());
 
-        for (core const& c : core_->domain_->cores_)
+        for (core const& c : core_->socket_->cores_)
         {
             for (pu const& p : c.pus_)
             {
@@ -46,12 +46,12 @@ namespace pika::resource {
         return result;
     }
 
-    std::vector<core> core::cores_sharing_numa_domain()
+    std::vector<core> core::cores_sharing_socket()
     {
         std::vector<core> result;
-        result.reserve(domain_->cores_.size());
+        result.reserve(socket_->cores_.size());
 
-        for (core const& c : domain_->cores_)
+        for (core const& c : socket_->cores_)
         {
             if (c.id_ != id_) { result.push_back(c); }
         }
@@ -175,21 +175,18 @@ namespace pika::resource {
     }
 
     void partitioner::add_resource(
-        numa_domain const& nd, std::string const& pool_name, bool exclusive /*= true*/)
+        socket const& nd, std::string const& pool_name, bool exclusive /*= true*/)
     {
         partitioner_.add_resource(nd, pool_name, exclusive);
     }
 
-    void partitioner::add_resource(std::vector<numa_domain> const& ndv,
-        std::string const& pool_name, bool exclusive /*= true*/)
+    void partitioner::add_resource(
+        std::vector<socket> const& ndv, std::string const& pool_name, bool exclusive /*= true*/)
     {
         partitioner_.add_resource(ndv, pool_name, exclusive);
     }
 
-    std::vector<numa_domain> const& partitioner::numa_domains() const
-    {
-        return partitioner_.numa_domains();
-    }
+    std::vector<socket> const& partitioner::sockets() const { return partitioner_.sockets(); }
 
     pika::threads::detail::topology const& partitioner::get_topology() const
     {

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -220,7 +220,7 @@ void init_resource_partitioner_handler(pika::resource::partitioner& rp,
     std::size_t threads_remaining = max_threads;
     std::size_t threads_in_pool = 0;
     // create pools randomly and add a random number of PUs to each pool
-    for (pika::resource::numa_domain const& d : rp.numa_domains())
+    for (pika::resource::socket const& d : rp.sockets())
     {
         for (pika::resource::core const& c : d.cores())
         {

--- a/libs/pika/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -128,7 +128,7 @@ void init_resource_partitioner_handler(
 
     // add one PU to each pool
     std::size_t thread_count = 0;
-    for (pika::resource::numa_domain const& d : rp.numa_domains())
+    for (pika::resource::socket const& d : rp.sockets())
     {
         for (pika::resource::core const& c : d.cores())
         {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -136,7 +136,7 @@ void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy sc
         PIKA_ASSERT(worker_pool_threads >= 1);
         std::size_t worker_pool_threads_added = 0;
 
-        for (pika::resource::numa_domain const& d : rp.numa_domains())
+        for (pika::resource::socket const& d : rp.sockets())
         {
             for (pika::resource::core const& c : d.cores())
             {

--- a/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -180,7 +180,7 @@ void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy sc
         std::size_t const worker_pool_threads = max_threads - 1;
         std::size_t worker_pool_threads_added = 0;
 
-        for (pika::resource::numa_domain const& d : rp.numa_domains())
+        for (pika::resource::socket const& d : rp.sockets())
         {
             for (pika::resource::core const& c : d.cores())
             {

--- a/libs/pika/thread_manager/tests/unit/thread_num.cpp
+++ b/libs/pika/thread_manager/tests/unit/thread_num.cpp
@@ -32,7 +32,7 @@ void test_scheduler(int argc, char* argv[], pika::resource::scheduling_policy sc
         std::size_t pools_added = 0;
 
         rp.set_default_pool_name("0");
-        for (pika::resource::numa_domain const& d : rp.numa_domains())
+        for (pika::resource::socket const& d : rp.sockets())
         {
             for (pika::resource::core const& c : d.cores())
             {


### PR DESCRIPTION
Still a draft. Tested on Grace-Hopper system to give correct results. This is only the minimal change needed which changes uses of topology `*numa_node*` functionality to `*socket*`.

Fixes #1223.

When dealing with thread affinity, this now uses sockets instead of numa nodes. This also means that the following changes:
- the resource partitioner helper object `resource::numa_domain` is now called `resource::socket` instead, including all related variables
- the `--pika:bind` option `numa` is now called `socket`

The following hasn't changed:
- The `numa-balanced` mapping is still called `numa-balanced`. Should we rename it `socket-balanced`?
- The `numa-sensitive` command line/config option is still called `numa-sensitive`. I think this still makes sense (even though many schedulers don't really take this into account?).
- The shared priority queue scheduler still deals with numa domains.

In short, when talking about affinity and going from socket/numa to pu, we now use sockets exclusively because numa to pu may be many to one, unlike socket to pu. When going the other way around, i.e. pu to socket/numa, we can still talk about pu to numa to understand if two pus belong to the same numa domain(s).