### PR TITLE
Make logstash submissions quieter

### DIFF
--- a/.gitlab/scripts/utilities.sh
+++ b/.gitlab/scripts/utilities.sh
@@ -16,7 +16,8 @@ function submit_logstash {
         --request POST \
         --header "Content-Type: application/json" \
         --data "@${1}" \
-        "${CSCS_LOGSTASH_URL}"
+        "${CSCS_LOGSTASH_URL}" \
+        || true
 }
 
 function json_merge {

--- a/.gitlab/scripts/utilities.sh
+++ b/.gitlab/scripts/utilities.sh
@@ -11,6 +11,8 @@ function submit_logstash {
     fi
 
     curl \
+        --silent \
+        --show-error \
         --request POST \
         --header "Content-Type: application/json" \
         --data "@${1}" \


### PR DESCRIPTION
- Only show errors, not progress, when curling to logstash
- Ignore errors when submitting to logstash (as a failure in submission shouldn't affect the pass/fail of the job as a whole; we don't mind if some submissions fail)