### PR TITLE
Adapt to `FindBoost` deprecation with CMake 3.30

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: b9e4e98f15b4a07814adf8b22da19e631f2749e4
+  SPACK_COMMIT: develop-2024-09-01
 
 .base_spack_image:
   timeout: 1 hours

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: develop-2024-08-18
+  SPACK_COMMIT: b9e4e98f15b4a07814adf8b22da19e631f2749e4
 
 .base_spack_image:
   timeout: 1 hours

--- a/cmake/pika_setup_boost.cmake
+++ b/cmake/pika_setup_boost.cmake
@@ -32,7 +32,7 @@ if(NOT TARGET pika_dependencies_boost)
   set(Boost_NO_BOOST_CMAKE ON) # disable the search for boost-cmake
 
   # Find the headers and get the version
-  find_package(Boost ${Boost_MINIMUM_VERSION} REQUIRED)
+  find_package(Boost ${Boost_MINIMUM_VERSION} CONFIG REQUIRED)
   if(NOT Boost_VERSION_STRING)
     set(Boost_VERSION_STRING
         "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}"
@@ -46,7 +46,8 @@ if(NOT TARGET pika_dependencies_boost)
 
   list(REMOVE_DUPLICATES __boost_libraries)
 
-  find_package(Boost ${Boost_MINIMUM_VERSION} MODULE REQUIRED COMPONENTS ${__boost_libraries})
+  pika_set_cmake_policy(CMP0167 NEW)  # deprecates FindBoost
+  find_package(Boost ${Boost_MINIMUM_VERSION} CONFIG REQUIRED COMPONENTS ${__boost_libraries})
 
   if(NOT Boost_FOUND)
     pika_error("Could not find Boost. Please set BOOST_ROOT to point to your Boost installation.")

--- a/cmake/pika_setup_boost.cmake
+++ b/cmake/pika_setup_boost.cmake
@@ -46,7 +46,7 @@ if(NOT TARGET pika_dependencies_boost)
 
   list(REMOVE_DUPLICATES __boost_libraries)
 
-  pika_set_cmake_policy(CMP0167 NEW)  # deprecates FindBoost
+  pika_set_cmake_policy(CMP0167 NEW) # deprecates FindBoost
   find_package(Boost ${Boost_MINIMUM_VERSION} CONFIG REQUIRED COMPONENTS ${__boost_libraries})
 
   if(NOT Boost_FOUND)


### PR DESCRIPTION
Fixes #1222

We require Boost version >= 1.71 in pika, `BoostConfig.cmake` is available in boost installations since 1.70, so only changing module to config was necessary. 