### PR TITLE
Use fewer cuBLAS/SOLVER handles in `cuda_pool`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
@@ -85,12 +85,11 @@ namespace pika::cuda::experimental {
         struct cublas_handles_holder
         {
             std::size_t const concurrency;
-            std::vector<cublas_handle> unsynchronized_handles;
-            std::atomic<std::size_t> synchronized_handle_index;
-            std::vector<cublas_handle> synchronized_handles;
+            std::atomic<std::size_t> handle_index;
+            std::vector<cublas_handle> handles;
             std::vector<std::mutex> handle_mutexes;
 
-            PIKA_EXPORT cublas_handles_holder();
+            PIKA_EXPORT cublas_handles_holder(std::size_t num_handles);
             cublas_handles_holder(cublas_handles_holder&&) = delete;
             cublas_handles_holder(cublas_handles_holder const&) = delete;
             cublas_handles_holder& operator=(cublas_handles_holder&&) = delete;
@@ -103,12 +102,11 @@ namespace pika::cuda::experimental {
         struct cusolver_handles_holder
         {
             std::size_t const concurrency;
-            std::vector<cusolver_handle> unsynchronized_handles;
-            std::atomic<std::size_t> synchronized_handle_index;
-            std::vector<cusolver_handle> synchronized_handles;
+            std::atomic<std::size_t> handle_index;
+            std::vector<cusolver_handle> handles;
             std::vector<std::mutex> handle_mutexes;
 
-            PIKA_EXPORT cusolver_handles_holder();
+            PIKA_EXPORT cusolver_handles_holder(std::size_t num_handles);
             cusolver_handles_holder(cusolver_handles_holder&&) = delete;
             cusolver_handles_holder(cusolver_handles_holder const&) = delete;
             cusolver_handles_holder& operator=(cusolver_handles_holder&&) = delete;
@@ -126,7 +124,8 @@ namespace pika::cuda::experimental {
             cusolver_handles_holder cusolver_handles;
 
             PIKA_EXPORT pool_data(int device, std::size_t num_normal_priority_streams_per_thread,
-                std::size_t num_high_priority_streams_per_thread, unsigned int flags);
+                std::size_t num_high_priority_streams_per_thread, unsigned int flags,
+                std::size_t num_cublas_handles, std::size_t num_cusolver_handles);
             pool_data(pool_data&&) = delete;
             pool_data(pool_data const&) = delete;
             pool_data& operator=(pool_data&&) = delete;
@@ -138,7 +137,8 @@ namespace pika::cuda::experimental {
     public:
         PIKA_EXPORT explicit cuda_pool(int device = 0,
             std::size_t num_normal_priority_streams_per_thread = 3,
-            std::size_t num_high_priority_streams_per_thread = 3, unsigned int flags = 0);
+            std::size_t num_high_priority_streams_per_thread = 3, unsigned int flags = 0,
+            std::size_t num_cublas_handles = 16, std::size_t num_cusolver_handles = 16);
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
         cuda_pool(cuda_pool&&) = default;
         PIKA_NVCC_PRAGMA_HD_WARNING_DISABLE
@@ -179,14 +179,18 @@ struct fmt::formatter<pika::cuda::experimental::cuda_pool> : fmt::formatter<std:
     auto format(pika::cuda::experimental::cuda_pool const& pool, FormatContext& ctx) const
     {
         bool valid{pool.data};
-        auto high_priority_streams =
+        auto num_high_priority_streams =
             valid ? pool.data->high_priority_streams.num_streams_per_thread : 0;
-        auto normal_priority_streams =
+        auto num_normal_priority_streams =
             valid ? pool.data->normal_priority_streams.num_streams_per_thread : 0;
+        auto num_cublas_handles = valid ? pool.data->cublas_handles.handles.size() : 0;
+        auto num_cusolver_handles = valid ? pool.data->cusolver_handles.handles.size() : 0;
         return fmt::formatter<std::string>::format(
             fmt::format("cuda_pool({}, num_high_priority_streams_per_thread = {}, "
-                        "num_normal_priority_streams_per_thread = {})",
-                fmt::ptr(pool.data.get()), high_priority_streams, normal_priority_streams),
+                        "num_normal_priority_streams_per_thread = {}, num_cublas_handles = {}, "
+                        "num_cusolver_handles = {})",
+                fmt::ptr(pool.data.get()), num_high_priority_streams, num_normal_priority_streams,
+                num_cublas_handles, num_cusolver_handles),
             ctx);
     }
 };

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_pool.hpp
@@ -89,7 +89,7 @@ namespace pika::cuda::experimental {
             std::vector<cublas_handle> handles;
             std::vector<std::mutex> handle_mutexes;
 
-            PIKA_EXPORT cublas_handles_holder(std::size_t num_handles);
+            PIKA_EXPORT explicit cublas_handles_holder(std::size_t num_handles);
             cublas_handles_holder(cublas_handles_holder&&) = delete;
             cublas_handles_holder(cublas_handles_holder const&) = delete;
             cublas_handles_holder& operator=(cublas_handles_holder&&) = delete;
@@ -106,7 +106,7 @@ namespace pika::cuda::experimental {
             std::vector<cusolver_handle> handles;
             std::vector<std::mutex> handle_mutexes;
 
-            PIKA_EXPORT cusolver_handles_holder(std::size_t num_handles);
+            PIKA_EXPORT explicit cusolver_handles_holder(std::size_t num_handles);
             cusolver_handles_holder(cusolver_handles_holder&&) = delete;
             cusolver_handles_holder(cusolver_handles_holder const&) = delete;
             cusolver_handles_holder& operator=(cusolver_handles_holder&&) = delete;


### PR DESCRIPTION
This changes the `cuda_pool` to only use "synchronized" handles, no matter which thread is using the handle (worker thread or non-worker thread). Each handle is protected by a mutex which must be held until a cuBLAS/SOLVER operation has been submitted (this part is unchanged for synchronized handles; previously worker thread handles did not use a mutex at all). The default values are 16 of each type of handle. In DLA-Future this seems to give virtually identical performance to the previous implementation using additional handles per worker thread.

16 handles by default was chosen based on DLA-Future showing that more handles don't improve performance any more. I tried 1 to 128 handles on the eigensolver miniapp. 8 handles already gave almost the best performance so I took one more step for the default. 1, 2, and 4 handles have noticeably slower performance (~10-20%) slower, with more handles approaching the best performance.

16 handles is also significantly less than the default we would previously have e.g. on a single Grace-Hopper module: 2 x 72 = 144 handles (two handles per core, 72 cores). Since each cuSOLVER handle uses ~250 MB and each cuBLAS handle ~60 MB of GPU memory, this is quite a large improvement in memory usage without sacrificing performance. Previously it would even be impossible to initialize a `cuda_pool` on a full 4-module Grace-Hopper system since pika would attempt to create 576 handles on a single GPU, which would require over 100 GB of GPU memory.