### PR TITLE
Relax thread bindings test

### DIFF
--- a/libs/pika/runtime/tests/unit/CMakeLists.txt
+++ b/libs/pika/runtime/tests/unit/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
   string(
     CONCAT
       process_mask_flag_expected_output
-      "   0: PU L#0\\(P#0\\), Core L#0\\(P#0\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
+      "   0: PU L#0\\(P#0\\), Core L#0\\(P#[0-9]+\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
       "   1: PU L#[0-9]+\\(P#1\\), Core L#[0-9]+\\(P#[0-9]+\\)(, Socket L#[0-9]+\\(P#[0-9]+\\))?(, NUMANode L#[0-9]+\\(P#[0-9]+\\))?(, Socket L#[0-9]+\\(P#[0-9]+\\))?, on pool \"default\"\n"
       "All tests passed."
   )


### PR DESCRIPTION
This further relaxes the regex used to check thread bindings. We really only care that the first thread is bound to the first PU. This separates the updated check from https://github.com/pika-org/pika/pull/1130.