### PR TITLE
Update spack commit in CI to fix clang 11 configuration

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: develop-2024-09-01
+  SPACK_COMMIT: develop-2024-09-15
 
 .base_spack_image:
   timeout: 1 hours


### PR DESCRIPTION
The clang 11 CI configuration is currently failing with
```
==> Error: ProcessError: Command exited with status 1:
    './b2' '--clean' '-j' '16' '--user-config=/tmp/root/spack-stage/spack-stage-boost-1.72.0-qnonvjuixruadplceoy4zl42eaku6tac/spack-src/user-config.jam' 'variant=release' '--disable-icu' 'link=static,shared' '--layout=system' 'toolset=clang' 'cxxstd=17' 'pch=off' 'visibility=hidden'
1 error found in build log:
     23    
     24       - Boost.Build documentation:
     25         http://www.boost.org/build/
     26    
     27    ==> [2024-09-10-12:28:55.608406] FILTER FILE: /tmp/root/spack-stage/
           spack-stage-boost-1.72.0-qnonvjuixruadplceoy4zl42eaku6tac/spack-src/
           project-config.jam [replacing "^\s*using clang.*"]
     28    ==> [2024-09-10-12:28:55.611217] './b2' '--clean' '-j' '16' '--user-
           config=/tmp/root/spack-stage/spack-stage-boost-1.72.0-qnonvjuixruadp
           lceoy4zl42eaku6tac/spack-src/user-config.jam' 'variant=release' '--d
           isable-icu' 'link=static,shared' '--layout=system' 'toolset=clang' '
           cxxstd=17' 'pch=off' 'visibility=hidden'
  >> 29    error: wrong library name 'json' in the --without-<library> option.
```
This is due to https://github.com/spack/spack/pull/46200 which did not take into account the compiled json library. https://github.com/spack/spack/pull/46200 fixes it. This PR simply updates the spack commit.