### PR TITLE
Use dockerhub credentials for pulling base image in CI

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -13,6 +13,7 @@ variables:
 .base_spack_image:
   timeout: 1 hours
   before_script:
+    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin
     - export DOCKERFILE_SHA=`sha256sum $DOCKERFILE | head -c 16`
     - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_COMMIT-$SPACK_REPO | sha256sum - | head -c 16`
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/$ARCH/pika-spack-base:$CONFIG_TAG


### PR DESCRIPTION
This is intended to work around occasional rate limiting happening in CI when pulling base images. Since CI uses anonymous access before this PR, often from the same nodes, the chances of being rate limited are higher. CI jobs fail when rate limiting happens.

Using credentials gives us our own rate limit. The rate limit is also higher than the anonymous usage. From https://www.docker.com/increase-rate-limits/:
> The rate limits of 100 container image requests per six hours for anonymous usage, and 200 container image requests per six hours for free Docker accounts are now in effect. Image requests exceeding these limits will be denied until the six hour window elapses.