### PR TITLE
Disable lock registration on address sanitizer CI configuration

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -59,6 +59,7 @@ jobs:
                 -DPIKA_WITH_COMPILER_WARNINGS=ON \
                 -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                 -DPIKA_WITH_SANITIZERS=On \
+                -DPIKA_WITH_VERIFY_LOCKS=Off \
                 -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer -Wno-error=ignored-optimization-argument" \
                 -DPIKA_WITH_STACKOVERFLOW_DETECTION=Off \
                 -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=On

--- a/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/pika/resource_partitioner/tests/unit/CMakeLists.txt
@@ -22,10 +22,6 @@ set(tests
 )
 
 set(cross_pool_injection_PARAMETERS THREADS -1)
-if(PIKA_WITH_SANITIZERS)
-  # This test triggers a possible false positive stack-use-after-scope in lock registration
-  list(APPEND cross_pool_injection_PARAMETERS "--pika:ini=pika.lock_detection=0")
-endif()
 set(scheduler_binding_check_PARAMETERS THREADS -1)
 
 set(named_pool_executor_PARAMETERS THREADS 4)


### PR DESCRIPTION
The apparent false-positive that was occuring in the cross_pool_injection test is also sometimes triggered in other tests, so I'm disabling lock registration completely on the address sanitizer CI configuration.