### PR TITLE
Clean up `mpi_base` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,15 +647,6 @@ if(PIKA_WITH_MPI)
     pika_add_config_define(PIKA_HAVE_MPI_ENV "\"${pika_mpi_env_}\"")
   endif()
 
-  pika_option(
-    PIKA_WITH_MPI_MULTITHREADED BOOL "Turn on MPI multithreading support (default: ON)." ON
-    CATEGORY "MPI"
-    ADVANCED
-  )
-  if(PIKA_WITH_MPI_MULTITHREADED)
-    pika_add_config_define(PIKA_HAVE_MPI_MULTITHREADED)
-  endif()
-
   if(MSVC)
     # FIXME: add OpenMPI specific flag here for now as the pika_add_compile_flag() below does not
     # add the extra options to the top level directory

--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -20,12 +20,12 @@ endif()
 
 # Default location is $PIKA_ROOT/libs/mpi/include
 set(async_mpi_headers
-    pika/async_mpi/mpi_exception.hpp pika/async_mpi/mpi_helpers.hpp pika/async_mpi/mpi_polling.hpp
-    pika/async_mpi/dispatch_mpi.hpp pika/async_mpi/trigger_mpi.hpp pika/async_mpi/transform_mpi.hpp
+    pika/async_mpi/mpi_helpers.hpp pika/async_mpi/mpi_polling.hpp pika/async_mpi/dispatch_mpi.hpp
+    pika/async_mpi/trigger_mpi.hpp pika/async_mpi/transform_mpi.hpp
 )
 
 # Default location is $PIKA_ROOT/libs/mpi/src
-set(mpi_sources mpi_exception.cpp mpi_polling.cpp)
+set(mpi_sources mpi_polling.cpp)
 
 include(pika_add_module)
 pika_add_module(

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -24,7 +24,6 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
-#include <pika/mpi_base/mpi.hpp>
 
 #include <exception>
 #include <tuple>
@@ -151,9 +150,10 @@ namespace pika::mpi::experimental::detail {
                             {
                                 PIKA_DETAIL_DP(mpi_tran<5>,
                                     debug(str<>("set_error"), "status != MPI_SUCCESS",
-                                        detail::error_message(status)));
+                                        mpi::detail::error_message(status)));
                                 ex::set_error(PIKA_MOVE(r.op_state.receiver),
-                                    std::make_exception_ptr(mpi_exception(status)));
+                                    std::make_exception_ptr(
+                                        mpi::exception(status, "dispatch mpi")));
                                 return;
                             }
                             // early poll just in case the request completed immediately

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -24,6 +24,8 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
+#include <pika/mpi_base/mpi.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 
 #include <exception>
 #include <tuple>

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -24,7 +24,6 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
-#include <pika/mpi_base/mpi.hpp>
 #include <pika/runtime/runtime.hpp>
 
 #include <exception>
@@ -85,7 +84,7 @@ namespace pika::mpi::experimental::detail {
         else
         {
             ex::set_error(PIKA_FORWARD(Receiver, receiver),
-                std::make_exception_ptr(mpi_exception(mpi_status)));
+                std::make_exception_ptr(mpi::exception(mpi_status, "set_error handler")));
         }
     }
 
@@ -125,7 +124,8 @@ namespace pika::mpi::experimental::detail {
                 if (status != MPI_SUCCESS)
                 {
                     ex::set_error(PIKA_MOVE(op_state.receiver),
-                        std::make_exception_ptr(mpi_exception(status)));
+                        std::make_exception_ptr(
+                            mpi::exception(status, "new_task_request_callback")));
                 }
                 else
                 {

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -24,6 +24,8 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
+#include <pika/mpi_base/mpi.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 #include <pika/runtime/runtime.hpp>
 
 #include <exception>

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <pika/config.hpp>
-#include <pika/async_mpi/mpi_exception.hpp>
 #include <pika/functional/unique_function.hpp>
 #include <pika/modules/concurrency.hpp>
 #include <pika/modules/execution_base.hpp>
@@ -15,6 +14,7 @@
 #include <pika/modules/resource_partitioner.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 #include <pika/runtime/thread_pool_helpers.hpp>
 #include <pika/synchronization/counting_semaphore.hpp>
 #include <pika/type_support/to_underlying.hpp>

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -14,7 +14,6 @@
 #include <pika/modules/resource_partitioner.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi.hpp>
-#include <pika/mpi_base/mpi_exception.hpp>
 #include <pika/runtime/thread_pool_helpers.hpp>
 #include <pika/synchronization/counting_semaphore.hpp>
 #include <pika/type_support/to_underlying.hpp>

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -25,7 +25,6 @@
 #include <pika/execution_base/sender.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
-#include <pika/mpi_base/mpi.hpp>
 
 #include <exception>
 #include <tuple>

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -25,6 +25,7 @@
 #include <pika/execution_base/sender.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
+#include <pika/mpi_base/mpi.hpp>
 
 #include <exception>
 #include <tuple>

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -24,7 +24,7 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
-#include <pika/mpi_base/mpi_exception.hpp>
+#include <pika/mpi_base/mpi.hpp>
 #include <pika/synchronization/condition_variable.hpp>
 
 #include <exception>

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -11,7 +11,6 @@
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
 #include <pika/async_mpi/dispatch_mpi.hpp>
-#include <pika/async_mpi/mpi_exception.hpp>
 #include <pika/async_mpi/mpi_polling.hpp>
 #include <pika/concepts/concepts.hpp>
 #include <pika/datastructures/variant.hpp>
@@ -25,7 +24,7 @@
 #include <pika/executors/thread_pool_scheduler.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/functional/invoke.hpp>
-#include <pika/mpi_base/mpi.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 #include <pika/synchronization/condition_variable.hpp>
 
 #include <exception>

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -822,14 +822,14 @@ namespace pika::mpi::experimental {
         if (init_mpi)
         {
             int provided, required = get_preferred_thread_mode();
-            pika::mpi::environment::init(nullptr, nullptr, required, required, provided);
+            mpi::detail::environment::init(nullptr, nullptr, required, required, provided);
         }
-        else if (!pika::mpi::environment::is_mpi_inititialized())
+        else if (!mpi::detail::environment::is_mpi_initialized())
         {
             throw mpi::exception(MPI_ERR_OTHER, "MPI must be initialized before using pika::mpi");
         }
-        detail::mpi_data_.rank_ = pika::mpi::environment::rank();
-        detail::mpi_data_.size_ = pika::mpi::environment::size();
+        detail::mpi_data_.rank_ = mpi::detail::environment::rank();
+        detail::mpi_data_.size_ = mpi::detail::environment::size();
 
         PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("init"), detail::mpi_data_));
 
@@ -887,7 +887,7 @@ namespace pika::mpi::experimental {
         }
 
         // clean up if we initialized mpi
-        pika::mpi::environment::finalize();
+        mpi::detail::environment::finalize();
 
         PIKA_DETAIL_DP(detail::mpi_debug<5>,
             debug(str<>("Clearing mode"), detail::mpi_data_, "disable_user_polling"));

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -6,7 +6,6 @@
 
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
-#include <pika/async_mpi/mpi_exception.hpp>
 #include <pika/async_mpi/mpi_polling.hpp>
 #include <pika/command_line_handling/get_env_var_as.hpp>
 #include <pika/concurrency/spinlock.hpp>
@@ -15,6 +14,7 @@
 #include <pika/modules/errors.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi_environment.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 #include <pika/resource_partitioner/detail/partitioner.hpp>
 #include <pika/string_util/case_conv.hpp>
 #include <pika/synchronization/condition_variable.hpp>
@@ -46,8 +46,7 @@
 namespace pika::mpi::experimental::detail {
     static inline void mpi_ext_continuation_result_check(int code)
     {
-        if (code != MPI_SUCCESS)
-            throw pika::mpi::experimental::mpi_exception(code, "MPI_EXT_CONTINUATION problem");
+        if (code != MPI_SUCCESS) throw pika::mpi::exception(code, "MPI_EXT_CONTINUATION problem");
     }
 }    // namespace pika::mpi::experimental::detail
 #endif
@@ -265,9 +264,9 @@ namespace pika::mpi::experimental {
         // function that converts an MPI error into an exception
         void pika_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
-            PIKA_DETAIL_DP(
-                mpi_debug<5>, debug(str<>("pika_MPI_Handler"), error_message(*errorcode)));
-            throw mpi_exception(*errorcode, error_message(*errorcode));
+            PIKA_DETAIL_DP(mpi_debug<5>,
+                debug(str<>("pika_MPI_Handler"), mpi::detail::error_message(*errorcode)));
+            throw mpi::exception(*errorcode, "pika MPI error->exception handler");
         }
 
         // -------------------------------------------------------------
@@ -823,21 +822,14 @@ namespace pika::mpi::experimental {
         if (init_mpi)
         {
             int provided, required = get_preferred_thread_mode();
-            pika::util::mpi_environment::init(nullptr, nullptr, required, required, provided);
-            MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
-            MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
+            pika::mpi::environment::init(nullptr, nullptr, required, required, provided);
         }
-        else
+        else if (!pika::mpi::environment::is_mpi_inititialized())
         {
-            int is_initialized = 0;
-            MPI_Initialized(&is_initialized);
-            if (is_initialized)
-            {
-                MPI_Comm_rank(MPI_COMM_WORLD, &detail::mpi_data_.rank_);
-                MPI_Comm_size(MPI_COMM_WORLD, &detail::mpi_data_.size_);
-            }
-            else { PIKA_DETAIL_DP(detail::mpi_debug<1>, error(str<>("mpi not initialized"))); }
+            throw mpi::exception(MPI_ERR_OTHER, "MPI must be initialized before using pika::mpi");
         }
+        detail::mpi_data_.rank_ = pika::mpi::environment::rank();
+        detail::mpi_data_.size_ = pika::mpi::environment::size();
 
         PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("init"), detail::mpi_data_));
 
@@ -895,7 +887,7 @@ namespace pika::mpi::experimental {
         }
 
         // clean up if we initialized mpi
-        pika::util::mpi_environment::finalize();
+        pika::mpi::environment::finalize();
 
         PIKA_DETAIL_DP(detail::mpi_debug<5>,
             debug(str<>("Clearing mode"), detail::mpi_data_, "disable_user_polling"));

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -344,7 +344,7 @@ int pika_main(pika::program_options::variables_map& vm)
     // Disable idle backoff on the default pool
     pika::threads::remove_scheduler_mode(::pika::threads::scheduler_mode::enable_idle_backoff);
 
-    pika::util::mpi_environment mpi_env;
+    pika::mpi::environment mpi_env;
     pika::detail::runtime* rt = pika::detail::get_runtime_ptr();
     pika::util::runtime_configuration cfg = rt->get_config();
     mpi_env.init(nullptr, nullptr, cfg);

--- a/libs/pika/include/include/pika/mpi.hpp
+++ b/libs/pika/include/include/pika/mpi.hpp
@@ -9,4 +9,5 @@
 #include <pika/config.hpp>
 #if defined(PIKA_HAVE_MPI)
 # include <pika/modules/async_mpi.hpp>
+# include <pika/modules/mpi_base.hpp>
 #endif

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -117,8 +117,8 @@ namespace pika::detail {
             static int rank = [&] {
 #if defined(PIKA_HAVE_MPI)
                 // First try to get the rank through MPI
-                if (pika::mpi::environment::is_mpi_inititialized())
-                    return pika::mpi::environment::rank();
+                if (mpi::detail::environment::is_mpi_initialized())
+                    return mpi::detail::environment::rank();
 #endif
                 // Otherwise guess based on environment variables
                 return helper.guess_rank();

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -17,6 +17,7 @@
 
 #if defined(PIKA_HAVE_MPI)
 # include <pika/mpi_base/mpi.hpp>
+# include <pika/mpi_base/mpi_environment.hpp>
 #endif
 
 #include <fmt/format.h>
@@ -114,16 +115,11 @@ namespace pika::detail {
             else { dest.append(std::string_view("----")); }
 
             static int rank = [&] {
-            // First try to get the rank through MPI
 #if defined(PIKA_HAVE_MPI)
-                int mpi_initialized = 0;
-                if (MPI_Initialized(&mpi_initialized) == MPI_SUCCESS && mpi_initialized)
-                {
-                    int rank = 0;
-                    if (MPI_Comm_rank(MPI_COMM_WORLD, &rank) == MPI_SUCCESS) { return rank; }
-                }
+                // First try to get the rank through MPI
+                if (pika::util::mpi_environment::is_mpi_inititialized())
+                    return pika::util::mpi_environment::rank();
 #endif
-
                 // Otherwise guess based on environment variables
                 return helper.guess_rank();
             }();

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -117,8 +117,8 @@ namespace pika::detail {
             static int rank = [&] {
 #if defined(PIKA_HAVE_MPI)
                 // First try to get the rank through MPI
-                if (pika::util::mpi_environment::is_mpi_inititialized())
-                    return pika::util::mpi_environment::rank();
+                if (pika::mpi::environment::is_mpi_inititialized())
+                    return pika::mpi::environment::rank();
 #endif
                 // Otherwise guess based on environment variables
                 return helper.guess_rank();

--- a/libs/pika/mpi_base/CMakeLists.txt
+++ b/libs/pika/mpi_base/CMakeLists.txt
@@ -10,8 +10,10 @@ if(NOT PIKA_WITH_MPI)
   return()
 endif()
 
-set(mpi_base_headers pika/mpi_base/mpi.hpp pika/mpi_base/mpi_environment.hpp)
-set(mpi_base_sources mpi_environment.cpp)
+set(mpi_base_headers pika/mpi_base/mpi.hpp pika/mpi_base/mpi_environment.hpp
+                     pika/mpi_base/mpi_exception.hpp
+)
+set(mpi_base_sources mpi_environment.cpp mpi_exception.cpp)
 
 include(pika_add_module)
 pika_add_module(

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 ETH Zurich
 //  Copyright (c) 2017 Mikael Simberg
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 ETH Zurich
 //  Copyright (c) 2013-2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -18,38 +18,38 @@
 
 # include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace util {
-        struct PIKA_EXPORT mpi_environment
-        {
-            // This function checks a list of environment variables to see if commonly set
-            // ones such as mpich, openmpi, slurm, etc are present.
-            // The list of env vars can be set via pika command line params,
-            // or defaults used from cmake configure time.
-            // Although this function is not currently used in pika,
-            // it is left for potential future use
-            static bool check_mpi_environment(runtime_configuration const& cfg);
+namespace pika::mpi {
+    struct PIKA_EXPORT environment
+    {
+        // This function checks a list of environment variables to see if commonly set
+        // ones such as mpich, openmpi, slurm, etc are present.
+        // The list of env vars can be set via pika command line params,
+        // or defaults used from cmake configure time.
+        // Although this function is not currently used in pika,
+        // it is left for potential future use
+        static bool check_environment(util::runtime_configuration const& cfg);
 
-            // calls mpi_init_thread with the thread level requested and reports
-            // any problem if the same level is not granted
-            static int init(
-                int* argc, char*** argv, const int required, const int minimal, int& provided);
+        // calls mpi_init_thread with the thread level requested and reports
+        // any problem if the same level is not granted
+        static int init(
+            int* argc, char*** argv, const int required, const int minimal, int& provided);
 
-            // finalize mpi, do not call unless init was previously called
-            static void finalize();
+        // finalize mpi, do not call unless init was previously called
+        static void finalize();
 
-            // returns true if mpi_environment::init has previously been called
-            static bool pika_called_init();
+        // returns true if mpi::environment::init has previously been called
+        static bool pika_called_init();
 
-            // convenience functions that retrieve mpi settings
-            static bool is_mpi_inititialized();
-            static int rank();
-            static int size();
-            static std::string get_processor_name();
+        // convenience functions that retrieve mpi settings
+        static bool is_mpi_inititialized();
+        static int rank();
+        static int size();
+        static std::string get_processor_name();
 
-        private:
-            static bool mpi_init_pika_;
-        };
-}}    // namespace pika::util
+    private:
+        static bool mpi_init_pika_;
+    };
+}    // namespace pika::mpi
 
 # include <pika/config/warnings_suffix.hpp>
 
@@ -59,12 +59,12 @@ namespace pika { namespace util {
 
 # include <pika/config/warnings_prefix.hpp>
 
-namespace pika { namespace util {
-        struct PIKA_EXPORT mpi_environment
-        {
-            static bool check_mpi_environment(runtime_configuration const& cfg);
-        };
-}}    // namespace pika::util
+namespace pika::mpi {
+    struct PIKA_EXPORT environment
+    {
+        static bool check_environment(runtime_configuration const& cfg);
+    };
+}    // namespace pika::mpi
 
 # include <pika/config/warnings_suffix.hpp>
 

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -9,15 +9,13 @@
 
 #include <pika/config.hpp>
 
-#if defined(PIKA_HAVE_MODULE_MPI_BASE)
+#include <pika/modules/runtime_configuration.hpp>
+#include <pika/mpi_base/mpi.hpp>
 
-# include <pika/modules/runtime_configuration.hpp>
-# include <pika/mpi_base/mpi.hpp>
+#include <cstdlib>
+#include <string>
 
-# include <cstdlib>
-# include <string>
-
-# include <pika/config/warnings_prefix.hpp>
+#include <pika/config/warnings_prefix.hpp>
 
 namespace pika::mpi::detail {
     struct PIKA_EXPORT environment
@@ -44,21 +42,4 @@ namespace pika::mpi::detail {
     };
 }    // namespace pika::mpi::detail
 
-# include <pika/config/warnings_suffix.hpp>
-
-#else
-
-# include <pika/modules/runtime_configuration.hpp>
-
-# include <pika/config/warnings_prefix.hpp>
-
-namespace pika::mpi {
-    struct PIKA_EXPORT environment
-    {
-        static bool check_environment(runtime_configuration const& cfg);
-    };
-}    // namespace pika::mpi
-
-# include <pika/config/warnings_suffix.hpp>
-
-#endif
+#include <pika/config/warnings_suffix.hpp>

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -10,7 +10,6 @@
 
 #if defined(PIKA_HAVE_MODULE_MPI_BASE)
 
-# include <pika/concurrency/spinlock.hpp>
 # include <pika/modules/runtime_configuration.hpp>
 # include <pika/mpi_base/mpi.hpp>
 
@@ -22,54 +21,33 @@
 namespace pika { namespace util {
         struct PIKA_EXPORT mpi_environment
         {
+            // This function checks a list of environment variables to see if commonly set
+            // ones such as mpich, openmpi, slurm, etc are present.
+            // The list of env vars can be set via pika command line params,
+            // or defaults used from cmake configure time.
+            // Although this function is not currently used in pika,
+            // it is left for potential future use
             static bool check_mpi_environment(runtime_configuration const& cfg);
 
+            // calls mpi_init_thread with the thread level requested and reports
+            // any problem if the same level is not granted
             static int init(
                 int* argc, char*** argv, const int required, const int minimal, int& provided);
-            static void init(int* argc, char*** argv, runtime_configuration& cfg);
+
+            // finalize mpi, do not call unless init was previously called
             static void finalize();
 
-            static bool enabled();
-            static bool multi_threaded();
-            static bool has_called_init();
+            // returns true if mpi_environment::init has previously been called
+            static bool pika_called_init();
 
+            // convenience functions that retrieve mpi settings
+            static bool is_mpi_inititialized();
             static int rank();
             static int size();
-
-            static MPI_Comm& communicator();
-
             static std::string get_processor_name();
 
-            struct PIKA_EXPORT scoped_lock
-            {
-                scoped_lock();
-                scoped_lock(scoped_lock const&) = delete;
-                scoped_lock& operator=(scoped_lock const&) = delete;
-                ~scoped_lock();
-                void unlock();
-            };
-
-            struct PIKA_EXPORT scoped_try_lock
-            {
-                scoped_try_lock();
-                scoped_try_lock(scoped_try_lock const&) = delete;
-                scoped_try_lock& operator=(scoped_try_lock const&) = delete;
-                ~scoped_try_lock();
-                void unlock();
-                bool locked;
-            };
-
-            using mutex_type = pika::concurrency::detail::spinlock;
-
         private:
-            static mutex_type mtx_;
-
-            static bool enabled_;
-            static bool has_called_init_;
-            static int provided_threading_flag_;
-            static MPI_Comm communicator_;
-
-            static int is_initialized_;
+            static bool mpi_init_pika_;
         };
 }}    // namespace pika::util
 

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -19,17 +19,9 @@
 
 # include <pika/config/warnings_prefix.hpp>
 
-namespace pika::mpi {
+namespace pika::mpi::detail {
     struct PIKA_EXPORT environment
     {
-        // This function checks a list of environment variables to see if commonly set
-        // ones such as mpich, openmpi, slurm, etc are present.
-        // The list of env vars can be set via pika command line params,
-        // or defaults used from cmake configure time.
-        // Although this function is not currently used in pika,
-        // it is left for potential future use
-        static bool check_environment(util::runtime_configuration const& cfg);
-
         // calls mpi_init_thread with the thread level requested and reports
         // any problem if the same level is not granted
         static int init(
@@ -42,7 +34,7 @@ namespace pika::mpi {
         static bool pika_called_init();
 
         // convenience functions that retrieve mpi settings
-        static bool is_mpi_inititialized();
+        static bool is_mpi_initialized();
         static int rank();
         static int size();
         static std::string get_processor_name();
@@ -50,7 +42,7 @@ namespace pika::mpi {
     private:
         static bool mpi_init_pika_;
     };
-}    // namespace pika::mpi
+}    // namespace pika::mpi::detail
 
 # include <pika/config/warnings_suffix.hpp>
 

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
@@ -11,18 +11,18 @@
 
 #include <string>
 
-namespace pika::mpi::experimental {
+namespace pika::mpi {
     namespace detail {
         PIKA_EXPORT std::string error_message(int code);
     }    // namespace detail
 
-    struct mpi_exception : pika::exception
+    struct exception : pika::exception
     {
-        PIKA_EXPORT explicit mpi_exception(int err_code, const std::string& msg = "");
+        PIKA_EXPORT explicit exception(int err_code, const std::string& msg = "");
         PIKA_EXPORT int get_mpi_errorcode() const noexcept;
 
     protected:
         int err_code_;
     };
 
-}    // namespace pika::mpi::experimental
+}    // namespace pika::mpi

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 ETH Zurich
 //  Copyright (c) 2020 John Biddiscombe
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -26,10 +26,9 @@ namespace pika { namespace util {
         bool detect_mpi_environment(util::runtime_configuration const& cfg, char const* default_env)
         {
 #if defined(__bgq__)
-            // If running on BG/Q, we can safely assume to always run in an
-            // MPI environment
+            // If running on BG/Q, we can safely assume to always run in an MPI environment
             return true;
-#else
+#endif
             std::string mpi_environment_strings = cfg.get_entry("pika.mpi.env", default_env);
 
             boost::char_separator<char> sep(";,: ");
@@ -45,9 +44,8 @@ namespace pika { namespace util {
                 }
             }
 
-            PIKA_LOG(info, "No known MPI environment variable found, disabling MPI support");
+            PIKA_LOG(info, "No known MPI environment variable found, no MPI support");
             return false;
-#endif
         }
     }    // namespace detail
 
@@ -62,24 +60,14 @@ namespace pika { namespace util {
 
 namespace pika { namespace util {
 
-    mpi_environment::mutex_type mpi_environment::mtx_;
-    bool mpi_environment::enabled_ = false;
-    bool mpi_environment::has_called_init_ = false;
-    int mpi_environment::provided_threading_flag_ = MPI_THREAD_SINGLE;
-    MPI_Comm mpi_environment::communicator_ = MPI_COMM_NULL;
-
-    int mpi_environment::is_initialized_ = -1;
+    bool mpi_environment::mpi_init_pika_ = false;
 
     ///////////////////////////////////////////////////////////////////////////
     int mpi_environment::init(int*, char***, const int required, const int minimal, int& provided)
     {
-        has_called_init_ = false;
-
-        // Check if MPI_Init has been called previously
-        int is_initialized = 0;
-        int retval = MPI_Initialized(&is_initialized);
-        if (MPI_SUCCESS != retval) { return retval; }
-        if (!is_initialized)
+        mpi_init_pika_ = false;
+        int retval = MPI_SUCCESS;
+        if (!mpi_environment::is_mpi_inititialized())
         {
             retval = MPI_Init_thread(nullptr, nullptr, required, &provided);
             if (MPI_SUCCESS != retval) { return retval; }
@@ -90,73 +78,17 @@ namespace pika { namespace util {
                     "pika::util::mpi_environment::init",
                     "MPI doesn't provide minimal requested thread level");
             }
-            has_called_init_ = true;
+            mpi_init_pika_ = true;
         }
         return retval;
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    void mpi_environment::init(int* argc, char*** argv, util::runtime_configuration& rtcfg)
+    bool mpi_environment::is_mpi_inititialized()
     {
-        if (enabled_) return;    // don't call twice
-
-        int this_rank = -1;
-        has_called_init_ = false;
-
-        enabled_ = check_mpi_environment(rtcfg);
-        if (!enabled_) { return; }
-
-        int required = MPI_THREAD_SINGLE;
-        int minimal = MPI_THREAD_SINGLE;
-# if defined(PIKA_HAVE_MPI_MULTITHREADED)
-        required = (pika::detail::get_entry_as(rtcfg, "pika.mpi.multithreaded", 1) != 0) ?
-            MPI_THREAD_MULTIPLE :
-            MPI_THREAD_SINGLE;
-
-#  if defined(MVAPICH2_VERSION) && defined(_POSIX_SOURCE)
-        // This enables multi threading support in MVAPICH2 if requested.
-        if (required == MPI_THREAD_MULTIPLE) setenv("MV2_ENABLE_AFFINITY", "0", 1);
-#  endif
-# endif
-
-        int retval = init(argc, argv, required, minimal, provided_threading_flag_);
-        if (MPI_SUCCESS != retval && MPI_ERR_OTHER != retval)
-        {
-            enabled_ = false;
-
-            int msglen = 0;
-            char message[MPI_MAX_ERROR_STRING + 1];
-            MPI_Error_string(retval, message, &msglen);
-            message[msglen] = '\0';
-
-            std::string msg("mpi_environment::init: MPI_Init_thread failed: ");
-            msg = msg + message + ".";
-            throw std::runtime_error(msg.c_str());
-        }
-
-        MPI_Comm_dup(MPI_COMM_WORLD, &communicator_);
-
-        if (provided_threading_flag_ < MPI_THREAD_SERIALIZED)
-        {
-            // explicitly disable mpi if not run by mpirun
-            rtcfg.add_entry("pika.mpi.multithreaded", "0");
-        }
-
-        if (provided_threading_flag_ == MPI_THREAD_FUNNELED)
-        {
-            enabled_ = false;
-            has_called_init_ = false;
-            throw std::runtime_error(
-                "mpi_environment::init: MPI_Init_thread: The underlying MPI implementation only "
-                "supports MPI_THREAD_FUNNELED. This mode is not supported by pika. Please pass "
-                "--pika:ini=pika.parcel.mpi.multithreaded=0 to explicitly disable MPI "
-                "multi-threading.");
-        }
-
-        this_rank = rank();
-
-        rtcfg.add_entry("pika.mpi.rank", std::to_string(this_rank));
-        rtcfg.add_entry("pika.mpi.processorname", get_processor_name());
+        int is_initialized = 0;
+        int retval = MPI_Initialized(&is_initialized);
+        if (MPI_SUCCESS != retval) { throw std::runtime_error("MPI_Initialized call failed"); }
+        return is_initialized;
     }
 
     std::string mpi_environment::get_processor_name()
@@ -170,7 +102,7 @@ namespace pika { namespace util {
 
     void mpi_environment::finalize()
     {
-        if (enabled() && has_called_init())
+        if (pika_called_init())
         {
             int is_finalized = 0;
             MPI_Finalized(&is_finalized);
@@ -178,64 +110,20 @@ namespace pika { namespace util {
         }
     }
 
-    bool mpi_environment::enabled() { return enabled_; }
-
-    bool mpi_environment::multi_threaded()
-    {
-        return provided_threading_flag_ >= MPI_THREAD_SERIALIZED;
-    }
-
-    bool mpi_environment::has_called_init() { return has_called_init_; }
+    bool mpi_environment::pika_called_init() { return mpi_init_pika_; }
 
     int mpi_environment::size()
     {
         int res(-1);
-        if (enabled()) MPI_Comm_size(communicator(), &res);
+        MPI_Comm_size(MPI_COMM_WORLD, &res);
         return res;
     }
 
     int mpi_environment::rank()
     {
         int res(-1);
-        if (enabled()) MPI_Comm_rank(communicator(), &res);
+        MPI_Comm_rank(MPI_COMM_WORLD, &res);
         return res;
-    }
-
-    MPI_Comm& mpi_environment::communicator() { return communicator_; }
-
-    mpi_environment::scoped_lock::scoped_lock()
-    {
-        if (!multi_threaded()) mtx_.lock();
-    }
-
-    mpi_environment::scoped_lock::~scoped_lock()
-    {
-        if (!multi_threaded()) mtx_.unlock();
-    }
-
-    void mpi_environment::scoped_lock::unlock()
-    {
-        if (!multi_threaded()) mtx_.unlock();
-    }
-
-    mpi_environment::scoped_try_lock::scoped_try_lock()
-      : locked(true)
-    {
-        if (!multi_threaded()) { locked = mtx_.try_lock(); }
-    }
-
-    mpi_environment::scoped_try_lock::~scoped_try_lock()
-    {
-        if (!multi_threaded() && locked) mtx_.unlock();
-    }
-
-    void mpi_environment::scoped_try_lock::unlock()
-    {
-        if (!multi_threaded() && locked)
-        {
-            locked = false;
-            mtx_.unlock();
-        }
     }
 }}    // namespace pika::util
 

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -12,6 +12,7 @@
 #include <pika/modules/mpi_base.hpp>
 #include <pika/modules/runtime_configuration.hpp>
 #include <pika/modules/util.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 
 #include <boost/tokenizer.hpp>
 

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -19,11 +19,11 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace pika { namespace util {
+namespace pika { namespace mpi {
 
     namespace detail {
 
-        bool detect_mpi_environment(util::runtime_configuration const& cfg, char const* default_env)
+        bool detect_environment(util::runtime_configuration const& cfg, char const* default_env)
         {
 #if defined(__bgq__)
             // If running on BG/Q, we can safely assume to always run in an MPI environment
@@ -49,82 +49,84 @@ namespace pika { namespace util {
         }
     }    // namespace detail
 
-    bool mpi_environment::check_mpi_environment(util::runtime_configuration const& cfg)
+    bool environment::check_environment(util::runtime_configuration const& cfg)
     {
         // log message was already generated
-        return detail::detect_mpi_environment(cfg, PIKA_HAVE_MPI_ENV);
+        return detail::detect_environment(cfg, PIKA_HAVE_MPI_ENV);
     }
-}}    // namespace pika::util
+}}    // namespace pika::mpi
 
 #if defined(PIKA_HAVE_MODULE_MPI_BASE)
 
-namespace pika { namespace util {
+namespace pika::mpi {
 
-    bool mpi_environment::mpi_init_pika_ = false;
+bool environment::mpi_init_pika_ = false;
 
-    ///////////////////////////////////////////////////////////////////////////
-    int mpi_environment::init(int*, char***, const int required, const int minimal, int& provided)
+///////////////////////////////////////////////////////////////////////////
+int environment::init(int*, char***, const int required, const int minimal, int& provided)
+{
+    mpi_init_pika_ = false;
+    int retval = MPI_SUCCESS;
+    if (!environment::is_mpi_inititialized())
     {
-        mpi_init_pika_ = false;
-        int retval = MPI_SUCCESS;
-        if (!mpi_environment::is_mpi_inititialized())
+        retval = MPI_Init_thread(nullptr, nullptr, required, &provided);
+        if (MPI_SUCCESS != retval) { return retval; }
+
+        if (provided < minimal)
         {
-            retval = MPI_Init_thread(nullptr, nullptr, required, &provided);
-            if (MPI_SUCCESS != retval) { return retval; }
-
-            if (provided < minimal)
-            {
-                PIKA_THROW_EXCEPTION(pika::error::invalid_status,
-                    "pika::util::mpi_environment::init",
-                    "MPI doesn't provide minimal requested thread level");
-            }
-            mpi_init_pika_ = true;
+            PIKA_THROW_EXCEPTION(pika::error::invalid_status, "pika::mpi::environment::init",
+                "MPI doesn't provide minimal requested thread level");
         }
-        return retval;
+        mpi_init_pika_ = true;
     }
+    return retval;
+}
 
-    bool mpi_environment::is_mpi_inititialized()
+bool environment::is_mpi_inititialized()
+{
+    int is_initialized = 0;
+    int retval = MPI_Initialized(&is_initialized);
+    if (MPI_SUCCESS != retval)
     {
-        int is_initialized = 0;
-        int retval = MPI_Initialized(&is_initialized);
-        if (MPI_SUCCESS != retval) { throw std::runtime_error("MPI_Initialized call failed"); }
-        return is_initialized;
+        throw mpi::exception(MPI_ERR_OTHER, "MPI_Initialized call failed");
     }
+    return is_initialized;
+}
 
-    std::string mpi_environment::get_processor_name()
+std::string environment::get_processor_name()
+{
+    char name[MPI_MAX_PROCESSOR_NAME + 1] = {'\0'};
+    int len = 0;
+    MPI_Get_processor_name(name, &len);
+
+    return name;
+}
+
+void environment::finalize()
+{
+    if (pika_called_init())
     {
-        char name[MPI_MAX_PROCESSOR_NAME + 1] = {'\0'};
-        int len = 0;
-        MPI_Get_processor_name(name, &len);
-
-        return name;
+        int is_finalized = 0;
+        MPI_Finalized(&is_finalized);
+        if (!is_finalized) { MPI_Finalize(); }
     }
+}
 
-    void mpi_environment::finalize()
-    {
-        if (pika_called_init())
-        {
-            int is_finalized = 0;
-            MPI_Finalized(&is_finalized);
-            if (!is_finalized) { MPI_Finalize(); }
-        }
-    }
+bool environment::pika_called_init() { return mpi_init_pika_; }
 
-    bool mpi_environment::pika_called_init() { return mpi_init_pika_; }
+int environment::size()
+{
+    int res(-1);
+    MPI_Comm_size(MPI_COMM_WORLD, &res);
+    return res;
+}
 
-    int mpi_environment::size()
-    {
-        int res(-1);
-        MPI_Comm_size(MPI_COMM_WORLD, &res);
-        return res;
-    }
-
-    int mpi_environment::rank()
-    {
-        int res(-1);
-        MPI_Comm_rank(MPI_COMM_WORLD, &res);
-        return res;
-    }
-}}    // namespace pika::util
+int environment::rank()
+{
+    int res(-1);
+    MPI_Comm_rank(MPI_COMM_WORLD, &res);
+    return res;
+}
+}    // namespace pika::mpi
 
 #endif

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 ETH Zurich
 //  Copyright (c) 2013-2015 Thomas Heller
 //  Copyright (c)      2020 Google
 //

--- a/libs/pika/mpi_base/src/mpi_exception.cpp
+++ b/libs/pika/mpi_base/src/mpi_exception.cpp
@@ -7,6 +7,7 @@
 
 #include <pika/config.hpp>
 #include <pika/errors/exception.hpp>
+#include <pika/mpi_base/mpi.hpp>
 #include <pika/mpi_base/mpi_exception.hpp>
 
 #include <cstddef>

--- a/libs/pika/mpi_base/src/mpi_exception.cpp
+++ b/libs/pika/mpi_base/src/mpi_exception.cpp
@@ -5,15 +5,15 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <pika/config.hpp>
-#include <pika/async_mpi/mpi_exception.hpp>
 #include <pika/errors/exception.hpp>
-#include <pika/mpi_base/mpi.hpp>
+#include <pika/mpi_base/mpi_exception.hpp>
 
 #include <cstddef>
 #include <memory>
+#include <mpi.h>
 #include <string>
 
-namespace pika::mpi::experimental {
+namespace pika::mpi {
     namespace detail {
         std::string error_message(int code)
         {
@@ -26,13 +26,13 @@ namespace pika::mpi::experimental {
     }    // namespace detail
 
     // -------------------------------------------------------------------------
-    // exception type for failed launch of MPI functions
-    mpi_exception::mpi_exception(int err_code, const std::string& msg)
+    // exception type for failed launch of MPI functions or other mpi problem
+    exception::exception(int err_code, const std::string& msg)
       : pika::exception(pika::error::bad_function_call,
             msg + std::string(" MPI returned with error: ") + detail::error_message(err_code))
       , err_code_(err_code)
     {
     }
 
-    int mpi_exception::get_mpi_errorcode() const noexcept { return err_code_; }
-}    // namespace pika::mpi::experimental
+    int exception::get_mpi_errorcode() const noexcept { return err_code_; }
+}    // namespace pika::mpi

--- a/libs/pika/mpi_base/src/mpi_exception.cpp
+++ b/libs/pika/mpi_base/src/mpi_exception.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 ETH Zurich
 //  Copyright (c) 2020 John Biddiscombe
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/pika/mpi_base/src/mpi_exception.cpp
+++ b/libs/pika/mpi_base/src/mpi_exception.cpp
@@ -12,7 +12,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <mpi.h>
 #include <string>
 
 namespace pika::mpi {

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -87,8 +87,8 @@ namespace pika::detail {
                 strm << "{stack-trace}: " << *back_trace << "\n";
             }
 #if defined(PIKA_HAVE_MPI)
-            if (pika::mpi::environment::is_mpi_inititialized())
-                strm << "{mpi-rank}: " << pika::mpi::environment::rank() << '\n';
+            if (mpi::detail::environment::is_mpi_initialized())
+                strm << "{mpi-rank}: " << mpi::detail::environment::rank() << '\n';
 #endif
             std::string const* hostname_ = xi.get<pika::detail::throw_hostname>();
             if (hostname_ && !hostname_->empty()) strm << "{hostname}: " << *hostname_ << "\n";

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -88,7 +88,7 @@ namespace pika::detail {
             }
 #if defined(PIKA_HAVE_MPI)
             if (mpi::detail::environment::is_mpi_initialized())
-                strm << "{mpi-rank}: " << mpi::detail::environment::rank() << '\n';
+                strm << "MPI rank: " << mpi::detail::environment::rank() << '\n';
 #endif
             std::string const* hostname_ = xi.get<pika::detail::throw_hostname>();
             if (hostname_ && !hostname_->empty()) strm << "{hostname}: " << *hostname_ << "\n";

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -23,6 +23,7 @@
 
 #if defined(PIKA_HAVE_MPI)
 # include <pika/mpi_base/mpi.hpp>
+# include <pika/mpi_base/mpi_environment.hpp>
 #endif
 
 #include <fmt/format.h>
@@ -85,19 +86,10 @@ namespace pika::detail {
                 // FIXME: add indentation to stack frame information
                 strm << "{stack-trace}: " << *back_trace << "\n";
             }
-
 #if defined(PIKA_HAVE_MPI)
-            int mpi_initialized = 0;
-            if (MPI_Initialized(&mpi_initialized) == MPI_SUCCESS && mpi_initialized)
-            {
-                int rank = 0;
-                if (MPI_Comm_rank(MPI_COMM_WORLD, &rank) == MPI_SUCCESS)
-                {
-                    strm << "{mpi-rank}: " << rank << '\n';
-                }
-            }
+            if (pika::util::mpi_environment::is_mpi_inititialized())
+                strm << "{mpi-rank}: " << pika::util::mpi_environment::rank() << '\n';
 #endif
-
             std::string const* hostname_ = xi.get<pika::detail::throw_hostname>();
             if (hostname_ && !hostname_->empty()) strm << "{hostname}: " << *hostname_ << "\n";
 

--- a/libs/pika/runtime/src/custom_exception_info.cpp
+++ b/libs/pika/runtime/src/custom_exception_info.cpp
@@ -87,8 +87,8 @@ namespace pika::detail {
                 strm << "{stack-trace}: " << *back_trace << "\n";
             }
 #if defined(PIKA_HAVE_MPI)
-            if (pika::util::mpi_environment::is_mpi_inititialized())
-                strm << "{mpi-rank}: " << pika::util::mpi_environment::rank() << '\n';
+            if (pika::mpi::environment::is_mpi_inititialized())
+                strm << "{mpi-rank}: " << pika::mpi::environment::rank() << '\n';
 #endif
             std::string const* hostname_ = xi.get<pika::detail::throw_hostname>();
             if (hostname_ && !hostname_->empty()) strm << "{hostname}: " << *hostname_ << "\n";

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -42,6 +42,7 @@
 
 #if defined(PIKA_HAVE_MPI)
 # include <pika/mpi_base/mpi.hpp>
+# include <pika/mpi_base/mpi_environment.hpp>
 #endif
 
 #if defined(PIKA_HAVE_TRACY)
@@ -905,15 +906,8 @@ namespace pika::detail {
             strm << std::string(79, '*') << '\n';
 
 #if defined(PIKA_HAVE_MPI)
-            int mpi_initialized = 0;
-            if (MPI_Initialized(&mpi_initialized) == MPI_SUCCESS && mpi_initialized)
-            {
-                int rank = 0;
-                if (MPI_Comm_rank(MPI_COMM_WORLD, &rank) == MPI_SUCCESS)
-                {
-                    strm << "MPI rank: " << rank << '\n';
-                }
-            }
+            if (pika::util::mpi_environment::is_mpi_inititialized())
+                strm << "{mpi-rank}: " << pika::util::mpi_environment::rank() << '\n';
 #endif
 
             for (std::size_t i = 0; i != num_threads; ++i)

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -907,7 +907,7 @@ namespace pika::detail {
 
 #if defined(PIKA_HAVE_MPI)
             if (mpi::detail::environment::is_mpi_initialized())
-                strm << "{mpi-rank}: " << mpi::detail::environment::rank() << '\n';
+                strm << "MPI rank: " << mpi::detail::environment::rank() << '\n';
 #endif
 
             for (std::size_t i = 0; i != num_threads; ++i)

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -906,8 +906,8 @@ namespace pika::detail {
             strm << std::string(79, '*') << '\n';
 
 #if defined(PIKA_HAVE_MPI)
-            if (pika::mpi::environment::is_mpi_inititialized())
-                strm << "{mpi-rank}: " << pika::mpi::environment::rank() << '\n';
+            if (mpi::detail::environment::is_mpi_initialized())
+                strm << "{mpi-rank}: " << mpi::detail::environment::rank() << '\n';
 #endif
 
             for (std::size_t i = 0; i != num_threads; ++i)

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -906,8 +906,8 @@ namespace pika::detail {
             strm << std::string(79, '*') << '\n';
 
 #if defined(PIKA_HAVE_MPI)
-            if (pika::util::mpi_environment::is_mpi_inititialized())
-                strm << "{mpi-rank}: " << pika::util::mpi_environment::rank() << '\n';
+            if (pika::mpi::environment::is_mpi_inititialized())
+                strm << "{mpi-rank}: " << pika::mpi::environment::rank() << '\n';
 #endif
 
             for (std::size_t i = 0; i != num_threads; ++i)


### PR DESCRIPTION
Remove unused features/functions/variables.

Most of mpi_base was brought in from HPX which needs MPI for it's internal communication (active messages) and it must therefore guarantee initialization and certain setup defaults whenever it might be used in a multi node environment.

pika only uses MPI when the user explicitly requests MPI and therefore the setup/teardown is always directed by the user and we can remove some unnecessary code/checks.

Replace some duplicated mpi initialized/rank fetch calls in pika body with reused functions from mpi_environment.
