### PR TITLE
Use C++20 in CUDA 12 CI configuration

### DIFF
--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -12,7 +12,7 @@ include:
   variables:
     SPACK_ARCH: linux-ubuntu22.04-haswell
     COMPILER: gcc@12.1.0
-    CXXSTD: 17
+    CXXSTD: 20
     GPU_TARGET: "60"
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system \
                  cxxstd=$CXXSTD ^boost@1.82.0 ^hwloc@2.9.1 ^cuda@12.0.0 ^fmt@10.0.0"

--- a/.gitlab/includes/gcc12_cuda12_pipeline.yml
+++ b/.gitlab/includes/gcc12_cuda12_pipeline.yml
@@ -15,7 +15,7 @@ include:
     CXXSTD: 20
     GPU_TARGET: "60"
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system \
-                 cxxstd=$CXXSTD ^boost@1.82.0 ^hwloc@2.9.1 ^cuda@12.0.0 ^fmt@10.0.0"
+                 cxxstd=$CXXSTD ^boost@1.82.0 ^hwloc@2.9.1 ^cuda@12.0.0 ^fmt@10.0.0 ^cmake@3.28"
     # PIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE is OFF to test the fallback implementation of PIKA_FORWARD.
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_CUDA_ARCHITECTURES=$GPU_TARGET \

--- a/cmake/pika_add_config_test.cmake
+++ b/cmake/pika_add_config_test.cmake
@@ -432,6 +432,31 @@ function(pika_check_for_cxx20_trivial_virtual_destructor)
 endfunction()
 
 # ##################################################################################################
+function(pika_check_for_cxx20_trivial_virtual_destructor_gpu)
+  if(PIKA_WITH_GPU_SUPPORT)
+    set(trivial_virtual_destructor_test_extension "cpp")
+    if(PIKA_WITH_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+      set(trivial_virtual_destructor_test_extension "cu")
+    elseif(PIKA_WITH_HIP)
+      set(trivial_virtual_destructor_test_extension "hip")
+    endif()
+
+    set(extra_cxxflags)
+    if(PIKA_WITH_CUDA AND CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+      set(extra_cxxflags "-x cu")
+    endif()
+
+    pika_add_config_test(
+      PIKA_WITH_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR_GPU
+      SOURCE
+        cmake/tests/cxx20_trivial_virtual_destructor.${trivial_virtual_destructor_test_extension}
+        GPU
+      FILE ${ARGN}
+    )
+  endif()
+endfunction()
+
+# ##################################################################################################
 function(pika_check_for_cxx23_static_call_operator)
   pika_add_config_test(
     PIKA_WITH_CXX23_STATIC_CALL_OPERATOR

--- a/cmake/pika_perform_cxx_feature_tests.cmake
+++ b/cmake/pika_perform_cxx_feature_tests.cmake
@@ -44,6 +44,10 @@ function(pika_perform_cxx_feature_tests)
     DEFINITIONS PIKA_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR
   )
 
+  pika_check_for_cxx20_trivial_virtual_destructor_gpu(
+    DEFINITIONS PIKA_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR_GPU
+  )
+
   pika_check_for_cxx23_static_call_operator(DEFINITIONS PIKA_HAVE_CXX23_STATIC_CALL_OPERATOR)
 
   pika_check_for_cxx23_static_call_operator_gpu(

--- a/cmake/tests/cxx20_trivial_virtual_destructor.cu
+++ b/cmake/tests/cxx20_trivial_virtual_destructor.cu
@@ -1,0 +1,1 @@
+cxx20_trivial_virtual_destructor.cpp

--- a/cmake/tests/cxx20_trivial_virtual_destructor.hip
+++ b/cmake/tests/cxx20_trivial_virtual_destructor.hip
@@ -1,0 +1,1 @@
+cxx20_trivial_virtual_destructor.cpp

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -59,6 +59,8 @@ namespace pika::detail {
     // - https://github.com/llvm/llvm-project/commit/73b22935a7a863679021598db6a45fcfb62cd321
     // - https://reviews.llvm.org/D119615
 #if defined(PIKA_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR) &&                                         \
+    (!defined(PIKA_HAVE_GPU_SUPPORT) ||                                                            \
+        defined(PIKA_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR_GPU)) &&                                \
     !(defined(PIKA_COMPUTE_CODE) && defined(PIKA_CLANG_VERSION) &&                                 \
         (PIKA_CLANG_VERSION >= 140000) && (PIKA_CLANG_VERSION < 150000))
     template <typename T>


### PR DESCRIPTION
Adds a configuration check to see if the GPU compiler supports trivial virtual destructors that can be used in constexpr contexts. nvcc at least up to version 12.6 does not support it (https://compiler-explorer.com/z/4hfvrnzcG).