### PR TITLE
Remove unnecessary status messages when detecting MPI continuations support

### DIFF
--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -13,10 +13,8 @@ endif()
 
 pika_check_for_mpix_continuations(PIKA_WITH_MPIX_CONTINUATIONS)
 if(PIKA_WITH_MPIX_CONTINUATIONS)
-  message(STATUS "MPIx Continuations detected")
   set(PIKA_MPI_MODES_LOOP_COUNT 79)
 else()
-  message(STATUS "MPIx Continuations not detected")
   set(PIKA_MPI_MODES_LOOP_COUNT 63)
 endif()
 


### PR DESCRIPTION
We already print:
```
-- Performing Test PIKA_WITH_MPIX_CONTINUATIONS - Failed
```
when performing the feature test itself. I propose to remove the trailing:
```
-- MPIx Continuations not detected
```
since:
- it says the same as the previous line (admittedly a bit nicer, but still)
- we only print the `Performing Test PIKA_WITH...` line for all other feature checks