### PR TITLE
Replace `PIKA_UNUSED` by `[[maybe_unused]]`

### DIFF
--- a/libs/pika/command_line_handling/src/late_command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/late_command_line_handling.cpp
@@ -11,7 +11,6 @@
 #include <pika/program_options/variables_map.hpp>
 #include <pika/runtime_configuration/runtime_configuration.hpp>
 #include <pika/string_util/from_string.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <cstdlib>

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
@@ -44,7 +44,6 @@
 #endif
 
 #include <pika/assert.hpp>
-#include <pika/type_support/unused.hpp>
 #include <pika/util/get_and_reset_value.hpp>
 
 // include unist.d conditionally to check for POSIX version. Not all OSs have

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
@@ -37,7 +37,6 @@
 #include <pika/coroutines/config/defines.hpp>
 #include <pika/coroutines/detail/get_stack_pointer.hpp>
 #include <pika/coroutines/detail/swap_context.hpp>
-#include <pika/type_support/unused.hpp>
 #include <pika/util/get_and_reset_value.hpp>
 
 #include <atomic>

--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
@@ -32,7 +32,6 @@
 
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
-#include <pika/type_support/unused.hpp>
 
 // include unist.d conditionally to check for POSIX version. Not all OSs have the
 // unistd header...

--- a/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/stackless_coroutine.hpp
@@ -16,7 +16,6 @@
 #include <pika/coroutines/thread_id_type.hpp>
 #include <pika/functional/detail/reset_function.hpp>
 #include <pika/functional/unique_function.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -22,7 +22,6 @@
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
 #include <pika/synchronization/counting_semaphore.hpp>
 #include <pika/type_support/pack.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <atomic>
 #include <exception>

--- a/libs/pika/execution/tests/unit/algorithm_require_started.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_require_started.cpp
@@ -7,6 +7,7 @@
 #include <pika/execution.hpp>
 #include <pika/execution_base/tests/algorithm_test_utils.hpp>
 #include <pika/testing.hpp>
+#include <pika/type_support/unused.hpp>
 
 #include <atomic>
 #include <exception>

--- a/libs/pika/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all.cpp
@@ -7,6 +7,7 @@
 #include <pika/config.hpp>
 #include <pika/modules/execution.hpp>
 #include <pika/testing.hpp>
+#include <pika/type_support/unused.hpp>
 
 #include <pika/execution_base/tests/algorithm_test_utils.hpp>
 

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -7,7 +7,6 @@
 #include <pika/execution_base/completion_scheduler.hpp>
 #include <pika/execution_base/sender.hpp>
 #include <pika/testing.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -37,7 +37,6 @@
 #include <pika/threading/thread.hpp>
 #include <pika/threading_base/detail/get_default_pool.hpp>
 #include <pika/type_support/pack.hpp>
-#include <pika/type_support/unused.hpp>
 #include <pika/util/get_entry_as.hpp>
 #include <pika/version.hpp>
 
@@ -243,7 +242,7 @@ namespace pika {
         ////////////////////////////////////////////////////////////////////////
         void init_environment(detail::command_line_handling& cmdline)
         {
-            PIKA_UNUSED(pika::detail::filesystem::initial_path());
+            pika::detail::filesystem::initial_path();
 
             pika::detail::set_assertion_handler(&pika::detail::assertion_handler);
             pika::detail::set_custom_exception_info_handler(&pika::detail::custom_exception_info);

--- a/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/pika/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -313,7 +313,7 @@ std::chrono::duration<double> bench_stencil3_iterator_v1()
     using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     // handle boundary elements explicitly
-    int result = values.back() + values.front() + values[1];
+    [[maybe_unused]] int result = values.back() + values.front() + values[1];
 
     std::for_each(r.first, r.second, [&result](reference val) {
         using std::get;
@@ -321,7 +321,6 @@ std::chrono::duration<double> bench_stencil3_iterator_v1()
     });
 
     result += values[partition_size - 2] + values.back() + values.front();
-    PIKA_UNUSED(result);
 
     return std::chrono::high_resolution_clock::now() - start;
 }
@@ -413,7 +412,7 @@ std::chrono::duration<double> bench_stencil3_iterator_v2()
     using reference = std::iterator_traits<decltype(r.first)>::reference;
 
     // handle boundary elements explicitly
-    int result = values.back() + values.front() + values[1];
+    [[maybe_unused]] int result = values.back() + values.front() + values[1];
 
     std::for_each(r.first, r.second, [&result](reference val) {
         using std::get;
@@ -421,7 +420,6 @@ std::chrono::duration<double> bench_stencil3_iterator_v2()
     });
 
     result += values[partition_size - 2] + values.back() + values.front();
-    PIKA_UNUSED(result);
 
     return std::chrono::high_resolution_clock::now() - start;
 }
@@ -435,7 +433,7 @@ std::chrono::duration<double> bench_stencil3_iterator_explicit()
     auto start = std::chrono::high_resolution_clock::now();
 
     // handle all elements explicitly
-    int result = values.back() + values.front() + values[1];
+    [[maybe_unused]] int result = values.back() + values.front() + values[1];
 
     auto range = pika::detail::irange(1, partition_size - 1);
 
@@ -443,7 +441,6 @@ std::chrono::duration<double> bench_stencil3_iterator_explicit()
         [&result, &values](std::size_t i) { result += values[i - 1] + values[i] + values[i + 1]; });
 
     result += values[partition_size - 2] + values.back() + values.front();
-    PIKA_UNUSED(result);
 
     return std::chrono::high_resolution_clock::now() - start;
 }

--- a/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
+++ b/libs/pika/lock_registration/include/pika/lock_registration/detail/register_locks.hpp
@@ -10,7 +10,6 @@
 #include <pika/config.hpp>
 #include <pika/concepts/has_member_xxx.hpp>
 #include <pika/functional/function.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <map>

--- a/libs/pika/program_options/tests/unit/parsers.cpp
+++ b/libs/pika/program_options/tests/unit/parsers.cpp
@@ -13,7 +13,6 @@
 #include <pika/program_options/value_semantic.hpp>
 #include <pika/program_options/variables_map.hpp>
 #include <pika/testing.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <cstdlib>    // for putenv

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_numa.hpp
@@ -13,7 +13,6 @@
 #include <pika/threading_base/thread_data.hpp>
 //
 #include <pika/thread_support/unlock_guard.hpp>
-#include <pika/type_support/unused.hpp>
 //
 #include <pika/schedulers/queue_holder_thread.hpp>
 //

--- a/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/condition_variable.hpp
@@ -18,7 +18,6 @@
 #include <pika/thread_support/assert_owns_lock.hpp>
 #include <pika/thread_support/unlock_guard.hpp>
 #include <pika/timing/steady_clock.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <mutex>
 #include <utility>

--- a/libs/pika/synchronization/include/pika/synchronization/latch.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/latch.hpp
@@ -12,7 +12,6 @@
 #include <pika/concurrency/cache_line_data.hpp>
 #include <pika/concurrency/spinlock.hpp>
 #include <pika/synchronization/detail/condition_variable.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/pika/synchronization/src/detail/condition_variable.cpp
+++ b/libs/pika/synchronization/src/detail/condition_variable.cpp
@@ -15,7 +15,6 @@
 #include <pika/thread_support/unlock_guard.hpp>
 #include <pika/threading_base/thread_helpers.hpp>
 #include <pika/timing/steady_clock.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/pika/synchronization/src/mutex.cpp
+++ b/libs/pika/synchronization/src/mutex.cpp
@@ -16,7 +16,6 @@
 #include <pika/synchronization/condition_variable.hpp>
 #include <pika/threading_base/thread_data.hpp>
 #include <pika/timing/steady_clock.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <mutex>
 #include <utility>

--- a/libs/pika/thread_manager/src/thread_manager.cpp
+++ b/libs/pika/thread_manager/src/thread_manager.cpp
@@ -26,7 +26,6 @@
 #include <pika/threading_base/thread_queue_init_parameters.hpp>
 #include <pika/timing/detail/timestamp.hpp>
 #include <pika/topology/topology.hpp>
-#include <pika/type_support/unused.hpp>
 #include <pika/util/get_entry_as.hpp>
 
 #include <cstddef>

--- a/libs/pika/thread_support/include/pika/thread_support/assert_owns_lock.hpp
+++ b/libs/pika/thread_support/include/pika/thread_support/assert_owns_lock.hpp
@@ -9,7 +9,6 @@
 #include <pika/config.hpp>
 #include <pika/assert.hpp>
 #include <pika/concepts/has_member_xxx.hpp>
-#include <pika/type_support/unused.hpp>
 
 #include <type_traits>
 


### PR DESCRIPTION
Removes unused `pika/type_support/unused.hpp` includes and removes some unnecessary uses of `PIKA_UNUSED`.