### PR TITLE
Remove slurm reservation and account used in CI

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -28,14 +28,9 @@ variables:
     reports:
       dotenv: base.env
 
-.gh200-slurm-account:
-  variables:
-    SLURM_ACCOUNT: g154
-    SLURM_RESERVATION: daint
-
 # We allow failure since santis is unstable
 base_spack_image_aarch64:
-  extends: [.container-builder-cscs-gh200, .base_spack_image, .gh200-slurm-account]
+  extends: [.container-builder-cscs-gh200, .base_spack_image]
   allow_failure: true
 base_spack_image_x86_64:
   extends: [.container-builder-cscs-zen2, .base_spack_image]
@@ -59,7 +54,7 @@ base_spack_image_x86_64:
 
 .compiler_image_template_santis:
   needs: [base_spack_image_aarch64]
-  extends: [.container-builder-cscs-gh200, .compiler_image_template, .gh200-slurm-account]
+  extends: [.container-builder-cscs-gh200, .compiler_image_template]
 
 .compiler_image_template_rosa:
   needs: [base_spack_image_x86_64]
@@ -81,7 +76,7 @@ base_spack_image_x86_64:
       dotenv: dependencies.env
 
 .dependencies_image_template_santis:
-  extends: [.container-builder-cscs-gh200, .dependencies_image_template, .gh200-slurm-account]
+  extends: [.container-builder-cscs-gh200, .dependencies_image_template]
 
 .dependencies_image_template_rosa:
   extends: [.container-builder-cscs-zen2, .dependencies_image_template]
@@ -116,7 +111,7 @@ base_spack_image_x86_64:
       dotenv: "$DOTENV_FILE"
 
 .build_template_santis:
-  extends: [.container-builder-cscs-gh200, .build_template, .gh200-slurm-account]
+  extends: [.container-builder-cscs-gh200, .build_template]
 
 .build_template_rosa:
   extends: [.container-builder-cscs-zen2, .build_template]


### PR DESCRIPTION
Undo #1257. No longer needed.