### PR TITLE
Allow pika to automatically create MPI pool on startup

### DIFF
--- a/libs/pika/async_mpi/CMakeLists.txt
+++ b/libs/pika/async_mpi/CMakeLists.txt
@@ -13,9 +13,9 @@ endif()
 
 pika_check_for_mpix_continuations(PIKA_WITH_MPIX_CONTINUATIONS)
 if(PIKA_WITH_MPIX_CONTINUATIONS)
-  set(PIKA_MPI_MODES_LOOP_COUNT 79)
+  set(PIKA_MPI_MODES_LOOP_COUNT 39)
 else()
-  set(PIKA_MPI_MODES_LOOP_COUNT 63)
+  set(PIKA_MPI_MODES_LOOP_COUNT 31)
 endif()
 
 # Default location is $PIKA_ROOT/libs/mpi/include

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -68,7 +68,7 @@ namespace pika::mpi::experimental::detail {
     // return a scheduler on the mpi pool
     inline auto mpi_pool_scheduler(execution::thread_priority p)
     {
-        if (!pool_exists()) return default_pool_scheduler(p);
+        if (!get_enable_pool()) return default_pool_scheduler(p);
         return ex::with_priority(
             ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p);
     }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_helpers.hpp
@@ -68,7 +68,7 @@ namespace pika::mpi::experimental::detail {
     // return a scheduler on the mpi pool
     inline auto mpi_pool_scheduler(execution::thread_priority p)
     {
-        if (!get_enable_pool()) return default_pool_scheduler(p);
+        if (!get_pool_enabled()) return default_pool_scheduler(p);
         return ex::with_priority(
             ex::thread_pool_scheduler{&resource::get_thread_pool(get_pool_name())}, p);
     }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -183,7 +183,6 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT bool create_pool(pika::resource::partitioner& rp, std::string const& pool_name,
             resource::polling_pool_creation_mode mode);
 
-        PIKA_EXPORT const std::string& get_pool_name();
         PIKA_EXPORT void register_pool(const std::string& pool_name);
 
         PIKA_EXPORT void register_polling();
@@ -214,6 +213,9 @@ namespace pika::mpi::experimental {
     /// when true pika::mpi can disable pool creation, or change the thread mode
     /// otherwise, the flags passed by the user to completion mode etc are honoured
     PIKA_EXPORT void enable_optimizations(bool enable);
+
+    /// return the name assigned to the mpi polling pool
+    PIKA_EXPORT const std::string& get_pool_name();
 
     // initialize the pika::mpi background request handler
     // All ranks should call this function (but only one thread per rank needs to do so)

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -71,11 +71,6 @@ namespace pika::mpi::experimental {
         /// on any error instead of the default behavior of program termination
         PIKA_EXPORT void set_error_handler();
 
-        // -----------------------------------------------------------------
-        /// Background progress function for MPI async operations
-        /// Checks for completed MPI_Requests and sets ready state in waiting receivers
-        PIKA_EXPORT pika::threads::detail::polling_status poll();
-
         /// utility function to avoid duplication in eager check locations
         PIKA_EXPORT bool poll_request(MPI_Request /*req*/);
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -195,17 +195,18 @@ namespace pika::mpi::experimental {
         /// set the maximum number of MPI_Request completions to handle at each polling event
         PIKA_EXPORT void set_max_polling_size(std::size_t);
         PIKA_EXPORT std::size_t get_max_polling_size();
+
+        // -----------------------------------------------------------------
+        /// Set/Get the pool_enabled flag
+        PIKA_EXPORT bool get_pool_enabled();
+        PIKA_EXPORT void set_pool_enabled(bool);
+
     }    // namespace detail
 
     /// return the total number of mpi requests currently in queues
     /// This number is an estimate as new work might be created/added during the call
     /// and so the returned value should be considered approximate (racy)
     PIKA_EXPORT size_t get_work_count();
-
-    // -----------------------------------------------------------------
-    /// Set/Get the polling and handler mode for continuations.
-    PIKA_EXPORT bool get_enable_pool();
-    PIKA_EXPORT void set_enable_pool(bool);
 
     // -----------------------------------------------------------------
     /// Set/Get the polling and handler mode for continuations.

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -196,14 +196,6 @@ namespace pika::mpi::experimental {
         /// set the maximum number of MPI_Request completions to handle at each polling event
         PIKA_EXPORT void set_max_polling_size(std::size_t);
         PIKA_EXPORT std::size_t get_max_polling_size();
-
-        // initialize the pika::mpi background request handler
-        // All ranks should call this function (but only one thread per rank needs to do so)
-        PIKA_EXPORT void start(
-            exception_mode errorhandler = no_handler, std::string pool_name = "");
-
-        // -----------------------------------------------------------------
-        PIKA_EXPORT void stop();
     }    // namespace detail
 
     /// return the total number of mpi requests currently in queues
@@ -223,6 +215,13 @@ namespace pika::mpi::experimental {
     /// otherwise, the flags passed by the user to completion mode etc are honoured
     PIKA_EXPORT void enable_optimizations(bool enable);
 
+    // initialize the pika::mpi background request handler
+    // All ranks should call this function (but only one thread per rank needs to do so)
+    PIKA_EXPORT void start_polling(
+        exception_mode errorhandler = no_handler, std::string pool_name = "");
+
+    PIKA_EXPORT void stop_polling();
+
     // -----------------------------------------------------------------
     // This RAII helper class ensures that MPI polling start/stop is handled correctly
     struct [[nodiscard]] enable_polling
@@ -231,9 +230,9 @@ namespace pika::mpi::experimental {
         explicit enable_polling(
             exception_mode errorhandler = no_handler, std::string const& pool_name = "")
         {
-            mpi::experimental::detail::start(errorhandler, pool_name);
+            start_polling(errorhandler, pool_name);
         }
 
-        ~enable_polling() { mpi::experimental::detail::stop(); }
+        ~enable_polling() { stop_polling(); }
     };
 }    // namespace pika::mpi::experimental

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -38,6 +38,19 @@ namespace pika::mpi::experimental {
         install_handler,
     };
 
+    /// This enumeration describes polling pool creation modes,
+    /// the user may request a dedicated pool that can be used by pika::mpi
+    /// MPI pool completion flags are passed on the command line or via env vars
+    /// the default mode is pika_decides: if running on one rank or a single thread
+    /// per rank, creation of the pool will be
+    enum polling_pool_creation_mode
+    {
+        /// if the completion mode requires it, a pool will be created at startup
+        mode_pika_decides = 0,
+        /// overrides command line flags/env vars - enables creation of a polling pool
+        mode_force_create = 1,
+    };
+
     namespace detail {
         using request_callback_function_type = pika::util::detail::unique_function<void(int)>;
 
@@ -164,11 +177,14 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT void restart_mpix();
 
         void init_resource_partitioner_handler(pika::resource::partitioner&,
-            pika::program_options::variables_map const& vm,
-            resource::polling_pool_creation_mode mode);
+            pika::program_options::variables_map const& vm, polling_pool_creation_mode mode);
 
+        /// creates a pool to be used for mpi polling, returns true if the pool was created
+        /// and false if it was not, due to lack of threads, or running on a single rank
+        /// passing a pool creation mode of force create will only fail if insufficient threads
+        /// exist to support one
         PIKA_EXPORT bool create_pool(pika::resource::partitioner& rp, std::string const& pool_name,
-            resource::polling_pool_creation_mode mode);
+            polling_pool_creation_mode mode);
 
         PIKA_EXPORT void register_pool(const std::string& pool_name);
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -216,7 +216,7 @@ namespace pika::mpi::experimental {
     PIKA_EXPORT std::size_t get_completion_mode();
     PIKA_EXPORT void set_completion_mode(std::size_t mode);
 
-    /// can be used to chooose between single/multi thread model when initializing MPI
+    /// can be used to choose between single/multi thread model when initializing MPI
     PIKA_EXPORT int get_preferred_thread_mode();
 
     /// when true pika::mpi can disable pool creation, or change the thread mode

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -201,37 +201,40 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT bool get_pool_enabled();
         PIKA_EXPORT void set_pool_enabled(bool);
 
+        // -----------------------------------------------------------------
+        /// Set/Get the polling and handler mode for continuations.
+        PIKA_EXPORT void set_completion_mode(std::size_t);
+
     }    // namespace detail
+
+    /// when true pika::mpi can disable pool creation, or change the thread mode
+    /// otherwise, the flags passed by the user to completion mode etc are honoured
+    PIKA_EXPORT void enable_optimizations(bool);
+
+    // -----------------------------------------------------------------
+    /// Set/Get the polling and handler mode for continuations.
+    PIKA_EXPORT std::size_t get_completion_mode();
+
+    /// can be used to choose between single/multi thread model when initializing MPI
+    PIKA_EXPORT int get_preferred_thread_mode();
 
     /// return the total number of mpi requests currently in queues
     /// This number is an estimate as new work might be created/added during the call
     /// and so the returned value should be considered approximate (racy)
     PIKA_EXPORT size_t get_work_count();
 
-    // -----------------------------------------------------------------
-    /// Set/Get the polling and handler mode for continuations.
-    PIKA_EXPORT std::size_t get_completion_mode();
-    PIKA_EXPORT void set_completion_mode(std::size_t);
-
-    /// can be used to choose between single/multi thread model when initializing MPI
-    PIKA_EXPORT int get_preferred_thread_mode();
-
-    /// when true pika::mpi can disable pool creation, or change the thread mode
-    /// otherwise, the flags passed by the user to completion mode etc are honoured
-    PIKA_EXPORT void enable_optimizations(bool);
-
     /// return the name assigned to the mpi polling pool
     PIKA_EXPORT const std::string& get_pool_name();
 
-    // initialize the pika::mpi background request handler
-    // All ranks should call this function (but only one thread per rank needs to do so)
+    /// initialize the pika::mpi background request handler
+    /// All ranks should call this function (but only one thread per rank needs to do so)
     PIKA_EXPORT void start_polling(
         exception_mode errorhandler = no_handler, std::string pool_name = "");
 
     PIKA_EXPORT void stop_polling();
 
     // -----------------------------------------------------------------
-    // This RAII helper class ensures that MPI polling start/stop is handled correctly
+    /// This RAII helper class ensures that MPI polling start/stop is handled correctly
     struct [[nodiscard]] enable_polling
     {
         /// an empty pool name tells pika to use the mpi pool if it exists

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -83,19 +83,19 @@ namespace pika::mpi::experimental {
             /// the calling thread performs the mpi operation, when unset, a transfer
             /// is made so that the invocation happens on a new task that
             /// would normally be on a dedicated pool if/when it exists
-            request_inline = 0b0000'0001,    // 2
+            request_inline = 0b0000'0001,    // 1
 
             /// this bit enables the inline execution of the completion handler for the
             /// request, when unset a transfer is made to move the completion handler
             /// from the polling thread onto a new one
-            completion_inline = 0b0000'0010,    // 4
+            completion_inline = 0b0000'0010,    // 2
 
             /// this bit enables the use of a high priority task flag
             /// 1) requests are boosted to high priority if they are passed the the mpi-pool
             ///    to ensure they execute before other polling tasks (reduce latency)
             /// 2) completions are boosted to high priority when sent to the main thread pool
             ///    so that the continuation is executed as quickly as possible
-            high_priority = 0b0000'0100,    // 8
+            high_priority = 0b0000'0100,    // 4
 
             /// 3 bits control the handler method,
             method_mask = 0b0011'1000,    // 56
@@ -117,11 +117,12 @@ namespace pika::mpi::experimental {
             ///
             /// * unspecified : reserved for development purposes or for customization by an
             /// application using pika
-            yield_while = 0b0000'0000,          // 0x00, 00 ... 7
-            suspend_resume = 0b0000'1000,       // 0x08, 08 ... 15
-            new_task = 0b0001'0000,             // 0x10, 16 ... 23
-            continuation = 0b0001'1000,         // 0x18, 24 ... 31
-            mpix_continuation = 0b0010'0000,    // 0x20, 32 ... 39
+            yield_while = 0b0000'0000,                                          // 0x00, 00 -> 7
+            suspend_resume = 0b0000'1000,                                       // 0x08, 08 -> 15
+            new_task = 0b0001'0000,                                             // 0x10, 16 -> 23
+            continuation = 0b0001'1000,                                         // 0x18, 24 -> 31
+            mpix_continuation = 0b0010'0000,                                    // 0x20, 32 -> 39
+            default_mode = continuation + completion_inline + high_priority,    // 24 + 2 + 4 = 30
         };
 
         /// 3 bits define continuation mode

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -228,7 +228,8 @@ namespace pika::mpi::experimental {
     struct [[nodiscard]] enable_polling
     {
         /// an empty pool name tells pika to use the mpi pool if it exists
-        enable_polling(exception_mode errorhandler = no_handler, std::string const& pool_name = "")
+        explicit enable_polling(
+            exception_mode errorhandler = no_handler, std::string const& pool_name = "")
         {
             mpi::experimental::detail::start(errorhandler, pool_name);
         }

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -166,9 +166,6 @@ namespace pika::mpi::experimental {
             }
         }
 
-        /// utility : needed by static checks when debugging
-        PIKA_EXPORT int comm_world_size();
-
         /// mpix extensions in openmpi to support mpi continuations
         using MPIX_Continue_cb_function = int(int rc, void* cb_data);
         PIKA_EXPORT void register_mpix_continuation(
@@ -176,9 +173,12 @@ namespace pika::mpi::experimental {
         /// called after each completed continuation to restart/re-enable continuation support
         PIKA_EXPORT void restart_mpix();
 
+        // -----------------------------------------------------------------
+        /// called at runtime start when command-line flags ask for an mpi pool
         void init_resource_partitioner_handler(pika::resource::partitioner&,
             pika::program_options::variables_map const& vm, polling_pool_creation_mode mode);
 
+        // -----------------------------------------------------------------
         /// creates a pool to be used for mpi polling, returns true if the pool was created
         /// and false if it was not, due to lack of threads, or running on a single rank
         /// passing a pool creation mode of force create will only fail if insufficient threads
@@ -186,8 +186,12 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT bool create_pool(pika::resource::partitioner& rp, std::string const& pool_name,
             polling_pool_creation_mode mode);
 
+        // -----------------------------------------------------------------
+        /// tell the pika::mpi frework which pool is being used for mpi polling
         PIKA_EXPORT void register_pool(const std::string& pool_name);
 
+        // -----------------------------------------------------------------
+        /// actually enable/disable the polling callback handler
         PIKA_EXPORT void register_polling();
         PIKA_EXPORT void unregister_polling();
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -175,9 +175,6 @@ namespace pika::mpi::experimental {
         PIKA_EXPORT void register_polling();
         PIKA_EXPORT void unregister_polling();
 
-        // returns false if no custom mpi pool has been created
-        PIKA_EXPORT bool pool_exists();
-
         // -----------------------------------------------------------------
         /// set the maximum number of MPI_Request completions to handle at each polling event
         PIKA_EXPORT void set_max_polling_size(std::size_t);

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -58,20 +58,6 @@ namespace pika::mpi::experimental {
             bool completions_inline = use_inline_completion(mode);
             bool requests_inline = use_inline_request(mode);
 
-#ifdef PIKA_DEBUG
-            // ----------------------------------------------------------
-            // the pool should exist if the completion mode needs it
-            int cwsize = detail::comm_world_size();
-            bool need_pool = (cwsize > 1 && use_pool(mode));
-            if (pool_exists() != need_pool)
-            {
-                PIKA_DETAIL_DP(mpi_tran<0>,
-                    error(str<>("transform_mpi"), "mode", mode, "pool_exists()", pool_exists(),
-                        "need_pool", need_pool));
-            }
-            PIKA_ASSERT(pool_exists() == need_pool);
-#endif
-
             execution::thread_priority p = use_priority_boost(mode) ?
                 execution::thread_priority::boost :
                 execution::thread_priority::normal;

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -735,7 +735,7 @@ namespace pika::mpi::experimental {
             if (!found)
                 PIKA_THROW_EXCEPTION(pika::error::bad_parameter, "mpi::register",
                     "Register failed '{}' does not exist", pool_name);
-            PIKA_DETAIL_DP(detail::mpi_debug<0>,
+            PIKA_DETAIL_DP(detail::mpi_debug<1>,
                 debug(str<>("register_pool"), "pool =", detail::polling_pool_name_));
         }
 
@@ -786,14 +786,12 @@ namespace pika::mpi::experimental {
             {
                 if (mpi_data_.size_ == 1)
                 {
-                    PIKA_DETAIL_DP(
-                        detail::mpi_debug<0>, warning(str<>("Pool disabled"), "single rank"));
+                    PIKA_LOG(warn, "MPI Pool creation disabled, running on a single rank");
                     do_create = false;
                 }
                 if (rp.get_number_requested_threads() < 2)
                 {
-                    PIKA_DETAIL_DP(detail::mpi_debug<0>,
-                        warning(str<>("Pool disabled"), "insufficient threads"));
+                    PIKA_LOG(warn, "MPI Pool creation disabled, insufficient threads");
                     do_create = false;
                 }
             }
@@ -812,7 +810,7 @@ namespace pika::mpi::experimental {
                 rp.add_resource(rp.sockets()[0].cores()[0].pus()[0], name);
                 register_pool(name);
             }
-            PIKA_DETAIL_DP(detail::mpi_debug<0>,
+            PIKA_DETAIL_DP(detail::mpi_debug<1>,
                 debug(str<>("create_pool"), (do_create ? "created" : "skipped"), "name",
                     get_pool_name(), "mode flags", bin<8>(detail::completion_flags_)));
             return do_create;
@@ -900,9 +898,10 @@ namespace pika::mpi::experimental {
         bool need_pool = (detail::comm_world_size() > 1 && get_enable_pool());
         if (detail::enable_pool_ != need_pool)
         {
-            PIKA_DETAIL_DP(detail::mpi_debug<0>,
-                warning(str<>("pika:::mpi"), "handler mode", mode, "and mpi pool existence status",
-                    detail::enable_pool_, "are inconsistent and may reduce performance"));
+            PIKA_LOG(warn,
+                "pika::mpi handler mode ({}) and mpi pool existence status ({}) "
+                "are inconsistent and may reduce performance",
+                mode, detail::enable_pool_);
         }
     }
 
@@ -948,7 +947,7 @@ namespace pika::mpi::experimental {
         if (detail::singlethreaded(get_completion_mode()) && detail::mpi_data_.optimizations_)
         {
             required = MPI_THREAD_SINGLE;
-            PIKA_DETAIL_DP(detail::mpi_debug<0>, debug(str<>("MPI_THREAD_SINGLE"), "overridden"));
+            PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("MPI_THREAD_SINGLE"), "overridden"));
         }
         return required;
     }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -713,9 +713,6 @@ namespace pika::mpi::experimental {
         }
 
         // -----------------------------------------------------------------
-        const std::string& get_pool_name() { return detail::polling_pool_name_; }
-
-        // -----------------------------------------------------------------
         void register_pool(const std::string& pool_name)
         {
             PIKA_DETAIL_DP(detail::mpi_debug<1>,
@@ -839,6 +836,9 @@ namespace pika::mpi::experimental {
     }    // namespace detail
 
     // -----------------------------------------------------------------
+    const std::string& get_pool_name() { return detail::polling_pool_name_; }
+
+    // -----------------------------------------------------------------
     // initialize the pika::mpi background request handler
     // All ranks should call this function,
     // but only one thread per rank needs to do so
@@ -850,7 +850,7 @@ namespace pika::mpi::experimental {
 
         if (pool_name.empty())
         {
-            pool_name = detail::pool_exists() ? detail::get_pool_name() :
+            pool_name = detail::pool_exists() ? get_pool_name() :
                                                 resource::get_partitioner().get_default_pool_name();
         }
         detail::register_pool(pool_name);
@@ -893,7 +893,7 @@ namespace pika::mpi::experimental {
                 MPI_UNDEFINED, MPI_INFO_NULL, &detail::mpi_data_.mpix_continuations_request));
 
             PIKA_DETAIL_DP(detail::mpi_debug<1>,
-                debug(str<>("MPIX"), "Enabled,", "pool =", detail::get_pool_name(), ", mode",
+                debug(str<>("MPIX"), "Enabled,", "pool =", get_pool_name(), ", mode",
                     detail::mode_string(get_completion_mode()), get_completion_mode(),
                     ptr(detail::mpi_data_.mpix_continuations_request)));
             // it is now safe to use the mpix request, {memory_order = not a critical code path}
@@ -923,7 +923,7 @@ namespace pika::mpi::experimental {
     // -----------------------------------------------------------------
     void stop_polling()
     {
-        detail::unregister_polling(pika::resource::get_thread_pool(detail::get_pool_name()));
+        detail::unregister_polling(pika::resource::get_thread_pool(get_pool_name()));
 
         // remove error handler if we installed it
         if (detail::mpi_data_.error_handler_initialized_)

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -213,7 +213,8 @@ namespace pika::mpi::experimental {
         // -----------------------------------------------------------------
         std::size_t get_completion_mode_default()
         {
-            return pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE", 0);
+            return pika::detail::get_env_var_as<std::size_t>("PIKA_MPI_COMPLETION_MODE",
+                pika::detail::to_underlying(handler_method::default_mode));
         }
 
         // -----------------------------------------------------------------

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -64,7 +64,7 @@ namespace pika::mpi::experimental {
 
         // -----------------------------------------------------------------
         /// Get the default value for mpi pool creation enable/disable
-        bool get_enable_pool_default();
+        bool get_pool_enabled_default();
         /// Get the default value for number of requests to poll for in calls to MPI_Test etc
         std::size_t get_polling_default();
         /// Get the default mode for completions/transfers of MPI requests to from pools
@@ -154,7 +154,7 @@ namespace pika::mpi::experimental {
         static mpi_data mpi_data_;
 
         // should pika use an mpi pool, default initialization
-        static bool enable_pool_{get_enable_pool_default()};
+        static bool enable_pool_{get_pool_enabled_default()};
 
         // default completion/handler mode for mpi continuations
         static std::size_t completion_flags_{get_completion_mode_default()};
@@ -206,7 +206,7 @@ namespace pika::mpi::experimental {
         }
 
         // -----------------------------------------------------------------
-        bool get_enable_pool_default()
+        bool get_pool_enabled_default()
         {
             return pika::detail::get_env_var_as<bool>("PIKA_MPI_ENABLE_POOL", false);
         }
@@ -822,6 +822,11 @@ namespace pika::mpi::experimental {
             int provided, required = get_preferred_thread_mode();
             mpi::detail::environment::init(nullptr, nullptr, required, required, provided);
         }
+
+        // -----------------------------------------------------------------
+        bool get_pool_enabled() { return detail::enable_pool_; }
+        void set_pool_enabled(bool mode) { detail::enable_pool_ = mode; }
+
     }    // namespace detail
 
     // -----------------------------------------------------------------
@@ -895,7 +900,7 @@ namespace pika::mpi::experimental {
 
         // ----------------------------------------------------------
         // the pool should exist if the completion mode needs it
-        bool need_pool = (detail::comm_world_size() > 1 && get_enable_pool());
+        bool need_pool = (detail::comm_world_size() > 1 && detail::get_pool_enabled());
         if (detail::enable_pool_ != need_pool)
         {
             PIKA_LOG(warn,
@@ -926,10 +931,6 @@ namespace pika::mpi::experimental {
 
     // -----------------------------------------------------------------
     size_t get_work_count() { return detail::mpi_data_.all_in_flight_; }
-
-    // -----------------------------------------------------------------
-    bool get_enable_pool() { return detail::enable_pool_; }
-    void set_enable_pool(bool mode) { detail::enable_pool_ = mode; }
 
     // -----------------------------------------------------------------
     std::size_t get_completion_mode() { return detail::completion_flags_; }

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -846,8 +846,13 @@ namespace pika::mpi::experimental {
     {
         // don't allow polling code to run until init has completed
         std::lock_guard<detail::mutex_type> lk(detail::mpi_data_.polling_vector_mtx_);
+        PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("start_polling"), detail::mpi_data_));
 
-        if (pool_name.empty()) pool_name = detail::get_pool_name();
+        if (pool_name.empty())
+        {
+            pool_name = detail::pool_exists() ? detail::get_pool_name() :
+                                                resource::get_partitioner().get_default_pool_name();
+        }
         detail::register_pool(pool_name);
 
         // --------------------------------------
@@ -858,8 +863,6 @@ namespace pika::mpi::experimental {
         }
         detail::mpi_data_.rank_ = mpi::detail::environment::rank();
         detail::mpi_data_.size_ = mpi::detail::environment::size();
-
-        PIKA_DETAIL_DP(detail::mpi_debug<1>, debug(str<>("init"), detail::mpi_data_));
 
         // --------------------------------------
         // install error handler (convert mpi errors into exceptoions

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -38,8 +38,6 @@ set(pool_creation_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
 set(pool_creation_NO_POOL ON)
 # cmake-format: on
 
-# note that because we add (eg) "_0_5" to the test name, we explicitly link pika_testing because
-# pika_add_unit_test expects "${name}_test"
 foreach(test ${tests})
 
   set(sources ${test}.cpp)
@@ -70,11 +68,12 @@ foreach(test ${tests})
         ${full_name_}
         ${${test}_PARAMETERS}
         EXECUTABLE
-        ${test}
+        ${test}_test
         ARGS
         $<$<BOOL:${enable_pool}>:--pika:mpi-enable-pool>
         "--pika:mpi-completion-mode=${polling_mode}"
       )
     endforeach()
   endforeach()
+  pika_add_unit_test("modules.async_mpi" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
-    DEPENDENCIES pika_testing ${${test}_DEPENDENCIES}
+    DEPENDENCIES ${${test}_DEPENDENCIES}
     FOLDER "Tests/Unit/Modules/AsyncMPI"
   )
 
@@ -70,7 +70,7 @@ foreach(test ${tests})
         ${full_name_}
         ${${test}_PARAMETERS}
         EXECUTABLE
-        ${test}_test
+        ${test}
         ARGS
         $<$<BOOL:${enable_pool}>:--pika:mpi-enable-pool>
         "--pika:mpi-completion-mode=${polling_mode}"

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -40,18 +40,23 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/AsyncMPI"
   )
 
-  foreach(polling_mode RANGE 0 ${PIKA_MPI_MODES_LOOP_COUNT} 1)
-    pika_add_pseudo_target(${test}_mode_${polling_mode}_test)
-    pika_add_pseudo_dependencies(${test}_mode_${polling_mode}_test ${test}_test)
-    pika_add_unit_test(
-      "modules.async_mpi"
-      ${test}_mode_${polling_mode}
-      ${${test}_PARAMETERS}
-      EXECUTABLE
-      ${test}_test
-      ARGS
-      "--pika:mpi-completion-mode=${polling_mode}"
-    )
+  foreach(enable_pool RANGE 1)
+    foreach(polling_mode RANGE 0 ${PIKA_MPI_MODES_LOOP_COUNT} 1)
+      set(temp_name_ ${test}_mode_${enable_pool}_${polling_mode})
+      message("generating ${temp_name_}")
+      pika_add_pseudo_target(${temp_name_}_test)
+      pika_add_pseudo_dependencies(${temp_name_}_test ${test}_test)
+      pika_add_unit_test(
+        "modules.async_mpi"
+        ${temp_name_}
+        ${${test}_PARAMETERS}
+        EXECUTABLE
+        ${test}_test
+        ARGS
+        $<$<BOOL:${enable_pool}>:--pika:mpi-enable-pool>
+        "--pika:mpi-completion-mode=${polling_mode}"
+      )
+    endforeach()
   endforeach()
   pika_add_unit_test("modules.async_mpi" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver)
+set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver pool_creation)
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
@@ -22,6 +22,9 @@ set(mpi_async_storage_PARAMETERS
 
 set(algorithm_transform_mpi_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)
+
+set(pool_creation_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
+set(pool_creation_DEPENDENCIES pika_execution_test_utilities)
 
 foreach(test ${tests})
 

--- a/libs/pika/async_mpi/tests/unit/CMakeLists.txt
+++ b/libs/pika/async_mpi/tests/unit/CMakeLists.txt
@@ -8,24 +8,38 @@ set(tests algorithm_transform_mpi mpi_ring_async_sender_receiver pool_creation)
 
 # cmake-format: off
 set(mpi_ring_async_sender_receiver_PARAMETERS
-    ARGS "--in-flight-limit=32" "--rounds=5" "--iterations=25" "--message-bytes=64"
-         "--pika:ignore-process-mask"
-    THREADS 4 RANKS 2 MPIWRAPPER
+    ARGS
+      "--in-flight-limit=2"
+      "--rounds=5"
+      "--iterations=25"
+      "--message-bytes=64"
+      "--pika:ignore-process-mask"
+    THREADS 4
+    RANKS 2
+    MPIWRAPPER
 )
 
 set(mpi_async_storage_PARAMETERS
-    ARGS "--in-flight-limit=256" "--localMB=256" "--transferKB=1024" "--seconds=1" 
-         "--pika:ignore-process-mask"
-    THREADS 4 RANKS 2 MPIWRAPPER
+    ARGS
+      "--in-flight-limit=256"
+      "--localMB=256"
+      "--transferKB=1024"
+      "--seconds=1"
+      "--pika:ignore-process-mask"
+    THREADS 4
+    RANKS 2
+    MPIWRAPPER
 )
-# cmake-format: on
 
 set(algorithm_transform_mpi_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
 set(algorithm_transform_mpi_DEPENDENCIES pika_execution_test_utilities)
 
 set(pool_creation_PARAMETERS THREADS 2 RANKS 2 MPIWRAPPER)
-set(pool_creation_DEPENDENCIES pika_execution_test_utilities)
+set(pool_creation_NO_POOL ON)
+# cmake-format: on
 
+# note that because we add (eg) "_0_5" to the test name, we explicitly link pika_testing because
+# pika_add_unit_test expects "${name}_test"
 foreach(test ${tests})
 
   set(sources ${test}.cpp)
@@ -36,19 +50,24 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
-    DEPENDENCIES ${${test}_DEPENDENCIES}
+    DEPENDENCIES pika_testing ${${test}_DEPENDENCIES}
     FOLDER "Tests/Unit/Modules/AsyncMPI"
   )
 
-  foreach(enable_pool RANGE 1)
+  # if NO_POOL is set, then we only use enable_pool=false and skip true
+  set(BOOL_RANGE 1) # 0..1
+  if(${${test}_NO_POOL})
+    set(BOOL_RANGE 0) # just 0
+  endif()
+
+  foreach(enable_pool RANGE ${BOOL_RANGE})
     foreach(polling_mode RANGE 0 ${PIKA_MPI_MODES_LOOP_COUNT} 1)
-      set(temp_name_ ${test}_mode_${enable_pool}_${polling_mode})
-      message("generating ${temp_name_}")
-      pika_add_pseudo_target(${temp_name_}_test)
-      pika_add_pseudo_dependencies(${temp_name_}_test ${test}_test)
+      set(full_name_ ${test}_mode_${enable_pool}_${polling_mode})
+      pika_add_pseudo_target(${full_name_}_test)
+      pika_add_pseudo_dependencies(${full_name_}_test ${test}_test)
       pika_add_unit_test(
         "modules.async_mpi"
-        ${temp_name_}
+        ${full_name_}
         ${${test}_PARAMETERS}
         EXECUTABLE
         ${test}_test
@@ -58,5 +77,4 @@ foreach(test ${tests})
       )
     endforeach()
   endforeach()
-  pika_add_unit_test("modules.async_mpi" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -129,7 +129,7 @@ PIKA_NO_SANITIZE_ADDRESS void test_exception_handler_code(MPI_Comm comm, MPI_Dat
 PIKA_NO_SANITIZE_ADDRESS void test_exception_no_handler(MPI_Comm comm)
 {
     // Use the default error handler MPI_ERRORS_ARE_FATAL
-    mpi::enable_user_polling enable_polling_no_errhandler;
+    mpi::enable_polling enable_polling_no_errhandler;
     {
         // Exception thrown based on the returned error code
         int *data = nullptr, count = 0;
@@ -162,9 +162,8 @@ int pika_main()
 
     {
         {
-            // Use the custom error handler from the async_mpi module which throws
-            // exceptions on error returned
-            mpi::enable_user_polling enable_polling(mpi::get_pool_name(), true);
+            // Use the custom error handler which throws exceptions on mpi errors
+            mpi::enable_polling enable_polling(mpi::exception_mode::install_handler);
             // Success path
             {
                 // MPI function pointer
@@ -249,21 +248,14 @@ int pika_main()
 }
 
 //----------------------------------------------------------------------------
-void init_resource_partitioner_handler(
-    pika::resource::partitioner&, pika::program_options::variables_map const& /*vm*/)
-{
-    namespace mpix = pika::mpi::experimental;
-    mpix::create_pool("", mpix::pool_create_mode::pika_decides);
-}
-
-//----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     MPI_Init(&argc, &argv);
 
-    // Set runtime initialization callback to init thread_pools
+    // -----------------
+    // Initialize and run pika. Ask for an mpi thread pool if polling mode requires it
     pika::init_params init_args;
-    init_args.rp_callback = &init_resource_partitioner_handler;
+    init_args.pool_creation_mode = ::pika::resource::polling_pool_creation_mode::mode_pika_decides;
 
     // Start runtime and collect runtime exit status
     auto result = pika::init(pika_main, argc, argv, init_args);

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -252,13 +252,8 @@ int main(int argc, char* argv[])
 {
     MPI_Init(&argc, &argv);
 
-    // -----------------
-    // Initialize and run pika. Ask for an mpi thread pool if polling mode requires it
-    pika::init_params init_args;
-    init_args.pool_creation_mode = ::pika::resource::polling_pool_creation_mode::mode_pika_decides;
-
     // Start runtime and collect runtime exit status
-    auto result = pika::init(pika_main, argc, argv, init_args);
+    auto result = pika::init(pika_main, argc, argv);
     PIKA_TEST_EQ(result, 0);
 
     MPI_Finalize();

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -370,7 +370,7 @@ int pika_main(pika::program_options::variables_map& vm)
     options.warmup = false;
     options.final = false;
 
-    // mpi::set_max_requests_in_flight(options.in_flight_limit);
+    mpi::set_max_requests_in_flight(options.in_flight_limit);
     nws_deb<1>.debug("set_max_requests_in_flight", rank, deb::dec<04>(options.in_flight_limit));
 
     nws_deb<1>.debug(
@@ -463,10 +463,10 @@ int main(int argc, char* argv[])
     pika::program_options::options_description cmdline(
         "Usage: " PIKA_APPLICATION_STRING " [options]");
 
-    // cmdline.add_options()("in-flight-limit",
-    //     pika::program_options::value<std::uint32_t>()->default_value(
-    //         mpi::get_max_requests_in_flight()),
-    //     "Apply a limit to the number of messages in flight.");
+    cmdline.add_options()("in-flight-limit",
+        pika::program_options::value<std::uint32_t>()->default_value(
+            mpi::get_max_requests_in_flight()),
+        "Apply a limit to the number of messages in flight.");
 
     cmdline.add_options()("localMB",
         pika::program_options::value<std::uint64_t>()->default_value(256),

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -545,10 +545,9 @@ int main(int argc, char* argv[])
     }
 
     // -----------------
-    // Initialize and run pika. Ask for an mpi thread pool if polling mode requires it
+    // Initialize and run pika.
     pika::init_params init_args;
     init_args.desc_cmdline = cmdline;
-    init_args.pool_creation_mode = ::pika::resource::mode_pika_decides;
 
     mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
 

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -328,10 +328,8 @@ struct message_receiver
 // this is called on a pika thread after the runtime starts up
 int pika_main(pika::program_options::variables_map& vm)
 {
-    // Do not initialize mpi (we do that ourselves), do install an error handler
-    mpix::init(false, true);
-    // Setup mpi polling on default pool, enable exceptions and init mpi internals
-    mpix::register_polling();
+    // Enable polling on mpi pool, install an error handler
+    mpix::enable_polling enable_polling(mpix::exception_mode::install_handler);
     //
     std::int32_t rank, size;
     MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -360,7 +358,7 @@ int pika_main(pika::program_options::variables_map& vm)
     limiter = std::make_unique<pika::counting_semaphore<>>(in_flight);
 
     mpi_poll_size = vm["mpi-polling-size"].as<std::uint32_t>();
-    mpix::set_max_polling_size(mpi_poll_size);
+    mpix::detail::set_max_polling_size(mpi_poll_size);
 
     std::uint32_t message_size = vm["message-bytes"].as<std::uint32_t>();
 
@@ -479,20 +477,6 @@ int pika_main(pika::program_options::variables_map& vm)
 }
 
 //----------------------------------------------------------------------------
-void init_resource_partitioner_handler(
-    pika::resource::partitioner&, pika::program_options::variables_map const& vm)
-{
-    // Don't create an MPI pool if the user disabled it
-    auto pool_mode = mpix::pool_create_mode::pika_decides;
-    if (vm["no-mpi-pool"].as<bool>()) { pool_mode = mpix::pool_create_mode::force_no_create; }
-
-    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
-
-    msr_deb<2>.debug(str<>("init RP"), "create_pool");
-    mpix::create_pool("", pool_mode);
-}
-
-//----------------------------------------------------------------------------
 // the normal int main function that is called at startup and runs on an OS
 // thread the user must call pika::init to start the pika runtime which
 // will execute pika_main on a pika thread
@@ -561,11 +545,12 @@ int main(int argc, char* argv[])
     }
 
     // -----------------
-    // Initialize and run pika.
+    // Initialize and run pika. Ask for an mpi thread pool if polling mode requires it
     pika::init_params init_args;
     init_args.desc_cmdline = cmdline;
-    // Set the callback to init thread_pools
-    init_args.rp_callback = &init_resource_partitioner_handler;
+    init_args.pool_creation_mode = ::pika::resource::mode_pika_decides;
+
+    mpix::enable_optimizations(vm["mpi-optimizations"].as<bool>());
 
     auto result = pika::init(pika_main, argc, argv, init_args);
     PIKA_TEST_EQ(result, 0);

--- a/libs/pika/async_mpi/tests/unit/pool_creation.cpp
+++ b/libs/pika/async_mpi/tests/unit/pool_creation.cpp
@@ -125,10 +125,8 @@ int main(int argc, char* argv[])
     MPI_Init(&argc, &argv);
 
     // ---------------------------------------
-    // Let pika create a pool for mpi using default settings
-    pika::init_params init_args1;
-    init_args1.pool_creation_mode = pika::resource::polling_pool_creation_mode::mode_pika_decides;
     // Start runtime and collect runtime exit status
+    pika::init_params init_args1;
     auto result1 = pika::init([&]() { return pika_main(""); }, argc, argv, init_args1);
     PIKA_TEST_EQ(result1, 0);
 

--- a/libs/pika/async_mpi/tests/unit/pool_creation.cpp
+++ b/libs/pika/async_mpi/tests/unit/pool_creation.cpp
@@ -7,7 +7,6 @@
 #include <pika/config/compiler_specific.hpp>
 #include <pika/exception.hpp>
 #include <pika/execution.hpp>
-#include <pika/execution_base/tests/algorithm_test_utils.hpp>
 #include <pika/init.hpp>
 #include <pika/mpi.hpp>
 #include <pika/testing.hpp>

--- a/libs/pika/async_mpi/tests/unit/pool_creation.cpp
+++ b/libs/pika/async_mpi/tests/unit/pool_creation.cpp
@@ -1,0 +1,131 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <pika/config/compiler_specific.hpp>
+#include <pika/exception.hpp>
+#include <pika/execution.hpp>
+#include <pika/execution_base/tests/algorithm_test_utils.hpp>
+#include <pika/init.hpp>
+#include <pika/mpi.hpp>
+#include <pika/testing.hpp>
+
+#include <atomic>
+#include <cstdlib>
+#include <mpi.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+static const std::string random_pool_name1 = "abcd12345qwerty";
+static const std::string random_pool_name2 = "ta-daa-500";
+
+namespace ex = pika::execution::experimental;
+namespace mpi = pika::mpi::experimental;
+namespace tt = pika::this_thread::experimental;
+
+// -----------------------------------------------------------------
+int pika_main(const std::string& pool_name)
+{
+    int size, rank;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    MPI_Datatype datatype = MPI_INT;
+
+    {
+        // Register polling on our custom pool
+        mpi::enable_polling enable_polling(mpi::exception_mode::install_handler, pool_name);
+        // Success path
+        {
+            // MPI function pointer
+            int data = 0, count = 1;
+            if (rank == 0) { data = 42; }
+            auto s = mpi::transform_mpi(ex::just(&data, count, datatype, 0, comm), MPI_Ibcast);
+            tt::sync_wait(PIKA_MOVE(s));
+            PIKA_TEST_EQ(data, 42);
+        }
+
+        // Operator| overload
+        {
+            // MPI function pointer
+            int data = 0, count = 1;
+            if (rank == 0) { data = 42; }
+            tt::sync_wait(
+                ex::just(&data, count, datatype, 0, comm) | mpi::transform_mpi(MPI_Ibcast));
+            PIKA_TEST_EQ(data, 42);
+        }
+
+    }    // let the user polling go out of scope
+
+    {
+        // Register polling on default pool
+        mpi::enable_polling enable_polling(mpi::exception_mode::install_handler,
+            pika::resource::get_partitioner().get_default_pool_name());
+        // Success path
+        {
+            // MPI function pointer
+            int data = 0, count = 1;
+            if (rank == 0) { data = 42; }
+            auto s = mpi::transform_mpi(ex::just(&data, count, datatype, 0, comm), MPI_Ibcast);
+            tt::sync_wait(PIKA_MOVE(s));
+            PIKA_TEST_EQ(data, 42);
+        }
+
+        // Operator| overload
+        {
+            // MPI function pointer
+            int data = 0, count = 1;
+            if (rank == 0) { data = 42; }
+            tt::sync_wait(
+                ex::just(&data, count, datatype, 0, comm) | mpi::transform_mpi(MPI_Ibcast));
+            PIKA_TEST_EQ(data, 42);
+        }
+    }    // let the user polling go out of scope
+
+    pika::finalize();
+    return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+void init_resource_partitioner_manual(
+    pika::resource::partitioner& rp, pika::program_options::variables_map const&)
+{
+    // Disable idle backoff on our custom pool
+    using pika::threads::scheduler_mode;
+    auto mode = scheduler_mode::default_mode;
+    mode = scheduler_mode(mode & ~scheduler_mode::enable_idle_backoff);
+
+    // Create a thread pool with a single core that we will use for communication related tasks
+    rp.create_thread_pool(
+        random_pool_name1, pika::resource::scheduling_policy::local_priority_fifo, mode);
+    rp.add_resource(rp.sockets()[0].cores()[0].pus()[0], random_pool_name1);
+}
+
+//----------------------------------------------------------------------------
+void init_resource_partitioner_mpi(
+    pika::resource::partitioner& rp, pika::program_options::variables_map const&)
+{
+    pika::mpi::experimental::detail::create_pool(
+        rp, random_pool_name2, pika::resource::polling_pool_creation_mode::mode_pika_decides);
+}
+
+//----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    // Set runtime initialization callback to manually create our thread pool
+    pika::init_params init_args;
+    init_args.rp_callback = &init_resource_partitioner_manual;
+
+    // Start runtime and collect runtime exit status
+    auto result = pika::init([&]() { return pika_main(random_pool_name1); }, argc, argv, init_args);
+    PIKA_TEST_EQ(result, 0);
+
+    MPI_Finalize();
+    return result;
+}

--- a/libs/pika/async_mpi/tests/unit/pool_creation.cpp
+++ b/libs/pika/async_mpi/tests/unit/pool_creation.cpp
@@ -86,7 +86,11 @@ void init_resource_partitioner_mpi(
 //----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
-    MPI_Init(&argc, &argv);
+    // -----------------
+    // Init MPI
+    int provided, preferred = MPI_THREAD_MULTIPLE;
+    MPI_Init_thread(&argc, &argv, preferred, &provided);
+    PIKA_TEST_EQ(provided, preferred);
 
     {
         // ---------------------------------------

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -396,6 +396,16 @@ namespace pika::detail {
     }
 
 #if defined(PIKA_HAVE_MPI)
+    bool handle_enable_mpi_pool(detail::manage_config& cfgmap,
+        pika::util::runtime_configuration const& rtcfg, pika::program_options::variables_map& vm)
+    {
+        bool enable_mpi_pool = cfgmap.get_value<bool>("pika.mpi.enable_pool",
+            pika::detail::get_entry_as<bool>(rtcfg, "pika.mpi.enable_pool", false));
+
+        enable_mpi_pool |= vm.count("pika:mpi-enable-pool");
+        return enable_mpi_pool;
+    }
+
     std::size_t handle_mpi_completion_mode(detail::manage_config& cfgmap,
         pika::util::runtime_configuration const& rtcfg, pika::program_options::variables_map& vm)
     {
@@ -550,6 +560,9 @@ namespace pika::detail {
         }
 
 #if defined(PIKA_HAVE_MPI)
+        bool enable_mpi_pool = detail::handle_enable_mpi_pool(cfgmap, rtcfg_, vm);
+        ini_config.emplace_back("pika.mpi.enable_pool=" + std::to_string(enable_mpi_pool));
+
         std::size_t const mpi_completion_mode =
             detail::handle_mpi_completion_mode(cfgmap, rtcfg_, vm);
         ini_config.emplace_back("pika.mpi.completion_mode=" + std::to_string(mpi_completion_mode));

--- a/libs/pika/command_line_handling/src/parse_command_line.cpp
+++ b/libs/pika/command_line_handling/src/parse_command_line.cpp
@@ -340,8 +340,11 @@ namespace pika::detail {
                 "no cross boundary stealing is allowed (default value: 0)")
 #if defined(PIKA_HAVE_MPI)
             ("pika:mpi-completion-mode", value<std::size_t>(),
-                "the pika MPI polling completion mode (only available if MPI "
-                "built with MPI support)")
+                "the pika MPI polling completion/handler mode "
+                "(only available if MPI built with MPI support)")
+            ("pika:mpi-enable-pool",
+                "enable the creation of a dedicated pool for mpi-polling "
+                "(only available if MPI built with MPI support and available threads>1).")
 #endif
         ;
 

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -74,9 +74,6 @@ namespace pika {
         mutable shutdown_function_type shutdown;
         pika::resource::partitioner_mode rp_mode = pika::resource::mode_default;
         detail::rp_callback_type rp_callback;
-#if defined(PIKA_HAVE_MPI)
-        pika::resource::polling_pool_creation_mode pool_creation_mode = pika::resource::mode_manual;
-#endif
     };
 
     PIKA_EXPORT int init(std::function<int(pika::program_options::variables_map&)> f, int argc,

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -72,8 +72,11 @@ namespace pika {
         std::vector<std::string> cfg;
         mutable startup_function_type startup;
         mutable shutdown_function_type shutdown;
-        pika::resource::partitioner_mode rp_mode = ::pika::resource::mode_default;
-        pika::detail::rp_callback_type rp_callback;
+        pika::resource::partitioner_mode rp_mode = pika::resource::mode_default;
+        detail::rp_callback_type rp_callback;
+#if defined(PIKA_HAVE_MPI)
+        pika::resource::polling_pool_creation_mode pool_creation_mode = pika::resource::mode_manual;
+#endif
     };
 
     PIKA_EXPORT int init(std::function<int(pika::program_options::variables_map&)> f, int argc,

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -140,7 +140,7 @@ namespace pika {
 #endif
 #if defined(PIKA_HAVE_MPI)
             pika::mpi::experimental::set_enable_pool(
-                pika::detail::get_entry_as<bool>(cmdline.rtcfg_, "pika.mpi.enable_pool", 0));
+                pika::detail::get_entry_as<bool>(cmdline.rtcfg_, "pika.mpi.enable_pool", false));
             pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
                 cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
@@ -324,8 +324,9 @@ namespace pika {
             }
 
 #if defined(PIKA_HAVE_MPI)
-            mpi::experimental::detail::init_resource_partitioner_handler(
-                rp, cmdline.vm_, resource::polling_pool_creation_mode::mode_pika_decides);
+            if (mpi::experimental::get_enable_pool())
+                mpi::experimental::detail::init_resource_partitioner_handler(rp, cmdline.vm_,
+                    mpi::experimental::polling_pool_creation_mode::mode_pika_decides);
 #endif
 
             // If thread_pools initialization in user main

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -141,8 +141,9 @@ namespace pika {
 #if defined(PIKA_HAVE_MPI)
             pika::mpi::experimental::detail::set_pool_enabled(
                 pika::detail::get_entry_as<bool>(cmdline.rtcfg_, "pika.mpi.enable_pool", false));
-            pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
-                cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
+            pika::mpi::experimental::detail::set_completion_mode(
+                pika::detail::get_entry_as<std::size_t>(
+                    cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
             init_logging(cmdline.rtcfg_);
         }

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -138,7 +138,7 @@ namespace pika {
             pika::util::detail::set_spinlock_deadlock_warning_limit(
                 cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
 #endif
-#ifdef PIKA_HAVE_MPI
+#if defined(PIKA_HAVE_MPI)
             pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
                 cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
@@ -320,6 +320,13 @@ namespace pika {
             case command_line_handling_result::success: break;
             case command_line_handling_result::exit: return 0;
             }
+
+#if defined(PIKA_HAVE_MPI)
+            if (params.pool_creation_mode !=
+                pika::resource::polling_pool_creation_mode::mode_manual)
+                mpi::experimental::detail::init_resource_partitioner_handler(
+                    rp, cmdline.vm_, params.pool_creation_mode);
+#endif
 
             // If thread_pools initialization in user main
             if (params.rp_callback) { params.rp_callback(rp, cmdline.vm_); }

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -139,7 +139,7 @@ namespace pika {
                 cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
 #endif
 #if defined(PIKA_HAVE_MPI)
-            pika::mpi::experimental::set_enable_pool(
+            pika::mpi::experimental::detail::set_pool_enabled(
                 pika::detail::get_entry_as<bool>(cmdline.rtcfg_, "pika.mpi.enable_pool", false));
             pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
                 cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
@@ -324,7 +324,7 @@ namespace pika {
             }
 
 #if defined(PIKA_HAVE_MPI)
-            if (mpi::experimental::get_enable_pool())
+            if (mpi::experimental::detail::get_pool_enabled())
                 mpi::experimental::detail::init_resource_partitioner_handler(rp, cmdline.vm_,
                     mpi::experimental::polling_pool_creation_mode::mode_pika_decides);
 #endif

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -139,6 +139,8 @@ namespace pika {
                 cmdline.rtcfg_.get_spinlock_deadlock_warning_limit());
 #endif
 #if defined(PIKA_HAVE_MPI)
+            pika::mpi::experimental::set_enable_pool(
+                pika::detail::get_entry_as<bool>(cmdline.rtcfg_, "pika.mpi.enable_pool", 0));
             pika::mpi::experimental::set_completion_mode(pika::detail::get_entry_as<std::size_t>(
                 cmdline.rtcfg_, "pika.mpi.completion_mode", 0));
 #endif
@@ -322,10 +324,8 @@ namespace pika {
             }
 
 #if defined(PIKA_HAVE_MPI)
-            if (params.pool_creation_mode !=
-                pika::resource::polling_pool_creation_mode::mode_manual)
-                mpi::experimental::detail::init_resource_partitioner_handler(
-                    rp, cmdline.vm_, params.pool_creation_mode);
+            mpi::experimental::detail::init_resource_partitioner_handler(
+                rp, cmdline.vm_, resource::polling_pool_creation_mode::mode_pika_decides);
 #endif
 
             // If thread_pools initialization in user main

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -220,9 +220,13 @@ namespace pika::resource::detail {
         // initial_thread_pools
         std::vector<socket> sockets_;
 
-        // store policy flags determining the general behavior of the
-        // resource_partitioner
+        // store policy flags determining the general behavior of the resource_partitioner
         resource::partitioner_mode mode_;
+
+#if defined(PIKA_HAVE_MPI)
+        // store policy flags determining the polling mode set at initialization
+        resource::polling_pool_creation_mode polling_mode_;
+#endif
 
         // topology information
         threads::detail::topology& topo_;

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -223,11 +223,6 @@ namespace pika::resource::detail {
         // store policy flags determining the general behavior of the resource_partitioner
         resource::partitioner_mode mode_;
 
-#if defined(PIKA_HAVE_MPI)
-        // store policy flags determining the polling mode set at initialization
-        resource::polling_pool_creation_mode polling_mode_;
-#endif
-
         // topology information
         threads::detail::topology& topo_;
 

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -37,8 +37,7 @@ namespace pika::resource {
     /// Returns false otherwise.
     PIKA_EXPORT bool is_partitioner_valid();
 
-    /// This enumeration describes the modes available when creating a
-    /// resource partitioner.
+    /// This enumeration describes the modes available when creating a resource partitioner.
     enum partitioner_mode
     {
         /// Default mode.
@@ -49,6 +48,25 @@ namespace pika::resource {
         /// Allow worker threads to be added and removed from thread pools.
         mode_allow_dynamic_pools = 2
     };
+
+#if defined(PIKA_HAVE_MPI)
+    /// This enumeration describes polling pool creation modes,
+    /// the user may request a dedicated pool that can be used by pika::mpi
+    /// MPI pool completion flags are passed on the command line or via env vars
+    /// When pika+MPI is disabled, no mpi pool will be created, the polling mode
+    /// is ignored and using xxx_enable/xxx_disable has no effect
+    enum polling_pool_creation_mode
+    {
+        /// the user must create a pool if they wish to use one with mpi
+        mode_manual = 0,
+        /// if the completion mode requires it, a pool will be created at startup
+        mode_pika_decides = 1,
+        /// overrides command line flags/env vars - enables creation of a polling pool
+        mode_force_create = 2,
+        /// overrides command line flags/env vars - disables creation of a polling pool
+        mode_force_no_create = 3,
+    };
+#endif
 
     using scheduler_function =
         util::detail::function<std::unique_ptr<pika::threads::detail::thread_pool_base>(

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner_fwd.hpp
@@ -49,25 +49,6 @@ namespace pika::resource {
         mode_allow_dynamic_pools = 2
     };
 
-#if defined(PIKA_HAVE_MPI)
-    /// This enumeration describes polling pool creation modes,
-    /// the user may request a dedicated pool that can be used by pika::mpi
-    /// MPI pool completion flags are passed on the command line or via env vars
-    /// When pika+MPI is disabled, no mpi pool will be created, the polling mode
-    /// is ignored and using xxx_enable/xxx_disable has no effect
-    enum polling_pool_creation_mode
-    {
-        /// the user must create a pool if they wish to use one with mpi
-        mode_manual = 0,
-        /// if the completion mode requires it, a pool will be created at startup
-        mode_pika_decides = 1,
-        /// overrides command line flags/env vars - enables creation of a polling pool
-        mode_force_create = 2,
-        /// overrides command line flags/env vars - disables creation of a polling pool
-        mode_force_no_create = 3,
-    };
-#endif
-
     using scheduler_function =
         util::detail::function<std::unique_ptr<pika::threads::detail::thread_pool_base>(
             pika::threads::detail::thread_pool_init_parameters,

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -182,6 +182,9 @@ namespace pika::resource::detail {
       : rtcfg_()
       , first_core_(std::size_t(-1))
       , mode_(mode_default)
+#if defined(PIKA_HAVE_MPI)
+      , polling_mode_(mode_manual)
+#endif
       , topo_(threads::detail::get_topology())
       , default_scheduler_mode_(threads::scheduler_mode::default_mode)
     {

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -182,9 +182,6 @@ namespace pika::resource::detail {
       : rtcfg_()
       , first_core_(std::size_t(-1))
       , mode_(mode_default)
-#if defined(PIKA_HAVE_MPI)
-      , polling_mode_(mode_manual)
-#endif
       , topo_(threads::detail::get_topology())
       , default_scheduler_mode_(threads::scheduler_mode::default_mode)
     {

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -339,6 +339,7 @@ namespace pika::util {
 
 #if defined(PIKA_HAVE_MPI)
             "[pika.mpi]",
+            "enable_pool = ${PIKA_MPI_ENABLE_POOL:0}",
             "completion_mode = ${PIKA_MPI_COMPLETION_MODE:0}",
 #endif
 

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -340,7 +340,7 @@ namespace pika::util {
 #if defined(PIKA_HAVE_MPI)
             "[pika.mpi]",
             "enable_pool = ${PIKA_MPI_ENABLE_POOL:0}",
-            "completion_mode = ${PIKA_MPI_COMPLETION_MODE:0}",
+            "completion_mode = ${PIKA_MPI_COMPLETION_MODE:30}",
 #endif
 
             "[pika.commandline]",


### PR DESCRIPTION
Add a configuration option to enable/disable creation of MPI pool. This removes the need for the user to setup a polling pool manually.

Move many functions into `detail` namespace to designate them as being for internal use only and not for general user consumption.

Clean up some of the enum flags and options that are used to setup pools and polling modes etc.

Change the default mode to "continuation mode" + "inline completion" + "high priority". The MPI pool is disabled by default. Fix #1143.
