### PR TITLE
Make `print_threshold` helper variables `inline constexpr`

### DIFF
--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/detail/cuda_debug.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/detail/cuda_debug.hpp
@@ -12,7 +12,6 @@
 #include <pika/debugging/print.hpp>
 
 namespace pika::cuda::experimental::detail {
-    using namespace pika::debug::detail;
     template <int Level>
-    static print_threshold<Level, 0> cud_debug("CUDA-EX");
+    inline constexpr pika::debug::detail::print_threshold<Level, 0> cud_debug("CUDA-EX");
 }    // namespace pika::cuda::experimental::detail

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -57,7 +57,7 @@ namespace pika::mpi::experimental {
         // by convention the title is 7 chars (for alignment)
         // a debug level of N shows messages with level 1..N
         template <int Level>
-        static debug::detail::print_threshold<Level, 0> mpi_debug("MPIPOLL");
+        inline constexpr debug::detail::print_threshold<Level, 0> mpi_debug("MPIPOLL");
 
         constexpr std::uint32_t max_poll_requests = 32;
 

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -44,7 +44,7 @@ constexpr int debug_level = 9;
 
 // cppcheck-suppress ConfigurationNotChecked
 template <int Level>
-static pika::debug::detail::print_threshold<Level, debug_level> nws_deb("STORAGE");
+inline constexpr pika::debug::detail::print_threshold<Level, debug_level> nws_deb("STORAGE");
 
 //----------------------------------------------------------------------------
 //
@@ -143,7 +143,7 @@ void test_send_recv(std::uint32_t rank, std::uint32_t nranks, std::mt19937& gen,
     std::uniform_int_distribution<std::uint64_t>& random_offset,
     std::uniform_int_distribution<std::uint64_t>& random_slot, test_options& options)
 {
-    static deb::print_threshold<1, debug_level> write_arr(" WRITE ");
+    static constexpr deb::print_threshold<1, debug_level> write_arr(" WRITE ");
 
     // this needs to scope all uses of mpi::experimental::executor
     std::string poolname = "default";

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<pika::counting_semaphore<>> limiter;
 // a debug level of zero disables messages with a priority>0
 // a debug level of N shows messages with priority<N
 template <int Level>
-static print_threshold<Level, 0> msr_deb("MPI_SR_");
+inline constexpr print_threshold<Level, 0> msr_deb("MPI_SR_");
 
 // ------------------------------------------------------------
 // caution: message_buffers will be constructed in-place in a buffer

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -484,7 +484,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         }
 
         template <typename T, typename V>
-        constexpr void set(T&, V const&)
+        static constexpr void set(T&, V const&)
         {
         }
 
@@ -586,7 +586,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         }
 
         template <typename T, typename V>
-        void set(T& var, V const& val)
+        static void set(T& var, V const& val)
         {
             var = val;
         }

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -59,8 +59,8 @@ namespace pika::debug::detail {
     constexpr int debug_level = 0;
 
     template <int Level>
-    static print_threshold<Level, debug_level> spq_deb("SPQUEUE");
-    static print_threshold<1, debug_level> spq_arr("SPQUEUE");
+    inline constexpr print_threshold<Level, debug_level> spq_deb("SPQUEUE");
+    inline constexpr print_threshold<1, debug_level> spq_arr("SPQUEUE");
 }    // namespace pika::debug::detail
 
 // ------------------------------------------------------------


### PR DESCRIPTION
Avoid using `static` as each translation unit will end up with its own instance. Functionally there should be no difference, but `inline constexpr` is more idiomatic. This also changes one function-level `static` to `static constexpr`.