### PR TITLE
Use `MPI_Init_thread` in `algorithm_transform_mpi` test

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -33,13 +33,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ccache-linux-sanitizers-address-undefined-leak
-      - name: Switch OpenMPI to MPICH
-        shell: bash
-        run: |
-            apt-get update
-            apt-get remove --yes mpi-default-dev
-            apt-get autoremove --yes
-            apt-get install --no-install-recommends --yes libmpich-dev
       - name: Configure
         shell: bash
         run: |
@@ -80,6 +73,11 @@ jobs:
             # https://github.com/actions/runner-images/issues/9491
             sysctl --write vm.mmap_rnd_bits=28
 
+            # We are certain that we want to run mpiexec as root despite warnings as that is the
+            # only user available in the container. Mistakes will only affect the current step.
+            export OMPI_ALLOW_RUN_AS_ROOT=1
+            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
             export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
             cd build
@@ -94,6 +92,11 @@ jobs:
         run: |
             # See above.
             sysctl --write vm.mmap_rnd_bits=28
+
+            # We are certain that we want to run mpiexec as root despite warnings as that is the
+            # only user available in the container. Mistakes will only affect the current step.
+            export OMPI_ALLOW_RUN_AS_ROOT=1
+            export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
             export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp

--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -80,6 +80,7 @@ jobs:
 
             export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
+            export LSAN_OPTIONS=suppressions=$PWD/tools/lsan.supp
             cd build
             ctest \
               --timeout 120 \
@@ -100,6 +101,7 @@ jobs:
 
             export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
+            export LSAN_OPTIONS=suppressions=$PWD/tools/lsan.supp
             cd build
             ctest \
               --timeout 120 \

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -234,11 +234,16 @@ int pika_main()
                 PIKA_TEST_EQ(data, 42);
             }
 
+            // MPICH does not support throwing exceptions from error handlers (lock issues, see
+            // https://github.com/pmodels/mpich/issues/7187)
+#if !defined(MPICH)
             test_exception_handler_code(comm, datatype);
 
         }    // let the user polling go out of scope
-
         test_exception_no_handler(comm);
+#else
+        }
+#endif
     }
 
     test_adl_isolation(mpi::transform_mpi(my_namespace::my_sender{}, [](MPI_Request*) {}));

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -250,7 +250,10 @@ int pika_main()
 //----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
-    MPI_Init(&argc, &argv);
+    int provided;
+    int preferred = MPI_THREAD_MULTIPLE;
+    MPI_Init_thread(&argc, &argv, preferred, &provided);
+    PIKA_TEST_EQ(provided, preferred);
 
     // Start runtime and collect runtime exit status
     auto result = pika::init(pika_main, argc, argv);

--- a/libs/pika/config/include/pika/config/compiler_specific.hpp
+++ b/libs/pika/config/include/pika/config/compiler_specific.hpp
@@ -163,22 +163,25 @@
 
 // clang-format on
 # if defined(PIKA_HAVE_SANITIZERS)
-#  if defined(__has_feature)
-#   if __has_feature(address_sanitizer)
-#    define PIKA_HAVE_ADDRESS_SANITIZER
-#    if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
-#     define PIKA_NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
-#    endif
-#   endif
-#   if __has_feature(thread_sanitizer)
-#    define PIKA_HAVE_THREAD_SANITIZER
-#   endif
-#  elif defined(__SANITIZE_ADDRESS__)    // MSVC defines this
+#  if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
 #   define PIKA_HAVE_ADDRESS_SANITIZER
+#   if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
+#    define PIKA_NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
+#   endif
+#  endif
+#  if defined(__SANITIZE_THREAD__) || (defined(__has_feature) && __has_feature(thread_sanitizer))
+#   define PIKA_HAVE_THREAD_SANITIZER
+#   if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
+#    define PIKA_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
+#   endif
 #  endif
 # endif
-#endif
 
-#if !defined(PIKA_NO_SANITIZE_ADDRESS)
-# define PIKA_NO_SANITIZE_ADDRESS
-#endif
+# if !defined(PIKA_NO_SANITIZE_ADDRESS)
+#  define PIKA_NO_SANITIZE_ADDRESS
+# endif
+# if !defined(PIKA_NO_SANITIZE_THREAD)
+#  define PIKA_NO_SANITIZE_THREAD
+# endif
+
+#endif    // doxygen

--- a/tools/lsan.supp
+++ b/tools/lsan.supp
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+leak:event_base_loop
+leak:ompi_mpi_finalize
+leak:ompi_mpi_init
+leak:orte_init


### PR DESCRIPTION
It's not really clear if we've just gotten lucky or if something else was going on in that test, but we should be initializing MPI with `MPI_THREAD_MULTIPLE` to be on the safe side.

Thank you @RMeli for noticing this.