### PR TITLE
Add `const` to `eval` function in debug print functionality

### DIFF
--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -496,7 +496,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         }
 
         template <typename Expr>
-        constexpr bool eval(Expr const&)
+        constexpr bool eval(Expr const&) const
         {
             return true;
         }
@@ -598,7 +598,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         }
 
         template <typename Expr>
-        auto eval(Expr const& e)
+        auto eval(Expr const& e) const
         {
             return e();
         }


### PR DESCRIPTION
Fixes #1273 

Recent merge missed a `const` modifier on the eval function 