### PR TITLE
Add more documentation on using custom allocators

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -125,5 +125,5 @@ base_spack_image_x86_64:
     - trap "${SOURCE_DIR}/.gitlab/scripts/collect_ctest_metrics.sh ${CTEST_XML}" EXIT
     - spack -e pika_ci build-env $spack_spec -- bash -c "ctest --output-junit ${CTEST_XML} --label-exclude COMPILE_ONLY --test-dir ${BUILD_DIR} -j$(($(nproc)/2)) --timeout 300 --output-on-failure --no-compress-output --no-tests=error"
     - export MIMALLOC_EAGER_COMMIT_DELAY=0
-    - export MIMALLOC_LARGE_OS_PAGES=1
+    - export MIMALLOC_ALLOW_LARGE_OS_PAGES=1
     - "${SOURCE_DIR}/.gitlab/scripts/run_performance_benchmarks.sh"

--- a/.jenkins/cscs-perftests/env-perftests.sh
+++ b/.jenkins/cscs-perftests/env-perftests.sh
@@ -13,4 +13,4 @@ spack_arch="cray-cnl7-broadwell"
 spack_spec="pika@main arch=${spack_arch} %${spack_compiler} malloc=mimalloc ^boost@${boost_version} ^hwloc@${hwloc_version}"
 
 export MIMALLOC_EAGER_COMMIT_DELAY=0
-export MIMALLOC_LARGE_OS_PAGES=1
+export MIMALLOC_ALLOW_LARGE_OS_PAGES=1

--- a/cmake/pika_setup_allocator.cmake
+++ b/cmake/pika_setup_allocator.cmake
@@ -84,7 +84,7 @@ if(NOT TARGET pika_dependencies_allocator)
       set(_use_custom_allocator TRUE)
 
       pika_warn(
-        "pika is using mimalloc as the allocator. Typically, exporting the following environment variables will further improve performance: MIMALLOC_EAGER_COMMIT_DELAY=0 and MIMALLOC_LARGE_OS_PAGES=1."
+        "pika is using mimalloc as the allocator. Typically, exporting the following environment variables will further improve performance: MIMALLOC_EAGER_COMMIT_DELAY=0 and MIMALLOC_ALLOW_LARGE_OS_PAGES=1."
       )
     endif()
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -245,6 +245,36 @@ following:
 - ``%q``: The parent task id and description.
 - ``%k``: The current task id and description.
 
+.. _malloc:
+
+Using custom allocators with pika
+=================================
+
+Typical use of pika can often lead to many small allocations from many different threads,
+potentially leading to suboptimal performance with the system allocator. By default, pika uses
+`mimalloc <https://github.com/microsoft/mimalloc>`__ as the memory allocator because it usually
+performs significantly better than the system allocator. In some cases, the system allocator or
+other custom allocators might perform better.
+
+Setting the following environment variables usually further improves performance with mimalloc:
+
+- ``MIMALLOC_EAGER_COMMIT_DELAY=0``
+- ``MIMALLOC_ALLOW_LARGE_OS_PAGES=1``
+
+We have observed mimalloc performing worse than the defaults with the above options on some systems,
+as well as worse than the system allocator. Always benchmark to find the most suitable allocator for
+your workload and system.
+
+To ease testing of different allocators, you may also configure pika with the system allocator and
+instead use ``LD_PRELOAD`` to replace the default allocator at runtime. This allows you to choose
+the allocator without rebuilding pika. To do so, export the ``LD_PRELOAD`` environment variable to
+point to the shared library of the allocator. For example, to use `jemalloc
+<https://jemalloc.net>`__, set ``LD_PRELOAD`` to the full path of ``libjemalloc.so``:
+
+.. code-block:: bash
+
+   export LD_PRELOAD=/path/to/libjemalloc.so
+
 .. _pika_stdexec:
 
 Relation to std::execution and stdexec


### PR DESCRIPTION
- Add some notes on tweaking mimalloc performance with environment variables
- Add warnings about always benchmarking, and mimalloc not always being the best choice
- Update uses of `MIMALLOC_LARGE_OS_PAGES` to `MIMALLOC_ALLOW_LARGE_OS_PAGES` (the former being an old, deprecated, spelling and the latter being the preferred spelling; the latter should also work on mimalloc 1.X).