### PR TITLE
Remove uses of `aligned_storage_t`

### DIFF
--- a/libs/pika/datastructures/include/pika/datastructures/detail/small_vector.hpp
+++ b/libs/pika/datastructures/include/pika/datastructures/detail/small_vector.hpp
@@ -145,7 +145,7 @@ namespace pika::detail {
             return *this;
         }
 
-        std::aligned_storage_t<sizeof(T), alignof(T)> memory_[Size];
+        alignas(T) memory_[Size * sizeof(T)];
         PIKA_NO_UNIQUE_ADDRESS allocator_memory_resource<T, Allocator> resource_;
         buffer_resource_type pool_;
         allocator_type allocator_;

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -107,7 +107,7 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
         union
         {
-            std::aligned_storage_t<embedded_storage_size, alignment_size> embedded_storage;
+            alignas(alignment_size) unsigned char embedded_storage[embedded_storage_size];
 #endif
             base_type* heap_storage = nullptr;
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)

--- a/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
+++ b/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
@@ -52,22 +52,24 @@ namespace pika::util::detail {
         }
 
         template <typename T>
+        struct aligned_storage_helper
+        {
+            alignas(T) unsigned char storage[sizeof(T)];
+        };
+
+        template <typename T>
         static void* allocate(void* storage, std::size_t storage_size)
         {
-            using storage_t = std::aligned_storage_t<sizeof(T), alignof(T)>;
-
-            if (sizeof(T) > storage_size) { return new storage_t; }
+            if (sizeof(T) > storage_size) { return new aligned_storage_helper<T>; }
             return storage;
         }
 
         template <typename T>
         static void _deallocate(void* obj, std::size_t storage_size, bool destroy)
         {
-            using storage_t = std::aligned_storage_t<sizeof(T), alignof(T)>;
-
             if (destroy) { get<T>(obj).~T(); }
 
-            if (sizeof(T) > storage_size) { delete static_cast<storage_t*>(obj); }
+            if (sizeof(T) > storage_size) { delete static_cast<aligned_storage_helper<T>*>(obj); }
         }
         void (*deallocate)(void*, std::size_t storage_size, bool);
 


### PR DESCRIPTION
`aligned_storage(_t)` is deprecated starting with C++23. Replace uses with `alignas(...) unsigned char[...]`.