### PR TITLE
Reenable SBO in `any_sender` and friends

### DIFF
--- a/libs/pika/datastructures/include/pika/datastructures/detail/small_vector.hpp
+++ b/libs/pika/datastructures/include/pika/datastructures/detail/small_vector.hpp
@@ -145,7 +145,7 @@ namespace pika::detail {
             return *this;
         }
 
-        std::aligned_storage_t<sizeof(T), alignof(T)> memory_[Size];
+        alignas(T) memory_[Size * sizeof(T)];
         PIKA_NO_UNIQUE_ADDRESS allocator_memory_resource<T, Allocator> resource_;
         buffer_resource_type pool_;
         allocator_type allocator_;

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -107,7 +107,7 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
         union
         {
-            std::aligned_storage_t<embedded_storage_size, alignment_size> embedded_storage;
+            alignas(alignment_size) unsigned char embedded_storage[embedded_storage_size];
 #endif
             base_type* heap_storage = nullptr;
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -37,6 +37,8 @@
 
 // SBO is currently disabled as it seems to be buggy in certain use cases. It can still be
 // explicitly forced to on by defining PIKA_DETAIL_ENABLE_ANY_SENDER_SBO.
+// TODO: Remove definition or enable unconditionally.
+#define PIKA_DETAIL_ENABLE_ANY_SENDER_SBO
 
 namespace pika::detail {
     template <typename T>
@@ -132,7 +134,7 @@ namespace pika::detail {
         bool using_embedded_storage() const noexcept
         {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
-            return object == reinterpret_cast<base_type const*>(&embedded_storage);
+            return object == static_cast<void const*>(embedded_storage);
 #else
             return false;
 #endif
@@ -167,15 +169,12 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
                 if (other.using_embedded_storage())
                 {
-                    auto p = reinterpret_cast<base_type*>(&embedded_storage);
-                    other.get().move_into(p);
-                    object = p;
+                    object = other.get().move_into(embedded_storage);
                 }
                 else
 #endif
                 {
-                    heap_storage = other.heap_storage;
-                    other.heap_storage = nullptr;
+                    heap_storage = std::exchange(other.heap_storage, nullptr);
                     object = heap_storage;
                 }
 
@@ -196,15 +195,12 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
                 if (other.using_embedded_storage())
                 {
-                    auto p = reinterpret_cast<base_type*>(&embedded_storage);
-                    other.get().move_into(p);
-                    object = p;
+                    object = other.get().move_into(embedded_storage);
                 }
                 else
 #endif
                 {
-                    heap_storage = other.heap_storage;
-                    other.heap_storage = nullptr;
+                    heap_storage = std::exchange(other.heap_storage, nullptr);
                     object = heap_storage;
                 }
 
@@ -274,9 +270,7 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
             if constexpr (can_use_embedded_storage<Impl>())
             {
-                Impl* p = reinterpret_cast<Impl*>(&embedded_storage);
-                new (p) Impl(PIKA_FORWARD(Ts, ts)...);
-                object = p;
+                object = new (embedded_storage) Impl(PIKA_FORWARD(Ts, ts)...);
             }
             else
 #endif
@@ -321,9 +315,7 @@ namespace pika::detail {
 #if defined(PIKA_DETAIL_ENABLE_ANY_SENDER_SBO)
                 if (other.using_embedded_storage())
                 {
-                    base_type* p = reinterpret_cast<base_type*>(&embedded_storage);
-                    other.get().clone_into(p);
-                    object = p;
+                    object = other.get().clone_into(embedded_storage);
                 }
                 else
 #endif
@@ -434,7 +426,7 @@ namespace pika::execution::experimental::detail {
     struct any_receiver_base
     {
         virtual ~any_receiver_base() = default;
-        virtual void move_into(void* p) = 0;
+        virtual any_receiver_base<Ts...>* move_into(unsigned char* p) = 0;
         virtual void set_value(Ts... ts) && = 0;
         virtual void set_error(std::exception_ptr ep) && noexcept = 0;
         virtual void set_stopped() && noexcept = 0;
@@ -447,7 +439,7 @@ namespace pika::execution::experimental::detail {
     template <typename... Ts>
     struct empty_any_receiver final : any_receiver_base<Ts...>
     {
-        void move_into(void*) override { PIKA_UNREACHABLE; }
+        any_receiver_base<Ts...>* move_into(unsigned char*) override { PIKA_UNREACHABLE; }
 
         bool empty() const noexcept override { return true; }
 
@@ -487,7 +479,10 @@ namespace pika::execution::experimental::detail {
         {
         }
 
-        void move_into(void* p) override { new (p) any_receiver_impl(PIKA_MOVE(receiver)); }
+        any_receiver_base<Ts...>* move_into(unsigned char* p) override
+        {
+            return new (p) any_receiver_impl(PIKA_MOVE(receiver));
+        }
 
         void set_value(Ts... ts) && override
         {
@@ -591,7 +586,7 @@ namespace pika::execution::experimental::detail {
     struct unique_any_sender_base
     {
         virtual ~unique_any_sender_base() noexcept = default;
-        virtual void move_into(void* p) = 0;
+        virtual unique_any_sender_base<Ts...>* move_into(unsigned char* p) = 0;
         virtual any_operation_state connect(any_receiver<Ts...>&& receiver) && = 0;
         virtual bool empty() const noexcept { return false; }
     };
@@ -599,8 +594,9 @@ namespace pika::execution::experimental::detail {
     template <typename... Ts>
     struct any_sender_base : public unique_any_sender_base<Ts...>
     {
+        virtual any_sender_base<Ts...>* move_into(unsigned char* p) = 0;
         virtual any_sender_base* clone() const = 0;
-        virtual void clone_into(void* p) const = 0;
+        virtual any_sender_base<Ts...>* clone_into(unsigned char* p) const = 0;
         using unique_any_sender_base<Ts...>::connect;
         virtual any_operation_state connect(any_receiver<Ts...>&& receiver) const& = 0;
     };
@@ -608,7 +604,7 @@ namespace pika::execution::experimental::detail {
     template <typename... Ts>
     struct empty_unique_any_sender final : unique_any_sender_base<Ts...>
     {
-        void move_into(void*) override { PIKA_UNREACHABLE; }
+        unique_any_sender_base<Ts...>* move_into(unsigned char*) override { PIKA_UNREACHABLE; }
 
         bool empty() const noexcept override { return true; }
 
@@ -621,11 +617,11 @@ namespace pika::execution::experimental::detail {
     template <typename... Ts>
     struct empty_any_sender final : any_sender_base<Ts...>
     {
-        void move_into(void*) override { PIKA_UNREACHABLE; }
+        any_sender_base<Ts...>* move_into(unsigned char*) override { PIKA_UNREACHABLE; }
 
         any_sender_base<Ts...>* clone() const override { PIKA_UNREACHABLE; }
 
-        void clone_into(void*) const override { PIKA_UNREACHABLE; }
+        any_sender_base<Ts...>* clone_into(unsigned char*) const override { PIKA_UNREACHABLE; }
 
         bool empty() const noexcept override { return true; }
 
@@ -655,7 +651,10 @@ namespace pika::execution::experimental::detail {
 
         ~unique_any_sender_impl() noexcept = default;
 
-        void move_into(void* p) override { new (p) unique_any_sender_impl(PIKA_MOVE(sender)); }
+        unique_any_sender_base<Ts...>* move_into(unsigned char* p) override
+        {
+            return new (p) unique_any_sender_impl(PIKA_MOVE(sender));
+        }
 
         any_operation_state connect(any_receiver<Ts...>&& receiver) && override
         {
@@ -677,11 +676,17 @@ namespace pika::execution::experimental::detail {
 
         ~any_sender_impl() noexcept = default;
 
-        void move_into(void* p) override { new (p) any_sender_impl(PIKA_MOVE(sender)); }
+        any_sender_base<Ts...>* move_into(unsigned char* p) override
+        {
+            return new (p) any_sender_impl(PIKA_MOVE(sender));
+        }
 
         any_sender_base<Ts...>* clone() const override { return new any_sender_impl(sender); }
 
-        void clone_into(void* p) const override { new (p) any_sender_impl(sender); }
+        any_sender_base<Ts...>* clone_into(unsigned char* p) const override
+        {
+            return new (p) any_sender_impl(sender);
+        }
 
         any_operation_state connect(any_receiver<Ts...>&& receiver) const& override
         {

--- a/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
+++ b/libs/pika/functional/include/pika/functional/detail/vtable/vtable.hpp
@@ -52,22 +52,24 @@ namespace pika::util::detail {
         }
 
         template <typename T>
+        struct aligned_storage_helper
+        {
+            alignas(T) unsigned char storage[sizeof(T)];
+        };
+
+        template <typename T>
         static void* allocate(void* storage, std::size_t storage_size)
         {
-            using storage_t = std::aligned_storage_t<sizeof(T), alignof(T)>;
-
-            if (sizeof(T) > storage_size) { return new storage_t; }
+            if (sizeof(T) > storage_size) { return new aligned_storage_helper<T>; }
             return storage;
         }
 
         template <typename T>
         static void _deallocate(void* obj, std::size_t storage_size, bool destroy)
         {
-            using storage_t = std::aligned_storage_t<sizeof(T), alignof(T)>;
-
             if (destroy) { get<T>(obj).~T(); }
 
-            if (sizeof(T) > storage_size) { delete static_cast<storage_t*>(obj); }
+            if (sizeof(T) > storage_size) { delete static_cast<aligned_storage_helper<T>*>(obj); }
         }
         void (*deallocate)(void*, std::size_t storage_size, bool);
 


### PR DESCRIPTION
Attempting to reenable SBO without any UB, but this needs more testing. We disabled SBO in the past because it was causing issues at least on LUMI, and I haven't re-tested it with these changes yet.

Based on #1280.