### PR TITLE
Suppress `hwloc_topology_load` leak reported by valgrind

### DIFF
--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -53,6 +53,15 @@
    ...
 }
 
+{
+   hwloc
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:hwloc_topology_load
+   ...
+}
+
 # CUDA
 {
     Generic CUDA


### PR DESCRIPTION
Suppresses warnings like:
```
==3585== 
==3585== HEAP SUMMARY:
==3585==     in use at exit: 150,459 bytes in 456 blocks
==3585==   total heap usage: 25,548 allocs, 25,092 frees, 5,775,479 bytes allocated
==3585== 
==3585== 24 bytes in 1 blocks are possibly lost in loss record 94 of 266
==3585==    at 0x4845828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3585==    by 0x4C46D29: hwloc_bitmap_dup (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DAE7: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DA75: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DA75: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DA75: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DA75: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C3DA75: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x4C41F52: hwloc_topology_load (in /usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3)
==3585==    by 0x7932C58: ???
==3585==    by 0x795788B: ???
==3585==    by 0x78E2802: ???
==3585== 
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: possible
   fun:malloc
   fun:hwloc_bitmap_dup
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.6.3
   fun:hwloc_topology_load
   obj:*
   obj:*
   obj:*
}
```

I've only seen this triggered on the MPI tests, so I'm assuming this is coming from inside OpenMPI and not our hwloc usage.