### PR TITLE
Add clang 19 CI configuration

### DIFF
--- a/.gitlab/includes/clang19_pipeline.yml
+++ b/.gitlab/includes/clang19_pipeline.yml
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include:
+  - local: '.gitlab/includes/common_pipeline.yml'
+  - local: '.gitlab/includes/common_spack_pipeline.yml'
+
+.variables_clang19_config:
+  variables:
+    SPACK_ARCH: linux-ubuntu22.04-zen2
+    COMPILER: clang@19.1.0
+    CXXSTD: 23
+    SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} \
+                 cxxflags=-stdlib=libc++ cxxflags=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
+                 malloc=system \
+                 cxxstd=$CXXSTD +stdexec ^boost@1.86.0 ^hwloc@2.11.1 \
+                 ^fmt cxxflags=-stdlib=libc++ cxxflags=-DLIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
+                 ^spdlog cxxflags=-stdlib=libc++ cxxflags=-DLIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
+                 ^stdexec@24.09"
+    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD \
+                  -DCMAKE_CXX_FLAGS='-stdlib=libc++ -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG' \
+                  -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
+                  -DPIKA_WITH_STDEXEC=ON"
+
+clang19_spack_compiler_image:
+  extends:
+    - .variables_clang19_config
+    - .compiler_image_template_rosa
+
+clang19_spack_image:
+  needs: [clang19_spack_compiler_image]
+  extends:
+    - .variables_clang19_config
+    - .dependencies_image_template_rosa
+
+clang19_build:
+  needs: [clang19_spack_image]
+  extends:
+    - .variables_clang19_config
+    - .build_template_rosa
+
+.clang19_test_common:
+  needs: [clang19_build]
+  extends:
+    - .variables_clang19_config
+    - .test_common_eiger_mc
+    - .test_template
+
+clang19_test_release:
+  extends: [.clang19_test_common]
+  image: $PERSIST_IMAGE_NAME_RELEASE
+
+clang19_test_debug:
+  extends: [.clang19_test_common]
+  image: $PERSIST_IMAGE_NAME_DEBUG

--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -8,7 +8,7 @@ include:
   - local: '.gitlab/includes/common_pipeline.yml'
 
 variables:
-  SPACK_COMMIT: develop-2024-09-15
+  SPACK_COMMIT: develop-2024-10-06
 
 .base_spack_image:
   timeout: 1 hours

--- a/.gitlab/pipelines_on_merge.yml
+++ b/.gitlab/pipelines_on_merge.yml
@@ -21,4 +21,5 @@ include:
   - local: '.gitlab/includes/clang16_pipeline.yml'
   - local: '.gitlab/includes/clang17_pipeline.yml'
   - local: '.gitlab/includes/clang18_pipeline.yml'
+  - local: '.gitlab/includes/clang19_pipeline.yml'
   - local: '.gitlab/includes/nvhpc24_7_pipeline.yml'

--- a/libs/pika/concurrency/include/pika/concurrency/deque.hpp
+++ b/libs/pika/concurrency/include/pika/concurrency/deque.hpp
@@ -123,47 +123,6 @@ namespace pika::concurrency::detail {
 
         pair lrs(std::memory_order mo = std::memory_order_acquire) const { return pair_.load(mo); }
 
-        node* left(std::memory_order mo = std::memory_order_acquire) const
-        {
-            return pair_.load(mo).get_left_ptr();
-        }
-
-        node* right(std::memory_order mo = std::memory_order_acquire) const
-        {
-            return pair_.load(mo).get_right_ptr();
-        }
-
-        tag_t status(std::memory_order mo = std::memory_order_acquire) const
-        {
-            return pair_.load(mo).get_left_tag();
-        }
-
-        tag_t tag(std::memory_order mo = std::memory_order_acquire) const
-        {
-            return pair_.load(mo).get_right_tag();
-        }
-
-        bool cas(deque_anchor& expected, deque_anchor const& desired,
-            std::memory_order mo = std::memory_order_acq_rel)
-        {
-            return pair_.compare_exchange_strong(expected.load(std::memory_order_acquire),
-                desired.load(std::memory_order_acquire), mo);
-        }
-
-        bool cas(pair& expected, deque_anchor const& desired,
-            std::memory_order mo = std::memory_order_acq_rel)
-        {
-            return pair_.compare_exchange_strong(
-                expected, desired.load(std::memory_order_acquire), mo);
-        }
-
-        bool cas(deque_anchor& expected, pair const& desired,
-            std::memory_order mo = std::memory_order_acq_rel)
-        {
-            return pair_.compare_exchange_strong(
-                expected.load(std::memory_order_acquire), desired, mo);
-        }
-
         bool cas(
             pair& expected, pair const& desired, std::memory_order mo = std::memory_order_acq_rel)
         {


### PR DESCRIPTION
Also enables libc++'s hardening mode (https://libcxx.llvm.org/Hardening.html).

I've initially enabled the strongest mode (`_LIBCPP_HARDENING_MODE_DEBUG`) but what checks are actually enabled seems to depend on the actual ABI used to compile libc++, so I don't know if all checks are actually enabled.

clang 19 warns about `aligned_storage_t` being deprecated, so this requires #1280.

clang 19 also diagnoses member functions that can't be instantiated, even if they're unused. `deque_anchor` had a few unused functions that could not be instantiated, but according to the standard they're allowed to not be instantiated. clang 19 diagnoses these even when unused leading to compilaton failures. This PR removes the unused member functions. A similar issue is https://github.com/llvm/llvm-project/issues/102177. https://github.com/llvm/llvm-project/issues/102177 gives a bit more motivation for the change. Supposedly GCC 15 will make the same change, so sooner or later we would be bitten by this anyway, and it's nice to have this diagnosed.

Fixes #1300.