### PR TITLE
Convert const West to East const format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -114,6 +114,7 @@ PenaltyReturnTypeOnItsOwnLine: 20
 PointerAlignment: Left
 PPIndentWidth: 1
 ReflowComments: false
+QualifierAlignment: Right
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: OuterScope
 SortIncludes:    true

--- a/cmake/tests/cpuid.cpp
+++ b/cmake/tests/cpuid.cpp
@@ -37,7 +37,7 @@ struct matcher
     uint32_t function;
     uint32_t registers_t::*reg;
     uint32_t bit;
-    const char* target;
+    char const* target;
 } options[] = {{0x0000'0001U, &registers_t::edx, 19, "clflush"},
     {0x0000'0001U, &registers_t::edx, 8, "cx8"}, {0x0000'0001U, &registers_t::ecx, 13, "cx16"},
     {0x0000'0001U, &registers_t::edx, 15, "cmov"}, {0x0000'0001U, &registers_t::edx, 5, "msr"},

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,7 +57,7 @@ The ``pika/init.hpp`` header provides functionality to manage the pika runtime.
    :language: c++
    :start-at: #include
 
-.. doxygenfunction:: pika::start(int argc, const char *const *argv, init_params const &params)
+.. doxygenfunction:: pika::start(int argc, char const* const* argv, init_params const &params)
 .. doxygenfunction:: pika::stop()
 .. doxygenfunction:: pika::finalize()
 .. doxygenfunction:: pika::wait()

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -68,7 +68,7 @@ int pika_main(variables_map& vm)
     {
         num_iterations = vm["delay-iterations"].as<std::uint64_t>();
 
-        const bool csv = vm.count("csv");
+        bool const csv = vm.count("csv");
 
         const std::size_t pxthreads = vm["pxthreads"].as<std::size_t>();
 

--- a/examples/jacobi_smp/jacobi.cpp
+++ b/examples/jacobi_smp/jacobi.cpp
@@ -26,7 +26,7 @@ using pika::program_options::variables_map;
 
 namespace jacobi_smp {
 
-    void jacobi_kernel(double* dst, const double* src, std::size_t n)
+    void jacobi_kernel(double* dst, double const* src, std::size_t n)
     {
 #ifdef PIKA_INTEL_VERSION
 # pragma vector always

--- a/examples/jacobi_smp/jacobi.hpp
+++ b/examples/jacobi_smp/jacobi.hpp
@@ -37,7 +37,7 @@ namespace jacobi_smp {
         std::size_t end_;
     };
 
-    void jacobi_kernel(double* dst, const double* src, std::size_t n);
+    void jacobi_kernel(double* dst, double const* src, std::size_t n);
 
     inline void report_timing(std::size_t n, std::size_t iterations, double elapsed)
     {

--- a/examples/jacobi_smp/jacobi_omp.hpp
+++ b/examples/jacobi_smp/jacobi_omp.hpp
@@ -35,7 +35,7 @@ namespace jacobi_smp {
             for (std::int64_t y = 1; y < std::int64_t(n - 1); ++y)
             {
                 double* dst = &(*grid_new)[y * n];
-                const double* src = &(*grid_new)[y * n];
+                double const* src = &(*grid_new)[y * n];
                 jacobi_kernel(dst, src, n);
             }
             std::swap(grid_new, grid_old);

--- a/examples/jacobi_smp/jacobi_pika.cpp
+++ b/examples/jacobi_smp/jacobi_pika.cpp
@@ -30,7 +30,7 @@ namespace jacobi_smp {
         for (std::size_t y = y_range.begin(); y < y_range.end(); ++y)
         {
             double* dst_ptr = &dst[y * n];
-            const double* src_ptr = &src[y * n];
+            double const* src_ptr = &src[y * n];
             jacobi_kernel(dst_ptr, src_ptr, n);
         }
     }

--- a/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
+++ b/libs/pika/allocator_support/include/pika/allocator_support/aligned_allocator.hpp
@@ -100,7 +100,7 @@ namespace pika::detail {
     {
         using value_type = T;
         using pointer = T*;
-        using const_pointer = const T*;
+        using const_pointer = T const*;
         using reference = T&;
         using const_reference = T const&;
         using size_type = std::size_t;

--- a/libs/pika/allocator_support/include/pika/allocator_support/internal_allocator.hpp
+++ b/libs/pika/allocator_support/include/pika/allocator_support/internal_allocator.hpp
@@ -33,7 +33,7 @@ namespace pika::detail {
     {
         using value_type = T;
         using pointer = T*;
-        using const_pointer = const T*;
+        using const_pointer = T const*;
         using reference = T&;
         using const_reference = T const&;
         using size_type = std::size_t;

--- a/libs/pika/assertion/include/pika/assert.hpp
+++ b/libs/pika/assertion/include/pika/assert.hpp
@@ -23,7 +23,7 @@
 namespace pika::detail {
     /// The signature for an assertion handler
     using assertion_handler_type = void (*)(
-        source_location const& loc, const char* expr, std::string const& msg);
+        source_location const& loc, char const* expr, std::string const& msg);
 
     /// Set the assertion handler to be used within a program. If the handler has been
     /// set already once, the call to this function will be ignored.

--- a/libs/pika/assertion/include/pika/assertion/evaluate_assert.hpp
+++ b/libs/pika/assertion/include/pika/assertion/evaluate_assert.hpp
@@ -16,6 +16,6 @@
 namespace pika::detail {
     /// \cond NOINTERNAL
     PIKA_EXPORT void handle_assert(
-        source_location const& loc, const char* expr, std::string const& msg) noexcept;
+        source_location const& loc, char const* expr, std::string const& msg) noexcept;
     /// \endcond
 }    // namespace pika::detail

--- a/libs/pika/assertion/include/pika/assertion/source_location.hpp
+++ b/libs/pika/assertion/include/pika/assertion/source_location.hpp
@@ -15,9 +15,9 @@ namespace pika::detail {
     /// called
     struct source_location
     {
-        const char* file_name;
+        char const* file_name;
         unsigned line_number;
-        const char* function_name;
+        char const* function_name;
     };
     PIKA_EXPORT std::ostream& operator<<(std::ostream& os, source_location const& loc);
 }    // namespace pika::detail

--- a/libs/pika/assertion/src/assertion.cpp
+++ b/libs/pika/assertion/src/assertion.cpp
@@ -23,7 +23,7 @@ namespace pika::detail {
     }
 
     void handle_assert(
-        source_location const& loc, const char* expr, std::string const& msg) noexcept
+        source_location const& loc, char const* expr, std::string const& msg) noexcept
     {
         if (get_handler() == nullptr)
         {

--- a/libs/pika/assertion/tests/unit/assert_fail.cpp
+++ b/libs/pika/assertion/tests/unit/assert_fail.cpp
@@ -10,7 +10,7 @@
 #include <string>
 
 [[noreturn]] void assertion_handler(
-    pika::detail::source_location const&, const char*, std::string const&)
+    pika::detail::source_location const&, char const*, std::string const&)
 {
     PIKA_TEST(true);
     std::exit(1);

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_polling_helper.hpp
@@ -18,8 +18,8 @@
 
 namespace pika::cuda::experimental {
 
-    PIKA_EXPORT const std::string& get_pool_name();
-    PIKA_EXPORT void set_pool_name(const std::string&);
+    PIKA_EXPORT std::string const& get_pool_name();
+    PIKA_EXPORT void set_pool_name(std::string const&);
 
     // -----------------------------------------------------------------
     // This RAII helper class enables polling for a scoped block

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -198,7 +198,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
             PIKA_NO_UNIQUE_ADDRESS std::decay_t<F> f;
             cuda_scheduler sched;
-            std::optional<std::reference_wrapper<const cuda_stream>> stream;
+            std::optional<std::reference_wrapper<cuda_stream const>> stream;
 
             struct then_with_cuda_stream_receiver_tag
             {

--- a/libs/pika/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/pika/async_cuda/src/cuda_event_callback.cpp
@@ -341,7 +341,7 @@ namespace pika::cuda::experimental::detail {
 }    // namespace pika::cuda::experimental::detail
 
 namespace pika::cuda::experimental {
-    PIKA_EXPORT const std::string& get_pool_name()
+    PIKA_EXPORT std::string const& get_pool_name()
     {
         if (pika::resource::pool_exists(detail::polling_pool_name))
         {
@@ -351,7 +351,7 @@ namespace pika::cuda::experimental {
         return resource::get_partitioner().get_default_pool_name();
     }
 
-    PIKA_EXPORT void set_pool_name(const std::string& name)
+    PIKA_EXPORT void set_pool_name(std::string const& name)
     {
         PIKA_DETAIL_DP(detail::cud_debug<2>, debug(debug::detail::str<>("set pool name"), name));
         detail::polling_pool_name = name;

--- a/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
+++ b/libs/pika/async_cuda/tests/performance/cuda_scheduler_throughput.cpp
@@ -105,7 +105,7 @@ void matrixMultiply(sMatrixSize& matrix_size, std::size_t device, std::size_t it
     const T alpha = 1.0f;
     const T beta = 0.0f;
 
-    auto test_function = [&](cu::cuda_scheduler& cuda_sched, const std::string& msg,
+    auto test_function = [&](cu::cuda_scheduler& cuda_sched, std::string const& msg,
                              std::size_t n_iters) {
         // time many cuda kernels spawned one after each other when they complete
         pika::chrono::detail::high_resolution_timer t1;

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -74,7 +74,7 @@ struct sMatrixSize
 // @param wB         width of matrix B
 // -------------------------------------------------------------------------
 template <typename T>
-void matrixMulCPU(T* C, const T* A, const T* B, unsigned int hA, unsigned int wA, unsigned int wB)
+void matrixMulCPU(T* C, T const* A, T const* B, unsigned int hA, unsigned int wA, unsigned int wB)
 {
     for (unsigned int i = 0; i < hA; ++i)
     {
@@ -95,7 +95,7 @@ void matrixMulCPU(T* C, const T* A, const T* B, unsigned int hA, unsigned int wA
 // -------------------------------------------------------------------------
 // Compute the L2 norm difference between two arrays
 inline bool compare_L2_err(
-    const float* reference, const float* data, const unsigned int len, const float epsilon)
+    float const* reference, float const* data, unsigned int const len, float const epsilon)
 {
     PIKA_ASSERT(epsilon >= 0);
 

--- a/libs/pika/async_cuda/tests/unit/cuda_sender.cu
+++ b/libs/pika/async_cuda/tests/unit/cuda_sender.cu
@@ -36,7 +36,7 @@ auto launch_saxpy_kernel(pika::cuda::experimental::cuda_scheduler& cuda_sched, S
     unsigned int& blocks, unsigned int& threads, void** args)
 {
     return ex::when_all(std::forward<Sender>(predecessor),
-               ex::just(reinterpret_cast<const void*>(&saxpy), dim3(blocks), dim3(threads), args,
+               ex::just(reinterpret_cast<void const*>(&saxpy), dim3(blocks), dim3(threads), args,
                    std::size_t(0))) |
         ex::continues_on(cuda_sched) | cu::then_with_stream(whip::launch_kernel);
 }

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cublas_exception.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cublas_exception.hpp
@@ -14,13 +14,13 @@
 
 namespace pika::cuda::experimental {
     namespace detail {
-        PIKA_EXPORT const char* cublas_get_error_string(cublasStatus_t error);
+        PIKA_EXPORT char const* cublas_get_error_string(cublasStatus_t error);
     }    // namespace detail
 
     struct cublas_exception : pika::exception
     {
         PIKA_EXPORT explicit cublas_exception(cublasStatus_t err);
-        PIKA_EXPORT cublas_exception(const std::string& msg, cublasStatus_t err);
+        PIKA_EXPORT cublas_exception(std::string const& msg, cublasStatus_t err);
         PIKA_EXPORT cublasStatus_t get_cublas_errorcode() const noexcept;
 
     protected:

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cusolver_exception.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cusolver_exception.hpp
@@ -15,13 +15,13 @@
 
 namespace pika::cuda::experimental {
     namespace detail {
-        PIKA_EXPORT const char* cusolver_get_error_string(cusolverStatus_t error);
+        PIKA_EXPORT char const* cusolver_get_error_string(cusolverStatus_t error);
     }    // namespace detail
 
     struct cusolver_exception : pika::exception
     {
         PIKA_EXPORT explicit cusolver_exception(cusolverStatus_t err);
-        PIKA_EXPORT cusolver_exception(const std::string& msg, cusolverStatus_t err);
+        PIKA_EXPORT cusolver_exception(std::string const& msg, cusolverStatus_t err);
         PIKA_EXPORT cusolverStatus_t get_cusolver_errorcode() const noexcept;
 
     protected:

--- a/libs/pika/async_cuda_base/src/cublas_exception.cpp
+++ b/libs/pika/async_cuda_base/src/cublas_exception.cpp
@@ -13,7 +13,7 @@
 
 namespace pika::cuda::experimental {
     namespace detail {
-        const char* cublas_get_error_string(cublasStatus_t error)
+        char const* cublas_get_error_string(cublasStatus_t error)
         {
             switch (error)
             {
@@ -61,7 +61,7 @@ namespace pika::cuda::experimental {
     {
     }
 
-    cublas_exception::cublas_exception(const std::string& msg, cublasStatus_t err)
+    cublas_exception::cublas_exception(std::string const& msg, cublasStatus_t err)
       : pika::exception(pika::error::bad_function_call, msg)
       , err_(err)
     {

--- a/libs/pika/async_cuda_base/src/cusolver_exception.cpp
+++ b/libs/pika/async_cuda_base/src/cusolver_exception.cpp
@@ -16,7 +16,7 @@
 
 namespace pika::cuda::experimental {
     namespace detail {
-        const char* cusolver_get_error_string(cusolverStatus_t error)
+        char const* cusolver_get_error_string(cusolverStatus_t error)
         {
             switch (error)
             {
@@ -84,7 +84,7 @@ namespace pika::cuda::experimental {
     {
     }
 
-    cusolver_exception::cusolver_exception(const std::string& msg, cusolverStatus_t err)
+    cusolver_exception::cusolver_exception(std::string const& msg, cusolverStatus_t err)
       : pika::exception(pika::error::bad_function_call, msg)
       , err_(err)
     {

--- a/libs/pika/async_cuda_base/tests/unit/cusolver_handle.cu
+++ b/libs/pika/async_cuda_base/tests/unit/cusolver_handle.cu
@@ -26,7 +26,7 @@ __global__ void kernel(float* p)
     p[i] = i;
 }
 
-void print_matrix(int m, int n, const double* A, int lda, const char* name)
+void print_matrix(int m, int n, double const* A, int lda, char const* name)
 {
     for (int row = 0; row < m; row++)
     {
@@ -120,9 +120,9 @@ int main()
     // This example is adapted from
     // https://docs.nvidia.com/cuda/cusolver/index.html#lu_examples
     {
-        const int m = 3;
-        const int lda = m;
-        const int ldb = m;
+        int const m = 3;
+        int const lda = m;
+        int const ldb = m;
 
         //       | 1 2 3  |
         //   A = | 4 5 6  |

--- a/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/mpi_polling.hpp
@@ -149,7 +149,7 @@ namespace pika::mpi::experimental {
         }
 
         /// used for debugging to show mode type in messages, should be removed
-        inline const char* mode_string(int flags)
+        inline char const* mode_string(int flags)
         {
             switch (get_handler_method(flags))
             {
@@ -184,7 +184,7 @@ namespace pika::mpi::experimental {
 
         // -----------------------------------------------------------------
         /// tell the pika::mpi frework which pool is being used for mpi polling
-        PIKA_EXPORT void register_pool(const std::string& pool_name);
+        PIKA_EXPORT void register_pool(std::string const& pool_name);
 
         // -----------------------------------------------------------------
         /// actually enable/disable the polling callback handler
@@ -224,7 +224,7 @@ namespace pika::mpi::experimental {
     PIKA_EXPORT size_t get_work_count();
 
     /// return the name assigned to the mpi polling pool
-    PIKA_EXPORT const std::string& get_pool_name();
+    PIKA_EXPORT std::string const& get_pool_name();
 
     /// initialize the pika::mpi background request handler
     /// All ranks should call this function (but only one thread per rank needs to do so)

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -745,7 +745,7 @@ namespace pika::mpi::experimental {
         }
 
         // -------------------------------------------------------------
-        void register_pool(const std::string& pool_name)
+        void register_pool(std::string const& pool_name)
         {
             bool found = false;
             for (std::size_t p = 0; p < resource::get_partitioner().get_num_pools(); ++p)
@@ -845,7 +845,7 @@ namespace pika::mpi::experimental {
     }    // namespace detail
 
     // -----------------------------------------------------------------
-    const std::string& get_pool_name() { return detail::polling_pool_name_; }
+    std::string const& get_pool_name() { return detail::polling_pool_name_; }
 
     // -----------------------------------------------------------------
     // Return the "best" mpi thread mode to use for initialization

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -114,7 +114,7 @@ PIKA_NO_SANITIZE_ADDRESS void test_exception_handler_code(MPI_Comm comm, MPI_Dat
             std::vector<std::string> err_msgs = {"null datatype", "MPI_DATATYPE_NULL",
                 "Invalid datatype", "MPI_ERR_TYPE", "Invalid root"};
             bool msg_ok = false;
-            for (const auto& msg : err_msgs)
+            for (auto const& msg : err_msgs)
             {
                 msg_ok |= (std::string(e.what()).find(msg) != std::string::npos);
             }

--- a/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_async_storage.cpp
@@ -101,7 +101,7 @@ struct perf
 };
 
 //----------------------------------------------------------------------------
-void display(perf const& data, const test_options& options)
+void display(perf const& data, test_options const& options)
 {
     std::stringstream temp;
     double IOPs_s = data.IOPs / data.time;

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -133,12 +133,12 @@ enum class msg_type : std::uint32_t
 // ------------------------------------------------------------
 // utility function to print out info after send/recv completes
 void msg_info(
-    std::uint32_t rank, std::uint32_t size, msg_type mtype, header h, const char* xmsg = nullptr)
+    std::uint32_t rank, std::uint32_t size, msg_type mtype, header h, char const* xmsg = nullptr)
 {
     if (output)
     {
         int other = (mtype == msg_type::send) ? next_rank(rank, size) : prev_rank(rank, size);
-        const char* msg = (mtype == msg_type::send) ? "send" : "recv";
+        char const* msg = (mtype == msg_type::send) ? "send" : "recv";
         std::stringstream temp;
         temp << dec<3>(rank) << "/" << dec<3>(size);
         // clang-format off

--- a/libs/pika/async_mpi/tests/unit/pool_creation.cpp
+++ b/libs/pika/async_mpi/tests/unit/pool_creation.cpp
@@ -33,7 +33,7 @@ namespace mpi = pika::mpi::experimental;
 namespace tt = pika::this_thread::experimental;
 
 // -----------------------------------------------------------------
-int pika_main(const std::string& pool_name)
+int pika_main(std::string const& pool_name)
 {
     int size, rank;
     MPI_Comm comm = MPI_COMM_WORLD;

--- a/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/command_line_handling.hpp
@@ -49,7 +49,7 @@ namespace pika::detail {
 
         command_line_handling_result call(
             pika::program_options::options_description const& desc_cmdline, int argc,
-            const char* const* argv);
+            char const* const* argv);
 
         pika::program_options::variables_map vm_;
         pika::util::runtime_configuration rtcfg_;
@@ -84,13 +84,13 @@ namespace pika::detail {
         void update_logging_settings(
             pika::program_options::variables_map& vm, std::vector<std::string>& ini_config);
 
-        void store_command_line(int argc, const char* const* argv);
+        void store_command_line(int argc, char const* const* argv);
         void store_unregistered_options(
             std::string const& cmd_name, std::vector<std::string> const& unregistered_options);
         bool handle_help_options(pika::program_options::options_description const& help);
 
         void handle_attach_debugger();
 
-        std::vector<std::string> preprocess_config_settings(int argc, const char* const* argv);
+        std::vector<std::string> preprocess_config_settings(int argc, char const* const* argv);
     };
 }    // namespace pika::detail

--- a/libs/pika/command_line_handling/include/pika/command_line_handling/get_env_var_as.hpp
+++ b/libs/pika/command_line_handling/include/pika/command_line_handling/get_env_var_as.hpp
@@ -17,7 +17,7 @@ namespace pika::detail {
 
     /// from env var name 's' get value if well-formed, otherwise return default
     template <typename T>
-    T get_env_var_as(const char* s, T def) noexcept
+    T get_env_var_as(char const* s, T def) noexcept
     {
         T val = def;
         char* env = std::getenv(s);

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -603,7 +603,7 @@ namespace pika::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void command_line_handling::store_command_line(int argc, const char* const* argv)
+    void command_line_handling::store_command_line(int argc, char const* const* argv)
     {
         // Collect the command line for diagnostic purposes.
         std::string command;
@@ -706,7 +706,7 @@ namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     // separate command line arguments from configuration settings
     std::vector<std::string> command_line_handling::preprocess_config_settings(
-        int argc, const char* const* argv)
+        int argc, char const* const* argv)
     {
         std::vector<std::string> options;
         options.reserve(static_cast<std::size_t>(argc) + ini_config_.size());
@@ -752,7 +752,7 @@ namespace pika::detail {
     ///////////////////////////////////////////////////////////////////////////
     command_line_handling_result command_line_handling::call(
         pika::program_options::options_description const& desc_cmdline, int argc,
-        const char* const* argv)
+        char const* const* argv)
     {
         // set the flag signaling that command line parsing has been done
         cmd_line_parsed_ = true;

--- a/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
+++ b/libs/pika/concurrency/include/pika/concurrency/concurrentqueue.hpp
@@ -503,14 +503,14 @@ namespace pika::concurrency::detail {
         // Recommended values are on the order of 1000-10000 unless the number of
         // consumer threads exceeds the number of idle cores (in which case try 0-100).
         // Only affects instances of the BlockingConcurrentQueue.
-        static const int MAX_SEMA_SPINS = 10000;
+        static int const MAX_SEMA_SPINS = 10000;
 
         // Whether to recycle dynamically-allocated blocks into an internal free list or
         // not. If false, only pre-allocated blocks (controlled by the constructor
         // arguments) will be recycled, and all others will be `free`d back to the heap.
         // Note that blocks consumed by explicit producers are only freed on destruction
         // of the queue (not following destruction of the token) regardless of this trait.
-        static const bool RECYCLE_ALLOCATED_BLOCKS = false;
+        static bool const RECYCLE_ALLOCATED_BLOCKS = false;
 
 #ifndef MCDBGQ_USE_RELACY
         // Memory allocation can be customized if needed.

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_impl.hpp
@@ -75,7 +75,7 @@
        A ContextImpl cannot be sliced by copying it to a ContextImplBase.
 
      - void swap_context(ContextImplBase& from,
-                         const ContextImplBase& to)
+                         ContextImplBase const& to)
 
        This free function is called unqualified (via ADL).
        Preconditions:

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -241,7 +241,7 @@ namespace pika::threads::coroutines {
 # endif
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
                 asan_stack_size = m_stack_size;
-                asan_stack_bottom = const_cast<const void*>(m_stack);
+                asan_stack_bottom = const_cast<void const*>(m_stack);
 # endif
 
                 set_sigsegv_handler();
@@ -341,7 +341,7 @@ namespace pika::threads::coroutines {
                 m_sp[funp_idx] = reinterpret_cast<void*>(funp);
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
                 asan_stack_size = m_stack_size;
-                asan_stack_bottom = const_cast<const void*>(m_stack);
+                asan_stack_bottom = const_cast<void const*>(m_stack);
 # endif
             }
 

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
@@ -212,7 +212,7 @@ namespace pika::threads::coroutines {
             /// Free function. Saves the current context in @p from
             /// and restores the context in @p to.
             friend void swap_context(ucontext_context_impl_base& from,
-                const ucontext_context_impl_base& to, default_hint)
+                ucontext_context_impl_base const& to, default_hint)
             {
                 [[maybe_unused]] int error = PIKA_COROUTINE_SWAP_CONTEXT(&from.m_ctx, &to.m_ctx);
                 PIKA_ASSERT(error == 0);
@@ -264,7 +264,7 @@ namespace pika::threads::coroutines {
 
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
                 asan_stack_size = m_stack_size;
-                asan_stack_bottom = const_cast<const void*>(m_stack);
+                asan_stack_bottom = const_cast<void const*>(m_stack);
 # endif
 # if defined(PIKA_HAVE_STACKOVERFLOW_DETECTION) && !defined(PIKA_HAVE_ADDRESS_SANITIZER)
                 // concept inspired by the following links:
@@ -378,7 +378,7 @@ namespace pika::threads::coroutines {
 
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
                     asan_stack_size = m_stack_size;
-                    asan_stack_bottom = const_cast<const void*>(m_stack);
+                    asan_stack_bottom = const_cast<void const*>(m_stack);
 # endif
                 }
             }

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
@@ -138,7 +138,7 @@ namespace pika::threads::coroutines {
              * default.
              */
             friend void swap_context(fibers_context_impl_base& from,
-                const fibers_context_impl_base& to, default_hint) noexcept
+                fibers_context_impl_base const& to, default_hint) noexcept
             {
                 if (!is_fiber())
                 {

--- a/libs/pika/coroutines/tests/regressions/coroutine_function_destructor_yield_4800.cpp
+++ b/libs/pika/coroutines/tests/regressions/coroutine_function_destructor_yield_4800.cpp
@@ -45,9 +45,9 @@ int pika_main()
     }
 
 #if defined(PIKA_WITH_VALGRIND)
-    const int num_iterations = 100;
+    int const num_iterations = 100;
 #else
-    const int num_iterations = 1000;
+    int const num_iterations = 1000;
 #endif
 
     // This is a more complicated example which sometimes leads to the yielder

--- a/libs/pika/datastructures/include/pika/datastructures/detail/variant.hpp
+++ b/libs/pika/datastructures/include/pika/datastructures/detail/variant.hpp
@@ -24,7 +24,7 @@ namespace std {
 
     // 20.7.2.1, constructors
     constexpr variant() noexcept(see below);
-    variant(const variant&);
+    variant(variant const&);
     variant(variant&&) noexcept(see below);
 
     template <class T> constexpr variant(T&&) noexcept(see below);
@@ -47,7 +47,7 @@ namespace std {
     ~variant();
 
     // 20.7.2.3, assignment
-    variant& operator=(const variant&);
+    variant& operator=(variant const&);
     variant& operator=(variant&&) noexcept(see below);
 
     template <class T> variant& operator=(T&&) noexcept(see below);
@@ -127,10 +127,10 @@ namespace std {
   constexpr T&& get(variant<Types...>&&);
 
   template <class T, class... Types>
-  constexpr const T& get(const variant<Types...>&);
+  constexpr T const& get(const variant<Types...>&);
 
   template <class T, class... Types>
-  constexpr const T&& get(const variant<Types...>&&);
+  constexpr T const&& get(const variant<Types...>&&);
 
   template <size_t I, class... Types>
   constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>

--- a/libs/pika/datastructures/tests/unit/small_vector.cpp
+++ b/libs/pika/datastructures/tests/unit/small_vector.cpp
@@ -114,49 +114,49 @@ namespace test {
         }
 
         friend bool operator==(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ == r.int_;
         }
 
         friend bool operator!=(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ != r.int_;
         }
 
         friend bool operator<(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ < r.int_;
         }
 
         friend bool operator<=(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ <= r.int_;
         }
 
         friend bool operator>=(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ >= r.int_;
         }
 
         friend bool operator>(
-            const movable_and_copyable_int& l, const movable_and_copyable_int& r) noexcept
+            movable_and_copyable_int const& l, movable_and_copyable_int const& r) noexcept
         {
             return l.int_ > r.int_;
         }
 
         int get_int() const noexcept { return int_; }
 
-        friend bool operator==(const movable_and_copyable_int& l, int r) noexcept
+        friend bool operator==(movable_and_copyable_int const& l, int r) noexcept
         {
             return l.get_int() == r;
         }
 
-        friend bool operator==(int l, const movable_and_copyable_int& r) noexcept
+        friend bool operator==(int l, movable_and_copyable_int const& r) noexcept
         {
             return l == r.get_int();
         }

--- a/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
+++ b/libs/pika/debugging/include/pika/debugging/demangle_helper.hpp
@@ -67,7 +67,7 @@ namespace pika::debug::detail {
 // --------------------------------------------------------------------
 namespace pika::debug {
     template <typename T = void>    // print a single type
-    inline std::string print_type(const char* = "")
+    inline std::string print_type(char const* = "")
     {
         return std::string(detail::cxx_type_id<T>().type_id());
     }
@@ -79,7 +79,7 @@ namespace pika::debug {
     }
 
     template <typename T, typename... Args>    // print a list of types
-    inline std::enable_if_t<sizeof...(Args) != 0, std::string> print_type(const char* delim = "")
+    inline std::enable_if_t<sizeof...(Args) != 0, std::string> print_type(char const* delim = "")
     {
         std::string temp(print_type<T>());
         return temp + delim + print_type<Args...>(delim);

--- a/libs/pika/debugging/include/pika/debugging/print.hpp
+++ b/libs/pika/debugging/include/pika/debugging/print.hpp
@@ -273,7 +273,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
     }
 
     template <typename... Args>
-    void tuple_print(std::ostream& os, const std::tuple<Args...>& t)
+    void tuple_print(std::ostream& os, std::tuple<Args...> const& t)
     {
         tuple_print(os, t, std::make_index_sequence<sizeof...(Args)>());
     }
@@ -427,7 +427,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
     template <>
     struct enable_print<false>
     {
-        constexpr enable_print(const char*) {}
+        constexpr enable_print(char const*) {}
 
         constexpr bool is_enabled() const { return false; }
 
@@ -490,7 +490,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
 
         // @todo, return void so that timers have zero footprint when disabled
         template <typename... Args>
-        constexpr empty_timed_var make_timer(const double, Args const&...) const
+        constexpr empty_timed_var make_timer(double const, Args const&...) const
         {
             return empty_timed_var{};
         }
@@ -518,7 +518,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         {
         }
 
-        constexpr enable_print(const char* p)
+        constexpr enable_print(char const* p)
           : prefix_(p)
         {
         }
@@ -592,7 +592,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
         }
 
         template <typename... Args>
-        constexpr timed_var<Args...> make_timer(const double delay, const Args... args) const
+        constexpr timed_var<Args...> make_timer(double const delay, const Args... args) const
         {
             return timed_var<Args...>(delay, args...);
         }

--- a/libs/pika/debugging/src/attach_debugger.cpp
+++ b/libs/pika/debugging/src/attach_debugger.cpp
@@ -22,7 +22,7 @@ namespace pika::debug::detail {
     void attach_debugger()
     {
 #if defined(_POSIX_VERSION) && defined(PIKA_HAVE_UNISTD_H)
-        volatile int i = 0;
+        int volatile i = 0;
         std::cerr << "PID: " << getpid()
                   << " ready for attaching debugger. Once attached set i = 1 and continue"
                   << std::endl;

--- a/libs/pika/debugging/src/print.cpp
+++ b/libs/pika/debugging/src/print.cpp
@@ -153,7 +153,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
     }
 
     ipaddr::ipaddr(std::uint32_t a)
-      : data_(reinterpret_cast<const uint8_t*>(&ipdata_))
+      : data_(reinterpret_cast<uint8_t const*>(&ipdata_))
       , ipdata_(a)
     {
     }
@@ -211,7 +211,7 @@ namespace PIKA_DETAIL_NS_DEBUG {
     }
 
     mem_crc32::mem_crc32(void const* a, std::size_t len)
-      : addr_(reinterpret_cast<const uint64_t*>(a))
+      : addr_(reinterpret_cast<uint64_t const*>(a))
       , len_(len)
     {
     }

--- a/libs/pika/errors/include/pika/errors/error.hpp
+++ b/libs/pika/errors/include/pika/errors/error.hpp
@@ -189,13 +189,13 @@ namespace std {
     template <>
     struct is_error_code_enum<pika::error>
     {
-        static const bool value = true;
+        static bool const value = true;
     };
 
     template <>
     struct is_error_condition_enum<pika::error>
     {
-        static const bool value = true;
+        static bool const value = true;
     };
 }    // namespace std
 /// \endcond

--- a/libs/pika/errors/include/pika/errors/exception.hpp
+++ b/libs/pika/errors/include/pika/errors/exception.hpp
@@ -213,7 +213,7 @@ namespace pika {
 
             ~std_exception() noexcept {}
 
-            const char* what() const noexcept override { return what_.c_str(); }
+            char const* what() const noexcept override { return what_.c_str(); }
         };
 
         struct PIKA_EXPORT bad_alloc : std::bad_alloc
@@ -229,7 +229,7 @@ namespace pika {
 
             ~bad_alloc() noexcept {}
 
-            const char* what() const noexcept override { return what_.c_str(); }
+            char const* what() const noexcept override { return what_.c_str(); }
         };
 
         struct PIKA_EXPORT bad_exception : std::bad_exception
@@ -245,7 +245,7 @@ namespace pika {
 
             ~bad_exception() noexcept {}
 
-            const char* what() const noexcept override { return what_.c_str(); }
+            char const* what() const noexcept override { return what_.c_str(); }
         };
 
         struct PIKA_EXPORT bad_cast : std::bad_cast
@@ -261,7 +261,7 @@ namespace pika {
 
             ~bad_cast() noexcept {}
 
-            const char* what() const noexcept override { return what_.c_str(); }
+            char const* what() const noexcept override { return what_.c_str(); }
         };
 
         struct PIKA_EXPORT bad_typeid : std::bad_typeid
@@ -277,7 +277,7 @@ namespace pika {
 
             ~bad_typeid() noexcept {}
 
-            const char* what() const noexcept override { return what_.c_str(); }
+            char const* what() const noexcept override { return what_.c_str(); }
         };
 
         template <typename Exception>

--- a/libs/pika/errors/src/error_code.cpp
+++ b/libs/pika/errors/src/error_code.cpp
@@ -20,7 +20,7 @@ namespace pika {
         class pika_category : public std::error_category
         {
         public:
-            const char* name() const noexcept { return "pika"; }
+            char const* name() const noexcept { return "pika"; }
 
             std::string message(int value) const
             {
@@ -40,7 +40,7 @@ namespace pika {
         class pika_category_rethrow : public std::error_category
         {
         public:
-            const char* name() const noexcept { return ""; }
+            char const* name() const noexcept { return ""; }
 
             std::string message(int) const noexcept { return ""; }
         };

--- a/libs/pika/execution_base/include/pika/execution_base/this_thread.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/this_thread.hpp
@@ -66,7 +66,7 @@ namespace pika::execution {
 
 namespace pika::util {
     template <typename Predicate>
-    void yield_while(Predicate&& predicate, const char* thread_name = nullptr,
+    void yield_while(Predicate&& predicate, char const* thread_name = nullptr,
         bool allow_timed_suspension = true)
     {
         auto yield_or_spin = allow_timed_suspension ?
@@ -87,7 +87,7 @@ namespace pika::util {
         // replaced if and when a better solution appears.
         template <typename Predicate>
         void yield_while_count(Predicate&& predicate, std::size_t required_count,
-            const char* thread_name = nullptr, bool allow_timed_suspension = true)
+            char const* thread_name = nullptr, bool allow_timed_suspension = true)
         {
             auto yield_or_spin = allow_timed_suspension ?
                 &pika::execution::this_thread::detail::yield_k :
@@ -115,12 +115,12 @@ namespace pika::util {
         template <typename Predicate>
         [[nodiscard]] bool yield_while_count_timeout(Predicate&& predicate,
             std::size_t required_count, std::chrono::duration<double> timeout,
-            const char* thread_name = nullptr, bool allow_timed_suspension = true)
+            char const* thread_name = nullptr, bool allow_timed_suspension = true)
         {
             // Seconds represented using a double
             using duration_type = std::chrono::duration<double>;
 
-            const bool use_timeout = timeout >= duration_type(0.0);
+            bool const use_timeout = timeout >= duration_type(0.0);
             auto yield_or_spin = allow_timed_suspension ?
                 &pika::execution::this_thread::detail::yield_k :
                 &pika::execution::this_thread::detail::spin_k;
@@ -151,12 +151,12 @@ namespace pika::util {
         template <typename Predicate>
         [[nodiscard]] bool
         yield_while_timeout(Predicate&& predicate, std::chrono::duration<double> timeout,
-            const char* thread_name = nullptr, bool allow_timed_suspension = true)
+            char const* thread_name = nullptr, bool allow_timed_suspension = true)
         {
             // Seconds represented using a double
             using duration_type = std::chrono::duration<double>;
 
-            const bool use_timeout = timeout >= duration_type(0.0);
+            bool const use_timeout = timeout >= duration_type(0.0);
             auto yield_or_spin = allow_timed_suspension ?
                 &pika::execution::this_thread::detail::yield_k :
                 &pika::execution::this_thread::detail::spin_k;

--- a/libs/pika/execution_base/src/agent_ref.cpp
+++ b/libs/pika/execution_base/src/agent_ref.cpp
@@ -18,7 +18,7 @@
 
 namespace pika::execution::detail {
 
-    void agent_ref::yield(const char* desc)
+    void agent_ref::yield(char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         // verify that there are no more registered locks for this OS-thread
@@ -28,7 +28,7 @@ namespace pika::execution::detail {
         impl_->yield(desc);
     }
 
-    void agent_ref::yield_k(std::size_t k, const char* desc)
+    void agent_ref::yield_k(std::size_t k, char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         // verify that there are no more registered locks for this OS-thread
@@ -38,7 +38,7 @@ namespace pika::execution::detail {
         impl_->yield_k(k, desc);
     }
 
-    void agent_ref::spin_k(std::size_t k, const char* desc)
+    void agent_ref::spin_k(std::size_t k, char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         // verify that there are no more registered locks for this OS-thread
@@ -48,7 +48,7 @@ namespace pika::execution::detail {
         impl_->spin_k(k, desc);
     }
 
-    void agent_ref::suspend(const char* desc)
+    void agent_ref::suspend(char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         // verify that there are no more registered locks for this OS-thread
@@ -58,25 +58,25 @@ namespace pika::execution::detail {
         impl_->suspend(desc);
     }
 
-    void agent_ref::resume(const char* desc)
+    void agent_ref::resume(char const* desc)
     {
         PIKA_ASSERT(*this != pika::execution::this_thread::detail::agent());
         impl_->resume(desc);
     }
 
-    void agent_ref::abort(const char* desc)
+    void agent_ref::abort(char const* desc)
     {
         PIKA_ASSERT(*this != pika::execution::this_thread::detail::agent());
         impl_->abort(desc);
     }
 
-    void agent_ref::sleep_for(pika::chrono::steady_duration const& sleep_duration, const char* desc)
+    void agent_ref::sleep_for(pika::chrono::steady_duration const& sleep_duration, char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         impl_->sleep_for(sleep_duration, desc);
     }
 
-    void agent_ref::sleep_until(pika::chrono::steady_time_point const& sleep_time, const char* desc)
+    void agent_ref::sleep_until(pika::chrono::steady_time_point const& sleep_time, char const* desc)
     {
         PIKA_ASSERT(*this == pika::execution::this_thread::detail::agent());
         impl_->sleep_until(sleep_time, desc);

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -225,7 +225,7 @@ void check_exception_ptr(std::exception_ptr eptr)
     {
         std::rethrow_exception(eptr);
     }
-    catch (const std::runtime_error& e)
+    catch (std::runtime_error const& e)
     {
         PIKA_TEST_EQ(std::string(e.what()), std::string("error"));
     }

--- a/libs/pika/functional/tests/unit/contains.cpp
+++ b/libs/pika/functional/tests/unit/contains.cpp
@@ -30,10 +30,10 @@ struct Seventeen
 //    int value;
 //};
 //
-//bool operator==(const ReturnInt& x, const ReturnInt& y)
+//bool operator==(ReturnInt const& x, ReturnInt const& y)
 //{ return x.value == y.value; }
 //
-//bool operator!=(const ReturnInt& x, const ReturnInt& y)
+//bool operator!=(ReturnInt const& x, ReturnInt const& y)
 //{ return x.value != y.value; }
 //
 //namespace contain_test {

--- a/libs/pika/functional/tests/unit/function.cpp
+++ b/libs/pika/functional/tests/unit/function.cpp
@@ -62,8 +62,8 @@ struct generate_three_obj
 };
 static int generate_five() { return 5; }
 static int generate_three() { return 3; }
-static string identity_str(const string& s) { return s; }
-static string string_cat(const string& s1, const string& s2) { return s1 + s2; }
+static string identity_str(string const& s) { return s; }
+static string string_cat(string const& s1, string const& s2) { return s1 + s2; }
 static int sum_ints(int x, int y) { return x + y; }
 
 struct write_const_1_nonconst_2
@@ -597,7 +597,7 @@ static void test_one_arg()
     pika::util::detail::function<string(string)> id(&identity_str);
     PIKA_TEST_EQ(id("str"), "str");
 
-    pika::util::detail::function<string(const char*)> id2(&identity_str);
+    pika::util::detail::function<string(char const*)> id2(&identity_str);
     PIKA_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
@@ -610,7 +610,7 @@ static void test_one_arg()
 
 static void test_two_args()
 {
-    pika::util::detail::function<string(const string&, const string&)> cat(&string_cat);
+    pika::util::detail::function<string(string const&, string const&)> cat(&string_cat);
     PIKA_TEST_EQ(cat("str", "ing"), "string");
 
     pika::util::detail::function<int(short, short)> sum(&sum_ints);
@@ -671,12 +671,12 @@ struct add_with_throw_on_copy
 
     add_with_throw_on_copy() {}
 
-    add_with_throw_on_copy(const add_with_throw_on_copy&)
+    add_with_throw_on_copy(add_with_throw_on_copy const&)
     {
         throw std::runtime_error("But this CAN'T throw");
     }
 
-    add_with_throw_on_copy& operator=(const add_with_throw_on_copy&)
+    add_with_throw_on_copy& operator=(add_with_throw_on_copy const&)
     {
         throw std::runtime_error("But this CAN'T throw");
     }
@@ -749,7 +749,7 @@ static void test_implicit()
 
 static void test_call_obj(pika::util::detail::function<int(int, int)> f) { PIKA_TEST(!f.empty()); }
 
-static void test_call_cref(const pika::util::detail::function<int(int, int)>& f)
+static void test_call_cref(pika::util::detail::function<int(int, int)> const& f)
 {
     PIKA_TEST(!f.empty());
 }
@@ -766,7 +766,7 @@ struct big_aggregating_structure
 
     big_aggregating_structure() { ++global_int; }
 
-    big_aggregating_structure(const big_aggregating_structure&) { ++global_int; }
+    big_aggregating_structure(big_aggregating_structure const&) { ++global_int; }
 
     ~big_aggregating_structure() { --global_int; }
 

--- a/libs/pika/functional/tests/unit/nothrow_swap.cpp
+++ b/libs/pika/functional/tests/unit/nothrow_swap.cpp
@@ -26,14 +26,14 @@ struct MaybeThrowOnCopy
     {
     }
 
-    MaybeThrowOnCopy(const MaybeThrowOnCopy& other)
+    MaybeThrowOnCopy(MaybeThrowOnCopy const& other)
       : value(other.value)
     {
         if (throwOnCopy) throw tried_to_copy();
     }
 
     // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
-    MaybeThrowOnCopy& operator=(const MaybeThrowOnCopy& other)
+    MaybeThrowOnCopy& operator=(MaybeThrowOnCopy const& other)
     {
         if (throwOnCopy) throw tried_to_copy();
         value = other.value;

--- a/libs/pika/ini/include/pika/ini/ini.hpp
+++ b/libs/pika/ini/include/pika/ini/ini.hpp
@@ -31,7 +31,7 @@ namespace pika::detail {
     {
     public:
         using entry_changed_func =
-            util::detail::function<void(const std::string&, const std::string&)>;
+            util::detail::function<void(std::string const&, std::string const&)>;
         using entry_type = std::pair<std::string, entry_changed_func>;
         using entry_map = std::map<std::string, entry_type>;
         using section_map = std::map<std::string, section>;

--- a/libs/pika/ini/src/ini.cpp
+++ b/libs/pika/ini/src/ini.cpp
@@ -39,7 +39,7 @@ extern char** environ;
 
 namespace pika::detail {
     // example ini line: line # comment
-    const char pattern_comment[] = "^([^#]*)(#.*)$";
+    char const pattern_comment[] = "^([^#]*)(#.*)$";
 
     inline std::string trim_whitespace(std::string const& s)
     {
@@ -64,7 +64,7 @@ namespace pika::detail {
         read(filename);
     }
 
-    section::section(const section& in)
+    section::section(section const& in)
       : root_(this_())
       , name_(in.get_name())
       , parent_name_(in.get_parent_name())

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -77,12 +77,12 @@ namespace pika {
     };
 
     PIKA_EXPORT int init(std::function<int(pika::program_options::variables_map&)> f, int argc,
-        const char* const* argv, init_params const& params = init_params());
-    PIKA_EXPORT int init(std::function<int(int, char**)> f, int argc, const char* const* argv,
+        char const* const* argv, init_params const& params = init_params());
+    PIKA_EXPORT int init(std::function<int(int, char**)> f, int argc, char const* const* argv,
         init_params const& params = init_params());
-    PIKA_EXPORT int init(std::function<int()> f, int argc, const char* const* argv,
+    PIKA_EXPORT int init(std::function<int()> f, int argc, char const* const* argv,
         init_params const& params = init_params());
-    PIKA_EXPORT int init(std::nullptr_t, int argc, const char* const* argv,
+    PIKA_EXPORT int init(std::nullptr_t, int argc, char const* const* argv,
         init_params const& params = init_params());
 
     /// Start the runtime.
@@ -96,7 +96,7 @@ namespace pika {
     /// @pre the runtime is stopped
     /// @post the runtime is running
     PIKA_EXPORT void start(std::function<int(pika::program_options::variables_map&)> f, int argc,
-        const char* const* argv, init_params const& params = init_params());
+        char const* const* argv, init_params const& params = init_params());
 
     /// Start the runtime.
     ///
@@ -108,7 +108,7 @@ namespace pika {
     /// @pre `(argc == 0 && argv == nullptr) || (argc >= 1 && argv != nullptr)`
     /// @pre the runtime is stopped
     /// @post the runtime is running
-    PIKA_EXPORT void start(std::function<int(int, char**)> f, int argc, const char* const* argv,
+    PIKA_EXPORT void start(std::function<int(int, char**)> f, int argc, char const* const* argv,
         init_params const& params = init_params());
 
     /// Start the runtime.
@@ -119,10 +119,10 @@ namespace pika {
     ///
     /// @pre `(argc == 0 && argv == nullptr) || (argc >= 1 && argv != nullptr)`
     /// @pre the runtime is not running
-    PIKA_EXPORT void start(std::function<int()> f, int argc, const char* const* argv,
+    PIKA_EXPORT void start(std::function<int()> f, int argc, char const* const* argv,
         init_params const& params = init_params());
 
-    PIKA_EXPORT void start(std::nullptr_t, int argc, const char* const* argv,
+    PIKA_EXPORT void start(std::nullptr_t, int argc, char const* const* argv,
         init_params const& params = init_params());
 
     /// Start the runtime.
@@ -136,7 +136,7 @@ namespace pika {
     /// @pre the runtime is not initialized
     /// @post the runtime is running
     PIKA_EXPORT void start(
-        int argc, const char* const* argv, init_params const& params = init_params());
+        int argc, char const* const* argv, init_params const& params = init_params());
 
     /// Stop the runtime.
     ///

--- a/libs/pika/init_runtime/src/init_logging.cpp
+++ b/libs/pika/init_runtime/src/init_logging.cpp
@@ -34,7 +34,7 @@
 
 namespace pika::detail {
     static void spdlog_format_thread_id(pika::threads::detail::thread_id_type const id,
-        const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest)
+        spdlog::details::log_msg const&, std::tm const&, spdlog::memory_buf_t& dest)
     {
         if (id)
         {
@@ -50,7 +50,7 @@ namespace pika::detail {
     class pika_thread_id_formatter_flag : public spdlog::custom_flag_formatter
     {
     public:
-        void format(const spdlog::details::log_msg& m, const std::tm& t,
+        void format(spdlog::details::log_msg const& m, std::tm const& t,
             spdlog::memory_buf_t& dest) override
         {
             spdlog_format_thread_id(threads::detail::get_self_id(), m, t, dest);
@@ -65,7 +65,7 @@ namespace pika::detail {
     class pika_parent_thread_id_formatter_flag : public spdlog::custom_flag_formatter
     {
     public:
-        void format(const spdlog::details::log_msg& m, const std::tm& t,
+        void format(spdlog::details::log_msg const& m, std::tm const& t,
             spdlog::memory_buf_t& dest) override
         {
             spdlog_format_thread_id(threads::detail::get_parent_id(), m, t, dest);
@@ -87,7 +87,7 @@ namespace pika::detail {
 
     public:
         void format(
-            const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
+            spdlog::details::log_msg const&, std::tm const&, spdlog::memory_buf_t& dest) override
         {
             format_id(dest, pika::get_thread_pool_num());
             dest.append(std::string_view("/"));
@@ -106,7 +106,7 @@ namespace pika::detail {
     {
     public:
         void format(
-            const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
+            spdlog::details::log_msg const&, std::tm const&, spdlog::memory_buf_t& dest) override
         {
             static PIKA_DETAIL_NS_DEBUG::hostname_print_helper helper{};
             static std::string_view hostname_str = helper.get_hostname();

--- a/libs/pika/init_runtime/src/init_runtime.cpp
+++ b/libs/pika/init_runtime/src/init_runtime.cpp
@@ -287,7 +287,7 @@ namespace pika {
         ///////////////////////////////////////////////////////////////////////
         int run_or_start(
             pika::util::detail::function<int(pika::program_options::variables_map& vm)> const& f,
-            int argc, const char* const* argv, init_params const& params, bool blocking)
+            int argc, char const* const* argv, init_params const& params, bool blocking)
         {
             if (pika::detail::get_runtime_ptr() != nullptr)
             {
@@ -357,7 +357,7 @@ namespace pika {
 
         int init_start_impl(
             pika::util::detail::function<int(pika::program_options::variables_map&)> f, int argc,
-            const char* const* argv, init_params const& params, bool blocking)
+            char const* const* argv, init_params const& params, bool blocking)
         {
             if (argc == 0 || argv == nullptr)
             {
@@ -379,12 +379,12 @@ namespace pika {
     }    // namespace detail
 
     int init(std::function<int(pika::program_options::variables_map&)> f, int argc,
-        const char* const* argv, init_params const& params)
+        char const* const* argv, init_params const& params)
     {
         return detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, true);
     }
 
-    int init(std::function<int(int, char**)> f, int argc, const char* const* argv,
+    int init(std::function<int(int, char**)> f, int argc, char const* const* argv,
         init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f =
@@ -392,21 +392,21 @@ namespace pika {
         return detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    int init(std::function<int()> f, int argc, const char* const* argv, init_params const& params)
+    int init(std::function<int()> f, int argc, char const* const* argv, init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f =
             pika::util::detail::bind(f);
         return detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
-    int init(std::nullptr_t, int argc, const char* const* argv, init_params const& params)
+    int init(std::nullptr_t, int argc, char const* const* argv, init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f;
         return detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, true);
     }
 
     void start(std::function<int(pika::program_options::variables_map&)> f, int argc,
-        const char* const* argv, init_params const& params)
+        char const* const* argv, init_params const& params)
     {
         if (detail::init_start_impl(PIKA_MOVE(f), argc, argv, params, false) != 0)
         {
@@ -414,7 +414,7 @@ namespace pika {
         }
     }
 
-    void start(std::function<int(int, char**)> f, int argc, const char* const* argv,
+    void start(std::function<int(int, char**)> f, int argc, char const* const* argv,
         init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f =
@@ -425,7 +425,7 @@ namespace pika {
         }
     }
 
-    void start(std::function<int()> f, int argc, const char* const* argv, init_params const& params)
+    void start(std::function<int()> f, int argc, char const* const* argv, init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f =
             pika::util::detail::bind(f);
@@ -435,7 +435,7 @@ namespace pika {
         }
     }
 
-    void start(std::nullptr_t, int argc, const char* const* argv, init_params const& params)
+    void start(std::nullptr_t, int argc, char const* const* argv, init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f;
         if (detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, false) != 0)
@@ -444,7 +444,7 @@ namespace pika {
         }
     }
 
-    void start(int argc, const char* const* argv, init_params const& params)
+    void start(int argc, char const* const* argv, init_params const& params)
     {
         pika::util::detail::function<int(pika::program_options::variables_map&)> main_f;
         if (detail::init_start_impl(PIKA_MOVE(main_f), argc, argv, params, false) != 0)

--- a/libs/pika/init_runtime/tests/unit/const_args_init.cpp
+++ b/libs/pika/init_runtime/tests/unit/const_args_init.cpp
@@ -32,7 +32,7 @@ int main()
     }
 
     {
-        const char* argv[] = {name.data(), nullptr};
+        char const* argv[] = {name.data(), nullptr};
 
         PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
 
@@ -50,7 +50,7 @@ int main()
     }
 
     {
-        const char* const argv[] = {name.data(), nullptr};
+        char const* const argv[] = {name.data(), nullptr};
 
         PIKA_TEST_EQ(pika::init(pika_main, argc, argv), 0);
 

--- a/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iter_sent.hpp
+++ b/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iter_sent.hpp
@@ -126,17 +126,17 @@ struct iterator
         return copy -= n;
     }
 
-    bool operator==(const iterator& that) const { return this->state == that.state; }
+    bool operator==(iterator const& that) const { return this->state == that.state; }
 
-    bool operator!=(const iterator& that) const { return this->state != that.state; }
+    bool operator!=(iterator const& that) const { return this->state != that.state; }
 
-    bool operator<(const iterator& that) const { return this->state < that.state; }
+    bool operator<(iterator const& that) const { return this->state < that.state; }
 
-    bool operator<=(const iterator& that) const { return this->state <= that.state; }
+    bool operator<=(iterator const& that) const { return this->state <= that.state; }
 
-    bool operator>(const iterator& that) const { return this->state > that.state; }
+    bool operator>(iterator const& that) const { return this->state > that.state; }
 
-    bool operator>=(const iterator& that) const { return this->state >= that.state; }
+    bool operator>=(iterator const& that) const { return this->state >= that.state; }
 
 protected:
     Value state;

--- a/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iterator_tests.hpp
+++ b/libs/pika/iterator_support/tests/include/pika/iterator_support/tests/iterator_tests.hpp
@@ -39,7 +39,7 @@ namespace tests {
 
         int foo() const { return x_; }
 
-        bool operator==(const dummy_type& d) const { return x_ == d.x_; }
+        bool operator==(dummy_type const& d) const { return x_ == d.x_; }
 
         int x_;
     };
@@ -376,8 +376,8 @@ namespace tests {
         Iterator i2(i);
         using value_type = typename std::iterator_traits<Iterator>::value_type;
         using reference = typename std::iterator_traits<Iterator>::reference;
-        PIKA_TEST((std::is_same<const value_type&, reference>::value));
-        const T& v2 = *i2;
+        PIKA_TEST((std::is_same<value_type const&, reference>::value));
+        T const& v2 = *i2;
         PIKA_TEST_EQ(v1, v2);
         //PIKA_TEST(is_lvalue_iterator<Iterator>::value);
         //PIKA_TEST(!is_non_const_lvalue_iterator<Iterator>::value);
@@ -473,17 +473,17 @@ namespace tests {
         using value_type = T;
         struct reference
         {
-            reference& operator=(const T&) { return *this; }
+            reference& operator=(T const&) { return *this; }
             operator value_type() { return static_object<T>::get(); }
         };
 
-        using pointer = const T*;
+        using pointer = T const*;
         using difference_type = std::ptrdiff_t;
 
         input_output_iterator_archetype() {}
-        self& operator=(const self&) { return *this; }
-        bool operator==(const self&) const { return true; }
-        bool operator!=(const self&) const { return true; }
+        self& operator=(self const&) { return *this; }
+        bool operator==(self const&) const { return true; }
+        bool operator!=(self const&) const { return true; }
         reference operator*() const { return reference(); }
         self& operator++() { return *this; }
         self operator++(int) { return *this; }
@@ -498,14 +498,14 @@ namespace tests {
     public:
         using iterator_category = std::input_iterator_tag;
         using value_type = T;
-        using reference = const T&;
-        using pointer = const T*;
+        using reference = T const&;
+        using pointer = T const*;
         using difference_type = std::ptrdiff_t;
         input_iterator_archetype_no_proxy() {}
         input_iterator_archetype_no_proxy(input_iterator_archetype_no_proxy const&) {}
-        self& operator=(const self&) { return *this; }
-        bool operator==(const self&) const { return true; }
-        bool operator!=(const self&) const { return true; }
+        self& operator=(self const&) { return *this; }
+        bool operator==(self const&) const { return true; }
+        bool operator!=(self const&) const { return true; }
         reference operator*() const { return static_object<T>::get(); }
         self& operator++() { return *this; }
         self operator++(int) { return *this; }
@@ -520,14 +520,14 @@ namespace tests {
     public:
         using iterator_category = std::forward_iterator_tag;
         using value_type = T;
-        using reference = const T&;
+        using reference = T const&;
         using pointer = T const*;
         using difference_type = std::ptrdiff_t;
         forward_iterator_archetype() {}
         forward_iterator_archetype(forward_iterator_archetype const&) {}
-        self& operator=(const self&) { return *this; }
-        bool operator==(const self&) const { return true; }
-        bool operator!=(const self&) const { return true; }
+        self& operator=(self const&) { return *this; }
+        bool operator==(self const&) const { return true; }
+        bool operator!=(self const&) const { return true; }
         reference operator*() const { return static_object<T>::get(); }
         self& operator++() { return *this; }
         self operator++(int) { return *this; }

--- a/libs/pika/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/is_iterator.cpp
@@ -53,7 +53,7 @@ struct bidirectional_traversal_iterator
     using difference_type = int;
     using value_type = int;
     using iterator_category = std::input_iterator_tag;
-    using pointer = const int*;
+    using pointer = int const*;
     using reference = void;
 
     int state;
@@ -87,32 +87,32 @@ struct bidirectional_traversal_iterator
         return copy;
     }
 
-    bool operator==(const bidirectional_traversal_iterator& that) const
+    bool operator==(bidirectional_traversal_iterator const& that) const
     {
         return this->state == that.state;
     }
 
-    bool operator!=(const bidirectional_traversal_iterator& that) const
+    bool operator!=(bidirectional_traversal_iterator const& that) const
     {
         return this->state != that.state;
     }
 
-    bool operator<(const bidirectional_traversal_iterator& that) const
+    bool operator<(bidirectional_traversal_iterator const& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const bidirectional_traversal_iterator& that) const
+    bool operator<=(bidirectional_traversal_iterator const& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const bidirectional_traversal_iterator& that) const
+    bool operator>(bidirectional_traversal_iterator const& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const bidirectional_traversal_iterator& that) const
+    bool operator>=(bidirectional_traversal_iterator const& that) const
     {
         return this->state >= that.state;
     }
@@ -123,7 +123,7 @@ struct random_access_traversal_iterator
     using difference_type = int;
     using value_type = int;
     using iterator_category = std::input_iterator_tag;
-    using pointer = const int*;
+    using pointer = int const*;
     using reference = void;
 
     int state;
@@ -183,37 +183,37 @@ struct random_access_traversal_iterator
         return copy -= n;
     }
 
-    difference_type operator-(const random_access_traversal_iterator& that) const
+    difference_type operator-(random_access_traversal_iterator const& that) const
     {
         return this->state - that.state;
     }
 
-    bool operator==(const random_access_traversal_iterator& that) const
+    bool operator==(random_access_traversal_iterator const& that) const
     {
         return this->state == that.state;
     }
 
-    bool operator!=(const random_access_traversal_iterator& that) const
+    bool operator!=(random_access_traversal_iterator const& that) const
     {
         return this->state != that.state;
     }
 
-    bool operator<(const random_access_traversal_iterator& that) const
+    bool operator<(random_access_traversal_iterator const& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const random_access_traversal_iterator& that) const
+    bool operator<=(random_access_traversal_iterator const& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const random_access_traversal_iterator& that) const
+    bool operator>(random_access_traversal_iterator const& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const random_access_traversal_iterator& that) const
+    bool operator>=(random_access_traversal_iterator const& that) const
     {
         return this->state >= that.state;
     }
@@ -232,7 +232,7 @@ void addition_result()
 
     struct C
     {
-        B operator+(const A&) const { return B{}; }
+        B operator+(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG((std::is_same<B, typename addition_result<C, A>::type>::value), "deduced type");
@@ -272,7 +272,7 @@ void equality_result()
 
     struct C
     {
-        B operator==(const A&) const { return B{}; }
+        B operator==(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG((std::is_same_v<B, equality_result_t<C, A>>), "deduced type");
@@ -294,7 +294,7 @@ void inequality_result()
 
     struct C
     {
-        B operator!=(const A&) const { return B{}; }
+        B operator!=(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG((std::is_same_v<B, inequality_result_t<C, A>>), "deduced type");
@@ -315,7 +315,7 @@ void inplace_addition_result()
 
     struct C
     {
-        B operator+=(const A&) const { return B{}; }
+        B operator+=(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG(
@@ -337,7 +337,7 @@ void inplace_subtraction_result()
 
     struct C
     {
-        B operator-=(const A&) const { return B{}; }
+        B operator-=(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG(
@@ -439,7 +439,7 @@ void subscript_result()
 
     struct C
     {
-        B operator[](const A&) const { return B{}; }
+        B operator[](A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG((std::is_same<B, typename subscript_result<C, A>::type>::value), "deduced type");
@@ -460,7 +460,7 @@ void subtraction_result()
 
     struct C
     {
-        B operator-(const A&) const { return B{}; }
+        B operator-(A const&) const { return B{}; }
     };
 
     PIKA_TEST_MSG(

--- a/libs/pika/iterator_support/tests/unit/iterator_adaptor.cpp
+++ b/libs/pika/iterator_support/tests/unit/iterator_adaptor.cpp
@@ -41,7 +41,7 @@ struct mult_functor
 template <typename Pair>
 struct select1st_
 {
-    const typename Pair::first_type& operator()(const Pair& x) const { return x.first; }
+    const typename Pair::first_type& operator()(Pair const& x) const { return x.first; }
 
     typename Pair::first_type& operator()(Pair& x) const { return x.first; }
 };
@@ -92,7 +92,7 @@ public:
 
     template <typename V2>
     ptr_iterator(
-        const ptr_iterator<V2>& x, std::enable_if_t<std::is_convertible<V2*, V*>::value>* = nullptr)
+        ptr_iterator<V2> const& x, std::enable_if_t<std::is_convertible<V2*, V*>::value>* = nullptr)
       : base_adaptor_type(x.base())
     {
     }
@@ -157,7 +157,7 @@ int main()
 {
     tests::dummy_type array[] = {tests::dummy_type(0), tests::dummy_type(1), tests::dummy_type(2),
         tests::dummy_type(3), tests::dummy_type(4), tests::dummy_type(5)};
-    const int N = sizeof(array) / sizeof(tests::dummy_type);
+    int const N = sizeof(array) / sizeof(tests::dummy_type);
 
     // sanity check, if this doesn't pass the test is buggy
     tests::random_access_iterator_test(array, N, array);
@@ -189,9 +189,9 @@ int main()
 
     {
         // Test computation of default when the Value is const
-        using Iter1 = ptr_iterator<const int>;
+        using Iter1 = ptr_iterator<int const>;
         PIKA_TEST((std::is_same<Iter1::value_type, int>::value));
-        PIKA_TEST((std::is_same<Iter1::reference, const int&>::value));
+        PIKA_TEST((std::is_same<Iter1::reference, int const&>::value));
 
         //PIKA_TEST(boost::is_readable_iterator<Iter1>::value);
         //PIKA_TEST(boost::is_lvalue_iterator<Iter1>::value);

--- a/libs/pika/iterator_support/tests/unit/iterator_facade.cpp
+++ b/libs/pika/iterator_support/tests/unit/iterator_facade.cpp
@@ -98,7 +98,7 @@ struct wrapper
     }
 
     template <typename U>
-    wrapper(const wrapper<U>& other, std::enable_if_t<std::is_convertible<U, T>::value>* = 0)
+    wrapper(wrapper<U> const& other, std::enable_if_t<std::is_convertible<U, T>::value>* = 0)
       : m_x(other.m_x)
     {
     }

--- a/libs/pika/iterator_support/tests/unit/transform_iterator2.cpp
+++ b/libs/pika/iterator_support/tests/unit/transform_iterator2.cpp
@@ -86,13 +86,13 @@ int mult_2(int* arg) { return *arg * 2; }
 struct polymorphic_mult_functor
 {
     template <typename T>
-    T operator()(const T* _arg) const
+    T operator()(T const* _arg) const
     {
         return *_arg * 2;
     }
 
     template <typename T>
-    T operator()(const T* _arg)
+    T operator()(T const* _arg)
     {
         PIKA_TEST(false);
         return *_arg * 2;
@@ -102,7 +102,7 @@ struct polymorphic_mult_functor
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    const int N = 10;
+    int const N = 10;
 
     // Test transform_iterator
     {

--- a/libs/pika/iterator_support/tests/unit/zip_iterator.cpp
+++ b/libs/pika/iterator_support/tests/unit/zip_iterator.cpp
@@ -71,7 +71,7 @@ int main(void)
 
     std::tuple<int, double> val_tuple(*zip_it_mixed);
 
-    std::tuple<const int&, double&> ref_tuple(*zip_it_mixed);
+    std::tuple<int const&, double&> ref_tuple(*zip_it_mixed);
 
     double dblOldVal = std::get<1>(ref_tuple);
     std::get<1>(ref_tuple) -= 41.;
@@ -130,11 +130,11 @@ int main(void)
 
     // typedefs for cons lists for dereferencing the zip iterator
     // made from the cons list above.
-    using cons_11_refs_type = tuple_cat_result_of_t<std::tuple<const int&>,
-        std::tuple<int&, int&, const int&, int&, int&, const int&, int&, int&, const int&,
-            const int&>>;
+    using cons_11_refs_type = tuple_cat_result_of_t<std::tuple<int const&>,
+        std::tuple<int&, int&, int const&, int&, int&, int const&, int&, int&, int const&,
+            int const&>>;
     //
-    using cons_12_refs_type = tuple_cat_result_of_t<std::tuple<const int&>, cons_11_refs_type>;
+    using cons_12_refs_type = tuple_cat_result_of_t<std::tuple<int const&>, cons_11_refs_type>;
 
     // typedef for zip iterator with 12 elements
     using zip_it_12_type = pika::util::zip_iterator<cons_12_its_type>;

--- a/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
+++ b/libs/pika/itt_notify/include/pika/modules/itt_notify.hpp
@@ -86,8 +86,8 @@ struct ___itt_counter;
 PIKA_EXPORT extern bool use_ittnotify_api;
 
 ///////////////////////////////////////////////////////////////////////////////
-PIKA_EXPORT void itt_sync_create(void* addr, const char* objtype, const char* objname) noexcept;
-PIKA_EXPORT void itt_sync_rename(void* addr, const char* name) noexcept;
+PIKA_EXPORT void itt_sync_create(void* addr, char const* objtype, char const* objname) noexcept;
+PIKA_EXPORT void itt_sync_rename(void* addr, char const* name) noexcept;
 PIKA_EXPORT void itt_sync_prepare(void* addr) noexcept;
 PIKA_EXPORT void itt_sync_acquired(void* addr) noexcept;
 PIKA_EXPORT void itt_sync_cancel(void* addr) noexcept;
@@ -121,7 +121,7 @@ PIKA_EXPORT ___itt_id* itt_make_id(void*, std::size_t);
 PIKA_EXPORT void itt_id_create(___itt_domain const*, ___itt_id* id) noexcept;
 PIKA_EXPORT void itt_id_destroy(___itt_id* id) noexcept;
 
-PIKA_EXPORT __itt_heap_function itt_heap_function_create(const char*, const char*) noexcept;
+PIKA_EXPORT __itt_heap_function itt_heap_function_create(char const*, char const*) noexcept;
 PIKA_EXPORT void itt_heap_allocate_begin(__itt_heap_function, std::size_t, int) noexcept;
 PIKA_EXPORT void itt_heap_allocate_end(__itt_heap_function, void**, std::size_t, int) noexcept;
 PIKA_EXPORT void itt_heap_free_begin(__itt_heap_function, void*) noexcept;
@@ -404,7 +404,7 @@ namespace pika { namespace util { namespace itt {
             if (use_ittnotify_api && id_)
             {
                 PIKA_ITT_COUNTER_SET_VALUE(
-                    id_, const_cast<void*>(static_cast<const void*>(&value)));
+                    id_, const_cast<void*>(static_cast<void const*>(&value)));
             }
         }
 
@@ -464,8 +464,8 @@ namespace pika { namespace util { namespace itt {
 
 #else
 
-inline constexpr void itt_sync_create(void*, const char*, const char*) noexcept {}
-inline constexpr void itt_sync_rename(void*, const char*) noexcept {}
+inline constexpr void itt_sync_create(void*, char const*, char const*) noexcept {}
+inline constexpr void itt_sync_rename(void*, char const*) noexcept {}
 inline constexpr void itt_sync_prepare(void*) noexcept {}
 inline constexpr void itt_sync_acquired(void*) noexcept {}
 inline constexpr void itt_sync_cancel(void*) noexcept {}
@@ -505,7 +505,7 @@ inline constexpr ___itt_id* itt_make_id(void*, unsigned long) { return nullptr; 
 inline constexpr void itt_id_create(___itt_domain const*, ___itt_id*) noexcept {}
 inline constexpr void itt_id_destroy(___itt_id*) noexcept {}
 
-inline constexpr __itt_heap_function itt_heap_function_create(const char*, const char*) noexcept
+inline constexpr __itt_heap_function itt_heap_function_create(char const*, char const*) noexcept
 {
     return nullptr;
 }

--- a/libs/pika/itt_notify/src/itt_notify.cpp
+++ b/libs/pika/itt_notify/src/itt_notify.cpp
@@ -413,12 +413,12 @@ namespace pika { namespace util { namespace itt {
 }}}    // namespace pika::util::itt
 
 ///////////////////////////////////////////////////////////////////////////////
-void itt_sync_create(void* addr, const char* objtype, const char* objname) noexcept
+void itt_sync_create(void* addr, char const* objtype, char const* objname) noexcept
 {
     PIKA_INTERNAL_ITT_SYNC_CREATE(addr, objtype, objname);
 }
 
-void itt_sync_rename(void* addr, const char* objname) noexcept
+void itt_sync_rename(void* addr, char const* objname) noexcept
 {
     PIKA_INTERNAL_ITT_SYNC_RENAME(addr, objname);
 }
@@ -503,7 +503,7 @@ void itt_id_create(___itt_domain const* domain, ___itt_id* id) noexcept
 void itt_id_destroy(___itt_id* id) noexcept { PIKA_INTERNAL_ITT_ID_DESTROY(id); }
 
 ///////////////////////////////////////////////////////////////////////////////
-__itt_heap_function itt_heap_function_create(const char* name, const char* domain) noexcept
+__itt_heap_function itt_heap_function_create(char const* name, char const* domain) noexcept
 {
     return PIKA_INTERNAL_ITT_HEAP_FUNCTION_CREATE(name, domain);
 }

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_environment.hpp
@@ -23,7 +23,7 @@ namespace pika::mpi::detail {
         // calls mpi_init_thread with the thread level requested and reports
         // any problem if the same level is not granted
         static int init(
-            int* argc, char*** argv, const int required, const int minimal, int& provided);
+            int* argc, char*** argv, int const required, int const minimal, int& provided);
 
         // finalize mpi, do not call unless init was previously called
         static void finalize();

--- a/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
+++ b/libs/pika/mpi_base/include/pika/mpi_base/mpi_exception.hpp
@@ -19,7 +19,7 @@ namespace pika::mpi {
 
     struct exception : pika::exception
     {
-        PIKA_EXPORT explicit exception(int err_code, const std::string& msg = "");
+        PIKA_EXPORT explicit exception(int err_code, std::string const& msg = "");
         PIKA_EXPORT int get_mpi_errorcode() const noexcept;
 
     protected:

--- a/libs/pika/mpi_base/src/mpi_environment.cpp
+++ b/libs/pika/mpi_base/src/mpi_environment.cpp
@@ -25,7 +25,7 @@ namespace pika::mpi::detail {
     bool environment::mpi_init_pika_ = false;
 
     ///////////////////////////////////////////////////////////////////////////
-    int environment::init(int*, char***, const int required, const int minimal, int& provided)
+    int environment::init(int*, char***, int const required, int const minimal, int& provided)
     {
         mpi_init_pika_ = false;
         int retval = MPI_SUCCESS;

--- a/libs/pika/mpi_base/src/mpi_exception.cpp
+++ b/libs/pika/mpi_base/src/mpi_exception.cpp
@@ -19,7 +19,7 @@ namespace pika::mpi {
         std::string error_message(int code)
         {
             int N = 1023;
-            const int len = 1024;
+            int const len = 1024;
             char buff[len] = {0};
             MPI_Error_string(code, buff, &N);
             return std::string(buff);
@@ -28,7 +28,7 @@ namespace pika::mpi {
 
     // -------------------------------------------------------------------------
     // exception type for failed launch of MPI functions or other mpi problem
-    exception::exception(int err_code, const std::string& msg)
+    exception::exception(int err_code, std::string const& msg)
       : pika::exception(pika::error::bad_function_call,
             msg + std::string(" MPI returned with error: ") + detail::error_message(err_code))
       , err_code_(err_code)

--- a/libs/pika/program_options/examples/config_file_types.cpp
+++ b/libs/pika/program_options/examples/config_file_types.cpp
@@ -18,7 +18,7 @@
 namespace po = pika::program_options;
 using namespace std;
 
-const double FLOAT_SEPARATION = 0.00000000001;
+double const FLOAT_SEPARATION = 0.00000000001;
 
 template <typename Double1, typename Double2>
 bool check_float(Double1 test, Double2 expected)
@@ -149,7 +149,7 @@ po::options_description set_options()
 
 vector<string> parse_file(stringstream& file, po::options_description& opts, po::variables_map& vm)
 {
-    const bool ALLOW_UNREGISTERED = true;
+    bool const ALLOW_UNREGISTERED = true;
     cout << file.str() << endl;
 
     po::parsed_options parsed = parse_config_file(file, opts, ALLOW_UNREGISTERED);

--- a/libs/pika/program_options/examples/custom_syntax.cpp
+++ b/libs/pika/program_options/examples/custom_syntax.cpp
@@ -24,7 +24,7 @@ using namespace std;
 /*  This custom option parse function recognize gcc-style
     option "-fbar" / "-fno-bar".
 */
-pair<string, string> reg_foo(const string& s)
+pair<string, string> reg_foo(string const& s)
 {
     if (s.find("-f") == 0)
     {

--- a/libs/pika/program_options/examples/multiple_sources.cpp
+++ b/libs/pika/program_options/examples/multiple_sources.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 // A helper function to simplify the main part.
 template <class T>
-ostream& operator<<(ostream& os, const vector<T>& v)
+ostream& operator<<(ostream& os, vector<T> const& v)
 {
     copy(v.begin(), v.end(), ostream_iterator<T>(os, " "));
     return os;

--- a/libs/pika/program_options/examples/option_groups.cpp
+++ b/libs/pika/program_options/examples/option_groups.cpp
@@ -78,7 +78,7 @@ int main(int ac, char* av[])
         }
         if (vm.count("help-module"))
         {
-            const auto& s = vm["help-module"].as<string>();
+            auto const& s = vm["help-module"].as<string>();
             if (s == "gui") { cout << gui; }
             else if (s == "backend") { cout << backend; }
             else

--- a/libs/pika/program_options/examples/options_description.cpp
+++ b/libs/pika/program_options/examples/options_description.cpp
@@ -18,7 +18,7 @@ using namespace std;
 
 // A helper function to simplify the main part.
 template <class T>
-ostream& operator<<(ostream& os, const vector<T>& v)
+ostream& operator<<(ostream& os, vector<T> const& v)
 {
     copy(v.begin(), v.end(), ostream_iterator<T>(os, " "));
     return os;

--- a/libs/pika/program_options/examples/real.cpp
+++ b/libs/pika/program_options/examples/real.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 /* Function used to check that 'opt1' and 'opt2' are not specified
    at the same time. */
-void conflicting_options(const variables_map& vm, const char* opt1, const char* opt2)
+void conflicting_options(variables_map const& vm, char const* opt1, char const* opt2)
 {
     if (vm.count(opt1) && !vm[opt1].defaulted() && vm.count(opt2) && !vm[opt2].defaulted())
     {
@@ -27,7 +27,7 @@ void conflicting_options(const variables_map& vm, const char* opt1, const char* 
 
 /* Function used to check that of 'for_what' is specified, then
    'required_option' is specified too. */
-void option_dependency(const variables_map& vm, const char* for_what, const char* required_option)
+void option_dependency(variables_map const& vm, char const* for_what, char const* required_option)
 {
     if (vm.count(for_what) && !vm[for_what].defaulted())
     {

--- a/libs/pika/program_options/examples/regex.cpp
+++ b/libs/pika/program_options/examples/regex.cpp
@@ -50,7 +50,7 @@ bool operator==(magic_number const& lhs, magic_number const& rhs) { return lhs.n
    This has no practical meaning, meant only to show how
    regex can be used to validate values.
 */
-void validate(std::any& v, const std::vector<std::string>& values, magic_number*, int)
+void validate(std::any& v, std::vector<std::string> const& values, magic_number*, int)
 {
     static std::regex r(R"(\d\d\d-(\d\d\d))");
 
@@ -59,7 +59,7 @@ void validate(std::any& v, const std::vector<std::string>& values, magic_number*
 
     // Extract the first string from 'values'. If there is more than
     // one string, it's an error, and exception will be thrown.
-    const std::string& s = validators::get_single_string(values);
+    std::string const& s = validators::get_single_string(values);
 
     // Do regex match and convert the interesting part to
     // int.

--- a/libs/pika/program_options/examples/response_file.cpp
+++ b/libs/pika/program_options/examples/response_file.cpp
@@ -92,7 +92,7 @@ int main(int ac, char* av[])
 
         if (vm.count("include-path"))
         {
-            const vector<string>& s = vm["include-path"].as<vector<string>>();
+            vector<string> const& s = vm["include-path"].as<vector<string>>();
             cout << "Include paths: ";
             copy(s.begin(), s.end(), ostream_iterator<string>(cout, " "));
             cout << "\n";

--- a/libs/pika/program_options/include/pika/program_options/detail/cmdline.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/cmdline.hpp
@@ -55,7 +55,7 @@ namespace pika::program_options::detail {
         using style_t = ::pika::program_options::command_line_style::style_t;
 
         using additional_parser =
-            std::function<std::pair<std::string, std::string>(const std::string&)>;
+            std::function<std::pair<std::string, std::string>(std::string const&)>;
 
         using style_parser = std::function<std::vector<option>(std::vector<std::string>&)>;
 
@@ -66,10 +66,10 @@ namespace pika::program_options::detail {
             unregistered options. They will be assigned index 1 and are
             assumed to have optional parameter.
         */
-        cmdline(const std::vector<std::string>& args);
+        cmdline(std::vector<std::string> const& args);
 
         /** @overload */
-        cmdline(int argc, const char* const* argv);
+        cmdline(int argc, char const* const* argv);
 
         void style(int style);
 
@@ -86,8 +86,8 @@ namespace pika::program_options::detail {
 
         void allow_unregistered();
 
-        void set_options_description(const options_description& desc);
-        void set_positional_options(const positional_options_description& m_positional);
+        void set_options_description(options_description const& desc);
+        void set_positional_options(positional_options_description const& m_positional);
 
         std::vector<option> run();
 
@@ -114,18 +114,18 @@ namespace pika::program_options::detail {
 
         bool is_style_active(style_t style) const;
 
-        void init(const std::vector<std::string>& args);
+        void init(std::vector<std::string> const& args);
 
         void finish_option(option& opt, std::vector<std::string>& other_tokens,
-            const std::vector<style_parser>& style_parsers);
+            std::vector<style_parser> const& style_parsers);
 
         // Copies of input.
         std::vector<std::string> m_args;
         style_t m_style;
         bool m_allow_unregistered;
 
-        const options_description* m_desc;
-        const positional_options_description* m_positional;
+        options_description const* m_desc;
+        positional_options_description const* m_positional;
 
         additional_parser m_additional_parser;
         style_parser m_style_parser;

--- a/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/config_file.hpp
@@ -62,7 +62,7 @@ namespace pika::program_options::detail {
             found_eof();
         }
         common_config_file_iterator(
-            const std::set<std::string>& allowed_options, bool allow_unregistered = false);
+            std::set<std::string> const& allowed_options, bool allow_unregistered = false);
 
         virtual ~common_config_file_iterator() = default;
 
@@ -87,10 +87,10 @@ namespace pika::program_options::detail {
             '*', then all options with the same prefix are
             allowed. For example, if 'name' is 'foo*', then 'foo1' and
             'foo_bar' are allowed. */
-        void add_option(const char* name);
+        void add_option(char const* name);
 
         // Returns true if 's' is a registered option name.
-        bool allowed_option(const std::string& s) const;
+        bool allowed_option(std::string const& s) const;
 
         // That's probably too much data for iterator, since
         // it will be copied, but let's not bother for now.
@@ -110,7 +110,7 @@ namespace pika::program_options::detail {
         /** Creates a config file parser for the specified stream.
         */
         basic_config_file_iterator(std::basic_istream<Char>& is,
-            const std::set<std::string>& allowed_options, bool allow_unregistered = false);
+            std::set<std::string> const& allowed_options, bool allow_unregistered = false);
 
     private:    // base overrides
         bool getline(std::string&) override;
@@ -129,7 +129,7 @@ namespace pika::program_options::detail {
 
     template <class Char>
     basic_config_file_iterator<Char>::basic_config_file_iterator(std::basic_istream<Char>& is,
-        const std::set<std::string>& allowed_options, bool allow_unregistered)
+        std::set<std::string> const& allowed_options, bool allow_unregistered)
       : common_config_file_iterator(allowed_options, allow_unregistered)
     {
         this->is.reset(&is, null_deleter());

--- a/libs/pika/program_options/include/pika/program_options/detail/convert.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/convert.hpp
@@ -20,38 +20,38 @@ namespace pika::program_options {
     /** Converts from local 8 bit encoding into wchar_t string using
         the specified locale facet. */
     PIKA_EXPORT std::wstring from_8_bit(
-        const std::string& s, const std::codecvt<wchar_t, char, std::mbstate_t>& cvt);
+        std::string const& s, std::codecvt<wchar_t, char, std::mbstate_t> const& cvt);
 
     /** Converts from wchar_t string into local 8 bit encoding into using
         the specified locale facet. */
     PIKA_EXPORT std::string to_8_bit(
-        const std::wstring& s, const std::codecvt<wchar_t, char, std::mbstate_t>& cvt);
+        std::wstring const& s, std::codecvt<wchar_t, char, std::mbstate_t> const& cvt);
 
     /** Converts 's', which is assumed to be in UTF8 encoding, into wide
         string. */
-    PIKA_EXPORT std::wstring from_utf8(const std::string& s);
+    PIKA_EXPORT std::wstring from_utf8(std::string const& s);
 
     /** Converts wide string 's' into string in UTF8 encoding. */
-    PIKA_EXPORT std::string to_utf8(const std::wstring& s);
+    PIKA_EXPORT std::string to_utf8(std::wstring const& s);
 
     /** Converts wide string 's' into local 8 bit encoding determined by
         the current locale. */
-    PIKA_EXPORT std::string to_local_8_bit(const std::wstring& s);
+    PIKA_EXPORT std::string to_local_8_bit(std::wstring const& s);
 
     /** Converts 's', which is assumed to be in local 8 bit encoding, into wide
         string. */
-    PIKA_EXPORT std::wstring from_local_8_bit(const std::string& s);
+    PIKA_EXPORT std::wstring from_local_8_bit(std::string const& s);
 
     /** Convert the input string into internal encoding used by
             program_options. Presence of this function allows to avoid
             specializing all methods which access input on wchar_t.
         */
-    PIKA_EXPORT std::string to_internal(const std::string&);
+    PIKA_EXPORT std::string to_internal(std::string const&);
     /** @overload */
-    PIKA_EXPORT std::string to_internal(const std::wstring&);
+    PIKA_EXPORT std::string to_internal(std::wstring const&);
 
     template <class T>
-    std::vector<std::string> to_internal(const std::vector<T>& s)
+    std::vector<std::string> to_internal(std::vector<T> const& s)
     {
         std::vector<std::string> result;
         for (std::size_t i = 0; i < s.size(); ++i) result.push_back(to_internal(s[i]));

--- a/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/parsers.hpp
@@ -21,13 +21,13 @@ namespace pika::program_options {
 
     template <class Char>
     basic_command_line_parser<Char>::basic_command_line_parser(
-        const std::vector<std::basic_string<Char>>& xargs)
+        std::vector<std::basic_string<Char>> const& xargs)
       : detail::cmdline(to_internal(xargs))
     {
     }
 
     template <class Char>
-    basic_command_line_parser<Char>::basic_command_line_parser(int argc, const Char* const argv[])
+    basic_command_line_parser<Char>::basic_command_line_parser(int argc, Char const* const argv[])
       : detail::cmdline(to_internal(std::vector<std::basic_string<Char>>(argv + 1, argv + argc)))
       , m_desc()
     {
@@ -35,7 +35,7 @@ namespace pika::program_options {
 
     template <class Char>
     basic_command_line_parser<Char>&
-    basic_command_line_parser<Char>::options(const options_description& desc)
+    basic_command_line_parser<Char>::options(options_description const& desc)
     {
         detail::cmdline::set_options_description(desc);
         m_desc = &desc;
@@ -44,7 +44,7 @@ namespace pika::program_options {
 
     template <class Char>
     basic_command_line_parser<Char>&
-    basic_command_line_parser<Char>::positional(const positional_options_description& desc)
+    basic_command_line_parser<Char>::positional(positional_options_description const& desc)
     {
         detail::cmdline::set_positional_options(desc);
         return *this;
@@ -96,8 +96,8 @@ namespace pika::program_options {
 
     template <class Char>
     basic_parsed_options<Char>
-    parse_command_line(int argc, const Char* const argv[], const options_description& desc,
-        int style, std::function<std::pair<std::string, std::string>(const std::string&)> ext)
+    parse_command_line(int argc, Char const* const argv[], options_description const& desc,
+        int style, std::function<std::pair<std::string, std::string>(std::string const&)> ext)
     {
         return basic_command_line_parser<Char>(argc, argv)
             .options(desc)
@@ -108,7 +108,7 @@ namespace pika::program_options {
 
     template <class Char>
     std::vector<std::basic_string<Char>> collect_unrecognized(
-        const std::vector<basic_option<Char>>& options, enum collect_unrecognized_mode mode)
+        std::vector<basic_option<Char>> const& options, enum collect_unrecognized_mode mode)
     {
         std::vector<std::basic_string<Char>> result;
         for (std::size_t i = 0; i < options.size(); ++i)

--- a/libs/pika/program_options/include/pika/program_options/detail/utf8_codecvt_facet.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/utf8_codecvt_facet.hpp
@@ -104,12 +104,12 @@ namespace pika::program_options::detail {
         virtual ~utf8_codecvt_facet();
 
     protected:
-        std::codecvt_base::result do_in(std::mbstate_t& state, const char* from,
-            const char* from_end, const char*& from_next, wchar_t* to, wchar_t* to_end,
+        std::codecvt_base::result do_in(std::mbstate_t& state, char const* from,
+            char const* from_end, char const*& from_next, wchar_t* to, wchar_t* to_end,
             wchar_t*& to_next) const override;
 
-        std::codecvt_base::result do_out(std::mbstate_t& state, const wchar_t* from,
-            const wchar_t* from_end, const wchar_t*& from_next, char* to, char* to_end,
+        std::codecvt_base::result do_out(std::mbstate_t& state, wchar_t const* from,
+            wchar_t const* from_end, wchar_t const*& from_next, char* to, char* to_end,
             char*& to_next) const override;
 
         bool invalid_continuing_octet(unsigned char octet_1) const
@@ -146,17 +146,17 @@ namespace pika::program_options::detail {
 
         int do_encoding() const noexcept override
         {
-            const int variable_byte_external_encoding = 0;
+            int const variable_byte_external_encoding = 0;
             return variable_byte_external_encoding;
         }
 
         // How many char objects can I process to get <= max_limit
         // wchar_t objects?
-        int do_length(std::mbstate_t&, const char* from, const char* from_end,
+        int do_length(std::mbstate_t&, char const* from, char const* from_end,
             std::size_t max_limit) const noexcept override;
 
         // Nonstandard override
-        virtual int do_length(const std::mbstate_t& s, const char* from, const char* from_end,
+        virtual int do_length(std::mbstate_t const& s, char const* from, char const* from_end,
             std::size_t max_limit) const noexcept
         {
             return do_length(const_cast<std::mbstate_t&>(s), from, from_end, max_limit);

--- a/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/detail/value_semantic.hpp
@@ -44,9 +44,9 @@ namespace pika::program_options {
     }
 
     template <class T, class Char>
-    void typed_value<T, Char>::notify(const std::any& value_store) const
+    void typed_value<T, Char>::notify(std::any const& value_store) const
     {
-        const T* value = std::any_cast<T>(&value_store);
+        T const* value = std::any_cast<T>(&value_store);
         if (m_store_to) { *m_store_to = *value; }
         if (m_notifier) { m_notifier(*value); }
     }
@@ -59,8 +59,8 @@ namespace pika::program_options {
            empty string if 'allow_empty' and throws validation_error
            otherwise. */
         template <class Char>
-        const std::basic_string<Char>&
-        get_single_string(const std::vector<std::basic_string<Char>>& v, bool allow_empty = false)
+        std::basic_string<Char> const&
+        get_single_string(std::vector<std::basic_string<Char>> const& v, bool allow_empty = false)
         {
             static std::basic_string<Char> empty;
             if (v.size() > 1)
@@ -73,7 +73,7 @@ namespace pika::program_options {
         }
 
         /* Throws multiple_occurrences if 'value' is not empty. */
-        PIKA_EXPORT void check_first_occurrence(const std::any& value);
+        PIKA_EXPORT void check_first_occurrence(std::any const& value);
     }    // namespace validators
 
     using namespace validators;
@@ -86,7 +86,7 @@ namespace pika::program_options {
         partial template ordering, just like the last 'long/int' parameter.
     */
     template <class T, class Char>
-    void validate(std::any& v, const std::vector<std::basic_string<Char>>& xs, T*, long)
+    void validate(std::any& v, std::vector<std::basic_string<Char>> const& xs, T*, long)
     {
         validators::check_first_occurrence(v);
         std::basic_string<Char> s(validators::get_single_string(xs));
@@ -94,26 +94,26 @@ namespace pika::program_options {
         {
             v = std::any(pika::detail::from_string<T>(s));
         }
-        catch (const pika::detail::bad_lexical_cast&)
+        catch (pika::detail::bad_lexical_cast const&)
         {
             throw invalid_option_value(s);
         }
     }
 
-    PIKA_EXPORT void validate(std::any& v, const std::vector<std::string>& xs, bool*, int);
+    PIKA_EXPORT void validate(std::any& v, std::vector<std::string> const& xs, bool*, int);
 
-    PIKA_EXPORT void validate(std::any& v, const std::vector<std::wstring>& xs, bool*, int);
+    PIKA_EXPORT void validate(std::any& v, std::vector<std::wstring> const& xs, bool*, int);
 
     // For some reason, this declaration, which is require by the standard,
     // cause msvc 7.1 to not generate code to specialization defined in
     // value_semantic.cpp
-    PIKA_EXPORT void validate(std::any& v, const std::vector<std::string>& xs, std::string*, int);
-    PIKA_EXPORT void validate(std::any& v, const std::vector<std::wstring>& xs, std::string*, int);
+    PIKA_EXPORT void validate(std::any& v, std::vector<std::string> const& xs, std::string*, int);
+    PIKA_EXPORT void validate(std::any& v, std::vector<std::wstring> const& xs, std::string*, int);
 
     /** Validates sequences. Allows multiple values per option occurrence
        and multiple occurrences. */
     template <class T, class Char>
-    void validate(std::any& v, const std::vector<std::basic_string<Char>>& s, std::vector<T>*, int)
+    void validate(std::any& v, std::vector<std::basic_string<Char>> const& s, std::vector<T>*, int)
     {
         if (!v.has_value()) { v = std::any(std::vector<T>()); }
         std::vector<T>* tv = std::any_cast<std::vector<T>>(&v);
@@ -131,7 +131,7 @@ namespace pika::program_options {
                 validate(a, cv, (T*) nullptr, 0);
                 tv->push_back(std::any_cast<T>(a));
             }
-            catch (const pika::detail::bad_lexical_cast& /*e*/)
+            catch (pika::detail::bad_lexical_cast const& /*e*/)
             {
                 throw invalid_option_value(s[i]);
             }
@@ -141,7 +141,7 @@ namespace pika::program_options {
     /** Validates optional arguments. */
     template <class T, class Char>
     void
-    validate(std::any& v, const std::vector<std::basic_string<Char>>& s, std::optional<T>*, int)
+    validate(std::any& v, std::vector<std::basic_string<Char>> const& s, std::optional<T>*, int)
     {
         validators::check_first_occurrence(v);
         validators::get_single_string(s);
@@ -152,7 +152,7 @@ namespace pika::program_options {
 
     template <class T, class Char>
     void typed_value<T, Char>::xparse(
-        std::any& value_store, const std::vector<std::basic_string<Char>>& new_tokens) const
+        std::any& value_store, std::vector<std::basic_string<Char>> const& new_tokens) const
     {
         // If no tokens were given, and the option accepts an implicit
         // value, then assign the implicit value as the stored value;

--- a/libs/pika/program_options/include/pika/program_options/eof_iterator.hpp
+++ b/libs/pika/program_options/include/pika/program_options/eof_iterator.hpp
@@ -69,7 +69,7 @@ namespace pika::program_options {
 
         void increment() { static_cast<Derived&>(*this).get(); }
 
-        bool equal(const eof_iterator& other) const
+        bool equal(eof_iterator const& other) const
         {
             if (m_at_eof && other.m_at_eof)
                 return true;
@@ -77,7 +77,7 @@ namespace pika::program_options {
                 return false;
         }
 
-        const ValueType& dereference() const { return m_value; }
+        ValueType const& dereference() const { return m_value; }
 
         bool m_at_eof;
         ValueType m_value;

--- a/libs/pika/program_options/include/pika/program_options/errors.hpp
+++ b/libs/pika/program_options/include/pika/program_options/errors.hpp
@@ -18,7 +18,7 @@
 
 namespace pika::program_options {
 
-    inline std::string strip_prefixes(const std::string& text)
+    inline std::string strip_prefixes(std::string const& text)
     {
         // "--foo-bar" -> "foo-bar"
         std::string::size_type i = text.find_first_not_of("-/");
@@ -30,7 +30,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT error : public std::logic_error
     {
     public:
-        error(const std::string& xwhat)
+        error(std::string const& xwhat)
           : std::logic_error(xwhat)
         {
         }
@@ -52,7 +52,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT invalid_command_line_style : public error
     {
     public:
-        invalid_command_line_style(const std::string& msg)
+        invalid_command_line_style(std::string const& msg)
           : error(msg)
         {
         }
@@ -62,7 +62,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT reading_file : public error
     {
     public:
-        reading_file(const char* filename)
+        reading_file(char const* filename)
           : error(std::string("can not read options configuration file '")
                       .append(filename)
                       .append("'"))
@@ -114,8 +114,8 @@ namespace pika::program_options {
         /** template with placeholders */
         std::string m_error_template;
 
-        error_with_option_name(const std::string& template_, const std::string& option_name = "",
-            const std::string& original_token = "", int option_style = 0);
+        error_with_option_name(std::string const& template_, std::string const& option_name = "",
+            std::string const& original_token = "", int option_style = 0);
 
         /** gcc says that throw specification on dtor is loosened
          *  without this line
@@ -125,7 +125,7 @@ namespace pika::program_options {
         /** Substitute
          *      parameter_name->value to create the error message from
          *      the error template */
-        void set_substitute(const std::string& parameter_name, const std::string& value)
+        void set_substitute(std::string const& parameter_name, std::string const& value)
         {
             m_substitutions[parameter_name] = value;
         }
@@ -133,7 +133,7 @@ namespace pika::program_options {
         /** If the parameter is missing, then make the
          *      from->to substitution instead */
         void set_substitute_default(
-            const std::string& parameter_name, const std::string& from, const std::string& to)
+            std::string const& parameter_name, std::string const& from, std::string const& to)
         {
             m_substitution_defaults[parameter_name] = std::make_pair(from, to);
         }
@@ -141,7 +141,7 @@ namespace pika::program_options {
         /** Add context to an exception */
         // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         void add_context(
-            const std::string& option_name, const std::string& original_token, int option_style)
+            std::string const& option_name, std::string const& original_token, int option_style)
         // NOLINTEND(bugprone-easily-swappable-parameters)
         {
             set_option_name(option_name);
@@ -152,31 +152,31 @@ namespace pika::program_options {
         void set_prefix(int option_style) { m_option_style = option_style; }
 
         /** Overridden in error_with_no_option_name */
-        virtual void set_option_name(const std::string& option_name)
+        virtual void set_option_name(std::string const& option_name)
         {
             set_substitute("option", option_name);
         }
 
         std::string get_option_name() const { return get_canonical_option_name(); }
 
-        void set_original_token(const std::string& original_token)
+        void set_original_token(std::string const& original_token)
         {
             set_substitute("original_token", original_token);
         }
 
         /** Creates the error_message on the fly
          *      Currently a thin wrapper for substitute_placeholders() */
-        const char* what() const noexcept override;
+        char const* what() const noexcept override;
 
     protected:
         /** Used to hold the error text returned by what() */
         mutable std::string m_message;    // For on-demand formatting in 'what'
 
         /** Makes all substitutions using the template */
-        virtual void substitute_placeholders(const std::string& error_template) const;
+        virtual void substitute_placeholders(std::string const& error_template) const;
 
         // helper function for substitute_placeholders
-        void replace_token(const std::string& from, const std::string& to) const;
+        void replace_token(std::string const& from, std::string const& to) const;
 
         /** Construct option name in accordance with the appropriate
          *  prefix style: i.e. long dash or short slash etc */
@@ -216,7 +216,7 @@ namespace pika::program_options {
     {
     public:
         // option name is constructed by the option_descriptor and never on the fly
-        required_option(const std::string& option_name)
+        required_option(std::string const& option_name)
           : error_with_option_name(
                 "the option '%canonical_option%' is required but missing", "", option_name)
         {
@@ -241,13 +241,13 @@ namespace pika::program_options {
     {
     public:
         error_with_no_option_name(
-            const std::string& template_, const std::string& original_token = "")
+            std::string const& template_, std::string const& original_token = "")
           : error_with_option_name(template_, "", original_token)
         {
         }
 
         /** Does NOT set option name, because no option name makes sense */
-        void set_option_name(const std::string&) override {}
+        void set_option_name(std::string const&) override {}
 
         ~error_with_no_option_name() noexcept {}
     };
@@ -256,7 +256,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT unknown_option : public error_with_no_option_name
     {
     public:
-        unknown_option(const std::string& original_token = "")
+        unknown_option(std::string const& original_token = "")
           : error_with_no_option_name("unrecognised option '%canonical_option%'", original_token)
         {
         }
@@ -268,7 +268,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT ambiguous_option : public error_with_no_option_name
     {
     public:
-        ambiguous_option(const std::vector<std::string>& xalternatives)
+        ambiguous_option(std::vector<std::string> const& xalternatives)
           : error_with_no_option_name("option '%canonical_option%' is ambiguous")
           , m_alternatives(xalternatives)
         {
@@ -276,11 +276,11 @@ namespace pika::program_options {
 
         ~ambiguous_option() noexcept {}
 
-        const std::vector<std::string>& alternatives() const noexcept { return m_alternatives; }
+        std::vector<std::string> const& alternatives() const noexcept { return m_alternatives; }
 
     protected:
         /** Makes all substitutions using the template */
-        void substitute_placeholders(const std::string& error_template) const override;
+        void substitute_placeholders(std::string const& error_template) const override;
 
     private:
         // TODO: copy ctor might throw
@@ -304,8 +304,8 @@ namespace pika::program_options {
             unrecognized_line
         };
 
-        invalid_syntax(kind_t kind, const std::string& option_name = "",
-            const std::string& original_token = "", int option_style = 0)
+        invalid_syntax(kind_t kind, std::string const& option_name = "",
+            std::string const& original_token = "", int option_style = 0)
           : error_with_option_name(get_template(kind), option_name, original_token, option_style)
           , m_kind(kind)
         {
@@ -327,7 +327,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT invalid_config_file_syntax : public invalid_syntax
     {
     public:
-        invalid_config_file_syntax(const std::string& invalid_line, kind_t kind)
+        invalid_config_file_syntax(std::string const& invalid_line, kind_t kind)
           : invalid_syntax(kind)
         {
             m_substitutions["invalid_line"] = invalid_line;
@@ -348,8 +348,8 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT invalid_command_line_syntax : public invalid_syntax
     {
     public:
-        invalid_command_line_syntax(kind_t kind, const std::string& option_name = "",
-            const std::string& original_token = "", int option_style = 0)
+        invalid_command_line_syntax(kind_t kind, std::string const& option_name = "",
+            std::string const& original_token = "", int option_style = 0)
           : invalid_syntax(kind, option_name, original_token, option_style)
         {
         }
@@ -370,8 +370,8 @@ namespace pika::program_options {
         };
 
     public:
-        validation_error(kind_t kind, const std::string& option_name = "",
-            const std::string& original_token = "", int option_style = 0)
+        validation_error(kind_t kind, std::string const& option_name = "",
+            std::string const& original_token = "", int option_style = 0)
           : error_with_option_name(get_template(kind), option_name, original_token, option_style)
           , m_kind(kind)
         {
@@ -391,15 +391,15 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT invalid_option_value : public validation_error
     {
     public:
-        invalid_option_value(const std::string& value);
-        invalid_option_value(const std::wstring& value);
+        invalid_option_value(std::string const& value);
+        invalid_option_value(std::wstring const& value);
     };
 
     /** Class thrown if there is an invalid bool value given */
     class PIKA_ALWAYS_EXPORT invalid_bool_value : public validation_error
     {
     public:
-        invalid_bool_value(const std::string& value);
+        invalid_bool_value(std::string const& value);
     };
 
 }    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/option.hpp
+++ b/libs/pika/program_options/include/pika/program_options/option.hpp
@@ -30,7 +30,7 @@ namespace pika::program_options {
           , case_insensitive(false)
         {
         }
-        basic_option(const std::string& xstring_key, const std::vector<std::string>& xvalue)
+        basic_option(std::string const& xstring_key, std::vector<std::string> const& xvalue)
           : string_key(xstring_key)
           , position_key(-1)
           , value(xvalue)

--- a/libs/pika/program_options/include/pika/program_options/options_description.hpp
+++ b/libs/pika/program_options/include/pika/program_options/options_description.hpp
@@ -240,7 +240,7 @@ namespace pika::program_options {
         using name2index_iterator = std::map<std::string, int>::const_iterator;
         using approximation_range = std::pair<name2index_iterator, name2index_iterator>;
 
-        //approximation_range find_approximation(const std::string& prefix) const;
+        //approximation_range find_approximation(std::string const& prefix) const;
 
         std::string m_caption;
         std::size_t const m_line_length;

--- a/libs/pika/program_options/include/pika/program_options/options_description.hpp
+++ b/libs/pika/program_options/include/pika/program_options/options_description.hpp
@@ -62,11 +62,11 @@ namespace pika::program_options {
             - otherwise, the part before "," specifies long name and the part
             after \-- short name.
         */
-        option_description(const char* name, const value_semantic* s);
+        option_description(char const* name, value_semantic const* s);
 
         /** Initializes the class with the passed data.
          */
-        option_description(const char* name, const value_semantic* s, const char* description);
+        option_description(char const* name, value_semantic const* s, char const* description);
 
         virtual ~option_description();
 
@@ -80,7 +80,7 @@ namespace pika::program_options {
         /** Given 'option', specified in the input source,
             returns 'true' if 'option' specifies *this.
         */
-        match_result match(const std::string& option, bool approx, bool long_ignore_case,
+        match_result match(std::string const& option, bool approx, bool long_ignore_case,
             bool short_ignore_case) const;
 
         /** Returns the key that should identify the option, in
@@ -91,7 +91,7 @@ namespace pika::program_options {
             If long name was specified, it's the long name, otherwise
             it's a short name with pre-pended '-'.
         */
-        const std::string& key(const std::string& option) const;
+        std::string const& key(std::string const& option) const;
 
         /** Returns the canonical name for the option description to enable the user to
             recognized a matching option.
@@ -102,15 +102,15 @@ namespace pika::program_options {
         */
         std::string canonical_display_name(int canonical_option_style = 0) const;
 
-        const std::string& long_name() const;
+        std::string const& long_name() const;
 
-        const std::pair<const std::string*, std::size_t> long_names() const;
+        const std::pair<std::string const*, std::size_t> long_names() const;
 
         /// Explanation of this option
-        const std::string& description() const;
+        std::string const& description() const;
 
         /// Semantic of option's value
-        std::shared_ptr<const value_semantic> semantic() const;
+        std::shared_ptr<value_semantic const> semantic() const;
 
         /// Returns the option name, formatted suitably for usage message.
         std::string format_name() const;
@@ -120,7 +120,7 @@ namespace pika::program_options {
         std::string format_parameter() const;
 
     private:
-        option_description& set_names(const char* name);
+        option_description& set_names(char const* name);
 
         /**
          * a one-character "switch" name - with its prefix,
@@ -140,7 +140,7 @@ namespace pika::program_options {
 
         // shared_ptr is needed to simplify memory management in
         // copy ctor and destructor.
-        std::shared_ptr<const value_semantic> m_value_semantic;
+        std::shared_ptr<value_semantic const> m_value_semantic;
     };
 
     class options_description;
@@ -152,12 +152,12 @@ namespace pika::program_options {
     public:
         options_description_easy_init(options_description* owner);
 
-        options_description_easy_init& operator()(const char* name, const char* description);
+        options_description_easy_init& operator()(char const* name, char const* description);
 
-        options_description_easy_init& operator()(const char* name, const value_semantic* s);
+        options_description_easy_init& operator()(char const* name, value_semantic const* s);
 
         options_description_easy_init& operator()(
-            const char* name, const value_semantic* s, const char* description);
+            char const* name, value_semantic const* s, char const* description);
 
     private:
         options_description* owner;
@@ -173,7 +173,7 @@ namespace pika::program_options {
     class PIKA_EXPORT options_description
     {
     public:
-        static const unsigned m_default_line_length;
+        static unsigned const m_default_line_length;
 
         /** Creates the instance. */
         options_description(unsigned line_length = m_default_line_length,
@@ -185,7 +185,7 @@ namespace pika::program_options {
             encroaches into this, then the description will start on the next
             line.
         */
-        options_description(const std::string& caption,
+        options_description(std::string const& caption,
             unsigned line_length = m_default_line_length,
             unsigned min_description_length = m_default_line_length / 2);
         /** Adds new variable description. Throws duplicate_variable_error if
@@ -198,7 +198,7 @@ namespace pika::program_options {
             a separate group.
             Returns *this.
         */
-        options_description& add(const options_description& desc);
+        options_description& add(options_description const& desc);
 
         /** Find the maximum width of the option column, including options
             in groups. */
@@ -213,19 +213,19 @@ namespace pika::program_options {
         */
         options_description_easy_init add_options();
 
-        const option_description& find(const std::string& name, bool approx,
+        option_description const& find(std::string const& name, bool approx,
             bool long_ignore_case = false, bool short_ignore_case = false) const;
 
-        const option_description* find_nothrow(const std::string& name, bool approx,
+        option_description const* find_nothrow(std::string const& name, bool approx,
             bool long_ignore_case = false, bool short_ignore_case = false) const;
 
-        const std::vector<std::shared_ptr<option_description>>& options() const;
+        std::vector<std::shared_ptr<option_description>> const& options() const;
 
         /** Produces a human readable output of 'desc', listing options,
             their descriptions and allowed parameters. Other options_description
             instances previously passed to add will be output separately. */
         friend PIKA_EXPORT std::ostream& operator<<(
-            std::ostream& os, const options_description& desc);
+            std::ostream& os, options_description const& desc);
 
         /** Outputs 'desc' to the specified stream, calling 'f' to output each
             option_description element. */
@@ -234,7 +234,7 @@ namespace pika::program_options {
     private:
 #if defined(PIKA_MSVC) && PIKA_MSVC >= 1800
         // prevent warning C4512: assignment operator could not be generated
-        options_description& operator=(const options_description&);
+        options_description& operator=(options_description const&);
 #endif
 
         using name2index_iterator = std::map<std::string, int>::const_iterator;
@@ -263,7 +263,7 @@ namespace pika::program_options {
     class PIKA_ALWAYS_EXPORT duplicate_option_error : public error
     {
     public:
-        duplicate_option_error(const std::string& xwhat)
+        duplicate_option_error(std::string const& xwhat)
           : error(xwhat)
         {
         }

--- a/libs/pika/program_options/include/pika/program_options/parsers.hpp
+++ b/libs/pika/program_options/include/pika/program_options/parsers.hpp
@@ -33,7 +33,7 @@ namespace pika::program_options {
     {
     public:
         explicit basic_parsed_options(
-            const options_description* xdescription, int options_prefix = 0)
+            options_description const* xdescription, int options_prefix = 0)
           : description(xdescription)
           , m_options_prefix(options_prefix)
         {
@@ -45,7 +45,7 @@ namespace pika::program_options {
             option_description passed to them, and issues of lifetime are
             up to the caller. Can be nullptr.
          */
-        const options_description* description;
+        options_description const* description;
 
         /** Mainly used for the diagnostic messages in exceptions.
          *  The canonical option prefix  for the parser which generated these results,
@@ -68,10 +68,10 @@ namespace pika::program_options {
     {
     public:
         /** Constructs wrapped options from options in UTF8 encoding. */
-        explicit basic_parsed_options(const basic_parsed_options<char>& po);
+        explicit basic_parsed_options(basic_parsed_options<char> const& po);
 
         std::vector<basic_option<wchar_t>> options;
-        const options_description* description;
+        options_description const* description;
 
         /** Stores UTF8 encoded options that were passed to constructor,
             to avoid reverse conversion in some cases. */
@@ -95,7 +95,7 @@ namespace pika::program_options {
     /** Augments basic_parsed_options<wchar_t> with conversion from
         'parsed_options' */
 
-    using ext_parser = std::function<std::pair<std::string, std::string>(const std::string&)>;
+    using ext_parser = std::function<std::pair<std::string, std::string>(std::string const&)>;
 
     /** Command line parser.
 
@@ -118,16 +118,16 @@ namespace pika::program_options {
         /** Creates a command line parser for the specified arguments
             list. The 'args' parameter should not include program name.
         */
-        basic_command_line_parser(const std::vector<std::basic_string<Char>>& args);
+        basic_command_line_parser(std::vector<std::basic_string<Char>> const& args);
         /** Creates a command line parser for the specified arguments
             list. The parameters should be the same as passed to 'main'.
         */
-        basic_command_line_parser(int argc, const Char* const argv[]);
+        basic_command_line_parser(int argc, Char const* const argv[]);
 
         /** Sets options descriptions to use. */
-        basic_command_line_parser& options(const options_description& desc);
+        basic_command_line_parser& options(options_description const& desc);
         /** Sets positional options description to use. */
-        basic_command_line_parser& positional(const positional_options_description& desc);
+        basic_command_line_parser& positional(positional_options_description const& desc);
 
         /** Sets the command line style. */
         basic_command_line_parser& style(int);
@@ -154,7 +154,7 @@ namespace pika::program_options {
         basic_command_line_parser& extra_style_parser(style_parser s);
 
     private:
-        const options_description* m_desc;
+        options_description const* m_desc;
     };
 
     using command_line_parser = basic_command_line_parser<char>;
@@ -164,9 +164,9 @@ namespace pika::program_options {
         and returns the result of calling the 'run' method.
      */
     template <class Char>
-    basic_parsed_options<Char> parse_command_line(int argc, const Char* const argv[],
-        const options_description&, int style = 0,
-        std::function<std::pair<std::string, std::string>(const std::string&)> ext = ext_parser());
+    basic_parsed_options<Char> parse_command_line(int argc, Char const* const argv[],
+        options_description const&, int style = 0,
+        std::function<std::pair<std::string, std::string>(std::string const&)> ext = ext_parser());
 
     /** Parse a config file.
 
@@ -174,7 +174,7 @@ namespace pika::program_options {
     */
     template <class Char>
     PIKA_EXPORT basic_parsed_options<Char> parse_config_file(
-        std::basic_istream<Char>&, const options_description&, bool allow_unregistered = false);
+        std::basic_istream<Char>&, options_description const&, bool allow_unregistered = false);
 
     /** Parse a config file.
 
@@ -183,7 +183,7 @@ namespace pika::program_options {
     */
     template <class Char = char>
     PIKA_EXPORT basic_parsed_options<Char> parse_config_file(
-        const char* filename, const options_description&, bool allow_unregistered = false);
+        char const* filename, options_description const&, bool allow_unregistered = false);
 
     /** Controls if the 'collect_unregistered' function should
         include positional options, or not. */
@@ -201,7 +201,7 @@ namespace pika::program_options {
     */
     template <class Char>
     std::vector<std::basic_string<Char>> collect_unrecognized(
-        const std::vector<basic_option<Char>>& options, enum collect_unrecognized_mode mode);
+        std::vector<basic_option<Char>> const& options, enum collect_unrecognized_mode mode);
 
     /** Parse environment.
 
@@ -213,7 +213,7 @@ namespace pika::program_options {
         different from the naming of command line options.
     */
     PIKA_EXPORT parsed_options parse_environment(
-        const options_description&, const std::function<std::string(std::string)>& name_mapper);
+        options_description const&, std::function<std::string(std::string)> const& name_mapper);
 
     /** Parse environment.
 
@@ -222,14 +222,14 @@ namespace pika::program_options {
         converting the remaining string into lower case.
     */
     PIKA_EXPORT parsed_options parse_environment(
-        const options_description&, const std::string& prefix);
+        options_description const&, std::string const& prefix);
 
     /** @overload
         This function exists to resolve ambiguity between the two above
         functions when second argument is of 'char*' type. There's implicit
         conversion to both std::function and string.
     */
-    PIKA_EXPORT parsed_options parse_environment(const options_description&, const char* prefix);
+    PIKA_EXPORT parsed_options parse_environment(options_description const&, char const* prefix);
 
     /** Splits a given string to a collection of single strings which
         can be passed to command_line_parser. The second parameter is
@@ -238,14 +238,14 @@ namespace pika::program_options {
         Splitting is done in a unix style way, with respect to quotes '"'
         and escape characters '\'
     */
-    PIKA_EXPORT std::vector<std::string> split_unix(const std::string& cmdline,
-        const std::string& separator = " \t", const std::string& quote = "'\"",
-        const std::string& escape = "\\");
+    PIKA_EXPORT std::vector<std::string> split_unix(std::string const& cmdline,
+        std::string const& separator = " \t", std::string const& quote = "'\"",
+        std::string const& escape = "\\");
 
     /** @overload */
-    PIKA_EXPORT std::vector<std::wstring> split_unix(const std::wstring& cmdline,
-        const std::wstring& separator = L" \t", const std::wstring& quote = L"'\"",
-        const std::wstring& escape = L"\\");
+    PIKA_EXPORT std::vector<std::wstring> split_unix(std::wstring const& cmdline,
+        std::wstring const& separator = L" \t", std::wstring const& quote = L"'\"",
+        std::wstring const& escape = L"\\");
 
 #ifdef PIKA_WINDOWS
     /** Parses the char* string which is passed to WinMain function on
@@ -254,10 +254,10 @@ namespace pika::program_options {
         runtime library and if it always exists.
         This function is available only on Windows.
     */
-    PIKA_EXPORT std::vector<std::string> split_winmain(const std::string& cmdline);
+    PIKA_EXPORT std::vector<std::string> split_winmain(std::string const& cmdline);
 
     /** @overload */
-    PIKA_EXPORT std::vector<std::wstring> split_winmain(const std::wstring& cmdline);
+    PIKA_EXPORT std::vector<std::wstring> split_winmain(std::wstring const& cmdline);
 #endif
 
 }    // namespace pika::program_options

--- a/libs/pika/program_options/include/pika/program_options/positional_options.hpp
+++ b/libs/pika/program_options/include/pika/program_options/positional_options.hpp
@@ -40,7 +40,7 @@ namespace pika::program_options {
             No calls to 'add' can be made after call with 'max_value' equal to
             '-1'.
         */
-        positional_options_description& add(const char* name, int max_count);
+        positional_options_description& add(char const* name, int max_count);
 
         /** Returns the maximum number of positional options that can
             be present. Can return (numeric_limits<unsigned>::max)() to
@@ -51,7 +51,7 @@ namespace pika::program_options {
             options at 'position'.
             Precondition: position < max_total_count()
         */
-        const std::string& name_for_position(unsigned position) const;
+        std::string const& name_for_position(unsigned position) const;
 
     private:
         // List of names corresponding to the positions. If the number of

--- a/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
+++ b/libs/pika/program_options/include/pika/program_options/value_semantic.hpp
@@ -56,7 +56,7 @@ namespace pika::program_options {
             option is specified more than once.
         */
         virtual void parse(
-            std::any& value_store, const std::vector<std::string>& new_tokens, bool utf8) const = 0;
+            std::any& value_store, std::vector<std::string> const& new_tokens, bool utf8) const = 0;
 
         /** Called to assign default value to 'value_store'. Returns
             true if default value is assigned, and false if no default
@@ -65,7 +65,7 @@ namespace pika::program_options {
 
         /** Called when final value of an option is determined.
         */
-        virtual void notify(const std::any& value_store) const = 0;
+        virtual void notify(std::any const& value_store) const = 0;
 
         virtual ~value_semantic() {}
     };
@@ -90,12 +90,12 @@ namespace pika::program_options {
     class PIKA_EXPORT value_semantic_codecvt_helper<char> : public value_semantic
     {
     private:    // base overrides
-        PIKA_EXPORT void parse(std::any& value_store, const std::vector<std::string>& new_tokens,
+        PIKA_EXPORT void parse(std::any& value_store, std::vector<std::string> const& new_tokens,
             bool utf8) const override;
 
     protected:    // interface for derived classes.
         virtual void xparse(
-            std::any& value_store, const std::vector<std::string>& new_tokens) const = 0;
+            std::any& value_store, std::vector<std::string> const& new_tokens) const = 0;
     };
 
     /** Helper conversion class for values that accept ascii
@@ -109,12 +109,12 @@ namespace pika::program_options {
     class PIKA_EXPORT value_semantic_codecvt_helper<wchar_t> : public value_semantic
     {
     private:    // base overrides
-        PIKA_EXPORT void parse(std::any& value_store, const std::vector<std::string>& new_tokens,
+        PIKA_EXPORT void parse(std::any& value_store, std::vector<std::string> const& new_tokens,
             bool utf8) const override;
 
     protected:    // interface for derived classes.
         virtual void xparse(
-            std::any& value_store, const std::vector<std::wstring>& new_tokens) const = 0;
+            std::any& value_store, std::vector<std::wstring> const& new_tokens) const = 0;
     };
 
     /** Class which specifies a simple handling of a value: the value will
@@ -142,13 +142,13 @@ namespace pika::program_options {
             any modifications.
          */
         void xparse(
-            std::any& value_store, const std::vector<std::string>& new_tokens) const override;
+            std::any& value_store, std::vector<std::string> const& new_tokens) const override;
 
         /** Does nothing. */
         bool apply_default(std::any&) const override { return false; }
 
         /** Does nothing. */
-        void notify(const std::any&) const override {}
+        void notify(std::any const&) const override {}
 
     private:
         bool m_zero_tokens;
@@ -165,7 +165,7 @@ namespace pika::program_options {
     public:
         // Returns the type of the value described by this
         // object.
-        virtual const std::type_info& value_type() const = 0;
+        virtual std::type_info const& value_type() const = 0;
         // Not really needed, since deletion from this
         // class is silly, but just in case.
         virtual ~typed_value_base() {}
@@ -194,7 +194,7 @@ namespace pika::program_options {
             if none is explicitly specified. The type 'T' should
             provide operator<< for ostream.
         */
-        typed_value* default_value(const T& v)
+        typed_value* default_value(T const& v)
         {
             m_default_value = std::any(v);
             m_default_value_as_text = pika::detail::to_string(v);
@@ -207,7 +207,7 @@ namespace pika::program_options {
             but textual representation of default value must be provided
             by the user.
         */
-        typed_value* default_value(const T& v, const std::string& textual)
+        typed_value* default_value(T const& v, std::string const& textual)
         {
             m_default_value = std::any(v);
             m_default_value_as_text = textual;
@@ -218,7 +218,7 @@ namespace pika::program_options {
             if the option is given, but without an adjacent value.
             Using this implies that an explicit value is optional,
         */
-        typed_value* implicit_value(const T& v)
+        typed_value* implicit_value(T const& v)
         {
             m_implicit_value = std::any(v);
             m_implicit_value_as_text = pika::detail::to_string(v);
@@ -226,7 +226,7 @@ namespace pika::program_options {
         }
 
         /** Specifies the name used to to the value in help message.  */
-        typed_value* value_name(const std::string& name)
+        typed_value* value_name(std::string const& name)
         {
             m_value_name = name;
             return this;
@@ -242,7 +242,7 @@ namespace pika::program_options {
             operator<< for ostream, but textual representation of default
             value must be provided by the user.
         */
-        typed_value* implicit_value(const T& v, const std::string& textual)
+        typed_value* implicit_value(T const& v, std::string const& textual)
         {
             m_implicit_value = std::any(v);
             m_implicit_value_as_text = textual;
@@ -251,7 +251,7 @@ namespace pika::program_options {
 
         /** Specifies a function to be called when the final value
             is determined. */
-        typed_value* notifier(std::function<void(const T&)> f)
+        typed_value* notifier(std::function<void(T const&)> f)
         {
             m_notifier = f;
             return this;
@@ -317,7 +317,7 @@ namespace pika::program_options {
         /** Creates an instance of the 'validator' class and calls
             its operator() to perform the actual conversion. */
         void xparse(std::any& value_store,
-            const std::vector<std::basic_string<Char>>& new_tokens) const override;
+            std::vector<std::basic_string<Char>> const& new_tokens) const override;
 
         /** If default value was specified via previous call to
             'default_value', stores that value into 'value_store'.
@@ -336,10 +336,10 @@ namespace pika::program_options {
         /** If an address of variable to store value was specified
             when creating *this, stores the value there. Otherwise,
             does nothing. */
-        void notify(const std::any& value_store) const override;
+        void notify(std::any const& value_store) const override;
 
     public:    // typed_value_base overrides
-        const std::type_info& value_type() const override { return typeid(T); }
+        std::type_info const& value_type() const override { return typeid(T); }
 
     private:
         T* m_store_to;
@@ -352,7 +352,7 @@ namespace pika::program_options {
         std::any m_implicit_value;
         std::string m_implicit_value_as_text;
         bool m_composing, m_implicit, m_multitoken, m_zero_tokens, m_required;
-        std::function<void(const T&)> m_notifier;
+        std::function<void(T const&)> m_notifier;
     };
 
     /** Creates a typed_value<T> instance. This function is the primary

--- a/libs/pika/program_options/include/pika/program_options/variables_map.hpp
+++ b/libs/pika/program_options/include/pika/program_options/variables_map.hpp
@@ -32,7 +32,7 @@ namespace pika::program_options {
         is not changed, even if 'options' specify some value.
     */
     PIKA_EXPORT
-    void store(const basic_parsed_options<char>& options, variables_map& m, bool utf8 = false);
+    void store(basic_parsed_options<char> const& options, variables_map& m, bool utf8 = false);
 
     /** Stores in 'm' all options that are defined in 'options'.
         If 'm' already has a non-defaulted value of an option, that value
@@ -40,7 +40,7 @@ namespace pika::program_options {
         This is wide character variant.
     */
     PIKA_EXPORT
-    void store(const basic_parsed_options<wchar_t>& options, variables_map& m);
+    void store(basic_parsed_options<wchar_t> const& options, variables_map& m);
 
     /** Runs all 'notify' function for options in 'm'. */
     PIKA_EXPORT void notify(variables_map& m);
@@ -55,7 +55,7 @@ namespace pika::program_options {
           : m_defaulted(false)
         {
         }
-        variable_value(const std::any& xv, bool xdefaulted)
+        variable_value(std::any const& xv, bool xdefaulted)
           : v(xv)
           , m_defaulted(xdefaulted)
         {
@@ -64,9 +64,9 @@ namespace pika::program_options {
         /** If stored value if of type T, returns that value. Otherwise,
             throws boost::bad_any_cast exception. */
         template <class T>
-        const T& as() const
+        T const& as() const
         {
-            return std::any_cast<const T&>(v);
+            return std::any_cast<T const&>(v);
         }
         /** @overload */
         template <class T>
@@ -81,7 +81,7 @@ namespace pika::program_options {
             given, but has default value. */
         bool defaulted() const;
         /** Returns the contained value. */
-        const std::any& value() const;
+        std::any const& value() const;
 
         /** Returns the contained value. */
         std::any& value();
@@ -94,10 +94,10 @@ namespace pika::program_options {
         // they are known only after all sources are stored. By that
         // time options_description for the first source might not
         // be easily accessible, so we need to store semantic here.
-        std::shared_ptr<const value_semantic> m_value_semantic;
+        std::shared_ptr<value_semantic const> m_value_semantic;
 
         friend PIKA_EXPORT void store(
-            const basic_parsed_options<char>& options, variables_map& m, bool);
+            basic_parsed_options<char> const& options, variables_map& m, bool);
 
         friend class PIKA_EXPORT variables_map;
     };
@@ -108,7 +108,7 @@ namespace pika::program_options {
     {
     public:
         abstract_variables_map();
-        abstract_variables_map(const abstract_variables_map* next);
+        abstract_variables_map(abstract_variables_map const* next);
 
         virtual ~abstract_variables_map() {}
 
@@ -126,7 +126,7 @@ namespace pika::program_options {
 
             - if there's a non-defaulted value, returns it.
         */
-        const variable_value& operator[](const std::string& name) const;
+        variable_value const& operator[](std::string const& name) const;
 
         /** Sets next variable map, which will be used to find
            variables not found in *this. */
@@ -135,9 +135,9 @@ namespace pika::program_options {
     private:
         /** Returns value of variable 'name' stored in *this, or
             empty value otherwise. */
-        virtual const variable_value& get(const std::string& name) const = 0;
+        virtual variable_value const& get(std::string const& name) const = 0;
 
-        const abstract_variables_map* m_next;
+        abstract_variables_map const* m_next;
     };
 
     /** Concrete variables map which store variables in real map.
@@ -151,10 +151,10 @@ namespace pika::program_options {
     {
     public:
         variables_map();
-        variables_map(const abstract_variables_map* next);
+        variables_map(abstract_variables_map const* next);
 
         // Resolve conflict between inherited operators.
-        const variable_value& operator[](const std::string& name) const
+        variable_value const& operator[](std::string const& name) const
         {
             return abstract_variables_map::operator[](name);
         }
@@ -167,14 +167,14 @@ namespace pika::program_options {
     private:
         /** Implementation of abstract_variables_map::get
             which does 'find' in *this. */
-        const variable_value& get(const std::string& name) const override;
+        variable_value const& get(std::string const& name) const override;
 
         /** Names of option with 'final' values \-- which should not
             be changed by subsequence assignments. */
         std::set<std::string> m_final;
 
         friend PIKA_EXPORT void store(
-            const basic_parsed_options<char>& options, variables_map& xm, bool utf8);
+            basic_parsed_options<char> const& options, variables_map& xm, bool utf8);
 
         /** Names of required options, filled by parser which has
             access to options_description.
@@ -191,7 +191,7 @@ namespace pika::program_options {
 
     inline bool variable_value::defaulted() const { return m_defaulted; }
 
-    inline const std::any& variable_value::value() const { return v; }
+    inline std::any const& variable_value::value() const { return v; }
 
     inline std::any& variable_value::value() { return v; }
 

--- a/libs/pika/program_options/src/cmdline.cpp
+++ b/libs/pika/program_options/src/cmdline.cpp
@@ -31,7 +31,7 @@ namespace pika::program_options {
     {
         // Initially, store the message in 'const char*' variable,
         // to avoid conversion to string in all cases.
-        const char* msg;
+        char const* msg;
         switch (kind)
         {
         case empty_adjacent_parameter:
@@ -69,15 +69,15 @@ namespace pika::program_options::detail {
     using namespace std;
     using namespace program_options;
 
-    cmdline::cmdline(const vector<string>& args) { init(args); }
+    cmdline::cmdline(vector<string> const& args) { init(args); }
 
-    cmdline::cmdline(int argc, const char* const* argv)
+    cmdline::cmdline(int argc, char const* const* argv)
     {
         init(vector<string>(
             argv + 1, argv + static_cast<std::size_t>(argc) + static_cast<std::size_t>(!argc)));
     }
 
-    void cmdline::init(const vector<string>& args)
+    void cmdline::init(vector<string> const& args)
     {
         this->m_args = args;
         m_style = command_line_style::default_style;
@@ -100,7 +100,7 @@ namespace pika::program_options::detail {
     {
         bool allow_some_long = (style & allow_long) || (style & allow_long_disguise);
 
-        const char* error = nullptr;
+        char const* error = nullptr;
         if (allow_some_long && !(style & long_allow_adjacent) && !(style & long_allow_next))
             error = "pika::program_options misconfiguration: choose one or other of "
                     "'command_line_style::long_allow_next' (whitespace separated arguments) or "
@@ -131,9 +131,9 @@ namespace pika::program_options::detail {
         return ((m_style & style) ? true : false);
     }
 
-    void cmdline::set_options_description(const options_description& desc) { m_desc = &desc; }
+    void cmdline::set_options_description(options_description const& desc) { m_desc = &desc; }
 
-    void cmdline::set_positional_options(const positional_options_description& positional)
+    void cmdline::set_positional_options(positional_options_description const& positional)
     {
         m_positional = &positional;
     }
@@ -219,7 +219,7 @@ namespace pika::program_options::detail {
                     // so that they can be added to next.back()'s values
                     // if appropriate.
                     finish_option(next.back(), args, style_parsers);
-                    for (const auto& j : next) result.push_back(j);
+                    for (auto const& j : next) result.push_back(j);
                 }
 
                 if (args.size() != current_size)
@@ -250,7 +250,7 @@ namespace pika::program_options::detail {
 
             if (opt.string_key.empty()) continue;
 
-            const option_description* xd = nullptr;
+            option_description const* xd = nullptr;
             try
             {
                 xd = m_desc->find_nothrow(opt.string_key, is_style_active(allow_guessing),
@@ -346,7 +346,7 @@ namespace pika::program_options::detail {
     }
 
     void cmdline::finish_option(
-        option& opt, vector<string>& other_tokens, const vector<style_parser>& style_parsers)
+        option& opt, vector<string>& other_tokens, vector<style_parser> const& style_parsers)
     {
         if (opt.string_key.empty()) return;
 
@@ -359,7 +359,7 @@ namespace pika::program_options::detail {
         try
         {
             // First check that the option is valid, and get its description.
-            const option_description* xd = m_desc->find_nothrow(opt.string_key,
+            option_description const* xd = m_desc->find_nothrow(opt.string_key,
                 is_style_active(allow_guessing), is_style_active(long_case_insensitive),
                 is_style_active(short_case_insensitive));
 
@@ -372,7 +372,7 @@ namespace pika::program_options::detail {
                 }
                 else { throw unknown_option(); }
             }
-            const option_description& d = *xd;
+            option_description const& d = *xd;
 
             // Canonize the name
             opt.string_key = d.key(opt.string_key);
@@ -418,7 +418,7 @@ namespace pika::program_options::detail {
                     if (!followed_option.empty())
                     {
                         original_token_for_exceptions = other_tokens[0];
-                        const option_description* od = m_desc->find_nothrow(other_tokens[0],
+                        option_description const* od = m_desc->find_nothrow(other_tokens[0],
                             is_style_active(allow_guessing), is_style_active(long_case_insensitive),
                             is_style_active(short_case_insensitive));
                         if (od)
@@ -450,7 +450,7 @@ namespace pika::program_options::detail {
     vector<option> cmdline::parse_long_option(vector<string>& args)
     {
         vector<option> result;
-        const string& tok = args[0];
+        string const& tok = args[0];
         if (tok.size() >= 3 && tok[0] == '-' && tok[1] == '-')
         {
             string name, adjacent;
@@ -478,7 +478,7 @@ namespace pika::program_options::detail {
 
     vector<option> cmdline::parse_short_option(vector<string>& args)
     {
-        const string& tok = args[0];
+        string const& tok = args[0];
         if (tok.size() >= 2 && tok[0] == '-' && tok[1] != '-')
         {
             vector<option> result;
@@ -494,7 +494,7 @@ namespace pika::program_options::detail {
             // option.
             for (;;)
             {
-                const option_description* d;
+                option_description const* d;
                 try
                 {
                     d = m_desc->find_nothrow(
@@ -544,7 +544,7 @@ namespace pika::program_options::detail {
     vector<option> cmdline::parse_dos_option(vector<string>& args)
     {
         vector<option> result;
-        const string& tok = args[0];
+        string const& tok = args[0];
         if (tok.size() >= 2 && tok[0] == '/')
         {
             string name = "-" + tok.substr(1, 1);
@@ -562,7 +562,7 @@ namespace pika::program_options::detail {
 
     vector<option> cmdline::parse_disguised_long_option(vector<string>& args)
     {
-        const string& tok = args[0];
+        string const& tok = args[0];
         if (tok.size() >= 2 &&
             ((tok[0] == '-' && tok[1] != '-') ||
                 ((m_style & allow_slash_for_short) && tok[0] == '/')))
@@ -591,7 +591,7 @@ namespace pika::program_options::detail {
     vector<option> cmdline::parse_terminator(vector<string>& args)
     {
         vector<option> result;
-        const string& tok = args[0];
+        string const& tok = args[0];
         if (tok == "--")
         {
             for (std::size_t i = 1; i < args.size(); ++i)

--- a/libs/pika/program_options/src/config_file.cpp
+++ b/libs/pika/program_options/src/config_file.cpp
@@ -19,14 +19,14 @@ namespace pika::program_options::detail {
     using namespace std;
 
     common_config_file_iterator::common_config_file_iterator(
-        const std::set<std::string>& allowed_options, bool allow_unregistered)
+        std::set<std::string> const& allowed_options, bool allow_unregistered)
       : allowed_options(allowed_options)
       , m_allow_unregistered(allow_unregistered)
     {
-        for (const auto& allowed_option : allowed_options) { add_option(allowed_option.c_str()); }
+        for (auto const& allowed_option : allowed_options) { add_option(allowed_option.c_str()); }
     }
 
-    void common_config_file_iterator::add_option(const char* name)
+    void common_config_file_iterator::add_option(char const* name)
     {
         string s(name);
         PIKA_ASSERT(!s.empty());
@@ -56,7 +56,7 @@ namespace pika::program_options::detail {
     }
 
     namespace {
-        string trim_ws(const string& s)
+        string trim_ws(string const& s)
         {
             string::size_type n, n2;
             n = s.find_first_not_of(" \t\r\n");
@@ -114,7 +114,7 @@ namespace pika::program_options::detail {
         if (!found) found_eof();
     }
 
-    bool common_config_file_iterator::allowed_option(const std::string& s) const
+    bool common_config_file_iterator::allowed_option(std::string const& s) const
     {
         set<string>::const_iterator i = allowed_options.find(s);
         if (i != allowed_options.end()) return true;

--- a/libs/pika/program_options/src/convert.cpp
+++ b/libs/pika/program_options/src/convert.cpp
@@ -31,15 +31,15 @@ namespace pika::program_options::detail {
        Experiments show that the performance loss is less than 10%.
     */
     template <class ToChar, class FromChar, class Fun>
-    std::basic_string<ToChar> convert(const std::basic_string<FromChar>& s, Fun fun)
+    std::basic_string<ToChar> convert(std::basic_string<FromChar> const& s, Fun fun)
 
     {
         std::basic_string<ToChar> result;
 
         std::mbstate_t state = std::mbstate_t();
 
-        const FromChar* from = s.data();
-        const FromChar* from_end = s.data() + s.size();
+        FromChar const* from = s.data();
+        FromChar const* from_end = s.data() + s.size();
         // The interface of cvt is not really iterator-like, and it's
         // not possible the tell the required output size without the conversion.
         // All we can is convert data by pieces.
@@ -74,7 +74,7 @@ namespace pika::program_options::detail {
 namespace pika::program_options {
 
     std::wstring from_8_bit(
-        const std::string& s, const std::codecvt<wchar_t, char, std::mbstate_t>& cvt)
+        std::string const& s, std::codecvt<wchar_t, char, std::mbstate_t> const& cvt)
     {
         using namespace std::placeholders;
         return detail::convert<wchar_t>(s,
@@ -83,7 +83,7 @@ namespace pika::program_options {
     }
 
     std::string to_8_bit(
-        const std::wstring& s, const std::codecvt<wchar_t, char, std::mbstate_t>& cvt)
+        std::wstring const& s, std::codecvt<wchar_t, char, std::mbstate_t> const& cvt)
     {
         using namespace std::placeholders;
         return detail::convert<char>(s,
@@ -95,23 +95,23 @@ namespace pika::program_options {
         pika::program_options::detail::utf8_codecvt_facet utf8_facet;
     }
 
-    std::wstring from_utf8(const std::string& s) { return from_8_bit(s, utf8_facet); }
+    std::wstring from_utf8(std::string const& s) { return from_8_bit(s, utf8_facet); }
 
-    std::string to_utf8(const std::wstring& s) { return to_8_bit(s, utf8_facet); }
+    std::string to_utf8(std::wstring const& s) { return to_8_bit(s, utf8_facet); }
 
-    std::wstring from_local_8_bit(const std::string& s)
+    std::wstring from_local_8_bit(std::string const& s)
     {
         using facet_type = std::codecvt<wchar_t, char, std::mbstate_t>;
         return from_8_bit(s, std::use_facet<facet_type>(std::locale()));
     }
 
-    std::string to_local_8_bit(const std::wstring& s)
+    std::string to_local_8_bit(std::wstring const& s)
     {
         using facet_type = std::codecvt<wchar_t, char, std::mbstate_t>;
         return to_8_bit(s, std::use_facet<facet_type>(std::locale()));
     }
 
-    std::string to_internal(const std::string& s) { return s; }
+    std::string to_internal(std::string const& s) { return s; }
 
-    std::string to_internal(const std::wstring& s) { return to_utf8(s); }
+    std::string to_internal(std::wstring const& s) { return to_utf8(s); }
 }    // namespace pika::program_options

--- a/libs/pika/program_options/src/options_description.cpp
+++ b/libs/pika/program_options/src/options_description.cpp
@@ -32,7 +32,7 @@ namespace pika::program_options {
     namespace {
 
         template <class Char>
-        std::basic_string<Char> tolower_(const std::basic_string<Char>& str)
+        std::basic_string<Char> tolower_(std::basic_string<Char> const& str)
         {
             std::basic_string<Char> result;
             for (typename std::basic_string<Char>::size_type i = 0; i < str.size(); ++i)
@@ -46,14 +46,14 @@ namespace pika::program_options {
 
     option_description::option_description() {}
 
-    option_description::option_description(const char* names, const value_semantic* s)
+    option_description::option_description(char const* names, value_semantic const* s)
       : m_value_semantic(s)
     {
         this->set_names(names);
     }
 
     option_description::option_description(
-        const char* names, const value_semantic* s, const char* description)
+        char const* names, value_semantic const* s, char const* description)
       : m_description(description)
       , m_value_semantic(s)
     {
@@ -63,12 +63,12 @@ namespace pika::program_options {
     option_description::~option_description() {}
 
     option_description::match_result option_description::match(
-        const std::string& option, bool approx, bool long_ignore_case, bool short_ignore_case) const
+        std::string const& option, bool approx, bool long_ignore_case, bool short_ignore_case) const
     {
         match_result result = no_match;
         std::string local_option = (long_ignore_case ? tolower_(option) : option);
 
-        for (const auto& long_name : m_long_names)
+        for (auto const& long_name : m_long_names)
         {
             std::string local_long_name((long_ignore_case ? tolower_(long_name) : long_name));
 
@@ -105,13 +105,13 @@ namespace pika::program_options {
         return result;
     }
 
-    const std::string& option_description::key(const std::string& option) const
+    std::string const& option_description::key(std::string const& option) const
     {
         // We make the arbitrary choice of using the first long
         // name as the key, regardless of anything else
         if (!m_long_names.empty())
         {
-            const std::string& first_long_name = *m_long_names.begin();
+            std::string const& first_long_name = *m_long_names.begin();
             if (first_long_name.find('*') != string::npos)
                 // The '*' character means we're long_name
                 // matches only part of the input. So, returning
@@ -149,7 +149,7 @@ namespace pika::program_options {
             return m_short_name;
     }
 
-    const std::string& option_description::long_name() const
+    std::string const& option_description::long_name() const
     {
         // NOTE: Upstream this is empty_string(""). However, nvc++ 22.11 fails
         // with:
@@ -163,15 +163,15 @@ namespace pika::program_options {
         return m_long_names.empty() ? empty_string : *m_long_names.begin();
     }
 
-    const std::pair<const std::string*, std::size_t> option_description::long_names() const
+    const std::pair<std::string const*, std::size_t> option_description::long_names() const
     {
         // reinterpret_cast is to please msvc 10.
         return (m_long_names.empty()) ?
-            std::pair<const std::string*, size_t>(reinterpret_cast<const std::string*>(0), 0) :
-            std::pair<const std::string*, size_t>(&(*m_long_names.begin()), m_long_names.size());
+            std::pair<std::string const*, size_t>(reinterpret_cast<std::string const*>(0), 0) :
+            std::pair<std::string const*, size_t>(&(*m_long_names.begin()), m_long_names.size());
     }
 
-    option_description& option_description::set_names(const char* _names)
+    option_description& option_description::set_names(char const* _names)
     {
         m_long_names.clear();
         std::istringstream iss(_names);
@@ -183,7 +183,7 @@ namespace pika::program_options {
         bool try_interpreting_last_name_as_a_switch = m_long_names.size() > 1;
         if (try_interpreting_last_name_as_a_switch)
         {
-            const std::string& last_name = *m_long_names.rbegin();
+            std::string const& last_name = *m_long_names.rbegin();
             if (last_name.length() == 1)
             {
                 m_short_name = '-' + last_name;
@@ -202,9 +202,9 @@ namespace pika::program_options {
         return *this;
     }
 
-    const std::string& option_description::description() const { return m_description; }
+    std::string const& option_description::description() const { return m_description; }
 
-    std::shared_ptr<const value_semantic> option_description::semantic() const
+    std::shared_ptr<value_semantic const> option_description::semantic() const
     {
         return m_value_semantic;
     }
@@ -234,7 +234,7 @@ namespace pika::program_options {
     }
 
     options_description_easy_init& options_description_easy_init::operator()(
-        const char* name, const char* description)
+        char const* name, char const* description)
     {
         // Create untyped semantic which accepts zero tokens: i.e.
         // no value can be specified on command line.
@@ -247,7 +247,7 @@ namespace pika::program_options {
     }
 
     options_description_easy_init& options_description_easy_init::operator()(
-        const char* name, const value_semantic* s)
+        char const* name, value_semantic const* s)
     {
         std::shared_ptr<option_description> d(new option_description(name, s));
         owner->add(d);
@@ -255,7 +255,7 @@ namespace pika::program_options {
     }
 
     options_description_easy_init& options_description_easy_init::operator()(
-        const char* name, const value_semantic* s, const char* description)
+        char const* name, value_semantic const* s, char const* description)
     {
         std::shared_ptr<option_description> d(new option_description(name, s, description));
 
@@ -263,7 +263,7 @@ namespace pika::program_options {
         return *this;
     }
 
-    const unsigned options_description::m_default_line_length = 80;
+    unsigned const options_description::m_default_line_length = 80;
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     options_description::options_description(unsigned line_length, unsigned min_description_length)
@@ -277,7 +277,7 @@ namespace pika::program_options {
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     options_description::options_description(
-        const std::string& caption, unsigned line_length, unsigned min_description_length)
+        std::string const& caption, unsigned line_length, unsigned min_description_length)
       // NOLINTEND(bugprone-easily-swappable-parameters)
       : m_caption(caption)
       , m_line_length(line_length)
@@ -293,12 +293,12 @@ namespace pika::program_options {
         belong_to_group.push_back(false);
     }
 
-    options_description& options_description::add(const options_description& desc)
+    options_description& options_description::add(options_description const& desc)
     {
         std::shared_ptr<options_description> d(new options_description(desc));
         groups.push_back(d);
 
-        for (const auto& option : desc.m_options)
+        for (auto const& option : desc.m_options)
         {
             add(option);
             belong_to_group.back() = true;
@@ -312,22 +312,22 @@ namespace pika::program_options {
         return options_description_easy_init(this);
     }
 
-    const option_description& options_description::find(
-        const std::string& name, bool approx, bool long_ignore_case, bool short_ignore_case) const
+    option_description const& options_description::find(
+        std::string const& name, bool approx, bool long_ignore_case, bool short_ignore_case) const
     {
-        const option_description* d =
+        option_description const* d =
             find_nothrow(name, approx, long_ignore_case, short_ignore_case);
         if (!d) throw unknown_option();
         return *d;
     }
 
-    const std::vector<std::shared_ptr<option_description>>& options_description::options() const
+    std::vector<std::shared_ptr<option_description>> const& options_description::options() const
     {
         return m_options;
     }
 
-    const option_description* options_description::find_nothrow(
-        const std::string& name, bool approx, bool long_ignore_case, bool short_ignore_case) const
+    option_description const* options_description::find_nothrow(
+        std::string const& name, bool approx, bool long_ignore_case, bool short_ignore_case) const
     {
         std::shared_ptr<option_description> found;
         bool had_full_match = false;
@@ -337,7 +337,7 @@ namespace pika::program_options {
         // We use linear search because matching specified option
         // name with the declared option name need to take care about
         // case sensitivity and trailing '*' and so we can't use simple map.
-        for (const auto& option : m_options)
+        for (auto const& option : m_options)
         {
             option_description::match_result r =
                 option->match(name, approx, long_ignore_case, short_ignore_case);
@@ -372,7 +372,7 @@ namespace pika::program_options {
     }
 
     PIKA_EXPORT
-    std::ostream& operator<<(std::ostream& os, const options_description& desc)
+    std::ostream& operator<<(std::ostream& os, options_description const& desc)
     {
         desc.print(os);
         return os;
@@ -502,7 +502,7 @@ namespace pika::program_options {
             }
         }
 
-        void format_description(std::ostream& os, const std::string& desc,
+        void format_description(std::ostream& os, std::string const& desc,
             std::size_t first_column_width, std::size_t line_length)
         {
             // we need to use one char less per line to work correctly if actual
@@ -541,7 +541,7 @@ namespace pika::program_options {
             }    // paragraphs
         }
 
-        void format_one(std::ostream& os, const option_description& opt,
+        void format_one(std::ostream& os, option_description const& opt,
             std::size_t first_column_width, std::size_t line_length)
         {
             stringstream ss;
@@ -578,14 +578,14 @@ namespace pika::program_options {
         std::size_t i;    // vc6 has broken for loop scoping
         for (i = 0; i < m_options.size(); ++i)
         {
-            const option_description& opt = *m_options[i];
+            option_description const& opt = *m_options[i];
             stringstream ss;
             ss << "  " << opt.format_name() << ' ' << opt.format_parameter();
             width = (std::max)(width, ss.str().size());
         }
 
         /* Get width of groups as well*/
-        for (const auto& group : groups)
+        for (auto const& group : groups)
             width = (std::max)(width, group->get_option_column_width());
 
         /* this is the column were description should start, if first
@@ -610,14 +610,14 @@ namespace pika::program_options {
         {
             if (belong_to_group[i]) continue;
 
-            const option_description& opt = *m_options[i];
+            option_description const& opt = *m_options[i];
 
             format_one(os, opt, width, m_line_length);
 
             os << "\n";
         }
 
-        for (const auto& group : groups)
+        for (auto const& group : groups)
         {
             os << "\n";
             group->print(os, width);

--- a/libs/pika/program_options/src/parsers.cpp
+++ b/libs/pika/program_options/src/parsers.cpp
@@ -33,7 +33,7 @@ namespace pika::program_options {
 
     namespace {
 
-        woption woption_from_option(const option& opt)
+        woption woption_from_option(option const& opt)
         {
             woption result;
             result.string_key = opt.string_key;
@@ -49,24 +49,24 @@ namespace pika::program_options {
         }
     }    // namespace
 
-    basic_parsed_options<wchar_t>::basic_parsed_options(const parsed_options& po)
+    basic_parsed_options<wchar_t>::basic_parsed_options(parsed_options const& po)
       : description(po.description)
       , utf8_encoded_options(po)
       , m_options_prefix(po.m_options_prefix)
     {
-        for (const auto& option : po.options) options.push_back(woption_from_option(option));
+        for (auto const& option : po.options) options.push_back(woption_from_option(option));
     }
 
     template <class Char>
     basic_parsed_options<Char> parse_config_file(
-        std::basic_istream<Char>& is, const options_description& desc, bool allow_unregistered)
+        std::basic_istream<Char>& is, options_description const& desc, bool allow_unregistered)
     {
         set<string> allowed_options;
 
-        const vector<shared_ptr<option_description>>& options = desc.options();
-        for (const auto& option : options)
+        vector<shared_ptr<option_description>> const& options = desc.options();
+        for (auto const& option : options)
         {
-            const option_description& d = *option;
+            option_description const& d = *option;
 
             if (d.long_name().empty())
                 throw error(
@@ -84,14 +84,14 @@ namespace pika::program_options {
     }
 
     template PIKA_EXPORT basic_parsed_options<char> parse_config_file(
-        std::basic_istream<char>& is, const options_description& desc, bool allow_unregistered);
+        std::basic_istream<char>& is, options_description const& desc, bool allow_unregistered);
 
     template PIKA_EXPORT basic_parsed_options<wchar_t> parse_config_file(
-        std::basic_istream<wchar_t>& is, const options_description& desc, bool allow_unregistered);
+        std::basic_istream<wchar_t>& is, options_description const& desc, bool allow_unregistered);
 
     template <class Char>
     basic_parsed_options<Char> parse_config_file(
-        const char* filename, const options_description& desc, bool allow_unregistered)
+        char const* filename, options_description const& desc, bool allow_unregistered)
     {
         // Parser return char strings
         std::basic_ifstream<Char> strm(filename);
@@ -105,13 +105,13 @@ namespace pika::program_options {
     }
 
     template PIKA_EXPORT basic_parsed_options<char> parse_config_file(
-        const char* filename, const options_description& desc, bool allow_unregistered);
+        char const* filename, options_description const& desc, bool allow_unregistered);
 
     template PIKA_EXPORT basic_parsed_options<wchar_t> parse_config_file(
-        const char* filename, const options_description& desc, bool allow_unregistered);
+        char const* filename, options_description const& desc, bool allow_unregistered);
 
     parsed_options parse_environment(
-        const options_description& desc, const std::function<std::string(std::string)>& name_mapper)
+        options_description const& desc, std::function<std::string(std::string)> const& name_mapper)
     {
         parsed_options result(&desc);
 
@@ -141,12 +141,12 @@ namespace pika::program_options {
         class prefix_name_mapper
         {
         public:
-            prefix_name_mapper(const std::string& prefix)
+            prefix_name_mapper(std::string const& prefix)
               : prefix(prefix)
             {
             }
 
-            std::string operator()(const std::string& s)
+            std::string operator()(std::string const& s)
             {
                 string result;
                 if (s.find(prefix) == 0)
@@ -166,12 +166,12 @@ namespace pika::program_options {
         };
     }    // namespace detail
 
-    parsed_options parse_environment(const options_description& desc, const std::string& prefix)
+    parsed_options parse_environment(options_description const& desc, std::string const& prefix)
     {
         return parse_environment(desc, detail::prefix_name_mapper(prefix));
     }
 
-    parsed_options parse_environment(const options_description& desc, const char* prefix)
+    parsed_options parse_environment(options_description const& desc, char const* prefix)
     {
         return parse_environment(desc, string(prefix));
     }

--- a/libs/pika/program_options/src/positional_options.cpp
+++ b/libs/pika/program_options/src/positional_options.cpp
@@ -17,7 +17,7 @@ namespace pika::program_options {
     positional_options_description::positional_options_description() {}
 
     positional_options_description& positional_options_description::add(
-        const char* name, int max_count)
+        char const* name, int max_count)
     {
         PIKA_ASSERT(max_count != -1 || m_trailing.empty());
 
@@ -33,7 +33,7 @@ namespace pika::program_options {
                                     (std::numeric_limits<unsigned>::max)();
     }
 
-    const std::string& positional_options_description::name_for_position(unsigned position) const
+    std::string const& positional_options_description::name_for_position(unsigned position) const
     {
         PIKA_ASSERT(position < max_total_count());
 

--- a/libs/pika/program_options/src/split.cpp
+++ b/libs/pika/program_options/src/split.cpp
@@ -16,8 +16,8 @@ namespace pika::program_options::detail {
 
     template <class Char>
     std::vector<std::basic_string<Char>>
-    split_unix(const std::basic_string<Char>& cmdline, const std::basic_string<Char>& separator,
-        const std::basic_string<Char>& quote, const std::basic_string<Char>& escape)
+    split_unix(std::basic_string<Char> const& cmdline, std::basic_string<Char> const& separator,
+        std::basic_string<Char> const& quote, std::basic_string<Char> const& escape)
     {
         using tokenizerT = boost::tokenizer<boost::escaped_list_separator<Char>,
             typename std::basic_string<Char>::const_iterator, std::basic_string<Char>>;
@@ -40,14 +40,14 @@ namespace pika::program_options {
 
     // Take a command line string and splits in into tokens, according
     // to the given collection of separators chars.
-    std::vector<std::string> split_unix(const std::string& cmdline, const std::string& separator,
-        const std::string& quote, const std::string& escape)
+    std::vector<std::string> split_unix(std::string const& cmdline, std::string const& separator,
+        std::string const& quote, std::string const& escape)
     {
         return detail::split_unix<char>(cmdline, separator, quote, escape);
     }
 
-    std::vector<std::wstring> split_unix(const std::wstring& cmdline, const std::wstring& separator,
-        const std::wstring& quote, const std::wstring& escape)
+    std::vector<std::wstring> split_unix(std::wstring const& cmdline, std::wstring const& separator,
+        std::wstring const& quote, std::wstring const& escape)
     {
         return detail::split_unix<wchar_t>(cmdline, separator, quote, escape);
     }

--- a/libs/pika/program_options/src/utf8_codecvt_facet.cpp
+++ b/libs/pika/program_options/src/utf8_codecvt_facet.cpp
@@ -36,8 +36,8 @@ namespace pika::program_options::detail {
     utf8_codecvt_facet::~utf8_codecvt_facet() {}
 
     // Translate incoming UTF-8 into UCS-4
-    std::codecvt_base::result utf8_codecvt_facet::do_in(std::mbstate_t& /*state*/, const char* from,
-        const char* from_end, const char*& from_next, wchar_t* to, wchar_t* to_end,
+    std::codecvt_base::result utf8_codecvt_facet::do_in(std::mbstate_t& /*state*/, char const* from,
+        char const* from_end, char const*& from_next, wchar_t* to, wchar_t* to_end,
         wchar_t*& to_next) const
     {
         // Basic algorithm:  The first octet determines how many
@@ -60,7 +60,7 @@ namespace pika::program_options::detail {
 
             // The first octet is   adjusted by a value dependent upon
             // the number   of "continuing octets" encoding the character
-            const int cont_octet_count = static_cast<int>(get_cont_octet_count(*from));
+            int const cont_octet_count = static_cast<int>(get_cont_octet_count(*from));
             const wchar_t octet1_modifier_table[] = {0x00, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc};
 
             // The unsigned char conversion is necessary in case char is
@@ -112,7 +112,7 @@ namespace pika::program_options::detail {
     }
 
     std::codecvt_base::result utf8_codecvt_facet::do_out(std::mbstate_t& /*state*/,
-        const wchar_t* from, const wchar_t* from_end, const wchar_t*& from_next, char* to,
+        wchar_t const* from, wchar_t const* from_end, wchar_t const*& from_next, char* to,
         char* to_end, char*& to_next) const
     {
         // RG - consider merging this table with the other one
@@ -171,7 +171,7 @@ namespace pika::program_options::detail {
     // How many char objects can I process to get <= max_limit
     // wchar_t objects?
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
-    int utf8_codecvt_facet::do_length(std::mbstate_t&, const char* from, const char* from_end,
+    int utf8_codecvt_facet::do_length(std::mbstate_t&, char const* from, char const* from_end,
         std::size_t max_limit) const noexcept
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
@@ -186,7 +186,7 @@ namespace pika::program_options::detail {
         // last measured character.
         std::size_t last_octet_count = 0;
         std::size_t char_count = 0;
-        const char* from_next = from;
+        char const* from_next = from;
         // Use "<" because the buffer may represent incomplete characters
         while (from_next + last_octet_count <= from_end && char_count <= max_limit)
         {

--- a/libs/pika/program_options/src/value_semantic.cpp
+++ b/libs/pika/program_options/src/value_semantic.cpp
@@ -22,13 +22,13 @@ namespace pika::program_options {
     using namespace std;
 
     namespace {
-        std::string convert_value(const std::wstring& s)
+        std::string convert_value(std::wstring const& s)
         {
             try
             {
                 return to_local_8_bit(s);
             }
-            catch (const std::exception&)
+            catch (std::exception const&)
             {
                 return "<unrepresentable unicode string>";
             }
@@ -36,13 +36,13 @@ namespace pika::program_options {
     }    // namespace
 
     void value_semantic_codecvt_helper<char>::parse(
-        std::any& value_store, const std::vector<std::string>& new_tokens, bool utf8) const
+        std::any& value_store, std::vector<std::string> const& new_tokens, bool utf8) const
     {
         if (utf8)
         {
             // Need to convert to local encoding.
             std::vector<string> local_tokens;
-            for (const auto& new_token : new_tokens)
+            for (auto const& new_token : new_tokens)
             {
                 std::wstring w = from_utf8(new_token);
                 local_tokens.push_back(to_local_8_bit(w));
@@ -57,18 +57,18 @@ namespace pika::program_options {
     }
 
     void value_semantic_codecvt_helper<wchar_t>::parse(
-        std::any& value_store, const std::vector<std::string>& new_tokens, bool utf8) const
+        std::any& value_store, std::vector<std::string> const& new_tokens, bool utf8) const
     {
         std::vector<wstring> tokens;
         if (utf8)
         {
             // Convert from utf8
-            for (const auto& new_token : new_tokens) { tokens.push_back(from_utf8(new_token)); }
+            for (auto const& new_token : new_tokens) { tokens.push_back(from_utf8(new_token)); }
         }
         else
         {
             // Convert from local encoding
-            for (const auto& new_token : new_tokens)
+            for (auto const& new_token : new_tokens)
             {
                 tokens.push_back(from_local_8_bit(new_token));
             }
@@ -98,7 +98,7 @@ namespace pika::program_options {
     }
 
     void untyped_value::xparse(
-        std::any& value_store, const std::vector<std::string>& new_tokens) const
+        std::any& value_store, std::vector<std::string> const& new_tokens) const
     {
         if (value_store.has_value()) throw multiple_occurrences();
         if (new_tokens.size() > 1) throw multiple_values();
@@ -122,7 +122,7 @@ namespace pika::program_options {
         Case is ignored. The 'xs' vector can either be empty, in which
         case the value is 'true', or can contain explicit value.
     */
-    void validate(std::any& v, const vector<string>& xs, bool*, int)
+    void validate(std::any& v, vector<string> const& xs, bool*, int)
     {
         check_first_occurrence(v);
         string s(get_single_string(xs, true));
@@ -142,7 +142,7 @@ namespace pika::program_options {
     // create auxiliary 'widen' routine to convert from char* into
     // needed string type, and that's more work.
     PIKA_EXPORT
-    void validate(std::any& v, const vector<wstring>& xs, bool*, int)
+    void validate(std::any& v, vector<wstring> const& xs, bool*, int)
     {
         check_first_occurrence(v);
         wstring s(get_single_string(xs, true));
@@ -158,14 +158,14 @@ namespace pika::program_options {
     }
 
     PIKA_EXPORT
-    void validate(std::any& v, const vector<string>& xs, std::string*, int)
+    void validate(std::any& v, vector<string> const& xs, std::string*, int)
     {
         check_first_occurrence(v);
         v = std::any(get_single_string(xs));
     }
 
     PIKA_EXPORT
-    void validate(std::any& v, const vector<wstring>& xs, std::string*, int)
+    void validate(std::any& v, vector<wstring> const& xs, std::string*, int)
     {
         check_first_occurrence(v);
         v = std::any(get_single_string(xs));
@@ -174,35 +174,35 @@ namespace pika::program_options {
     namespace validators {
 
         PIKA_EXPORT
-        void check_first_occurrence(const std::any& value)
+        void check_first_occurrence(std::any const& value)
         {
             if (value.has_value()) throw multiple_occurrences();
         }
     }    // namespace validators
 
-    invalid_option_value::invalid_option_value(const std::string& bad_value)
+    invalid_option_value::invalid_option_value(std::string const& bad_value)
       : validation_error(validation_error::invalid_option_value)
     {
         set_substitute("value", bad_value);
     }
 
 #ifndef BOOST_NO_STD_WSTRING
-    invalid_option_value::invalid_option_value(const std::wstring& bad_value)
+    invalid_option_value::invalid_option_value(std::wstring const& bad_value)
       : validation_error(validation_error::invalid_option_value)
     {
         set_substitute("value", convert_value(bad_value));
     }
 #endif
 
-    invalid_bool_value::invalid_bool_value(const std::string& bad_value)
+    invalid_bool_value::invalid_bool_value(std::string const& bad_value)
       : validation_error(validation_error::invalid_bool_value)
     {
         set_substitute("value", bad_value);
     }
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
-    error_with_option_name::error_with_option_name(const std::string& template_,
-        const std::string& option_name, const std::string& original_token, int option_style)
+    error_with_option_name::error_with_option_name(std::string const& template_,
+        std::string const& option_name, std::string const& original_token, int option_style)
       // NOLINTEND(bugprone-easily-swappable-parameters)
       : error(template_)
       , m_option_style(option_style)
@@ -217,7 +217,7 @@ namespace pika::program_options {
         m_substitutions["original_token"] = original_token;
     }
 
-    const char* error_with_option_name::what() const noexcept
+    char const* error_with_option_name::what() const noexcept
     {
         // will substitute tokens each time what is run()
         substitute_placeholders(m_error_template);
@@ -225,7 +225,7 @@ namespace pika::program_options {
         return m_message.c_str();
     }
 
-    void error_with_option_name::replace_token(const string& from, const string& to) const
+    void error_with_option_name::replace_token(string const& from, string const& to) const
     {
         for (;;)
         {
@@ -272,7 +272,7 @@ namespace pika::program_options {
         return option_name;
     }
 
-    void error_with_option_name::substitute_placeholders(const string& error_template) const
+    void error_with_option_name::substitute_placeholders(string const& error_template) const
     {
         m_message = error_template;
         std::map<std::string, std::string> substitutions(m_substitutions);
@@ -282,7 +282,7 @@ namespace pika::program_options {
         //
         //  replace placeholder with defaults if values are missing
         //
-        for (const auto& substitution_default : m_substitution_defaults)
+        for (auto const& substitution_default : m_substitution_defaults)
         {
             // missing parameter: use default
             if (substitutions.count(substitution_default.first) == 0 ||
@@ -301,7 +301,7 @@ namespace pika::program_options {
             replace_token('%' + substitution.first + '%', substitution.second);
     }
 
-    void ambiguous_option::substitute_placeholders(const string& original_error_template) const
+    void ambiguous_option::substitute_placeholders(string const& original_error_template) const
     {
         // For short forms, all alternatives must be identical, by
         //      definition, to the specified option, so we don't need to
@@ -341,7 +341,7 @@ namespace pika::program_options {
     {
         // Initially, store the message in 'const char*' variable,
         // to avoid conversion to std::string in all cases.
-        const char* msg;
+        char const* msg;
         switch (kind)
         {
         case invalid_bool_value:

--- a/libs/pika/program_options/src/variables_map.cpp
+++ b/libs/pika/program_options/src/variables_map.cpp
@@ -25,13 +25,13 @@ namespace pika::program_options {
     // First, performs semantic actions for 'oa'.
     // Then, stores in 'm' all options that are defined in 'desc'.
     PIKA_EXPORT
-    void store(const parsed_options& options, variables_map& xm, bool utf8)
+    void store(parsed_options const& options, variables_map& xm, bool utf8)
     {
         // TODO: what if we have different definition
         // for the same option name during different calls
         // 'store'.
         PIKA_ASSERT(options.description);
-        const options_description& desc = *options.description;
+        options_description const& desc = *options.description;
 
         // We need to access map's operator[], not the overridden version
         // variables_map. Ehmm.. messy.
@@ -67,7 +67,7 @@ namespace pika::program_options {
                 if (xm.m_final.count(option_name)) continue;
 
                 original_token = !opts.original_tokens.empty() ? opts.original_tokens[0] : "";
-                const option_description& d = desc.find(option_name, false, false, false);
+                option_description const& d = desc.find(option_name, false, false, false);
 
                 variable_value& v = m[option_name];
                 if (v.defaulted())
@@ -98,10 +98,10 @@ namespace pika::program_options {
         xm.m_final.insert(new_final.begin(), new_final.end());
 
         // Second, apply default values and store required options.
-        const vector<shared_ptr<option_description>>& all = desc.options();
+        vector<shared_ptr<option_description>> const& all = desc.options();
         for (i = 0; i < all.size(); ++i)
         {
-            const option_description& d = *all[i];
+            option_description const& d = *all[i];
             string key = d.key("");
             // FIXME: this logic relies on knowledge of option_description
             // internals.
@@ -133,7 +133,7 @@ namespace pika::program_options {
         }
     }
 
-    void store(const wparsed_options& options, variables_map& m)
+    void store(wparsed_options const& options, variables_map& m)
     {
         store(options.utf8_encoded_options, m, true);
     }
@@ -145,19 +145,19 @@ namespace pika::program_options {
     {
     }
 
-    abstract_variables_map::abstract_variables_map(const abstract_variables_map* next)
+    abstract_variables_map::abstract_variables_map(abstract_variables_map const* next)
       : m_next(next)
     {
     }
 
-    const variable_value& abstract_variables_map::operator[](const std::string& name) const
+    variable_value const& abstract_variables_map::operator[](std::string const& name) const
     {
-        const variable_value& v = get(name);
+        variable_value const& v = get(name);
         if (v.empty() && m_next)
             return (*m_next)[name];
         else if (v.defaulted() && m_next)
         {
-            const variable_value& v2 = (*m_next)[name];
+            variable_value const& v2 = (*m_next)[name];
             if (!v2.empty() && !v2.defaulted())
                 return v2;
             else
@@ -170,7 +170,7 @@ namespace pika::program_options {
 
     variables_map::variables_map() {}
 
-    variables_map::variables_map(const abstract_variables_map* next)
+    variables_map::variables_map(abstract_variables_map const* next)
       : abstract_variables_map(next)
     {
     }
@@ -182,7 +182,7 @@ namespace pika::program_options {
         m_required.clear();
     }
 
-    const variable_value& variables_map::get(const std::string& name) const
+    variable_value const& variables_map::get(std::string const& name) const
     {
         static variable_value empty;
         const_iterator i = this->find(name);
@@ -197,8 +197,8 @@ namespace pika::program_options {
         // This checks if all required options occur
         for (map<string, string>::const_iterator r = m_required.begin(); r != m_required.end(); ++r)
         {
-            const string& opt = r->first;
-            const string& display_opt = r->second;
+            string const& opt = r->first;
+            string const& display_opt = r->second;
             map<string, variable_value>::const_iterator iter = find(opt);
             if (iter == end() || iter->second.empty()) { throw required_option(display_opt); }
         }

--- a/libs/pika/program_options/src/winmain.cpp
+++ b/libs/pika/program_options/src/winmain.cpp
@@ -25,7 +25,7 @@ namespace pika { namespace program_options {
         //    http://article.gmane.org/gmane.comp.lib.boost.user/3005
         //    http://msdn.microsoft.com/library/en-us/vccelng/htm/progs_12.asp
         PIKA_EXPORT
-        std::vector<std::string> split_winmain(const std::string& input)
+        std::vector<std::string> split_winmain(std::string const& input)
         {
             std::vector<std::string> result;
 
@@ -95,11 +95,11 @@ namespace pika { namespace program_options {
             return result;
         }
 
-        std::vector<std::wstring> split_winmain(const std::wstring& cmdline)
+        std::vector<std::wstring> split_winmain(std::wstring const& cmdline)
         {
             std::vector<std::wstring> result;
             std::vector<std::string> aux = split_winmain(to_internal(cmdline));
-            for (const auto& i : aux) result.push_back(from_utf8(i));
+            for (auto const& i : aux) result.push_back(from_utf8(i));
             return result;
         }
 

--- a/libs/pika/program_options/tests/unit/cmdline.cpp
+++ b/libs/pika/program_options/tests/unit/cmdline.cpp
@@ -30,15 +30,15 @@ using namespace std;
    we'd have to specify the type of exception that should be thrown.
 */
 
-const int s_success = 0;
-const int s_unknown_option = 1;
-const int s_ambiguous_option = 2;
+int const s_success = 0;
+int const s_unknown_option = 1;
+int const s_ambiguous_option = 2;
 // const int s_long_not_allowed = 3;
 // const int s_long_adjacent_not_allowed = 4;
 // const int s_short_adjacent_not_allowed = 5;
-const int s_empty_adjacent_parameter = 6;
-const int s_missing_parameter = 7;
-const int s_extra_parameter = 8;
+int const s_empty_adjacent_parameter = 6;
+int const s_missing_parameter = 7;
+int const s_extra_parameter = 8;
 // const int s_unrecognized_line = 9;
 
 int translate_syntax_error_kind(invalid_command_line_syntax::kind_t k)
@@ -60,9 +60,9 @@ int translate_syntax_error_kind(invalid_command_line_syntax::kind_t k)
 
 struct test_case
 {
-    const char* input;
+    char const* input;
     int expected_status;
-    const char* expected_result;
+    char const* expected_result;
 };
 
 /* Parses the syntax description in 'syntax' and initialized
@@ -70,7 +70,7 @@ struct test_case
    The "pika::program_options" in parameter type is needed because CW9
    has std::detail and it causes an ambiguity.
 */
-void apply_syntax(options_description& desc, const char* syntax)
+void apply_syntax(options_description& desc, char const* syntax)
 {
     string s;
     stringstream ss;
@@ -104,7 +104,7 @@ void apply_syntax(options_description& desc, const char* syntax)
     }
 }
 
-void test_cmdline(const char* syntax, command_line_style::style_t style, const test_case* cases)
+void test_cmdline(char const* syntax, command_line_style::style_t style, test_case const* cases)
 {
     for (int i = 0; cases[i].input; ++i)
     {

--- a/libs/pika/program_options/tests/unit/optional.cpp
+++ b/libs/pika/program_options/tests/unit/optional.cpp
@@ -14,7 +14,7 @@
 
 namespace po = pika::program_options;
 
-std::vector<std::string> sv(const char* array[], unsigned size)
+std::vector<std::string> sv(char const* array[], unsigned size)
 {
     std::vector<std::string> r;
     for (unsigned i = 0; i < size; ++i) r.emplace_back(array[i]);
@@ -34,8 +34,8 @@ void test_optional()
         ;
     // clang-format on
 
-    const char* cmdline1_[] = {"--foo=12", "--bar", "1"};
-    std::vector<std::string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(const char*));
+    char const* cmdline1_[] = {"--foo=12", "--bar", "1"};
+    std::vector<std::string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(char const*));
 
     po::variables_map vm;
     po::store(po::command_line_parser(cmdline1).options(desc).run(), vm);

--- a/libs/pika/program_options/tests/unit/options_exception.cpp
+++ b/libs/pika/program_options/tests/unit/options_exception.cpp
@@ -31,13 +31,13 @@ void test_ambiguous()
         ("output,o", value<string>(), "the output file");
     // clang-format on
 
-    const char* cmdline[] = {"program", "-c", "file", "-o", "anotherfile"};
+    char const* cmdline[] = {"program", "-c", "file", "-o", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
     }
     catch (ambiguous_option& e)
@@ -58,13 +58,13 @@ void test_ambiguous_long()
         ("output,o", value<string>(), "the output file");
     // clang-format on
 
-    const char* cmdline[] = {"program", "--cfgfile", "file", "--output", "anotherfile"};
+    char const* cmdline[] = {"program", "--cfgfile", "file", "--output", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
     }
     catch (ambiguous_option& e)
@@ -86,13 +86,13 @@ void test_ambiguous_multiple_long_names()
         ("output,foo,o", value<string>(), "the output file");
     // clang-format on
 
-    const char* cmdline[] = {"program", "--foo", "file"};
+    char const* cmdline[] = {"program", "--foo", "file"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
     }
     catch (ambiguous_option& e)
@@ -109,13 +109,13 @@ void test_unknown_option()
     options_description desc;
     desc.add_options()("cfgfile,c", value<string>(), "the configfile");
 
-    const char* cmdline[] = {"program", "-c", "file", "-f", "anotherfile"};
+    char const* cmdline[] = {"program", "-c", "file", "-f", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
     }
     catch (unknown_option& e)
@@ -131,14 +131,14 @@ void test_multiple_values()
     desc.add_options()("cfgfile,c", value<string>()->multitoken(), "the config file")(
         "output,o", value<string>(), "the output file");
 
-    const char* cmdline[] = {
+    char const* cmdline[] = {
         "program", "-o", "fritz", "hugo", "--cfgfile", "file", "c", "-o", "text.out"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
         notify(vm);
     }
@@ -162,13 +162,13 @@ void test_multiple_occurrences()
     options_description desc;
     desc.add_options()("cfgfile,c", value<string>(), "the configfile");
 
-    const char* cmdline[] = {"program", "--cfgfile", "file", "-c", "anotherfile"};
+    char const* cmdline[] = {"program", "--cfgfile", "file", "-c", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
         notify(vm);
     }
@@ -184,13 +184,13 @@ void test_multiple_occurrences_with_different_names()
     options_description desc;
     desc.add_options()("cfgfile,config-file,c", value<string>(), "the configfile");
 
-    const char* cmdline[] = {"program", "--config-file", "file", "--cfgfile", "anotherfile"};
+    char const* cmdline[] = {"program", "--config-file", "file", "--cfgfile", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
         notify(vm);
     }
@@ -207,13 +207,13 @@ void test_multiple_occurrences_with_non_key_names()
     options_description desc;
     desc.add_options()("cfgfile,config-file,c", value<string>(), "the configfile");
 
-    const char* cmdline[] = {"program", "--config-file", "file", "-c", "anotherfile"};
+    char const* cmdline[] = {"program", "--config-file", "file", "-c", "anotherfile"};
 
     variables_map vm;
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
         notify(vm);
     }
@@ -230,14 +230,14 @@ void test_missing_value()
     desc.add_options()("cfgfile,c", value<string>()->multitoken(), "the config file")(
         "output,o", value<string>(), "the output file");
     // missing value for option '-c'
-    const char* cmdline[] = {"program", "-c", "-c", "output.txt"};
+    char const* cmdline[] = {"program", "-c", "-c", "output.txt"};
 
     variables_map vm;
 
     try
     {
         store(parse_command_line(
-                  sizeof(cmdline) / sizeof(const char*), const_cast<char**>(cmdline), desc),
+                  sizeof(cmdline) / sizeof(char const*), const_cast<char**>(cmdline), desc),
             vm);
         notify(vm);
     }

--- a/libs/pika/program_options/tests/unit/parsers.cpp
+++ b/libs/pika/program_options/tests/unit/parsers.cpp
@@ -28,33 +28,33 @@
 using namespace pika::program_options;
 using namespace std;
 
-pair<string, vector<vector<string>>> msp(const string& s1)
+pair<string, vector<vector<string>>> msp(string const& s1)
 {
     return std::make_pair(s1, vector<vector<string>>());
 }
 
-pair<string, vector<vector<string>>> msp(const string& s1, const string& s2)
+pair<string, vector<vector<string>>> msp(string const& s1, string const& s2)
 {
     vector<vector<string>> v(1);
     v[0].push_back(s2);
     return std::make_pair(s1, v);
 }
 
-void check_value(const option& option, const char* name, const char* value)
+void check_value(option const& option, char const* name, char const* value)
 {
     PIKA_TEST_EQ(option.string_key, name);
     PIKA_TEST_EQ(option.value.size(), std::size_t(1));
     PIKA_TEST_EQ(option.value.front(), value);
 }
 
-vector<string> sv(const char* array[], unsigned size)
+vector<string> sv(char const* array[], unsigned size)
 {
     vector<string> r;
     for (unsigned i = 0; i < size; ++i) r.emplace_back(array[i]);
     return r;
 }
 
-pair<string, string> additional_parser(const std::string&) { return pair<string, string>(); }
+pair<string, string> additional_parser(std::string const&) { return pair<string, string>(); }
 
 namespace command_line {
 
@@ -65,9 +65,9 @@ namespace command_line {
         desc.add_options()("foo,f", new untyped_value(), "")("bar,b", value<std::string>(), "")(
             "car,voiture", new untyped_value())("dog,dawg", new untyped_value())(
             "baz", new untyped_value())("plug*", new untyped_value());
-        const char* cmdline3_[] = {"--foo=12", "-f4", "--bar=11", "-b4", "--voiture=15",
+        char const* cmdline3_[] = {"--foo=12", "-f4", "--bar=11", "-b4", "--voiture=15",
             "--dawg=16", "--dog=17", "--plug3=10"};
-        vector<string> cmdline3 = sv(cmdline3_, sizeof(cmdline3_) / sizeof(const char*));
+        vector<string> cmdline3 = sv(cmdline3_, sizeof(cmdline3_) / sizeof(char const*));
         vector<option> a3 = command_line_parser(cmdline3).options(desc).run().options;
         PIKA_TEST_EQ(a3.size(), 8u);
         check_value(a3[0], "foo", "12");
@@ -82,7 +82,7 @@ namespace command_line {
         // Regression test: check that '0' as style is interpreted as
         // 'default_style'
         vector<option> a4 = parse_command_line(
-            sizeof(cmdline3_) / sizeof(const char*), cmdline3_, desc, 0, additional_parser)
+            sizeof(cmdline3_) / sizeof(char const*), cmdline3_, desc, 0, additional_parser)
                                 .options;
         // The default style is unix-style, where the first argument on the command-line
         // is the name of a binary, not an option value, so that should be ignored
@@ -99,22 +99,22 @@ namespace command_line {
     void test_not_crashing_with_empty_string_values()
     {
         // Check that we don't crash on empty values of type 'string'
-        const char* cmdline4[] = {"", "--open", ""};
+        char const* cmdline4[] = {"", "--open", ""};
         options_description desc2;
         desc2.add_options()("open", value<string>());
         variables_map vm;
         store(parse_command_line(
-                  sizeof(cmdline4) / sizeof(const char*), const_cast<char**>(cmdline4), desc2),
+                  sizeof(cmdline4) / sizeof(char const*), const_cast<char**>(cmdline4), desc2),
             vm);
     }
 
     void test_multitoken()
     {
-        const char* cmdline5[] = {"", "-p7", "-o", "1", "2", "3", "-x8"};
+        char const* cmdline5[] = {"", "-p7", "-o", "1", "2", "3", "-x8"};
         options_description desc3;
         desc3.add_options()(",p", value<string>())(",o", value<string>()->multitoken())(
             ",x", value<string>());
-        vector<option> a5 = parse_command_line(sizeof(cmdline5) / sizeof(const char*),
+        vector<option> a5 = parse_command_line(sizeof(cmdline5) / sizeof(char const*),
             const_cast<char**>(cmdline5), desc3, 0, additional_parser)
                                 .options;
         PIKA_TEST_EQ(a5.size(), 3u);
@@ -130,13 +130,13 @@ namespace command_line {
     void test_multitoken_and_multiname()
     {
         // the long_names() API function was introduced in Boost V1.68
-        const char* cmdline[] = {
+        char const* cmdline[] = {
             "program", "-fone", "-b", "two", "--foo", "three", "four", "-zfive", "--fee", "six"};
         options_description desc;
         desc.add_options()("bar,b", value<string>())("foo,fee,f", value<string>()->multitoken())(
             "fizbaz,baz,z", value<string>());
 
-        vector<option> parsed_options = parse_command_line(sizeof(cmdline) / sizeof(const char*),
+        vector<option> parsed_options = parse_command_line(sizeof(cmdline) / sizeof(char const*),
             const_cast<char**>(cmdline), desc, 0, additional_parser)
                                             .options;
 
@@ -150,10 +150,10 @@ namespace command_line {
         check_value(parsed_options[3], "fizbaz", "five");
         check_value(parsed_options[4], "foo", "six");
 
-        const char* cmdline_2[] = {
+        char const* cmdline_2[] = {
             "program", "-fone", "-b", "two", "--fee", "three", "four", "-zfive", "--foo", "six"};
 
-        parsed_options = parse_command_line(sizeof(cmdline_2) / sizeof(const char*),
+        parsed_options = parse_command_line(sizeof(cmdline_2) / sizeof(char const*),
             const_cast<char**>(cmdline_2), desc, 0, additional_parser)
                              .options;
 
@@ -177,9 +177,9 @@ namespace command_line {
             "values")("file", value<std::string>(), "the file to process");
         positional_options_description p;
         p.add("file", 1);
-        const char* cmdline6[] = {"", "-m", "token1", "token2", "--", "some_file"};
+        char const* cmdline6[] = {"", "-m", "token1", "token2", "--", "some_file"};
         vector<option> a6 = command_line_parser(
-            sizeof(cmdline6) / sizeof(const char*), const_cast<char**>(cmdline6))
+            sizeof(cmdline6) / sizeof(char const*), const_cast<char**>(cmdline6))
                                 .options(desc4)
                                 .positional(p)
                                 .run()
@@ -206,7 +206,7 @@ void test_command_line()
     command_line::test_multitoken_and_multiname();
 }
 
-void test_config_file(const char* config_file)
+void test_config_file(char const* config_file)
 {
     // the long_names() API function was introduced in Boost V1.68
     options_description desc;
@@ -214,7 +214,7 @@ void test_config_file(const char* config_file)
         "empty_value", new untyped_value)("plug*", new untyped_value)("m1.v1", new untyped_value)(
         "m1.v2", new untyped_value)("m1.v3,alias3", new untyped_value)("b", bool_switch());
 
-    const char content1[] = " gv1 = 0#asd\n"
+    char const content1[] = " gv1 = 0#asd\n"
                             "empty_value = \n"
                             "plug3 = 7\n"
                             "b = true\n"
@@ -272,8 +272,8 @@ void test_unregistered()
 {
     options_description desc;
 
-    const char* cmdline1_[] = {"--foo=12", "--bar", "1"};
-    vector<string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(const char*));
+    char const* cmdline1_[] = {"--foo=12", "--bar", "1"};
+    vector<string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(char const*));
     vector<option> a1 =
         command_line_parser(cmdline1).options(desc).allow_unregistered().run().options;
 
@@ -299,7 +299,7 @@ void test_unregistered()
 
     PIKA_TEST_EQ(vm.size(), 0u);
 
-    const char content1[] = "gv1 = 0\n"
+    char const content1[] = "gv1 = 0\n"
                             "[m1]\n"
                             "v1 = 1\n";
 

--- a/libs/pika/program_options/tests/unit/required.cpp
+++ b/libs/pika/program_options/tests/unit/required.cpp
@@ -65,7 +65,7 @@ void required_throw_test()
     }
 }
 
-void simple_required_test(const char* config_file)
+void simple_required_test(char const* config_file)
 {
     options_description opts;
     // clang-format off

--- a/libs/pika/program_options/tests/unit/split.cpp
+++ b/libs/pika/program_options/tests/unit/split.cpp
@@ -19,11 +19,11 @@
 using namespace pika::program_options;
 using namespace std;
 
-void check_value(const string& option, const string& value) { PIKA_TEST_EQ(option, value); }
+void check_value(string const& option, string const& value) { PIKA_TEST_EQ(option, value); }
 
-void split_whitespace(const options_description& description)
+void split_whitespace(options_description const& description)
 {
-    const char* cmdline = "prg --input input.txt \r --optimization 4  \t  --opt \n  option";
+    char const* cmdline = "prg --input input.txt \r --optimization 4  \t  --opt \n  option";
 
     vector<string> tokens = split_unix(cmdline, " \t\n\r");
 
@@ -42,9 +42,9 @@ void split_whitespace(const options_description& description)
     notify(vm);
 }
 
-void split_equalsign(const options_description& description)
+void split_equalsign(options_description const& description)
 {
-    const char* cmdline = "prg --input=input.txt  --optimization=4 --opt=option";
+    char const* cmdline = "prg --input=input.txt  --optimization=4 --opt=option";
 
     vector<string> tokens = split_unix(cmdline, "= ");
 
@@ -62,9 +62,9 @@ void split_equalsign(const options_description& description)
     notify(vm);
 }
 
-void split_semi(const options_description& description)
+void split_semi(options_description const& description)
 {
-    const char* cmdline = "prg;--input input.txt;--optimization 4;--opt option";
+    char const* cmdline = "prg;--input input.txt;--optimization 4;--opt option";
 
     vector<string> tokens = split_unix(cmdline, "; ");
 
@@ -82,9 +82,9 @@ void split_semi(const options_description& description)
     notify(vm);
 }
 
-void split_quotes(const options_description& description)
+void split_quotes(options_description const& description)
 {
-    const char* cmdline =
+    char const* cmdline =
         R"(prg --input "input.txt input.txt" --optimization 4 --opt "option1 option2")";
 
     vector<string> tokens = split_unix(cmdline, " ");
@@ -103,9 +103,9 @@ void split_quotes(const options_description& description)
     notify(vm);
 }
 
-void split_escape(const options_description& description)
+void split_escape(options_description const& description)
 {
-    const char* cmdline =
+    char const* cmdline =
         R"(prg --input \"input.txt\" --optimization 4 --opt \"option1\ option2\")";
 
     vector<string> tokens = split_unix(cmdline, " ");
@@ -124,9 +124,9 @@ void split_escape(const options_description& description)
     notify(vm);
 }
 
-void split_single_quote(const options_description& description)
+void split_single_quote(options_description const& description)
 {
-    const char* cmdline =
+    char const* cmdline =
         "prg --input 'input.txt input.txt' --optimization 4 --opt 'option1 option2'";
 
     vector<string> tokens = split_unix(cmdline, " ", "'");
@@ -145,9 +145,9 @@ void split_single_quote(const options_description& description)
     notify(vm);
 }
 
-void split_defaults(const options_description& description)
+void split_defaults(options_description const& description)
 {
-    const char* cmdline =
+    char const* cmdline =
         "prg --input \t \'input file.txt\' \t   --optimization 4 --opt \\\"option1\\ option2\\\"";
 
     vector<string> tokens = split_unix(cmdline);

--- a/libs/pika/program_options/tests/unit/unicode.cpp
+++ b/libs/pika/program_options/tests/unit/unicode.cpp
@@ -82,14 +82,14 @@ void test_native_to_unicode()
     PIKA_TEST(vm["foo"].as<wstring>() == L"\x044F");
 }
 
-vector<wstring> sv(const wchar_t* array[], unsigned size)
+vector<wstring> sv(wchar_t const* array[], unsigned size)
 {
     vector<wstring> r;
     for (unsigned i = 0; i < size; ++i) r.emplace_back(array[i]);
     return r;
 }
 
-void check_value(const woption& option, const char* name, const wchar_t* value)
+void check_value(woption const& option, char const* name, wchar_t const* value)
 {
     PIKA_TEST_EQ(option.string_key, name);
     PIKA_TEST_EQ(option.value.size(), std::size_t(1));
@@ -105,7 +105,7 @@ void test_command_line()
         ("bar,b", value<std::string>(), "")("baz", new untyped_value())(
             "qux,plug*", new untyped_value());
 
-    const wchar_t* cmdline4_[] = {L"--foo=1\u0FF52", L"-f4", L"--bar=11", L"-b4", L"--plug3=10"};
+    wchar_t const* cmdline4_[] = {L"--foo=1\u0FF52", L"-f4", L"--bar=11", L"-b4", L"--plug3=10"};
     vector<wstring> cmdline4 = sv(cmdline4_, sizeof(cmdline4_) / sizeof(cmdline4_[0]));
     vector<woption> a4 = wcommand_line_parser(cmdline4).options(desc).run().options;
 

--- a/libs/pika/program_options/tests/unit/variable_map.cpp
+++ b/libs/pika/program_options/tests/unit/variable_map.cpp
@@ -28,7 +28,7 @@
 using namespace pika::program_options;
 using namespace std;
 
-vector<string> sv(const char* array[], unsigned size)
+vector<string> sv(char const* array[], unsigned size)
 {
     vector<string> r;
     for (unsigned i = 0; i < size; ++i) r.emplace_back(array[i]);
@@ -48,8 +48,8 @@ void test_variable_map()
         ;
     // clang-format on
 
-    const char* cmdline3_[] = {"--foo='12'", "--bar=11", "-z3", "-ofoo"};
-    vector<string> cmdline3 = sv(cmdline3_, sizeof(cmdline3_) / sizeof(const char*));
+    char const* cmdline3_[] = {"--foo='12'", "--bar=11", "-z3", "-ofoo"};
+    vector<string> cmdline3 = sv(cmdline3_, sizeof(cmdline3_) / sizeof(char const*));
     parsed_options a3 = command_line_parser(cmdline3).options(desc).run();
 
     variables_map vm;
@@ -71,8 +71,8 @@ void test_variable_map()
         ;
     // clang-format on
 
-    const char* cmdline4_[] = {"--zee", "--zak=13"};
-    vector<string> cmdline4 = sv(cmdline4_, sizeof(cmdline4_) / sizeof(const char*));
+    char const* cmdline4_[] = {"--zee", "--zak=13"};
+    vector<string> cmdline4 = sv(cmdline4_, sizeof(cmdline4_) / sizeof(char const*));
     parsed_options a4 = command_line_parser(cmdline4).options(desc).run();
 
     variables_map vm2;
@@ -93,8 +93,8 @@ void test_variable_map()
         ;
     // clang-format on
 
-    const char* cmdline5_[] = {"--voo=1"};
-    vector<string> cmdline5 = sv(cmdline5_, sizeof(cmdline5_) / sizeof(const char*));
+    char const* cmdline5_[] = {"--voo=1"};
+    vector<string> cmdline5 = sv(cmdline5_, sizeof(cmdline5_) / sizeof(char const*));
     parsed_options a5 = command_line_parser(cmdline5).options(desc2).run();
 
     variables_map vm3;
@@ -117,8 +117,8 @@ void test_variable_map()
 
     /* The -m option is implicit. It does not have value in inside the token,
        and we should not grab the next token.  */
-    const char* cmdline6_[] = {"--imp=1", "-m", "--foo=1"};
-    vector<string> cmdline6 = sv(cmdline6_, sizeof(cmdline6_) / sizeof(const char*));
+    char const* cmdline6_[] = {"--imp=1", "-m", "--foo=1"};
+    vector<string> cmdline6 = sv(cmdline6_, sizeof(cmdline6_) / sizeof(char const*));
     parsed_options a6 = command_line_parser(cmdline6).options(desc3).run();
 
     variables_map vm4;
@@ -132,7 +132,7 @@ void test_variable_map()
 
 int stored_value;
 
-void notifier(const vector<int>& v) { stored_value = v.front(); }
+void notifier(vector<int> const& v) { stored_value = v.front(); }
 
 void test_semantic_values()
 {
@@ -164,8 +164,8 @@ void test_semantic_values()
     notify(vm);
     PIKA_TEST_EQ(vm.count("biz"), std::size_t(1));
     PIKA_TEST_EQ(vm.count("baz"), std::size_t(1));
-    const vector<string> av = vm["biz"].as<vector<string>>();
-    const vector<string> av2 = vm["baz"].as<vector<string>>();
+    vector<string> const av = vm["biz"].as<vector<string>>();
+    vector<string> const av2 = vm["baz"].as<vector<string>>();
     string exp1[] = {"a", "b x"};
     PIKA_TEST(av == vector<string>(exp1, exp1 + 2));
     string exp2[] = {"q", "q", "w"};
@@ -208,13 +208,13 @@ void test_priority()
         // This will have values in both sources, and values should be combined
         ("include", value<vector<int>>()->composing());
 
-    const char* cmdline1_[] = {"--first=1", "--aux=10", "--first=3", "--include=1"};
-    vector<string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(const char*));
+    char const* cmdline1_[] = {"--first=1", "--aux=10", "--first=3", "--include=1"};
+    vector<string> cmdline1 = sv(cmdline1_, sizeof(cmdline1_) / sizeof(char const*));
 
     parsed_options p1 = command_line_parser(cmdline1).options(desc).run();
 
-    const char* cmdline2_[] = {"--first=12", "--second=7", "--include=7"};
-    vector<string> cmdline2 = sv(cmdline2_, sizeof(cmdline2_) / sizeof(const char*));
+    char const* cmdline2_[] = {"--first=12", "--second=7", "--include=7"};
+    vector<string> cmdline2 = sv(cmdline2_, sizeof(cmdline2_) / sizeof(char const*));
 
     parsed_options p2 = command_line_parser(cmdline2).options(desc).run();
 

--- a/libs/pika/program_options/tests/unit/winmain.cpp
+++ b/libs/pika/program_options/tests/unit/winmain.cpp
@@ -19,7 +19,7 @@
 using namespace pika::program_options;
 using namespace std;
 
-void check_equal(const std::vector<string>& actual, char const** expected, int n)
+void check_equal(std::vector<string> const& actual, char const** expected, int n)
 {
     if (actual.size() != n)
     {

--- a/libs/pika/resource_partitioner/examples/system_characteristics.hpp
+++ b/libs/pika/resource_partitioner/examples/system_characteristics.hpp
@@ -22,7 +22,7 @@ void print_system_characteristics()
 
     pika::detail::runtime* rt = pika::detail::get_runtime_ptr();
     pika::util::runtime_configuration cfg = rt->get_config();
-    const pika::threads::detail::topology& topo = rt->get_topology();
+    pika::threads::detail::topology const& topo = rt->get_topology();
 
     // -------------------------------------- //
     //      print runtime characteristics     //

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/detail/partitioner.hpp
@@ -52,7 +52,7 @@ namespace pika::resource::detail {
 
     private:
         init_pool_data(
-            const std::string& name, scheduling_policy policy, pika::threads::scheduler_mode mode);
+            std::string const& name, scheduling_policy policy, pika::threads::scheduler_mode mode);
 
         init_pool_data(std::string const& name, scheduler_function create_func,
             pika::threads::scheduler_mode mode);
@@ -101,15 +101,15 @@ namespace pika::resource::detail {
         }
         void add_resource(pika::resource::pu const& p, std::string const& pool_name, bool exclusive,
             std::size_t num_threads = 1);
-        void add_resource(const std::vector<pika::resource::pu>& pv, std::string const& pool_name,
+        void add_resource(std::vector<pika::resource::pu> const& pv, std::string const& pool_name,
             bool exclusive = true);
         void add_resource(
-            const pika::resource::core& c, std::string const& pool_name, bool exclusive = true);
-        void add_resource(const std::vector<pika::resource::core>& cv, std::string const& pool_name,
+            pika::resource::core const& c, std::string const& pool_name, bool exclusive = true);
+        void add_resource(std::vector<pika::resource::core> const& cv, std::string const& pool_name,
             bool exclusive = true);
         void add_resource(
-            const pika::resource::socket& nd, std::string const& pool_name, bool exclusive = true);
-        void add_resource(const std::vector<pika::resource::socket>& ndv,
+            pika::resource::socket const& nd, std::string const& pool_name, bool exclusive = true);
+        void add_resource(std::vector<pika::resource::socket> const& ndv,
             std::string const& pool_name, bool exclusive = true);
 
         pika::detail::affinity_data const& get_affinity_data() const { return affinity_data_; }
@@ -164,12 +164,12 @@ namespace pika::resource::detail {
         std::size_t expand_pool(
             std::string const& pool_name, util::detail::function<void(std::size_t)> const& add_pu);
 
-        void set_default_pool_name(const std::string& name)
+        void set_default_pool_name(std::string const& name)
         {
             initial_thread_pools_[0].pool_name_ = name;
         }
 
-        const std::string& get_default_pool_name() const
+        std::string const& get_default_pool_name() const
         {
             return initial_thread_pools_[0].pool_name_;
         }

--- a/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
+++ b/libs/pika/resource_partitioner/include/pika/resource_partitioner/partitioner.hpp
@@ -136,7 +136,7 @@ namespace pika::resource {
         // allow the default pool to be renamed to something else
         PIKA_EXPORT void set_default_pool_name(std::string const& name);
 
-        PIKA_EXPORT const std::string& get_default_pool_name() const;
+        PIKA_EXPORT std::string const& get_default_pool_name() const;
 
         ///////////////////////////////////////////////////////////////////////
         // Functions to add processing units to thread pools via

--- a/libs/pika/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/detail_partitioner.cpp
@@ -650,7 +650,7 @@ namespace pika::resource::detail {
     void partitioner::add_resource(
         std::vector<core> const& cv, std::string const& pool_name, bool exclusive)
     {
-        for (const core& c : cv) { add_resource(c.pus_, pool_name, exclusive); }
+        for (core const& c : cv) { add_resource(c.pus_, pool_name, exclusive); }
     }
 
     void partitioner::add_resource(socket const& nd, std::string const& pool_name, bool exclusive)
@@ -661,7 +661,7 @@ namespace pika::resource::detail {
     void partitioner::add_resource(
         std::vector<socket> const& ndv, std::string const& pool_name, bool exclusive)
     {
-        for (const socket& d : ndv) { add_resource(d, pool_name, exclusive); }
+        for (socket const& d : ndv) { add_resource(d, pool_name, exclusive); }
     }
 
     void partitioner::set_scheduler(scheduling_policy sched, std::string const& pool_name)
@@ -732,7 +732,7 @@ namespace pika::resource::detail {
         return get_pool_data(l, pool_index).num_threads_;
     }
 
-    std::size_t partitioner::get_num_threads(const std::string& pool_name) const
+    std::size_t partitioner::get_num_threads(std::string const& pool_name) const
     {
         std::unique_lock<mutex_type> l(mtx_);
         return get_pool_data(l, pool_name).num_threads_;

--- a/libs/pika/resource_partitioner/src/partitioner.cpp
+++ b/libs/pika/resource_partitioner/src/partitioner.cpp
@@ -145,7 +145,7 @@ namespace pika::resource {
         partitioner_.set_default_pool_name(name);
     }
 
-    const std::string& partitioner::get_default_pool_name() const
+    std::string const& partitioner::get_default_pool_name() const
     {
         return partitioner_.get_default_pool_name();
     }

--- a/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -76,13 +76,13 @@ int pika_main(variables_map& vm)
     // randomly create normal priority tasks
     // and then a set of HP tasks in periodic bursts
     // Use task plotting tools to validate that scheduling is correct
-    const int np_loop = vm["nnp"].as<int>();
-    const int hp_loop = vm["nhp"].as<int>();
-    const int np_m = vm["mnp"].as<int>();
-    const int hp_m = vm["mhp"].as<int>();
-    const int cycles = vm["cycles"].as<int>();
+    int const np_loop = vm["nnp"].as<int>();
+    int const hp_loop = vm["nhp"].as<int>();
+    int const np_m = vm["mnp"].as<int>();
+    int const hp_m = vm["mhp"].as<int>();
+    int const cycles = vm["cycles"].as<int>();
 
-    const int np_total = np_loop * cycles;
+    int const np_total = np_loop * cycles;
     //
     struct dec_counter
     {

--- a/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime_handlers.hpp
@@ -18,7 +18,7 @@
 
 namespace pika::detail {
     [[noreturn]] PIKA_EXPORT void assertion_handler(
-        pika::detail::source_location const& loc, const char* expr, std::string const& msg);
+        pika::detail::source_location const& loc, char const* expr, std::string const& msg);
 #if defined(PIKA_HAVE_VERIFY_LOCKS)
     PIKA_EXPORT void registered_locks_error_handler();
     PIKA_EXPORT bool register_locks_predicate();

--- a/libs/pika/runtime/src/runtime_handlers.cpp
+++ b/libs/pika/runtime/src/runtime_handlers.cpp
@@ -29,7 +29,7 @@
 namespace pika::detail {
 
     [[noreturn]] void assertion_handler(
-        pika::detail::source_location const& loc, const char* expr, std::string const& msg)
+        pika::detail::source_location const& loc, char const* expr, std::string const& msg)
     {
         static thread_local bool handling_assertion = false;
 

--- a/libs/pika/runtime/src/thread_stacktrace.cpp
+++ b/libs/pika/runtime/src/thread_stacktrace.cpp
@@ -63,7 +63,7 @@ namespace pika::detail {
         std::stringstream tmp;
         //
         int count = 0;
-        for (const auto& data : tlist)
+        for (auto const& data : tlist)
         {
             fmt::print(tmp, "Stack trace {} : {:#012x} : \n{}\n\n\n", count,
                 reinterpret_cast<uintptr_t>(data),

--- a/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/queue_holder_thread.hpp
@@ -154,13 +154,13 @@ namespace pika::threads::detail {
         // ------------------------------------------------------------
         struct queue_mc_print
         {
-            const QueueType* const q_;
-            explicit queue_mc_print(const QueueType* const q)
+            QueueType const* const q_;
+            explicit queue_mc_print(QueueType const* const q)
               : q_(q)
             {
             }
             //
-            friend std::ostream& operator<<(std::ostream& os, const queue_mc_print& d)
+            friend std::ostream& operator<<(std::ostream& os, queue_mc_print const& d)
             {
                 os << "n " << debug::detail::dec<3>(d.q_->new_tasks_count_.data_) << " w "
                    << debug::detail::dec<3>(d.q_->work_items_count_.data_);
@@ -170,13 +170,13 @@ namespace pika::threads::detail {
 
         struct queue_data_print
         {
-            const queue_holder_thread* q_;
-            explicit queue_data_print(const queue_holder_thread* q)
+            queue_holder_thread const* q_;
+            explicit queue_data_print(queue_holder_thread const* q)
               : q_(q)
             {
             }
             //
-            friend std::ostream& operator<<(std::ostream& os, const queue_data_print& d)
+            friend std::ostream& operator<<(std::ostream& os, queue_data_print const& d)
             {
                 os << "D " << debug::detail::dec<2>(d.q_->domain_index_) << " Q "
                    << debug::detail::dec<3>(d.q_->queue_index_) << " TM "
@@ -199,7 +199,7 @@ namespace pika::threads::detail {
         // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         queue_holder_thread(QueueType* bp_queue, QueueType* hp_queue, QueueType* np_queue,
             QueueType* lp_queue, std::size_t domain, std::size_t queue, std::size_t thread_num,
-            std::size_t owner, const thread_queue_init_parameters& init, std::thread::id owner_id)
+            std::size_t owner, thread_queue_init_parameters const& init, std::thread::id owner_id)
           // NOLINTEND(bugprone-easily-swappable-parameters)
           : bp_queue_(bp_queue)
           , hp_queue_(hp_queue)
@@ -937,7 +937,7 @@ namespace pika::threads::detail {
         }
 
         // ------------------------------------------------------------
-        void debug_queues(const char* prefix)
+        void debug_queues(char const* prefix)
         {
             static auto deb_queues =
                 ::pika::detail::tq_deb.make_timer(1, debug::detail::str<>("debug_queues"));

--- a/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/shared_priority_queue_scheduler.hpp
@@ -105,9 +105,9 @@ namespace pika::threads::detail {
 
         struct init_parameter
         {
-            init_parameter(std::size_t num_worker_threads, const core_ratios& cores_per_queue,
+            init_parameter(std::size_t num_worker_threads, core_ratios const& cores_per_queue,
                 pika::detail::affinity_data const& affinity_data,
-                const thread_queue_init_parameters& thread_queue_init,
+                thread_queue_init_parameters const& thread_queue_init,
                 char const* description = "shared_priority_queue_scheduler")
               : num_worker_threads_(num_worker_threads)
               , cores_per_queue_(cores_per_queue)
@@ -117,7 +117,7 @@ namespace pika::threads::detail {
             {
             }
 
-            init_parameter(std::size_t num_worker_threads, const core_ratios& cores_per_queue,
+            init_parameter(std::size_t num_worker_threads, core_ratios const& cores_per_queue,
                 pika::detail::affinity_data const& affinity_data, char const* description)
               : num_worker_threads_(num_worker_threads)
               , cores_per_queue_(cores_per_queue)
@@ -287,7 +287,7 @@ namespace pika::threads::detail {
             std::size_t domain_num;
             std::size_t q_index;
 
-            [[maybe_unused]] const char* msg = nullptr;
+            [[maybe_unused]] char const* msg = nullptr;
 
             std::unique_lock<pu_mutex_type> l;
 
@@ -424,7 +424,7 @@ namespace pika::threads::detail {
         template <typename T>
         // NOLINTBEGIN(bugprone-easily-swappable-parameters)
         bool steal_by_function(std::size_t domain, std::size_t q_index, bool steal_numa,
-            bool steal_core, thread_holder_type* origin, T& var, const char* prefix,
+            bool steal_core, thread_holder_type* origin, T& var, char const* prefix,
             util::detail::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation_HP,
@@ -677,7 +677,7 @@ namespace pika::threads::detail {
             std::size_t q_index = std::size_t(-1);
 
             std::unique_lock<pu_mutex_type> l;
-            [[maybe_unused]] const char* msg;
+            [[maybe_unused]] char const* msg;
 
             using execution::thread_schedule_hint_mode;
 
@@ -996,7 +996,7 @@ namespace pika::threads::detail {
             // worker threads and assign them into groups based on locality
             // even if the thread numbering is arbitrary
             std::sort(locations.begin(), locations.end(),
-                [](const dcp_tuple& a, const dcp_tuple& b) -> bool {
+                [](dcp_tuple const& a, dcp_tuple const& b) -> bool {
                     return (std::get<0>(a) == std::get<0>(b)) ?
                         ((std::get<1>(a) == std::get<1>(b)) ? (std::get<2>(a) < std::get<2>(b)) :
                                                               (std::get<1>(a) < std::get<1>(b))) :

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue_mc.hpp
@@ -115,7 +115,7 @@ namespace pika::threads::detail {
 
     public:
         explicit thread_queue_mc(
-            const thread_queue_init_parameters& parameters, std::size_t queue_num = std::size_t(-1))
+            thread_queue_init_parameters const& parameters, std::size_t queue_num = std::size_t(-1))
           : parameters_(parameters)
           , queue_index_(static_cast<int>(queue_num))
           , holder_(nullptr)

--- a/libs/pika/string_util/include/pika/string_util/bad_lexical_cast.hpp
+++ b/libs/pika/string_util/include/pika/string_util/bad_lexical_cast.hpp
@@ -22,7 +22,7 @@ namespace pika::detail {
         {
         }
 
-        const char* what() const noexcept override;
+        char const* what() const noexcept override;
 
         virtual ~bad_lexical_cast() noexcept;
 

--- a/libs/pika/string_util/src/bad_lexical_cast.cpp
+++ b/libs/pika/string_util/src/bad_lexical_cast.cpp
@@ -9,7 +9,7 @@
 #include <typeinfo>
 
 namespace pika::detail {
-    const char* bad_lexical_cast::what() const noexcept
+    char const* bad_lexical_cast::what() const noexcept
     {
         return "bad lexical cast: source type value could not be interpreted as target";
     }

--- a/libs/pika/string_util/tests/unit/string_split.cpp
+++ b/libs/pika/string_util/tests/unit/string_split.cpp
@@ -20,7 +20,7 @@ int main()
     std::string str2("Xx-abc--xX-abb-xx");
     std::string str3("xx");
     std::string strempty("");
-    const char* pch1 = "xx-abc--xx-abb";
+    char const* pch1 = "xx-abc--xx-abb";
     std::vector<std::string> tokens;
 
     // split tests

--- a/libs/pika/synchronization/src/stop_token.cpp
+++ b/libs/pika/synchronization/src/stop_token.cpp
@@ -247,7 +247,7 @@ namespace pika::detail {
             auto* cb = callbacks_;
             callbacks_ = cb->next_;
 
-            const bool more_callbacks = callbacks_ != nullptr;
+            bool const more_callbacks = callbacks_ != nullptr;
             if (more_callbacks) callbacks_->prev_ = &callbacks_;
 
             // Mark this item as removed from the list.

--- a/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/pika/synchronization/tests/unit/async_rw_mutex.cpp
@@ -64,7 +64,7 @@ public:
 // from the async_rw_mutex senders.
 struct checker
 {
-    const bool expect_readonly;
+    bool const expect_readonly;
     const std::size_t expected_predecessor_value;
     std::atomic<std::size_t>& count;
     const std::size_t count_min;

--- a/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
+++ b/libs/pika/thread_manager/include/pika/modules/thread_manager.hpp
@@ -232,7 +232,7 @@ namespace pika::threads::detail {
             return total_used_processing_punits;
         }
 
-        hwloc_bitmap_ptr get_pool_numa_bitmap(const std::string& pool_name) const
+        hwloc_bitmap_ptr get_pool_numa_bitmap(std::string const& pool_name) const
         {
             return get_pool(pool_name).get_numa_domain_bitmap();
         }

--- a/libs/pika/threading/include/pika/threading/thread.hpp
+++ b/libs/pika/threading/include/pika/threading/thread.hpp
@@ -40,7 +40,7 @@ namespace pika {
     class PIKA_EXPORT thread
     {
         using mutex_type = pika::concurrency::detail::spinlock;
-        void terminate(const char* function, const char* reason) const;
+        void terminate(char const* function, char const* reason) const;
 
     public:
         class id;

--- a/libs/pika/threading/tests/unit/condition_variable2.cpp
+++ b/libs/pika/threading/tests/unit/condition_variable2.cpp
@@ -40,7 +40,7 @@ void cv_wait(pika::stop_token stoken, int /* id */, bool& ready, pika::mutex& re
         PIKA_TEST(!stoken.stop_requested());
         PIKA_TEST(notify_called);
     }
-    catch (const char* e)
+    catch (char const* e)
     {
         PIKA_TEST(!notify_called);
     }

--- a/libs/pika/threading/tests/unit/stack_check.cpp
+++ b/libs/pika/threading/tests/unit/stack_check.cpp
@@ -23,7 +23,7 @@
 using info = std::tuple<std::size_t, std::ptrdiff_t, std::ptrdiff_t>;
 using info_stack = std::stack<info>;
 
-void stack_remaining(const char* txt, info_stack& stack)
+void stack_remaining(char const* txt, info_stack& stack)
 {
 #if defined(PIKA_HAVE_THREADS_GET_STACK_POINTER)
     std::size_t stack_ptr = pika::threads::coroutines::detail::get_stack_ptr();

--- a/libs/pika/threading/tests/unit/stop_token_cb1.cpp
+++ b/libs/pika/threading/tests/unit/stop_token_cb1.cpp
@@ -402,7 +402,7 @@ void test_cancellation_single_thread_performance()
 
     auto time3 = end - start;
 
-    auto report = [](const char* label, auto time, std::uint64_t count) {
+    auto report = [](char const* label, auto time, std::uint64_t count) {
         auto ms = std::chrono::duration<double, std::milli>(time).count();
         auto ns = std::chrono::duration<double, std::nano>(time).count();
         std::cout << label << " took " << ms << "ms (" << (ns / static_cast<double>(count))

--- a/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
+++ b/libs/pika/threading_base/include/pika/threading_base/scheduler_base.hpp
@@ -159,7 +159,7 @@ namespace pika::threads::detail {
         // either threads in same domain, or not in same domain
         // depending on the predicate
         std::vector<std::size_t> domain_threads(std::size_t local_id,
-            const std::vector<std::size_t>& ts,
+            std::vector<std::size_t> const& ts,
             util::detail::function<bool(std::size_t, std::size_t)> pred);
 
 #ifdef PIKA_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -385,7 +385,7 @@ struct fmt::formatter<pika::threads::detail::scheduler_base> : fmt::formatter<st
     {
         return fmt::formatter<std::string>::format(
             fmt::format(
-                "{}({})", scheduler.get_description(), static_cast<const void*>(&scheduler)),
+                "{}({})", scheduler.get_description(), static_cast<void const*>(&scheduler)),
             ctx);
     }
 };

--- a/libs/pika/threading_base/src/execution_agent.cpp
+++ b/libs/pika/threading_base/src/execution_agent.cpp
@@ -50,43 +50,43 @@ namespace pika::threads::detail {
         return fmt::format("{}: {}", id, get_thread_id_data(id)->get_description());
     }
 
-    void execution_agent::yield(const char* desc)
+    void execution_agent::yield(char const* desc)
     {
         do_yield(desc, thread_schedule_state::pending);
     }
 
-    void execution_agent::yield_k(std::size_t k, const char* desc)
+    void execution_agent::yield_k(std::size_t k, char const* desc)
     {
         if (k < 16) { PIKA_SMT_PAUSE; }
         else if (k < 32 || k & 1) { do_yield(desc, thread_schedule_state::pending_boost); }
         else { do_yield(desc, thread_schedule_state::pending); }
     }
 
-    void execution_agent::spin_k(std::size_t k, const char*)
+    void execution_agent::spin_k(std::size_t k, char const*)
     {
         for (std::size_t i = 0; i < k; ++i) { PIKA_SMT_PAUSE; }
     }
 
-    void execution_agent::resume(const char* desc)
+    void execution_agent::resume(char const* desc)
     {
         do_resume(desc, thread_restart_state::signaled);
     }
 
-    void execution_agent::abort(const char* desc) { do_resume(desc, thread_restart_state::abort); }
+    void execution_agent::abort(char const* desc) { do_resume(desc, thread_restart_state::abort); }
 
-    void execution_agent::suspend(const char* desc)
+    void execution_agent::suspend(char const* desc)
     {
         do_yield(desc, thread_schedule_state::suspended);
     }
 
     void execution_agent::sleep_for(
-        pika::chrono::steady_duration const& sleep_duration, const char* desc)
+        pika::chrono::steady_duration const& sleep_duration, char const* desc)
     {
         sleep_until(sleep_duration.from_now(), desc);
     }
 
     void execution_agent::sleep_until(
-        pika::chrono::steady_time_point const& sleep_time, const char* desc)
+        pika::chrono::steady_time_point const& sleep_time, char const* desc)
     {
         // Just yield until time has passed by...
         auto now = std::chrono::steady_clock::now();
@@ -121,7 +121,7 @@ namespace pika::threads::detail {
     };
 #endif
 
-    thread_restart_state execution_agent::do_yield(const char* desc, thread_schedule_state state)
+    thread_restart_state execution_agent::do_yield(char const* desc, thread_schedule_state state)
     {
         thread_id_ref_type id = self_.get_thread_id();    // keep alive
         if (PIKA_UNLIKELY(!id))
@@ -177,7 +177,7 @@ namespace pika::threads::detail {
         return statex;
     }
 
-    void execution_agent::do_resume(const char* /* desc */, thread_restart_state statex)
+    void execution_agent::do_resume(char const* /* desc */, thread_restart_state statex)
     {
         auto thrd = self_.get_thread_id();
         set_thread_state(PIKA_MOVE(thrd), thread_schedule_state::pending, statex,

--- a/libs/pika/threading_base/src/print.cpp
+++ b/libs/pika/threading_base/src/print.cpp
@@ -73,7 +73,7 @@ namespace pika::debug::detail {
                     pika::threads::detail::get_self_id_data();
                 os << hex<12, std::uintptr_t>(reinterpret_cast<std::uintptr_t>(dummy)) << " ";
             }
-            const char* pool = "--------";
+            char const* pool = "--------";
             auto tid = pika::threads::detail::get_self_id();
             if (tid != threads::detail::invalid_thread_id)
             {

--- a/libs/pika/topology/include/pika/topology/topology.hpp
+++ b/libs/pika/topology/include/pika/topology/topology.hpp
@@ -188,7 +188,7 @@ namespace pika::threads::detail {
 
         /// \brief Prints the \param m to os in a human readable form
         void print_affinity_mask(std::ostream& os, std::size_t num_thread, mask_cref_type m,
-            const std::string& pool_name) const;
+            std::string const& pool_name) const;
 
         /// \brief Reduce thread priority of the current thread.
         ///
@@ -252,11 +252,11 @@ namespace pika::threads::detail {
             pika_hwloc_membind_policy policy, int flags) const;
 
         threads::detail::mask_type get_area_membind_nodeset(
-            const void* addr, std::size_t len) const;
+            void const* addr, std::size_t len) const;
 
-        bool set_area_membind_nodeset(const void* addr, std::size_t len, void* nodeset) const;
+        bool set_area_membind_nodeset(void const* addr, std::size_t len, void* nodeset) const;
 
-        int get_numa_domain(const void* addr) const;
+        int get_numa_domain(void const* addr) const;
 
         /// Free memory that was previously allocated by allocate
         void deallocate(void* addr, std::size_t len) const;

--- a/libs/pika/topology/src/topology.cpp
+++ b/libs/pika/topology/src/topology.cpp
@@ -901,7 +901,7 @@ namespace pika::threads::detail {
     }
 
     void topology::print_affinity_mask(std::ostream& os, std::size_t num_thread, mask_cref_type m,
-        const std::string& pool_name) const
+        std::string const& pool_name) const
     {
         pika::detail::ios_flags_saver ifs(os);
         bool first = true;
@@ -1300,7 +1300,7 @@ namespace pika::threads::detail {
 #endif
     }
 
-    bool topology::set_area_membind_nodeset(const void* addr, std::size_t len, void* nodeset) const
+    bool topology::set_area_membind_nodeset(void const* addr, std::size_t len, void* nodeset) const
     {
 #if !defined(__APPLE__)
         hwloc_membind_policy_t policy = ::HWLOC_MEMBIND_BIND;
@@ -1341,7 +1341,7 @@ namespace pika::threads::detail {
     }    // namespace
 
     threads::detail::mask_type topology::get_area_membind_nodeset(
-        const void* addr, std::size_t len) const
+        void const* addr, std::size_t len) const
     {
         pika_hwloc_bitmap_wrapper& nodeset = bitmap_storage();
         if (!nodeset) { nodeset.reset(hwloc_bitmap_alloc()); }
@@ -1367,7 +1367,7 @@ namespace pika::threads::detail {
         return bitmap_to_mask(ns, HWLOC_OBJ_NUMANODE);
     }
 
-    int topology::get_numa_domain(const void* addr) const
+    int topology::get_numa_domain(void const* addr) const
     {
 #if HWLOC_API_VERSION >= 0x0001'0b06
         pika_hwloc_bitmap_wrapper& nodeset = bitmap_storage();

--- a/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
+++ b/libs/pika/topology/tests/unit/from_string_cpu_mask.cpp
@@ -40,7 +40,7 @@ void test_valid()
 #endif
     };
 
-    for (const auto& t : tests)
+    for (auto const& t : tests)
     {
         auto mask = pika::detail::from_string<pika::threads::detail::mask_type>(t.str);
 #if defined(PIKA_HAVE_MAX_CPU_COUNT)
@@ -68,7 +68,7 @@ void test_invalid()
     const std::vector<std::string> tests{
         "", "0", "0x", "Ob", "foobar", "x0xff", "0xffg", " 0xabcdefgh\t"};
 
-    for (const auto& t : tests)
+    for (auto const& t : tests)
     {
         try
         {

--- a/libs/pika/type_support/include/pika/type_support/equality.hpp
+++ b/libs/pika/type_support/include/pika/type_support/equality.hpp
@@ -22,9 +22,9 @@ namespace pika::detail {
 
     template <typename T, typename U>
     struct equality_result<T, U,
-        std::void_t<decltype(std::declval<const T&>() == std::declval<const U&>())>>
+        std::void_t<decltype(std::declval<T const&>() == std::declval<U const&>())>>
     {
-        using type = decltype(std::declval<const T&>() == std::declval<const U&>());
+        using type = decltype(std::declval<T const&>() == std::declval<U const&>());
     };
 
     template <typename T, typename U>
@@ -38,9 +38,9 @@ namespace pika::detail {
 
     template <typename T, typename U>
     struct inequality_result<T, U,
-        std::void_t<decltype(std::declval<const T&>() != std::declval<const U&>())>>
+        std::void_t<decltype(std::declval<T const&>() != std::declval<U const&>())>>
     {
-        using type = decltype(std::declval<const T&>() != std::declval<const U&>());
+        using type = decltype(std::declval<T const&>() != std::declval<U const&>());
     };
 
     template <typename T, typename U>

--- a/testing/performance_testing/include/pika/testing/performance.hpp
+++ b/testing/performance_testing/include/pika/testing/performance.hpp
@@ -73,6 +73,6 @@ namespace pika::util {
 
     PIKA_EXPORT void perftests_print_times();
 
-    PIKA_EXPORT void print_cdash_timing(const char* name, double time);
-    PIKA_EXPORT void print_cdash_timing(const char* name, std::uint64_t time);
+    PIKA_EXPORT void print_cdash_timing(char const* name, double time);
+    PIKA_EXPORT void print_cdash_timing(char const* name, std::uint64_t time);
 }    // namespace pika::util

--- a/testing/performance_testing/src/performance.cpp
+++ b/testing/performance_testing/src/performance.cpp
@@ -53,14 +53,14 @@ namespace pika::util {
 
     void perftests_print_times() { std::cout << detail::times(); }
 
-    void print_cdash_timing(const char* name, double time)
+    void print_cdash_timing(char const* name, double time)
     {
         fmt::print(std::cout,
             "<DartMeasurement name=\"{}\" type=\"numeric/double\">{}</DartMeasurement>\n", name,
             time);
     }
 
-    void print_cdash_timing(const char* name, std::uint64_t time)
+    void print_cdash_timing(char const* name, std::uint64_t time)
     {
         print_cdash_timing(name, static_cast<double>(time) / 1e9);
     }

--- a/tests/performance/local/htts_v2/htts2_tbb.cpp
+++ b/tests/performance/local/htts_v2/htts2_tbb.cpp
@@ -48,7 +48,7 @@ private:
         stage_tasks_functor& outer;
 
     public:
-        void operator()(const tbb::blocked_range<std::uint64_t>& r) const
+        void operator()(tbb::blocked_range<std::uint64_t> const& r) const
         {
             for (std::uint64_t i = r.begin(); i != r.end(); ++i)
             {

--- a/tests/performance/local/task_overhead.cpp
+++ b/tests/performance/local/task_overhead.cpp
@@ -48,7 +48,7 @@ static std::uint64_t num_threads = 1;
 static std::string info_string = "";
 
 ///////////////////////////////////////////////////////////////////////////////
-void print_stats(const char* title, const char* wait, const char* sched, std::int64_t count,
+void print_stats(char const* title, char const* wait, char const* sched, std::int64_t count,
     double duration, bool csv)
 {
     std::ostringstream temp;
@@ -71,7 +71,7 @@ void print_stats(const char* title, const char* wait, const char* sched, std::in
     //pika::util::print_cdash_timing(title, duration);
 }
 
-const char* sched_name(ex::thread_pool_scheduler const&) { return "thread_pool_scheduler"; }
+char const* sched_name(ex::thread_pool_scheduler const&) { return "thread_pool_scheduler"; }
 
 ///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
@@ -82,7 +82,7 @@ double null_function() noexcept
 {
     if (num_iterations > 0)
     {
-        const int array_size = 4096;
+        int const array_size = 4096;
         std::array<double, array_size> dummy;
         for (std::uint64_t i = 0; i < num_iterations; ++i)
         {
@@ -106,7 +106,7 @@ void function_senders_when_all_vector(std::uint64_t count, bool csv, Scheduler& 
     tt::sync_wait(ex::when_all_vector(std::move(senders)));
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("schedule", "WhenAll", sched_name(sched), count, duration, csv);
 }
 
@@ -126,7 +126,7 @@ void function_senders_when_all_vector_eager(std::uint64_t count, bool csv, Sched
     tt::sync_wait(ex::when_all_vector(std::move(senders)));
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("schedule", "WhenAllEager", sched_name(sched), count, duration, csv);
 }
 
@@ -143,7 +143,7 @@ void function_senders_when_all_vector_any_sender(std::uint64_t count, bool csv, 
     tt::sync_wait(ex::when_all_vector(std::move(senders)));
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("schedule", "WhenAllAnySender", sched_name(sched), count, duration, csv);
 }
 
@@ -164,7 +164,7 @@ void function_senders_when_all_vector_eager_any_sender(
     tt::sync_wait(ex::when_all_vector(std::move(senders)));
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("schedule", "WhenAllEagerAnySender", sched_name(sched), count, duration, csv);
 }
 
@@ -173,7 +173,7 @@ void function_sliding_semaphore_execute(std::uint64_t count, bool csv, Scheduler
 {
     // start the clock
     high_resolution_timer walltime;
-    const int sem_count = 5000;
+    int const sem_count = 5000;
     pika::sliding_semaphore sem(sem_count);
     for (std::uint64_t i = 0; i < count; ++i)
     {
@@ -186,7 +186,7 @@ void function_sliding_semaphore_execute(std::uint64_t count, bool csv, Scheduler
     sem.wait(count + sem_count - 1);
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("execute", "Sliding-Sem", sched_name(sched), count, duration, csv);
 }
 
@@ -209,7 +209,7 @@ void function_register_work(std::uint64_t count, bool csv)
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("register_work", "latch", "none", count, duration, csv);
 }
 
@@ -241,7 +241,7 @@ void function_create_thread(std::uint64_t count, bool csv)
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("create_thread", "latch", "none", count, duration, csv);
 }
 
@@ -299,7 +299,7 @@ void function_create_thread_hierarchical_placement(std::uint64_t count, bool csv
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("create_thread_hierarchical", "latch", "none", count, duration, csv);
 }
 
@@ -332,7 +332,7 @@ void function_apply_hierarchical_placement(std::uint64_t count, bool csv)
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("execute_hierarchical", "latch", "thread_pool_scheduler", count, duration, csv);
 }
 
@@ -348,7 +348,7 @@ int pika_main(variables_map& vm)
             numa_sensitive = 0;
 
         bool test_all = (vm.count("test-all") > 0);
-        const int repetitions = vm["repetitions"].as<int>();
+        int const repetitions = vm["repetitions"].as<int>();
 
         if (vm.count("info")) info_string = vm["info"].as<std::string>();
 

--- a/tests/performance/local/task_overhead_report.cpp
+++ b/tests/performance/local/task_overhead_report.cpp
@@ -41,7 +41,7 @@ double null_function() noexcept
 {
     if (num_iterations > 0)
     {
-        const int array_size = 4096;
+        int const array_size = 4096;
         std::array<double, array_size> dummy;
         for (std::uint64_t i = 0; i < num_iterations; ++i)
         {
@@ -53,7 +53,7 @@ double null_function() noexcept
 }
 
 void measure_function_create_thread_hierarchical_placement(
-    std::uint64_t count, const int repetitions)
+    std::uint64_t count, int const repetitions)
 {
     auto sched = pika::threads::detail::get_self_id_data()->get_scheduler_base();
 
@@ -124,7 +124,7 @@ int pika_main(variables_map& vm)
         else
             numa_sensitive = 0;
 
-        const int repetitions = vm["repetitions"].as<int>();
+        int const repetitions = vm["repetitions"].as<int>();
 
         if (vm.count("info")) info_string = vm["info"].as<std::string>();
 

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -100,7 +100,7 @@ void print_results(std::uint64_t cores, double walltime, double warmup_estimate,
         header = false;
         cout << "Delay,Tasks,STasks,OS_Threads,Execution_Time_sec,Warmup_sec";
 
-        for (const auto& counter_shortname : counter_shortnames)
+        for (auto const& counter_shortname : counter_shortnames)
         {
             cout << "," << counter_shortname;
         }


### PR DESCRIPTION
Convert all files and add simple script for making conversion using

sed -i -E 's/const ([a-zA-Z0-9_<>,:]+)&/\1 const\&/g'

NB. the character set includes alphanumeric as well as "_<>,:" to allow const std::vector<std::vector, allocator> expressions to be correctly detected. Other might be needed for more complex parameter lists.
