### PR TITLE
Make valgrind memcheck suppressions more generic

### DIFF
--- a/tools/valgrind/memcheck.supp
+++ b/tools/valgrind/memcheck.supp
@@ -38,7 +38,7 @@
 {
    ORTE event loop
    Memcheck:Leak
-   fun:malloc
+   fun:*alloc
    ...
    fun:event_base_loop
    ...
@@ -47,7 +47,7 @@
 {
    ORTE event loop
    Memcheck:Leak
-   fun:malloc
+   fun:*alloc
    ...
    fun:pmix_server_init
    ...
@@ -56,7 +56,7 @@
 {
    hwloc
    Memcheck:Leak
-   fun:malloc
+   fun:*alloc
    ...
    fun:hwloc_topology_load
    ...


### PR DESCRIPTION
Suppress both malloc and realloc leaks.