### PR TITLE
Move manual `std::cerr` output to use `PIKA_LOG`

### DIFF
--- a/.inshpect.toml
+++ b/.inshpect.toml
@@ -344,6 +344,7 @@ patterns = [
     { pattern = '\bpika::intrusive_ptr\b', include = 'pika/memory/intrusive_ptr.hpp' },
     { pattern = '\bpika::detail::from_string\b', include = 'pika/string_util/from_string.hpp' },
     { pattern = '\bpika::detail::to_string\b', include = 'pika/string_util/to_string.hpp' },
+    { pattern = '\bPIKA_LOG\b', include = 'pika/logging.hpp' },
     { pattern = '\bPIKA_PP_CAT\b', include = 'pika/preprocessor/cat.hpp' },
     { pattern = '\bPIKA_PP_EXPAND\b', include = 'pika/preprocessor/expand.hpp' },
     { pattern = '\bPIKA_PP_NARGS\b', include = 'pika/preprocessor/nargs.hpp' },

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -11,6 +11,7 @@
 #include <pika/concurrency/spinlock.hpp>
 #include <pika/datastructures/detail/small_vector.hpp>
 #include <pika/debugging/print.hpp>
+#include <pika/logging.hpp>
 #include <pika/modules/errors.hpp>
 #include <pika/modules/threading_base.hpp>
 #include <pika/mpi_base/mpi_environment.hpp>

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -10,6 +10,7 @@
 #include <pika/command_line_handling/parse_command_line.hpp>
 #include <pika/debugging/attach_debugger.hpp>
 #include <pika/functional/detail/reset_function.hpp>
+#include <pika/logging.hpp>
 #include <pika/preprocessor/stringize.hpp>
 #include <pika/program_options/options_description.hpp>
 #include <pika/program_options/variables_map.hpp>
@@ -117,7 +118,7 @@ namespace pika::detail {
 
         if (!mask_string.empty())
         {
-            fmt::print(std::cerr,
+            PIKA_LOG(warn,
                 "Explicit process mask is set with --pika:process-mask or PIKA_PROCESS_MASK, but "
                 "thread binding is not supported on macOS. The process mask will be ignored.");
             mask_string = "";
@@ -125,9 +126,9 @@ namespace pika::detail {
 #else
         if (!mask_string.empty() && !use_process_mask)
         {
-            fmt::print(std::cerr,
+            PIKA_LOG(warn,
                 "Explicit process mask is set with --pika:process-mask or PIKA_PROCESS_MASK, but "
-                "--pika:ignore-process-mask is also set. The process mask will be ignored.\n");
+                "--pika:ignore-process-mask is also set. The process mask will be ignored.");
         }
 #endif
 
@@ -467,9 +468,10 @@ namespace pika::detail {
 #if defined(__APPLE__)
             if (affinity_bind_ != "none")
             {
-                std::cerr << "Warning: thread binding set to \"" << affinity_bind_
-                          << "\" but thread binding is not supported on macOS. Ignoring option."
-                          << std::endl;
+                PIKA_LOG(warn,
+                    "Thread binding set to \"{}\" but thread binding is not supported on macOS. "
+                    "Ignoring option.",
+                    affinity_bind_);
             }
             affinity_bind_ = "";
 #else
@@ -481,9 +483,10 @@ namespace pika::detail {
 #if defined(__APPLE__)
         if (pu_step_ != 1)
         {
-            std::cerr << "Warning: PU step set to \"" << pu_step_
-                      << "\" but thread binding is not supported on macOS. Ignoring option."
-                      << std::endl;
+            PIKA_LOG(warn,
+                "PU step set to \"{}\" but thread binding is not supported on macOS. "
+                "Ignoring option.",
+                pu_step_);
             pu_step_ = 1;
         }
 #endif
@@ -497,9 +500,10 @@ namespace pika::detail {
         if (pu_offset_ != std::size_t(-1))
         {
 #if defined(__APPLE__)
-            std::cerr << "Warning: PU offset set to \"" << pu_offset_
-                      << "\" but thread binding is not supported on macOS. Ignoring option."
-                      << std::endl;
+            PIKA_LOG(warn,
+                "PU offset set to \"{}\" but thread binding is not supported on macOS. Ignoring "
+                "option.",
+                pu_offset_);
             pu_offset_ = std::size_t(-1);
             ini_config.emplace_back("pika.pu_offset=0");
 #else
@@ -680,12 +684,11 @@ namespace pika::detail {
             if (option != "off" && option != "startup" && option != "exception" &&
                 option != "test-failure")
             {
-                // clang-format off
-                std::cerr <<
-                    "pika::init: command line warning: --pika:attach-debugger: "
-                    "invalid option: " << option << ". Allowed values are "
-                    "'off', 'startup', 'exception' or 'test-failure'" << std::endl;
-                // clang-format on
+                PIKA_LOG(warn,
+                    "pika::init: command line warning: --pika:attach-debugger: invalid option: "
+                    "\"{}\". Allowed values are \"off\", \"startup\", \"exception\" or "
+                    "\"test-failure\"",
+                    option);
             }
             else
             {
@@ -884,22 +887,22 @@ namespace pika::detail {
             if (num_threads_ == 1 && get_number_of_default_threads(false) != 1 &&
                 !command_line_arguments_given)
             {
-                std::cerr
-                    << "The pika runtime will be started with only one worker thread because the "
-                       "process mask has restricted the available resources to only one thread. If "
-                       "this is unintentional make sure the process mask contains the resources "
-                       "you need or use --pika:ignore-process-mask to use all resources. Use "
-                       "--pika:print-bind to print the thread bindings used by pika.\n";
+                PIKA_LOG(warn,
+                    "The pika runtime will be started with only one worker thread because the "
+                    "process mask has restricted the available resources to only one thread. If "
+                    "this is unintentional make sure the process mask contains the resources "
+                    "you need or use --pika:ignore-process-mask to use all resources. Use "
+                    "--pika:print-bind to print the thread bindings used by pika.");
             }
             else if (num_cores_ == 1 && get_number_of_default_cores(false) != 1 &&
                 !command_line_arguments_given)
             {
-                fmt::print(std::cerr,
+                PIKA_LOG(warn,
                     "The pika runtime will be started on only one core with {} worker threads "
                     "because the process mask has restricted the available resources to only one "
                     "core. If this is unintentional make sure the process mask contains the "
                     "resources you need or use --pika:ignore-process-mask to use all resources. "
-                    "Use --pika:print-bind to print the thread bindings used by pika.\n",
+                    "Use --pika:print-bind to print the thread bindings used by pika.",
                     num_threads_);
             }
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -17,6 +17,7 @@
 #include <pika/execution_base/sender.hpp>
 #include <pika/functional/bind_front.hpp>
 #include <pika/functional/detail/tag_fallback_invoke.hpp>
+#include <pika/logging.hpp>
 #include <pika/type_support/detail/with_result_of.hpp>
 #include <pika/type_support/pack.hpp>
 
@@ -70,7 +71,7 @@ namespace pika {
          switch (mode)                                                                             \
          {                                                                                         \
          case require_started_mode::terminate_on_unstarted:                                        \
-             fmt::print(std::cerr, "{}: {}\n", f, message);                                        \
+             PIKA_LOG(err, "{}: {}\n", f, message);                                                \
              std::terminate();                                                                     \
              break;                                                                                \
                                                                                                    \

--- a/libs/pika/runtime/src/runtime.cpp
+++ b/libs/pika/runtime/src/runtime.cpp
@@ -1021,11 +1021,11 @@ namespace pika::detail {
 
             // Always report the exception early in case the runtime becomes deadlocked because of the
             // thrown exception and isn't able to shut down.
-            fmt::print(std::cerr,
+            PIKA_LOG(warn,
                 "The pika runtime caught the following exception in the entry point (typically "
                 "pika_main). The exception may be rethrown later by pika::init or pika::stop. The "
                 "pika runtime will wait for all tasks to finish, but may be deadlocked because of "
-                "the exception.\n");
+                "the exception.");
             detail::report_exception_and_continue(exception_);
 
             // Then call user-registered error handlers if available.

--- a/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
+++ b/libs/pika/schedulers/include/pika/schedulers/thread_queue.hpp
@@ -12,6 +12,7 @@
 #include <pika/assert.hpp>
 #include <pika/concurrency/cache_line_data.hpp>
 #include <pika/functional/function.hpp>
+#include <pika/logging.hpp>
 #include <pika/modules/errors.hpp>
 #include <pika/schedulers/deadlock_detection.hpp>
 #include <pika/schedulers/lockfree_queue_backends.hpp>

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -13,6 +13,7 @@
 #include <pika/execution_base/this_thread.hpp>
 #include <pika/functional/deferred_call.hpp>
 #include <pika/functional/detail/invoke.hpp>
+#include <pika/logging.hpp>
 #include <pika/modules/errors.hpp>
 #include <pika/modules/schedulers.hpp>
 #include <pika/thread_pools/scheduled_thread_pool.hpp>


### PR DESCRIPTION
Also adds an inshpect rule to check that when `PIKA_LOG` is used `pika/logging.hpp` is included.

All output that was changed in this PR are now warnings. Please comment if you feel like they should be using a different logging level.