### PR TITLE
Change `set_value` CPO to use member functions instead of `tag_invoke`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -249,19 +249,21 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 }
 
                 template <typename... Ts>
-                auto set_value(Ts&&... ts) noexcept
+                auto set_value(Ts&&... ts) && noexcept
                     -> decltype(PIKA_INVOKE(PIKA_MOVE(f), op_state.sched, stream.value(), ts...),
                         void())
                 {
+                    auto r = PIKA_MOVE(*this);
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
                             using ts_element_type = std::tuple<std::decay_t<Ts>...>;
-                            op_state.ts.template emplace<ts_element_type>(PIKA_FORWARD(Ts, ts)...);
-                            [[maybe_unused]] auto& t = std::get<ts_element_type>(op_state.ts);
+                            r.op_state.ts.template emplace<ts_element_type>(
+                                PIKA_FORWARD(Ts, ts)...);
+                            [[maybe_unused]] auto& t = std::get<ts_element_type>(r.op_state.ts);
 
-                            if (!op_state.stream)
+                            if (!r.op_state.stream)
                             {
-                                op_state.stream.emplace(op_state.sched.get_next_stream());
+                                r.op_state.stream.emplace(r.op_state.sched.get_next_stream());
                             }
 
                             // If the next receiver is also a
@@ -272,11 +274,11 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                             if constexpr (is_then_with_cuda_stream_receiver<
                                               std::decay_t<Receiver>>::value)
                             {
-                                if (op_state.sched == op_state.receiver.op_state.sched)
+                                if (r.op_state.sched == r.op_state.receiver.op_state.sched)
                                 {
-                                    PIKA_ASSERT(op_state.stream);
-                                    PIKA_ASSERT(!op_state.receiver.op_state.stream);
-                                    op_state.receiver.op_state.stream = op_state.stream;
+                                    PIKA_ASSERT(r.op_state.stream);
+                                    PIKA_ASSERT(!r.op_state.receiver.op_state.stream);
+                                    r.op_state.receiver.op_state.stream = r.op_state.stream;
 
                                     successor_uses_same_stream = true;
                                 }
@@ -290,8 +292,8 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                             {
                                 std::apply(
                                     [&](auto&... ts) mutable {
-                                        PIKA_INVOKE(PIKA_MOVE(op_state.f), op_state.sched,
-                                            op_state.stream.value(), ts...);
+                                        PIKA_INVOKE(PIKA_MOVE(r.op_state.f), r.op_state.sched,
+                                            r.op_state.stream.value(), ts...);
                                     },
                                     t);
 
@@ -307,14 +309,14 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                                         // stream when a
                                         // non-then_with_cuda_stream receiver is
                                         // connected.
-                                        set_value_immediate_void(op_state);
+                                        set_value_immediate_void(r.op_state);
                                     }
                                     else
                                     {
                                         // When the streams are different, we
                                         // add a callback which will call
                                         // set_value on the receiver.
-                                        set_value_event_callback_void(op_state);
+                                        set_value_event_callback_void(r.op_state);
                                     }
                                 }
                                 else
@@ -323,16 +325,16 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                                     // then_with_cuda_stream_receiver, we add a
                                     // callback which will call set_value on the
                                     // receiver.
-                                    set_value_event_callback_void(op_state);
+                                    set_value_event_callback_void(r.op_state);
                                 }
                             }
                             else
                             {
                                 std::apply(
                                     [&](auto&... ts) mutable {
-                                        op_state.result.template emplace<invoke_result_type>(
-                                            PIKA_INVOKE(PIKA_MOVE(op_state.f), op_state.sched,
-                                                op_state.stream.value(), ts...));
+                                        r.op_state.result.template emplace<invoke_result_type>(
+                                            PIKA_INVOKE(PIKA_MOVE(r.op_state.f), r.op_state.sched,
+                                                r.op_state.stream.value(), ts...));
                                     },
                                     t);
 
@@ -348,7 +350,8 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                                         // stream when a
                                         // non-then_with_cuda_stream receiver is
                                         // connected.
-                                        set_value_immediate_non_void<invoke_result_type>(op_state);
+                                        set_value_immediate_non_void<invoke_result_type>(
+                                            r.op_state);
                                     }
                                     else
                                     {
@@ -356,7 +359,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                                         // add a callback which will call
                                         // set_value on the receiver.
                                         set_value_event_callback_non_void<invoke_result_type>(
-                                            op_state);
+                                            r.op_state);
                                     }
                                 }
                                 else
@@ -365,13 +368,14 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                                     // then_with_cuda_stream_receiver, we add a
                                     // callback which will call set_value on the
                                     // receiver.
-                                    set_value_event_callback_non_void<invoke_result_type>(op_state);
+                                    set_value_event_callback_non_void<invoke_result_type>(
+                                        r.op_state);
                                 }
                             }
                         },
                         [&](std::exception_ptr ep) mutable {
                             pika::execution::experimental::set_error(
-                                PIKA_MOVE(op_state.receiver), PIKA_MOVE(ep));
+                                PIKA_MOVE(r.op_state.receiver), PIKA_MOVE(ep));
                         });
                 }
 
@@ -382,25 +386,6 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                     return {};
                 }
             };
-
-            // This should be a hidden friend in then_with_cuda_stream_receiver.
-            // However, nvcc does not know how to compile it with some argument
-            // types ("error: no instance of overloaded function std::forward
-            // matches the argument list").
-            template <typename... Ts>
-            friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                then_with_cuda_stream_receiver&& r, Ts&&... ts) noexcept
-                -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...))
-            {
-                // nvcc fails to compile this with std::forward<Ts>(ts)...  or
-                // static_cast<Ts&&>(ts)... so we explicitly use
-                // static_cast<decltype(ts)>(ts)... as a workaround.
-#if defined(PIKA_HAVE_CUDA)
-                r.set_value(static_cast<decltype(ts)&&>(ts)...);
-#else
-                r.set_value(PIKA_FORWARD(Ts, ts)...);
-#endif
-            }
 
             using operation_state_type =
                 pika::execution::experimental::connect_result_t<std::decay_t<Sender>,

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -117,9 +117,9 @@ namespace pika::mpi::experimental::detail {
                 // otherwise return the request by passing it to set_value
                 template <typename... Ts,
                     typename = std::enable_if_t<is_mpi_request_invocable_v<F, Ts...>>>
-                friend constexpr void
-                tag_invoke(ex::set_value_t, dispatch_mpi_receiver r, Ts&&... ts) noexcept
+                constexpr void set_value(Ts&&... ts) && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
                             using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -115,9 +115,10 @@ namespace pika::mpi::experimental::detail {
 
                 // receive the MPI Request and set a callback to be
                 // triggered when the mpi request completes
-                friend constexpr void tag_invoke(
-                    ex::set_value_t, trigger_mpi_receiver r, MPI_Request request) noexcept
+                constexpr void set_value(MPI_Request request) && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
+
                     // early exit check
                     if (request == MPI_REQUEST_NULL)
                     {

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -79,9 +79,10 @@ namespace pika::drop_op_state_detail {
         };
 
         template <typename... Ts>
-        friend void tag_invoke(pika::execution::experimental::set_value_t,
-            drop_op_state_receiver_type r, Ts&&... ts) noexcept
+        void set_value(Ts&&... ts) && noexcept
         {
+            auto r = PIKA_MOVE(*this);
+
             PIKA_ASSERT(r.op_state != nullptr);
             PIKA_ASSERT(r.op_state->op_state.has_value());
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -53,9 +53,9 @@ namespace pika::drop_value_detail {
         }
 
         template <typename... Ts>
-        friend void tag_invoke(pika::execution::experimental::set_value_t,
-            drop_value_receiver_type&& r, Ts&&...) noexcept
+        void set_value(Ts&&...) && noexcept
         {
+            auto r = PIKA_MOVE(*this);
             pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -236,14 +236,14 @@ namespace pika::ensure_started_detail {
 #endif
 
                 template <typename... Ts>
-                friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                    ensure_started_receiver r, Ts&&... ts) noexcept
+                auto set_value(Ts&&... ts) && noexcept
                     -> decltype(std::declval<
                                     pika::detail::variant<pika::detail::monostate, value_type>>()
                                     .template emplace<value_type>(
                                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...)),
                         void())
                 {
+                    auto r = PIKA_MOVE(*this);
                     r.state->v.template emplace<value_type>(
                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
                     r.state->set_predecessor_done();

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -196,9 +196,9 @@ namespace pika::let_error_detail {
                 template <typename... Ts,
                     typename = std::enable_if_t<std::is_invocable_v<
                         pika::execution::experimental::set_value_t, Receiver&&, Ts...>>>
-                friend void tag_invoke(pika::execution::experimental::set_value_t,
-                    let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
+                void set_value(Ts&&... ts) && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
                     pika::execution::experimental::set_value(
                         PIKA_MOVE(r.receiver), PIKA_FORWARD(Ts, ts)...);
                 }

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -231,36 +231,26 @@ namespace pika::let_value_detail {
                     pika::detail::monostate>;
 
                 template <typename... Ts>
-                void set_value(Ts&&... ts)
-                {
-                    pika::detail::try_catch_exception_ptr(
-                        [&]() {
-                            op_state.predecessor_ts
-                                .template emplace<std::tuple<std::decay_t<Ts>...>>(
-                                    PIKA_FORWARD(Ts, ts)...);
-                            pika::detail::visit(
-                                set_value_visitor{PIKA_MOVE(receiver), PIKA_MOVE(f), op_state},
-                                op_state.predecessor_ts);
-                        },
-                        [&](std::exception_ptr ep) {
-                            pika::execution::experimental::set_error(
-                                PIKA_MOVE(receiver), PIKA_MOVE(ep));
-                        });
-                }
-
-                template <typename... Ts>
-                friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                    let_value_predecessor_receiver&& r, Ts&&... ts) noexcept
+                auto set_value(Ts&&... ts) && noexcept
                     -> decltype(std::declval<predecessor_ts_type>()
                                     .template emplace<std::tuple<std::decay_t<Ts>...>>(
                                         PIKA_FORWARD(Ts, ts)...),
                         void())
                 {
-                    // set_value is in a member function only because of a
-                    // compiler bug in GCC 7. When the body of set_value is
-                    // inlined here compilation fails with an internal
-                    // compiler error.
-                    r.set_value(PIKA_FORWARD(Ts, ts)...);
+                    auto r = PIKA_MOVE(*this);
+                    pika::detail::try_catch_exception_ptr(
+                        [&]() {
+                            r.op_state.predecessor_ts
+                                .template emplace<std::tuple<std::decay_t<Ts>...>>(
+                                    PIKA_FORWARD(Ts, ts)...);
+                            pika::detail::visit(
+                                set_value_visitor{PIKA_MOVE(r.receiver), PIKA_MOVE(f), r.op_state},
+                                r.op_state.predecessor_ts);
+                        },
+                        [&](std::exception_ptr ep) {
+                            pika::execution::experimental::set_error(
+                                PIKA_MOVE(r.receiver), PIKA_MOVE(ep));
+                        });
                 }
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -120,9 +120,9 @@ namespace pika {
             };
 
             template <typename... Ts>
-            friend void tag_invoke(pika::execution::experimental::set_value_t,
-                require_started_receiver_type r, Ts&&... ts) noexcept
+            void set_value(Ts&&... ts) && noexcept
             {
+                auto r = PIKA_MOVE(*this);
                 PIKA_ASSERT(r.op_state != nullptr);
                 pika::execution::experimental::set_value(
                     PIKA_MOVE(r.op_state->receiver), PIKA_FORWARD(Ts, ts)...);
@@ -381,8 +381,7 @@ namespace pika {
 
                 s.connected = true;
                 return
-                {
-                    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                {    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                     *std::exchange(s.sender, std::nullopt), PIKA_FORWARD(Receiver, receiver)
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
                                                                 ,

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -181,13 +181,13 @@ namespace pika::schedule_from_detail {
                     pika::detail::monostate>;
 
                 template <typename... Ts>
-                friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                    predecessor_sender_receiver&& r, Ts&&... ts) noexcept
+                auto set_value(Ts&&... ts) && noexcept
                     -> decltype(std::declval<value_type>()
                                     .template emplace<std::tuple<std::decay_t<Ts>...>>(
                                         PIKA_FORWARD(Ts, ts)...),
                         void())
                 {
+                    auto r = PIKA_MOVE(*this);
                     // nvcc fails to compile this with std::forward<Ts>(ts)...
                     // or static_cast<Ts&&>(ts)... so we explicitly use
                     // static_cast<decltype(ts)>(ts)... as a workaround.
@@ -252,9 +252,9 @@ namespace pika::schedule_from_detail {
                     r.op_state.set_stopped_scheduler_sender();
                 }
 
-                friend void tag_invoke(pika::execution::experimental::set_value_t,
-                    scheduler_sender_receiver&& r) noexcept
+                void set_value() && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
                     r.op_state.set_value_scheduler_sender();
                 }
             };

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -184,18 +184,11 @@ namespace pika::schedule_from_detail {
                 auto set_value(Ts&&... ts) && noexcept
                     -> decltype(std::declval<value_type>()
                                     .template emplace<std::tuple<std::decay_t<Ts>...>>(
-                                        PIKA_FORWARD(Ts, ts)...),
+                                        std::forward<Ts>(ts)...),
                         void())
                 {
-                    auto r = PIKA_MOVE(*this);
-                    // nvcc fails to compile this with std::forward<Ts>(ts)...
-                    // or static_cast<Ts&&>(ts)... so we explicitly use
-                    // static_cast<decltype(ts)>(ts)... as a workaround.
-# if defined(PIKA_HAVE_CUDA)
-                    r.op_state.set_value_predecessor_sender(static_cast<decltype(ts)&&>(ts)...);
-# else
-                    r.op_state.set_value_predecessor_sender(PIKA_FORWARD(Ts, ts)...);
-# endif
+                    auto r = std::move(*this);
+                    r.op_state.set_value_predecessor_sender(std::forward<Ts>(ts)...);
                 }
             };
 
@@ -254,7 +247,7 @@ namespace pika::schedule_from_detail {
 
                 void set_value() && noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
+                    auto r = std::move(*this);
                     r.op_state.set_value_scheduler_sender();
                 }
             };

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -190,14 +190,14 @@ namespace pika::split_detail {
                     value_type_helper>;
 
                 template <typename... Ts>
-                friend auto tag_invoke(pika::execution::experimental::set_value_t, split_receiver r,
-                    Ts&&... ts) noexcept
+                auto set_value(Ts&&... ts) && noexcept
                     -> decltype(std::declval<
                                     pika::detail::variant<pika::detail::monostate, value_type>>()
                                     .template emplace<value_type>(
                                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...)),
                         void())
                 {
+                    auto r = PIKA_MOVE(*this);
                     r.state->v.template emplace<value_type>(
                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -147,13 +147,13 @@ namespace pika::split_tuple_detail {
 #endif
 
             template <typename T>
-            friend auto tag_invoke(pika::execution::experimental::set_value_t,
-                split_tuple_receiver&& r, T&& t) noexcept
+            auto set_value(T&& t) && noexcept
                 -> decltype(std::declval<
                                 pika::detail::variant<pika::detail::monostate, value_type>>()
                                 .template emplace<value_type>(PIKA_FORWARD(T, t)),
                     void())
             {
+                auto r = PIKA_MOVE(*this);
                 r.state.v.template emplace<value_type>(PIKA_FORWARD(T, t));
 
                 r.state.set_predecessor_done();

--- a/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
@@ -67,9 +67,9 @@ namespace pika::start_detached_detail {
             };
 
             template <typename... Ts>
-            friend void tag_invoke(pika::execution::experimental::set_value_t,
-                start_detached_receiver&& r, Ts&&...) noexcept
+            void set_value(Ts&&...) && noexcept
             {
+                auto r = PIKA_MOVE(*this);
                 r.op_state.release();
             }
         };

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -177,9 +177,9 @@ namespace pika::sync_wait_detail {
         template <typename... Us,
             typename = std::enable_if_t<(is_void_result && sizeof...(Us) == 0) ||
                 (!is_void_result && sizeof...(Us) == 1)>>
-        friend void tag_invoke(pika::execution::experimental::set_value_t,
-            sync_wait_receiver_type&& r, Us&&... us) noexcept
+        void set_value(Us&&... us) && noexcept
         {
+            auto r = PIKA_MOVE(*this);
             r.state.value.template emplace<value_type>(PIKA_FORWARD(Us, us)...);
             r.signal_set_called();
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -56,9 +56,9 @@ namespace pika::unpack_detail {
         }
 
         template <typename Ts>
-        friend void tag_invoke(
-            pika::execution::experimental::set_value_t, unpack_receiver_type&& r, Ts&& ts) noexcept
+        void set_value(Ts&& ts) && noexcept
         {
+            auto r = PIKA_MOVE(*this);
             std::apply(pika::util::detail::bind_front(
                            pika::execution::experimental::set_value, PIKA_MOVE(r.receiver)),
                 PIKA_FORWARD(Ts, ts));

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -105,7 +105,7 @@ namespace pika::when_all_impl {
         auto set_value(Ts&&... ts) && noexcept
             -> decltype(set_value_helper(index_pack_type{}, PIKA_FORWARD(Ts, ts)...), void())
         {
-            auto r = PIKA_MOVE(*this);
+            auto r = std::move(*this);
             if constexpr (OperationState::sender_pack_size > 0)
             {
                 if (!r.op_state.set_stopped_error_called)

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -102,12 +102,13 @@ namespace pika::when_all_impl {
             typename pika::util::detail::make_index_pack<OperationState::sender_pack_size>::type;
 
         template <typename... Ts>
-        auto set_value(Ts&&... ts) noexcept
+        auto set_value(Ts&&... ts) && noexcept
             -> decltype(set_value_helper(index_pack_type{}, PIKA_FORWARD(Ts, ts)...), void())
         {
+            auto r = PIKA_MOVE(*this);
             if constexpr (OperationState::sender_pack_size > 0)
             {
-                if (!op_state.set_stopped_error_called)
+                if (!r.op_state.set_stopped_error_called)
                 {
                     try
                     {
@@ -115,34 +116,18 @@ namespace pika::when_all_impl {
                     }
                     catch (...)
                     {
-                        if (!op_state.set_stopped_error_called.exchange(true))
+                        if (!r.op_state.set_stopped_error_called.exchange(true))
                         {
                             // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            op_state.error = std::current_exception();
+                            r.op_state.error = std::current_exception();
                         }
                     }
                 }
             }
 
-            op_state.finish();
+            r.op_state.finish();
         }
     };
-
-    // Due to what appears to be a bug in clang this is not a hidden friend
-    // of when_all_receiver. The trailing decltype for SFINAE in the member
-    // set_value would give an error about accessing an incomplete type, if
-    // the member set_value were a hidden friend tag_invoke overload
-    // instead. Note that the receiver is unconstrained. That is because
-    // OperationState in when_all_receiver<OperationState> cannot be deduced
-    // when when_all_receiver is an alias template. Since this is in a
-    // unique namespace nothing but when_all_receiver should ever find this
-    // overload.
-    template <typename Receiver, typename... Ts>
-    auto tag_invoke(pika::execution::experimental::set_value_t, Receiver&& r, Ts&&... ts) noexcept
-        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
-    {
-        r.set_value(PIKA_FORWARD(Ts, ts)...);
-    }
 
     template <typename... Senders>
     struct when_all_sender_impl

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -176,9 +176,9 @@ namespace pika::when_all_vector_detail {
                 };
 
                 template <typename... Ts>
-                friend void tag_invoke(pika::execution::experimental::set_value_t,
-                    when_all_vector_receiver&& r, Ts&&... ts) noexcept
+                void set_value(Ts&&... ts) && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
                     if (!r.op_state.set_stopped_error_called)
                     {
                         try

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -539,10 +539,10 @@ namespace pika::execution::experimental::detail {
         any_receiver& operator=(any_receiver const&) = delete;
 
         template <typename... Ts_>
-        friend auto tag_invoke(
-            pika::execution::experimental::set_value_t, any_receiver&& r, Ts_&&... ts) noexcept
+        auto set_value(Ts_&&... ts) && noexcept
             -> decltype(std::declval<base_type>().set_value(PIKA_FORWARD(Ts_, ts)...))
         {
+            auto r = PIKA_MOVE(*this);
             // We first move the storage to a temporary variable so that
             // this any_receiver is empty after this set_value. Doing
             // PIKA_MOVE(storage.get()).set_value(...) would leave us with a

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -136,12 +136,12 @@ namespace pika::execution::experimental {
         template <typename Receiver, typename... Ts>
         PIKA_FORCEINLINE constexpr auto
         PIKA_STATIC_CALL_OPERATOR(Receiver&& receiver, Ts&&... ts) noexcept
-            -> decltype(PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...))
+            -> decltype(std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...))
         {
             static_assert(
-                noexcept(PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...)),
+                noexcept(std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...)),
                 "std::execution receiver set_value member function must be noexcept");
-            return PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...);
+            return std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...);
         }
     } set_value{};
 

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -131,8 +131,18 @@ namespace pika::execution::experimental {
     struct is_receiver_of;
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_value_t : pika::functional::detail::tag<set_value_t>
+    struct set_value_t
     {
+        template <typename Receiver, typename... Ts>
+        PIKA_FORCEINLINE constexpr auto
+        PIKA_STATIC_CALL_OPERATOR(Receiver&& receiver, Ts&&... ts) noexcept
+            -> decltype(PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...))
+        {
+            static_assert(
+                noexcept(PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...)),
+                "std::execution receiver set_value member function must be noexcept");
+            return PIKA_FORWARD(Receiver, receiver).set_value(PIKA_FORWARD(Ts, ts)...);
+        }
     } set_value{};
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -151,10 +151,10 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    friend auto tag_invoke(
-        pika::execution::experimental::set_value_t, callback_receiver&& r, Ts&&... ts) noexcept
+    auto set_value(Ts&&... ts) && noexcept
         -> decltype(PIKA_INVOKE(std::declval<std::decay_t<F>>(), std::forward<Ts>(ts)...), void())
     {
+        auto r = PIKA_MOVE(*this);
         PIKA_INVOKE(r.f, std::forward<Ts>(ts)...);
         r.set_value_called = true;
     }
@@ -190,9 +190,9 @@ struct error_callback_receiver
     };
 
     template <typename... Ts>
-    friend void tag_invoke(
-        pika::execution::experimental::set_value_t, error_callback_receiver&& r, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
+        auto r = PIKA_MOVE(*this);
         PIKA_TEST(r.expect_set_value);
     }
 

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -241,8 +241,7 @@ struct error_receiver
     };
 
     template <typename... Ts>
-    friend void
-    tag_invoke(pika::execution::experimental::set_value_t, error_receiver&&, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
         PIKA_TEST(false);
     }

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -31,7 +31,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, receiver_1&&, int) noexcept { value_called = true; }
+        void set_value(int) && noexcept { value_called = true; }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_1 const&) noexcept
         {
@@ -64,7 +64,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, receiver_3, int) noexcept { value_called = true; }
+        void set_value(int) && noexcept { value_called = true; }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_3 const&) noexcept
         {
@@ -81,10 +81,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, non_receiver_1, int) noexcept
-        {
-            value_called = true;
-        }
+        void set_value(int) noexcept { value_called = true; }
     };
 
     struct non_receiver_2
@@ -96,10 +93,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, non_receiver_2, int) noexcept
-        {
-            value_called = true;
-        }
+        void set_value(int) && noexcept { value_called = true; }
     };
 
     struct non_receiver_3
@@ -111,10 +105,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, non_receiver_3, int) noexcept
-        {
-            value_called = true;
-        }
+        void set_value(int) noexcept { value_called = true; }
     };
 
     struct non_receiver_4
@@ -128,10 +119,7 @@ namespace mylib {
             error_called = true;
         }
 
-        friend void tag_invoke(ex::set_value_t, non_receiver_4&, int) noexcept
-        {
-            value_called = true;
-        }
+        void set_value(int) & noexcept { value_called = true; }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, non_receiver_4 const&) noexcept
         {

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -74,7 +74,7 @@ struct receiver
 
     friend void tag_invoke(ex::set_stopped_t, receiver&&) noexcept {}
 
-    friend void tag_invoke(ex::set_value_t, receiver&& r, int v) noexcept { r.i.get() = v; }
+    void set_value(int v) && noexcept { i.get() = v; }
 
     friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver const&) noexcept
     {
@@ -156,10 +156,7 @@ struct void_receiver
 
     friend void tag_invoke(ex::set_stopped_t, void_receiver&&) noexcept {}
 
-    friend void tag_invoke(ex::set_value_t, void_receiver&&) noexcept
-    {
-        ++void_receiver_set_value_calls;
-    }
+    void set_value() && noexcept { ++void_receiver_set_value_calls; }
 
     friend constexpr ex::empty_env tag_invoke(ex::get_env_t, void_receiver const&) noexcept
     {

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -389,9 +389,9 @@ namespace pika::thread_pool_bulk_detail {
                 }
 
                 template <typename... Ts>
-                friend void tag_invoke(pika::execution::experimental::set_value_t,
-                    bulk_receiver&& r, Ts&&... ts) noexcept
+                void set_value(Ts&&... ts) && noexcept
                 {
+                    auto r = PIKA_MOVE(*this);
                     // Don't spawn tasks if there is no work to be done
                     if (r.op_state->shape == 0)
                     {

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -68,13 +68,13 @@ struct check_context_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
-        PIKA_TEST_NEQ(r.parent_id, std::this_thread::get_id());
+        PIKA_TEST_NEQ(parent_id, std::this_thread::get_id());
         PIKA_TEST_NEQ(std::thread::id(), std::this_thread::get_id());
-        std::lock_guard l{r.mtx};
-        r.executed = true;
-        r.cond.notify_one();
+        std::lock_guard l{mtx};
+        executed = true;
+        cond.notify_one();
     }
 
     friend constexpr pika::execution::experimental::empty_env tag_invoke(
@@ -226,8 +226,9 @@ struct callback_receiver
     friend void tag_invoke(ex::set_stopped_t, callback_receiver&&) noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
-    friend void tag_invoke(ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
+        auto r = PIKA_MOVE(*this);
         r.f();
         std::lock_guard l{r.mtx};
         r.executed = true;

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -75,14 +75,14 @@ struct check_context_receiver
     }
 
     template <typename... Ts>
-    friend void tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
-        PIKA_TEST_NEQ(r.parent_id, pika::this_thread::get_id());
+        PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
         PIKA_TEST_NEQ(pika::thread::id(pika::threads::detail::invalid_thread_id),
             pika::this_thread::get_id());
-        std::lock_guard l{r.mtx};
-        r.executed = true;
-        r.cond.notify_one();
+        std::lock_guard l{mtx};
+        executed = true;
+        cond.notify_one();
     }
 
     friend constexpr pika::execution::experimental::empty_env tag_invoke(
@@ -234,12 +234,12 @@ struct callback_receiver
     friend void tag_invoke(ex::set_stopped_t, callback_receiver&&) noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
-    friend void tag_invoke(ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
+    void set_value(Ts&&...) && noexcept
     {
-        r.f();
-        std::lock_guard l{r.mtx};
-        r.executed = true;
-        r.cond.notify_one();
+        f();
+        std::lock_guard l{mtx};
+        executed = true;
+        cond.notify_one();
     }
 
     friend constexpr pika::execution::experimental::empty_env tag_invoke(


### PR DESCRIPTION
Part of #1204. Changes the `set_value` CPO to dispatch to `set_value` member functions instead of using `tag_invoke`. No compatibility is provided for receivers still wishing to use `tag_invoke`.

The `set_value` member is _mandated_ to be noexcept, so we `static_assert` inside the CPO to check that this is the case.

Consistently changes all `set_value` members to move the receiver by value into the `set_value` function scope, to emulate taking the receiver by value. With `tag_invoke` this was easily done by taking the receiver by value as a function parameter, but with a member function this isn't possible (without deducing this https://wg21.link/p0847), so we do the next best thing. I have not changed receivers in tests to consistently move the receiver into the function scope.

The change to a member function also triggers some compilation failures with nvcc not liking the `PIKA_MOVE`/`PIKA_FORWARD` macros. Given that #1325 is coming up soon anyway, I'm changing the offending places unconditionally to use `std::move`/`std::forward`.