### PR TITLE
Remove stray newline in `require_started` sender adaptor error message

### DIFF
--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -71,7 +71,7 @@ namespace pika {
          switch (mode)                                                                             \
          {                                                                                         \
          case require_started_mode::terminate_on_unstarted:                                        \
-             PIKA_LOG(err, "{}: {}\n", f, message);                                                \
+             PIKA_LOG(err, "{}: {}", f, message);                                                  \
              std::terminate();                                                                     \
              break;                                                                                \
                                                                                                    \


### PR DESCRIPTION
I missed this leftover newline in #1291 and was a bit too eager in merging #1291.