### PR TITLE
Fix references in documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -14,6 +14,7 @@ FILE_PATTERNS          = *.cpp *.hpp *.cu
 RECURSIVE              = YES
 EXCLUDE_PATTERNS       = */test */detail
 EXCLUDE_SYMBOLS        = "*detail*"
+EXTRACT_ALL            = YES
 ENABLE_PREPPROCESSING  = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -140,12 +140,12 @@ namespace pika {
 
     /// @brief Stop the runtime.
     ///
-    /// Waits until @ref pika::finalize has been called and there is no more activity on the
-    /// runtime. See @ref pika::wait. The runtime can be started again after calling @ref
-    /// pika::stop. Must be called from outside the runtime.
+    /// Waits until @ref pika::finalize() has been called and there is no more activity on the
+    /// runtime. See @ref pika::wait(). The runtime can be started again after calling @ref
+    /// pika::stop(). Must be called from outside the runtime.
     ///
-    /// @return the return value of the callable passed to @p pika::start, if any. If none was
-    /// passed, returns 0.
+    /// @return the return value of the callable passed to @ref pika::start(int, char const* const*,
+    /// init_params const&)", if any. If none was passed, returns 0.
     ///
     /// @pre the runtime is initialized
     /// @pre the calling thread is not a pika task
@@ -154,10 +154,10 @@ namespace pika {
 
     /// @brief Signal the runtime that it may be stopped.
     ///
-    /// Until @ref pika::finalize has been called, @ref pika::stop will not return. This function
-    /// exists to distinguish between the runtime being idle but still expecting work to be
-    /// scheduled on it and the runtime being idle and ready to be shutdown. Unlike @pika::stop,
-    /// @ref pika::finalize can be called from within or outside the runtime.
+    /// Until @ref pika::finalize() has been called, @ref pika::stop() will not return. This
+    /// function exists to distinguish between the runtime being idle but still expecting work to be
+    /// scheduled on it and the runtime being idle and ready to be shutdown. Unlike @ref
+    /// pika::stop(), @ref pika::finalize() can be called from within or outside the runtime.
     ///
     /// @pre the runtime is initialized
     PIKA_EXPORT void finalize();

--- a/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
+++ b/libs/pika/init_runtime/include/pika/init_runtime/init_runtime.hpp
@@ -85,7 +85,7 @@ namespace pika {
     PIKA_EXPORT int init(std::nullptr_t, int argc, char const* const* argv,
         init_params const& params = init_params());
 
-    /// Start the runtime.
+    /// @brief Start the runtime.
     ///
     /// @param f entry point of the first task on the pika runtime. f will be passed all non-pika
     /// command line arguments.
@@ -98,7 +98,7 @@ namespace pika {
     PIKA_EXPORT void start(std::function<int(pika::program_options::variables_map&)> f, int argc,
         char const* const* argv, init_params const& params = init_params());
 
-    /// Start the runtime.
+    /// @brief Start the runtime.
     ///
     /// @param f entry point of the first task on the pika runtime. f will be passed all non-pika
     /// command line arguments.
@@ -111,7 +111,7 @@ namespace pika {
     PIKA_EXPORT void start(std::function<int(int, char**)> f, int argc, char const* const* argv,
         init_params const& params = init_params());
 
-    /// Start the runtime.
+    /// @brief Start the runtime.
     ///
     /// @param f entry point of the first task on the pika runtime
     /// @param argc number of arguments in argv
@@ -125,7 +125,7 @@ namespace pika {
     PIKA_EXPORT void start(std::nullptr_t, int argc, char const* const* argv,
         init_params const& params = init_params());
 
-    /// Start the runtime.
+    /// @brief Start the runtime.
     ///
     /// No task is created on the runtime.
     ///
@@ -138,7 +138,7 @@ namespace pika {
     PIKA_EXPORT void start(
         int argc, char const* const* argv, init_params const& params = init_params());
 
-    /// Stop the runtime.
+    /// @brief Stop the runtime.
     ///
     /// Waits until @ref pika::finalize has been called and there is no more activity on the
     /// runtime. See @ref pika::wait. The runtime can be started again after calling @ref
@@ -152,7 +152,7 @@ namespace pika {
     /// @post the runtime is not initialized
     PIKA_EXPORT int stop();
 
-    /// Signal the runtime that it may be stopped.
+    /// @brief Signal the runtime that it may be stopped.
     ///
     /// Until @ref pika::finalize has been called, @ref pika::stop will not return. This function
     /// exists to distinguish between the runtime being idle but still expecting work to be
@@ -162,7 +162,7 @@ namespace pika {
     /// @pre the runtime is initialized
     PIKA_EXPORT void finalize();
 
-    /// Wait for the runtime to be idle.
+    /// @brief Wait for the runtime to be idle.
     ///
     /// Waits until the runtime is idle. This includes tasks scheduled on the thread pools as well
     /// as non-tasks such as CUDA kernels submitted through pika facilities. Can be called from
@@ -172,7 +172,7 @@ namespace pika {
     /// @post all work submitted before the call to wait is completed
     PIKA_EXPORT void wait();
 
-    /// Suspend the runtime.
+    /// @brief Suspend the runtime.
     ///
     /// Waits until the runtime is idle and suspends worker threads on all thread pools. Work can be
     /// scheduled on the runtime even when it is suspended, but no progress will be made.
@@ -182,7 +182,7 @@ namespace pika {
     /// @post runtime is suspended
     PIKA_EXPORT void suspend();
 
-    /// Resume the runtime.
+    /// @brief Resume the runtime.
     ///
     /// Resumes the runtime by waking all worker threads on all thread pools.
     ///

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -437,7 +437,7 @@ namespace pika::detail {
 }    // namespace pika::detail
 
 namespace pika {
-    /// Returns true when the runtime is initialized, false otherwise.
+    /// @brief Returns true when the runtime is initialized, false otherwise.
     ///
     /// Returns true while in a @ref pika::init call, or between calls of @ref pika::start and @ref
     /// pika::stop, otherwise false.

--- a/libs/pika/runtime/include/pika/runtime/runtime.hpp
+++ b/libs/pika/runtime/include/pika/runtime/runtime.hpp
@@ -439,8 +439,8 @@ namespace pika::detail {
 namespace pika {
     /// @brief Returns true when the runtime is initialized, false otherwise.
     ///
-    /// Returns true while in a @ref pika::init call, or between calls of @ref pika::start and @ref
-    /// pika::stop, otherwise false.
+    /// Returns true between calls of @ref pika::start(int, char const* const*, init_params const&)
+    /// and @ref pika::stop(), otherwise false.
     ///
     /// Added in 0.22.0.
     PIKA_EXPORT bool is_runtime_initialized() noexcept;


### PR DESCRIPTION
- Use `EXTRACT_ALL = YES` to make sure references can be resolved
- Use explicit function signatures e.g. for `pika::start` so that a link is actually generated (since there are multiple overloads)
- Fix the wrong `@pika::stop` syntax (missing `@ref`)
- For consistency: use `@ref pika::stop()`, i.e. empty parentheses for functions that don't take any parameters

As a bonus: adds `@brief` to the first lines of the documentation for each function.