### PR TITLE
Relax regex for the `require_started_terminated` test

### DIFF
--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -57,5 +57,5 @@ set_tests_properties(
   tests.unit.modules.execution.algorithm_require_started_terminate
   PROPERTIES
     PASS_REGULAR_EXPRESSION
-    ".*~require_started_sender: A require_started sender was never started\nstd::terminate called*"
+    ".*~require_started_sender: A require_started sender was never started\n.*std::terminate called.*"
 )


### PR DESCRIPTION
With APEX enabled, APEX's output may be interleaved between the logging messages and the terminate message, so allow for output to come in between the two.

Also allows any output at the end of the output.

Another follow-up to #1291 and #1296.