### PR TITLE
Don't include doxygen output in documentation output artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
             pip install --requirement $PWD/docs/requirements.txt
       - name: Build documentation
         run: |
-            export PIKA_DOCS_DOXYGEN_OUTPUT_DIRECTORY=$PWD/build/docs/doxygen
+            export PIKA_DOCS_DOXYGEN_OUTPUT_DIRECTORY=$PWD/build/doxygen
             export PIKA_DOCS_DOXYGEN_INPUT_ROOT=$PWD
             mkdir -p $PIKA_DOCS_DOXYGEN_OUTPUT_DIRECTORY
             doxygen docs/Doxyfile


### PR DESCRIPTION
Currently the doxygen output is put in the same directory as the html files generated by sphinx. Since they don't need to be kept together, and the doxygen output isn't needed for the final artifact, this PR moves the doxygen output to a separate directory that is not uploaded by the documentation workflow.