### PR TITLE
Work around occasional resource partitioner test segfaults

### DIFF
--- a/.gitlab/includes/clang15_pipeline.yml
+++ b/.gitlab/includes/clang15_pipeline.yml
@@ -17,7 +17,8 @@ include:
                  ^hwloc@2.8.0"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_MAX_CPU_COUNT=256 -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
-                  -DPIKA_WITH_UNITY_BUILD=OFF -DPIKA_WITH_THREAD_STACK_MMAP=OFF"
+                  -DPIKA_WITH_UNITY_BUILD=OFF -DPIKA_WITH_THREAD_STACK_MMAP=OFF \
+                  -DPIKA_WITH_STACKTRACES=OFF"
 
 clang15_spack_compiler_image:
   extends:

--- a/.gitlab/includes/clang17_pipeline.yml
+++ b/.gitlab/includes/clang17_pipeline.yml
@@ -16,7 +16,8 @@ include:
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.83.0 \
                  ^hwloc@2.9.1"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_THREAD_STACK_MMAP=OFF"
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_THREAD_STACK_MMAP=OFF \
+                  -DPIKA_WITH_STACKTRACES=OFF"
 
 clang17_spack_compiler_image:
   extends:

--- a/.gitlab/includes/gcc12_pipeline.yml
+++ b/.gitlab/includes/gcc12_pipeline.yml
@@ -16,8 +16,8 @@ include:
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD ^boost@1.79.0 \
                  ^hwloc@2.7.0"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_MALLOC=system \
-                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
-
+                  -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DPIKA_WITH_THREAD_STACK_MMAP=OFF \
+                  -DPIKA_WITH_STACKTRACES=OFF"
 gcc12_spack_compiler_image:
   extends:
     - .variables_gcc12_config


### PR DESCRIPTION
See #1316 for more details. This PR works around the issue by disabling stacktrace collection on the CI configurations that disable mmap for stacks. I've also disabled mmap for stacks on one GCC CI configuration, to make sure we don't test it only using clang.

A more permanent solution may be to use libunwind for stacktrace collection, as noted in #1316. Considering using mmap for stacks is the default I won't make that change in this PR.