### PR TITLE
Test and fix lifetimes of `transform_mpi` values

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -237,9 +237,8 @@ namespace pika::mpi::experimental {
         friend constexpr PIKA_FORCEINLINE auto
         tag_fallback_invoke(dispatch_mpi_t, Sender&& sender, F&& f)
         {
-            auto snd1 = detail::dispatch_mpi_sender<Sender, F>{
+            return detail::dispatch_mpi_sender<Sender, F>{
                 PIKA_FORWARD(Sender, sender), PIKA_FORWARD(F, f)};
-            return pika::execution::experimental::make_unique_any_sender(std::move(snd1));
         }
 
         template <typename F>

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -78,21 +78,21 @@ namespace pika::mpi::experimental {
 
             if (requests_inline)
             {
-                return PIKA_FORWARD(Sender, sender) |
-                    let_value([=, f = std::forward<F>(f)](auto&... args) {
+                return std::forward<Sender>(sender) |
+                    let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
-                                   PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
+                                   std::move(snd0), std::move(f)} |
                             let_value(completion_snd);
                     });
             }
             else
             {
-                return PIKA_FORWARD(Sender, sender) | continues_on(mpi_pool_scheduler(p)) |
-                    let_value([=, f = std::forward<F>(f)](auto&... args) {
+                return std::forward<Sender>(sender) | continues_on(mpi_pool_scheduler(p)) |
+                    let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
-                                   PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
+                                   std::move(snd0), std::move(f)} |
                             let_value(completion_snd);
                     });
             }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -82,22 +82,16 @@ namespace pika::mpi::experimental {
             {
                 return std::forward<Sender>(sender) |
                     let_value([=, f = std::forward<F>(f)](auto&&... args) mutable {
-                        std::tuple<decltype(args)&...> ts{args...};
-                        auto snd0 = just(ts) | ex::unpack();
-                        return dispatch_mpi_sender<decltype(snd0), F>{
-                                   std::move(snd0), std::move(f)} |
-                            let_value(completion_snd);
+                        return just(std::tuple<decltype(args)&...>{args...}) | ex::unpack() |
+                            dispatch_mpi(std::move(f)) | let_value(completion_snd);
                     });
             }
             else
             {
                 return std::forward<Sender>(sender) | continues_on(mpi_pool_scheduler(p)) |
                     let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
-                        std::tuple<decltype(args)&...> ts{args...};
-                        auto snd0 = just(ts) | ex::unpack();
-                        return dispatch_mpi_sender<decltype(snd0), F>{
-                                   std::move(snd0), std::move(f)} |
-                            let_value(completion_snd);
+                        return just(std::tuple<decltype(args)&...>{args...}) | ex::unpack() |
+                            dispatch_mpi(std::move(f)) | let_value(completion_snd);
                     });
             }
         }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -79,7 +79,7 @@ namespace pika::mpi::experimental {
             if (requests_inline)
             {
                 return PIKA_FORWARD(Sender, sender) |
-                    let_value([=, f = std::move(f)](auto&... args) {
+                    let_value([=, f = std::move(f)](auto... args) {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
@@ -89,7 +89,7 @@ namespace pika::mpi::experimental {
             else
             {
                 return PIKA_FORWARD(Sender, sender) | continues_on(mpi_pool_scheduler(p)) |
-                    let_value([=, f = std::move(f)](auto&... args) {
+                    let_value([=, f = std::move(f)](auto... args) {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -81,7 +81,7 @@ namespace pika::mpi::experimental {
             if (requests_inline)
             {
                 return std::forward<Sender>(sender) |
-                    let_value([=, f = std::forward<F>(f)](auto&&... args) mutable {
+                    let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
                         return just(std::tuple<decltype(args)&...>{args...}) | ex::unpack() |
                             dispatch_mpi(std::move(f)) | let_value(completion_snd);
                     });

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -82,7 +82,7 @@ namespace pika::mpi::experimental {
             {
                 return std::forward<Sender>(sender) |
                     let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
-                        return just(std::tuple<decltype(args)&...>{args...}) | ex::unpack() |
+                        return just(std::forward_as_tuple(args...)) | ex::unpack() |
                             dispatch_mpi(std::move(f)) | let_value(completion_snd);
                     });
             }
@@ -90,7 +90,7 @@ namespace pika::mpi::experimental {
             {
                 return std::forward<Sender>(sender) | continues_on(mpi_pool_scheduler(p)) |
                     let_value([=, f = std::forward<F>(f)](auto&... args) mutable {
-                        return just(std::tuple<decltype(args)&...>{args...}) | ex::unpack() |
+                        return just(std::forward_as_tuple(args...)) | ex::unpack() |
                             dispatch_mpi(std::move(f)) | let_value(completion_snd);
                     });
             }

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -79,7 +79,7 @@ namespace pika::mpi::experimental {
             if (requests_inline)
             {
                 return PIKA_FORWARD(Sender, sender) |
-                    let_value([=, f = std::move(f)](auto... args) {
+                    let_value([=, f = std::forward<F>(f)](auto&... args) {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
@@ -89,7 +89,7 @@ namespace pika::mpi::experimental {
             else
             {
                 return PIKA_FORWARD(Sender, sender) | continues_on(mpi_pool_scheduler(p)) |
-                    let_value([=, f = std::move(f)](auto... args) {
+                    let_value([=, f = std::forward<F>(f)](auto&... args) {
                         auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -80,7 +80,7 @@ namespace pika::mpi::experimental {
             {
                 return PIKA_FORWARD(Sender, sender) |
                     let_value([=, f = std::move(f)](auto&... args) {
-                        auto snd0 = just(std::forward<decltype(args)>(args)...);
+                        auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
                             let_value(completion_snd);
@@ -90,7 +90,7 @@ namespace pika::mpi::experimental {
             {
                 return PIKA_FORWARD(Sender, sender) | continues_on(mpi_pool_scheduler(p)) |
                     let_value([=, f = std::move(f)](auto&... args) {
-                        auto snd0 = just(std::forward<decltype(args)>(args)...);
+                        auto snd0 = just(args...);
                         return dispatch_mpi_sender<decltype(snd0), F>{
                                    PIKA_MOVE(snd0), PIKA_FORWARD(F, f)} |
                             let_value(completion_snd);

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -218,7 +218,7 @@ int pika_main()
                     ex::drop_operation_state() |
                     mpi::transform_mpi([](auto& data, MPI_Datatype datatype, int i, MPI_Comm comm,
                                            MPI_Request* request) {
-                        MPI_Ibcast(&data, 1, datatype, i, comm, request);
+                        MPI_Ibcast(&data.x, 1, datatype, i, comm, request);
                     });
                 tt::sync_wait(PIKA_MOVE(s));
             }

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -212,6 +212,17 @@ int pika_main()
                 tt::sync_wait(PIKA_MOVE(s));
             }
 
+            {
+                auto s = ex::just(custom_type_non_default_constructible_non_copyable{42}, datatype,
+                             0, comm) |
+                    ex::drop_operation_state() |
+                    mpi::transform_mpi([](auto& data, MPI_Datatype datatype, int i, MPI_Comm comm,
+                                           MPI_Request* request) {
+                        MPI_Ibcast(&data, 1, datatype, i, comm, request);
+                    });
+                tt::sync_wait(PIKA_MOVE(s));
+            }
+
             // transform_mpi should be able to handle reference types (by copying
             // them to the operation state)
             {

--- a/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/pika/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -228,9 +228,10 @@ int pika_main()
             {
                 int data = 0, count = 1;
                 if (rank == 0) { data = 42; }
-                auto s = mpi::transform_mpi(
-                    const_reference_sender<int>{count}, [&](int& count, MPI_Request* request) {
-                        MPI_Ibcast(&data, count, datatype, 0, comm, request);
+                auto s = mpi::transform_mpi(const_reference_sender<int>{count},
+                    [&](int& count_transform_mpi, MPI_Request* request) {
+                        PIKA_TEST(&count_transform_mpi != &count);
+                        MPI_Ibcast(&data, count_transform_mpi, datatype, 0, comm, request);
                     });
                 tt::sync_wait(PIKA_MOVE(s));
                 PIKA_TEST_EQ(data, 42);

--- a/libs/pika/config/include/pika/config/compiler_specific.hpp
+++ b/libs/pika/config/include/pika/config/compiler_specific.hpp
@@ -162,14 +162,20 @@
 #endif
 
 // clang-format on
+# if !defined(__has_feature)
+#  define PIKA_HAS_FEATURE(x) 0
+# else
+#  define PIKA_HAS_FEATURE(x) __has_feature(x)
+# endif
+
 # if defined(PIKA_HAVE_SANITIZERS)
-#  if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#  if defined(__SANITIZE_ADDRESS__) || PIKA_HAS_FEATURE(address_sanitizer)
 #   define PIKA_HAVE_ADDRESS_SANITIZER
 #   if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
 #    define PIKA_NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
 #   endif
 #  endif
-#  if defined(__SANITIZE_THREAD__) || (defined(__has_feature) && __has_feature(thread_sanitizer))
+#  if defined(__SANITIZE_THREAD__) || PIKA_HAS_FEATURE(thread_sanitizer)
 #   define PIKA_HAVE_THREAD_SANITIZER
 #   if defined(PIKA_GCC_VERSION) || defined(PIKA_CLANG_VERSION)
 #    define PIKA_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))


### PR DESCRIPTION
The `transform_mpi` sender adaptor was not ensuring that the references passed to user-provided MPI callables are kept alive until the MPI request completes. This fixes that by adding an explicit `let_value` around the helper adaptors of `transform_mpi`. This PR also adds a number of new tests that trigger the issue if the `let_value` is not in place.