### PR TITLE
Use `versionadded` directive in rst to document `require_started` version

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -107,6 +107,8 @@ All sender adaptors are `customization point objects (CPOs)
 
 .. doxygenvariable:: pika::execution::experimental::require_started
 
+.. versionadded:: 0.21.0
+
 .. literalinclude:: ../examples/documentation/require_started_documentation.cpp
    :language: c++
    :start-at: #include

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -465,8 +465,6 @@ namespace pika {
         /// operation state has not been started.
         /// The operation state of a \p require_started sender is allowed to not be started if it
         /// has been explicitly requested with the \p discard member function.
-        ///
-        /// Added in 0.21.0.
         inline constexpr require_started_t require_started{};
 
     }    // namespace execution::experimental


### PR DESCRIPTION
Follows the change in #1311.