### PR TITLE
Revert #1295

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -117,9 +117,9 @@ namespace pika::mpi::experimental::detail {
                 // otherwise return the request by passing it to set_value
                 template <typename... Ts,
                     typename = std::enable_if_t<is_mpi_request_invocable_v<F, Ts...>>>
-                constexpr void set_value(Ts&&... ts) && noexcept
+                friend constexpr void
+                tag_invoke(ex::set_value_t, dispatch_mpi_receiver r, Ts&&... ts) noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
                     pika::detail::try_catch_exception_ptr(
                         [&]() mutable {
                             using invoke_result_type = mpi_request_invoke_result_t<F, Ts...>;

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -115,10 +115,9 @@ namespace pika::mpi::experimental::detail {
 
                 // receive the MPI Request and set a callback to be
                 // triggered when the mpi request completes
-                constexpr void set_value(MPI_Request request) && noexcept
+                friend constexpr void tag_invoke(
+                    ex::set_value_t, trigger_mpi_receiver r, MPI_Request request) noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
-
                     // early exit check
                     if (request == MPI_REQUEST_NULL)
                     {

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -95,12 +95,11 @@ namespace pika::bulk_detail {
             }
 
             template <typename... Ts>
-            void set_value(Ts&&... ts) && noexcept
+            void set_value(Ts&&... ts)
             {
-                auto r = PIKA_MOVE(*this);
                 pika::detail::try_catch_exception_ptr(
                     [&]() {
-                        for (auto const& s : r.shape) { PIKA_INVOKE(r.f, s, ts...); }
+                        for (auto const& s : shape) { PIKA_INVOKE(f, s, ts...); }
                         pika::execution::experimental::set_value(
                             PIKA_MOVE(receiver), PIKA_FORWARD(Ts, ts)...);
                     },
@@ -108,6 +107,20 @@ namespace pika::bulk_detail {
                         pika::execution::experimental::set_error(
                             PIKA_MOVE(receiver), PIKA_MOVE(ep));
                     });
+            }
+
+            template <typename... Ts>
+            friend auto tag_invoke(
+                pika::execution::experimental::set_value_t, bulk_receiver&& r, Ts&&... ts) noexcept
+                -> decltype(pika::execution::experimental::set_value(
+                                std::declval<std::decay_t<Receiver>&&>(), PIKA_FORWARD(Ts, ts)...),
+                    void())
+            {
+                // set_value is in a member function only because of a
+                // compiler bug in GCC 7. When the body of set_value is
+                // inlined here compilation fails with an internal compiler
+                // error.
+                r.set_value(PIKA_FORWARD(Ts, ts)...);
             }
         };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -79,10 +79,9 @@ namespace pika::drop_op_state_detail {
         };
 
         template <typename... Ts>
-        void set_value(Ts&&... ts) && noexcept
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            drop_op_state_receiver_type r, Ts&&... ts) noexcept
         {
-            auto r = PIKA_MOVE(*this);
-
             PIKA_ASSERT(r.op_state != nullptr);
             PIKA_ASSERT(r.op_state->op_state.has_value());
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -53,9 +53,9 @@ namespace pika::drop_value_detail {
         }
 
         template <typename... Ts>
-        void set_value(Ts&&...) && noexcept
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            drop_value_receiver_type&& r, Ts&&...) noexcept
         {
-            auto r = PIKA_MOVE(*this);
             pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -236,14 +236,14 @@ namespace pika::ensure_started_detail {
 #endif
 
                 template <typename... Ts>
-                auto set_value(Ts&&... ts) && noexcept
+                friend auto tag_invoke(pika::execution::experimental::set_value_t,
+                    ensure_started_receiver r, Ts&&... ts) noexcept
                     -> decltype(std::declval<
                                     pika::detail::variant<pika::detail::monostate, value_type>>()
                                     .template emplace<value_type>(
                                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...)),
                         void())
                 {
-                    auto r = PIKA_MOVE(*this);
                     r.state->v.template emplace<value_type>(
                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
                     r.state->set_predecessor_done();

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -196,9 +196,9 @@ namespace pika::let_error_detail {
                 template <typename... Ts,
                     typename = std::enable_if_t<std::is_invocable_v<
                         pika::execution::experimental::set_value_t, Receiver&&, Ts...>>>
-                void set_value(Ts&&... ts) && noexcept
+                friend void tag_invoke(pika::execution::experimental::set_value_t,
+                    let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
                     pika::execution::experimental::set_value(
                         PIKA_MOVE(r.receiver), PIKA_FORWARD(Ts, ts)...);
                 }

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -120,9 +120,9 @@ namespace pika {
             };
 
             template <typename... Ts>
-            void set_value(Ts&&... ts) && noexcept
+            friend void tag_invoke(pika::execution::experimental::set_value_t,
+                require_started_receiver_type r, Ts&&... ts) noexcept
             {
-                auto r = PIKA_MOVE(*this);
                 PIKA_ASSERT(r.op_state != nullptr);
                 pika::execution::experimental::set_value(
                     PIKA_MOVE(r.op_state->receiver), PIKA_FORWARD(Ts, ts)...);
@@ -381,7 +381,8 @@ namespace pika {
 
                 s.connected = true;
                 return
-                {    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                {
+                    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                     *std::exchange(s.sender, std::nullopt), PIKA_FORWARD(Receiver, receiver)
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
                                                                 ,

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -190,14 +190,14 @@ namespace pika::split_detail {
                     value_type_helper>;
 
                 template <typename... Ts>
-                auto set_value(Ts&&... ts) && noexcept
+                friend auto tag_invoke(pika::execution::experimental::set_value_t, split_receiver r,
+                    Ts&&... ts) noexcept
                     -> decltype(std::declval<
                                     pika::detail::variant<pika::detail::monostate, value_type>>()
                                     .template emplace<value_type>(
                                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...)),
                         void())
                 {
-                    auto r = PIKA_MOVE(*this);
                     r.state->v.template emplace<value_type>(
                         std::make_tuple<>(PIKA_FORWARD(Ts, ts)...));
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -147,13 +147,13 @@ namespace pika::split_tuple_detail {
 #endif
 
             template <typename T>
-            auto set_value(T&& t) && noexcept
+            friend auto tag_invoke(pika::execution::experimental::set_value_t,
+                split_tuple_receiver&& r, T&& t) noexcept
                 -> decltype(std::declval<
                                 pika::detail::variant<pika::detail::monostate, value_type>>()
                                 .template emplace<value_type>(PIKA_FORWARD(T, t)),
                     void())
             {
-                auto r = PIKA_MOVE(*this);
                 r.state.v.template emplace<value_type>(PIKA_FORWARD(T, t));
 
                 r.state.set_predecessor_done();

--- a/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
@@ -67,9 +67,9 @@ namespace pika::start_detached_detail {
             };
 
             template <typename... Ts>
-            void set_value(Ts&&...) && noexcept
+            friend void tag_invoke(pika::execution::experimental::set_value_t,
+                start_detached_receiver&& r, Ts&&...) noexcept
             {
-                auto r = PIKA_MOVE(*this);
                 r.op_state.release();
             }
         };

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -177,9 +177,9 @@ namespace pika::sync_wait_detail {
         template <typename... Us,
             typename = std::enable_if_t<(is_void_result && sizeof...(Us) == 0) ||
                 (!is_void_result && sizeof...(Us) == 1)>>
-        void set_value(Us&&... us) && noexcept
+        friend void tag_invoke(pika::execution::experimental::set_value_t,
+            sync_wait_receiver_type&& r, Us&&... us) noexcept
         {
-            auto r = PIKA_MOVE(*this);
             r.state.value.template emplace<value_type>(PIKA_FORWARD(Us, us)...);
             r.signal_set_called();
         }

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -55,10 +55,10 @@ namespace pika::then_detail {
             pika::execution::experimental::set_stopped(PIKA_MOVE(r.receiver));
         }
 
+    private:
         template <typename... Ts>
-        void set_value(Ts&&... ts) && noexcept
+        void set_value_helper(Ts&&... ts) noexcept
         {
-            auto r = PIKA_MOVE(*this);
             pika::detail::try_catch_exception_ptr(
                 [&]() {
                     if constexpr (std::is_void_v<std::invoke_result_t<F, Ts...>>)
@@ -66,28 +66,37 @@ namespace pika::then_detail {
                     // Certain versions of GCC with optimizations fail on
                     // the move with an internal compiler error.
 # if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
-                        PIKA_INVOKE(std::move(r.f), PIKA_FORWARD(Ts, ts)...);
+                        PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...);
 # else
-                        PIKA_INVOKE(PIKA_MOVE(r.f), PIKA_FORWARD(Ts, ts)...);
+                        PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...);
 # endif
-                        pika::execution::experimental::set_value(PIKA_MOVE(r.receiver));
+                        pika::execution::experimental::set_value(PIKA_MOVE(receiver));
                     }
                     else
                     {
                     // Certain versions of GCC with optimizations fail on
                     // the move with an internal compiler error.
 # if defined(PIKA_GCC_VERSION) && (PIKA_GCC_VERSION < 100000)
-                        pika::execution::experimental::set_value(PIKA_MOVE(r.receiver),
-                            PIKA_INVOKE(std::move(r.f), PIKA_FORWARD(Ts, ts)...));
+                        pika::execution::experimental::set_value(PIKA_MOVE(receiver),
+                            PIKA_INVOKE(std::move(f), PIKA_FORWARD(Ts, ts)...));
 # else
-                        pika::execution::experimental::set_value(PIKA_MOVE(r.receiver),
-                            PIKA_INVOKE(PIKA_MOVE(r.f), PIKA_FORWARD(Ts, ts)...));
+                        pika::execution::experimental::set_value(PIKA_MOVE(receiver),
+                            PIKA_INVOKE(PIKA_MOVE(f), PIKA_FORWARD(Ts, ts)...));
 # endif
                     }
                 },
                 [&](std::exception_ptr ep) {
-                    pika::execution::experimental::set_error(PIKA_MOVE(r.receiver), PIKA_MOVE(ep));
+                    pika::execution::experimental::set_error(PIKA_MOVE(receiver), PIKA_MOVE(ep));
                 });
+        }
+
+        template <typename... Ts>
+        friend void tag_invoke(
+            pika::execution::experimental::set_value_t, then_receiver_type&& r, Ts&&... ts) noexcept
+        {
+            // GCC 7 fails with an internal compiler error unless the actual
+            // body is in a helper function.
+            r.set_value_helper(PIKA_FORWARD(Ts, ts)...);
         }
     };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -56,9 +56,9 @@ namespace pika::unpack_detail {
         }
 
         template <typename Ts>
-        void set_value(Ts&& ts) && noexcept
+        friend void tag_invoke(
+            pika::execution::experimental::set_value_t, unpack_receiver_type&& r, Ts&& ts) noexcept
         {
-            auto r = PIKA_MOVE(*this);
             std::apply(pika::util::detail::bind_front(
                            pika::execution::experimental::set_value, PIKA_MOVE(r.receiver)),
                 PIKA_FORWARD(Ts, ts));

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -102,13 +102,12 @@ namespace pika::when_all_impl {
             typename pika::util::detail::make_index_pack<OperationState::sender_pack_size>::type;
 
         template <typename... Ts>
-        auto set_value(Ts&&... ts) && noexcept
+        auto set_value(Ts&&... ts) noexcept
             -> decltype(set_value_helper(index_pack_type{}, PIKA_FORWARD(Ts, ts)...), void())
         {
-            auto r = std::move(*this);
             if constexpr (OperationState::sender_pack_size > 0)
             {
-                if (!r.op_state.set_stopped_error_called)
+                if (!op_state.set_stopped_error_called)
                 {
                     try
                     {
@@ -116,18 +115,34 @@ namespace pika::when_all_impl {
                     }
                     catch (...)
                     {
-                        if (!r.op_state.set_stopped_error_called.exchange(true))
+                        if (!op_state.set_stopped_error_called.exchange(true))
                         {
                             // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            r.op_state.error = std::current_exception();
+                            op_state.error = std::current_exception();
                         }
                     }
                 }
             }
 
-            r.op_state.finish();
+            op_state.finish();
         }
     };
+
+    // Due to what appears to be a bug in clang this is not a hidden friend
+    // of when_all_receiver. The trailing decltype for SFINAE in the member
+    // set_value would give an error about accessing an incomplete type, if
+    // the member set_value were a hidden friend tag_invoke overload
+    // instead. Note that the receiver is unconstrained. That is because
+    // OperationState in when_all_receiver<OperationState> cannot be deduced
+    // when when_all_receiver is an alias template. Since this is in a
+    // unique namespace nothing but when_all_receiver should ever find this
+    // overload.
+    template <typename Receiver, typename... Ts>
+    auto tag_invoke(pika::execution::experimental::set_value_t, Receiver&& r, Ts&&... ts) noexcept
+        -> decltype(r.set_value(PIKA_FORWARD(Ts, ts)...), void())
+    {
+        r.set_value(PIKA_FORWARD(Ts, ts)...);
+    }
 
     template <typename... Senders>
     struct when_all_sender_impl

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -176,9 +176,9 @@ namespace pika::when_all_vector_detail {
                 };
 
                 template <typename... Ts>
-                void set_value(Ts&&... ts) && noexcept
+                friend void tag_invoke(pika::execution::experimental::set_value_t,
+                    when_all_vector_receiver&& r, Ts&&... ts) noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
                     if (!r.op_state.set_stopped_error_called)
                     {
                         try

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -539,10 +539,10 @@ namespace pika::execution::experimental::detail {
         any_receiver& operator=(any_receiver const&) = delete;
 
         template <typename... Ts_>
-        auto set_value(Ts_&&... ts) && noexcept
+        friend auto tag_invoke(
+            pika::execution::experimental::set_value_t, any_receiver&& r, Ts_&&... ts) noexcept
             -> decltype(std::declval<base_type>().set_value(PIKA_FORWARD(Ts_, ts)...))
         {
-            auto r = PIKA_MOVE(*this);
             // We first move the storage to a temporary variable so that
             // this any_receiver is empty after this set_value. Doing
             // PIKA_MOVE(storage.get()).set_value(...) would leave us with a

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -131,18 +131,8 @@ namespace pika::execution::experimental {
     struct is_receiver_of;
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_value_t
+    struct set_value_t : pika::functional::detail::tag<set_value_t>
     {
-        template <typename Receiver, typename... Ts>
-        PIKA_FORCEINLINE constexpr auto
-        PIKA_STATIC_CALL_OPERATOR(Receiver&& receiver, Ts&&... ts) noexcept
-            -> decltype(std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...))
-        {
-            static_assert(
-                noexcept(std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...)),
-                "std::execution receiver set_value member function must be noexcept");
-            return std::forward<Receiver>(receiver).set_value(std::forward<Ts>(ts)...);
-        }
     } set_value{};
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -151,10 +151,10 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    auto set_value(Ts&&... ts) && noexcept
+    friend auto tag_invoke(
+        pika::execution::experimental::set_value_t, callback_receiver&& r, Ts&&... ts) noexcept
         -> decltype(PIKA_INVOKE(std::declval<std::decay_t<F>>(), std::forward<Ts>(ts)...), void())
     {
-        auto r = PIKA_MOVE(*this);
         PIKA_INVOKE(r.f, std::forward<Ts>(ts)...);
         r.set_value_called = true;
     }
@@ -190,9 +190,9 @@ struct error_callback_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&...) && noexcept
+    friend void tag_invoke(
+        pika::execution::experimental::set_value_t, error_callback_receiver&& r, Ts&&...) noexcept
     {
-        auto r = PIKA_MOVE(*this);
         PIKA_TEST(r.expect_set_value);
     }
 

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -241,7 +241,8 @@ struct error_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&...) && noexcept
+    friend void
+    tag_invoke(pika::execution::experimental::set_value_t, error_receiver&&, Ts&&...) noexcept
     {
         PIKA_TEST(false);
     }

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -31,7 +31,7 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) && noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, receiver_1&&, int) noexcept { value_called = true; }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_1 const&) noexcept
         {
@@ -64,7 +64,7 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) && noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, receiver_3, int) noexcept { value_called = true; }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_3 const&) noexcept
         {
@@ -81,7 +81,10 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, non_receiver_1, int) noexcept
+        {
+            value_called = true;
+        }
     };
 
     struct non_receiver_2
@@ -93,7 +96,10 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) && noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, non_receiver_2, int) noexcept
+        {
+            value_called = true;
+        }
     };
 
     struct non_receiver_3
@@ -105,7 +111,10 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, non_receiver_3, int) noexcept
+        {
+            value_called = true;
+        }
     };
 
     struct non_receiver_4
@@ -119,7 +128,10 @@ namespace mylib {
             error_called = true;
         }
 
-        void set_value(int) & noexcept { value_called = true; }
+        friend void tag_invoke(ex::set_value_t, non_receiver_4&, int) noexcept
+        {
+            value_called = true;
+        }
 
         friend constexpr ex::empty_env tag_invoke(ex::get_env_t, non_receiver_4 const&) noexcept
         {

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -74,7 +74,7 @@ struct receiver
 
     friend void tag_invoke(ex::set_stopped_t, receiver&&) noexcept {}
 
-    void set_value(int v) && noexcept { i.get() = v; }
+    friend void tag_invoke(ex::set_value_t, receiver&& r, int v) noexcept { r.i.get() = v; }
 
     friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver const&) noexcept
     {
@@ -156,7 +156,10 @@ struct void_receiver
 
     friend void tag_invoke(ex::set_stopped_t, void_receiver&&) noexcept {}
 
-    void set_value() && noexcept { ++void_receiver_set_value_calls; }
+    friend void tag_invoke(ex::set_value_t, void_receiver&&) noexcept
+    {
+        ++void_receiver_set_value_calls;
+    }
 
     friend constexpr ex::empty_env tag_invoke(ex::get_env_t, void_receiver const&) noexcept
     {

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -389,9 +389,9 @@ namespace pika::thread_pool_bulk_detail {
                 }
 
                 template <typename... Ts>
-                void set_value(Ts&&... ts) && noexcept
+                friend void tag_invoke(pika::execution::experimental::set_value_t,
+                    bulk_receiver&& r, Ts&&... ts) noexcept
                 {
-                    auto r = PIKA_MOVE(*this);
                     // Don't spawn tasks if there is no work to be done
                     if (r.op_state->shape == 0)
                     {

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -75,14 +75,14 @@ struct check_context_receiver
     }
 
     template <typename... Ts>
-    void set_value(Ts&&...) && noexcept
+    friend void tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...) noexcept
     {
-        PIKA_TEST_NEQ(parent_id, pika::this_thread::get_id());
+        PIKA_TEST_NEQ(r.parent_id, pika::this_thread::get_id());
         PIKA_TEST_NEQ(pika::thread::id(pika::threads::detail::invalid_thread_id),
             pika::this_thread::get_id());
-        std::lock_guard l{mtx};
-        executed = true;
-        cond.notify_one();
+        std::lock_guard l{r.mtx};
+        r.executed = true;
+        r.cond.notify_one();
     }
 
     friend constexpr pika::execution::experimental::empty_env tag_invoke(
@@ -234,12 +234,12 @@ struct callback_receiver
     friend void tag_invoke(ex::set_stopped_t, callback_receiver&&) noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
-    void set_value(Ts&&...) && noexcept
+    friend void tag_invoke(ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
     {
-        f();
-        std::lock_guard l{mtx};
-        executed = true;
-        cond.notify_one();
+        r.f();
+        std::lock_guard l{r.mtx};
+        r.executed = true;
+        r.cond.notify_one();
     }
 
     friend constexpr pika::execution::experimental::empty_env tag_invoke(


### PR DESCRIPTION
The PR passed pika's tests, but leads to uses of empty `any_sender`s in DLA-Future. It's still unclear if the mistake is in DLA-Future or pika. Reverting the change in `let_value` is enough to make DLA-Future's tests pass again, but reverting the whole PR until I've investigated it further (other algorithms may have issues that we don't trigger in DLA-Future).