### PR TITLE
Update release procedure and script

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: pika 0.29.0
+title: pika 0.30.1
 repository-code: https://github.com/pika-org/pika
 message: >-
   If you use this software, please cite it using the
@@ -43,8 +43,8 @@ keywords:
   - thread pool
 license: BSL-1.0
 license-url: https://opensource.org/license/bsl-1-0
-version: 0.29.0
-date-released: '2024-10-04'
+version: 0.30.1
+date-released: '2024-11-19'
 references:
   - title: "HPX - The C++ Standard Library for Parallelism and Concurrency"
     doi: 10.21105/joss.02352

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -76,6 +76,8 @@ pika follows `Semantic Versioning <https://semver.org>`__.
 #. Make sure ``PIKA_VERSION_MAJOR/MINOR/PATCH`` in ``CMakeLists.txt`` contain
    the correct values. Change them if needed.
 
+#. Update the version in the ``CITATION.cff`` file (both in the title and the ``version`` field).
+
 #. When making a post-1.0.0 major release, remove deprecated functionality if
    appropriate.
 

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -17,9 +17,11 @@ VERSION_MINOR=$(sed -n 's/set(PIKA_VERSION_MINOR \(.*\))/\1/p' CMakeLists.txt)
 VERSION_PATCH=$(sed -n 's/set(PIKA_VERSION_PATCH \(.*\))/\1/p' CMakeLists.txt)
 VERSION_TAG=$(sed -n 's/set(PIKA_VERSION_TAG "\(.*\)")/\1/p' CMakeLists.txt)
 VERSION_FULL_NOTAG=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+REGEX_VERSION_FULL_NOTAG="$(echo ${VERSION_FULL_NOTAG} | sed s/\\./\\\\./g)"
 VERSION_FULL_TAG=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TAG}
 VERSION_TITLE="pika ${VERSION_FULL_NOTAG}"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RELEASE_DATE=$(date '+%Y-%m-%d')
 
 if ! which hub >/dev/null 2>&1; then
     echo "Hub not installed on this system (see https://hub.github.com/). Exiting."
@@ -64,8 +66,8 @@ if [ -z "${VERSION_TAG}" ]; then
         sanity_errors=$((sanity_errors + 1))
     fi
 
-    printf "Checking that %s also has a date set for %s... " "${changelog_path}" "${VERSION_FULL_NOTAG}"
-    if grep "## ${VERSION_FULL_NOTAG} ([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})" "${changelog_path}"; then
+    printf "Checking that %s also has today's date set for %s... " "${changelog_path}" "${VERSION_FULL_NOTAG}"
+    if grep "## ${REGEX_VERSION_FULL_NOTAG} (${RELEASE_DATE})" "${changelog_path}"; then
         echo "OK"
     else
         echo "Missing"

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -20,6 +20,7 @@ VERSION_FULL_NOTAG=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
 REGEX_VERSION_FULL_NOTAG="$(echo ${VERSION_FULL_NOTAG} | sed s/\\./\\\\./g)"
 VERSION_FULL_TAG=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TAG}
 VERSION_TITLE="pika ${VERSION_FULL_NOTAG}"
+REGEX_VERSION_TITLE="$(echo ${VERSION_TITLE} | sed s/\\./\\\\./g)"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 RELEASE_DATE=$(date '+%Y-%m-%d')
 
@@ -49,6 +50,7 @@ else
 fi
 
 changelog_path="docs/changelog.md"
+cff_path="CITATION.cff"
 
 if [ -z "${VERSION_TAG}" ]; then
     echo "You are about to tag and create a final release on GitHub."
@@ -68,6 +70,30 @@ if [ -z "${VERSION_TAG}" ]; then
 
     printf "Checking that %s also has today's date set for %s... " "${changelog_path}" "${VERSION_FULL_NOTAG}"
     if grep "## ${REGEX_VERSION_FULL_NOTAG} (${RELEASE_DATE})" "${changelog_path}"; then
+        echo "OK"
+    else
+        echo "Missing"
+        sanity_errors=$((sanity_errors + 1))
+    fi
+
+    printf "Checking that %s has correct version for %s... " "${cff_path}" "${VERSION_FULL_NOTAG}"
+    if grep "^version: ${REGEX_VERSION_FULL_NOTAG}" "${cff_path}"; then
+        echo "OK"
+    else
+        echo "Missing"
+        sanity_errors=$((sanity_errors + 1))
+    fi
+
+    printf "Checking that %s has correct title for %s... " "${cff_path}" "${VERSION_FULL_NOTAG}"
+    if grep "^title: ${REGEX_VERSION_TITLE}" "${cff_path}"; then
+        echo "OK"
+    else
+        echo "Missing"
+        sanity_errors=$((sanity_errors + 1))
+    fi
+
+    printf "Checking that %s has today's date... " "${cff_path}"
+    if grep "^date-released: '${RELEASE_DATE}'" "${cff_path}"; then
         echo "OK"
     else
         echo "Missing"

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -31,6 +31,21 @@ if ! [[ "$CURRENT_BRANCH" =~ ^release-[0-9]+\.[0-9]+\.X$ ]]; then
     exit 1
 fi
 
+printf "Checking that the git repository is in a clean state... "
+if [[ $(git status --porcelain | wc -l) -eq 0 ]]; then
+    echo "OK"
+else
+    echo "ERROR"
+    git status -s
+    echo "Do you want to continue anyway?"
+    select yn in "Yes" "No"; do
+        case $yn in
+        Yes) break ;;
+        No) exit ;;
+        esac
+    done
+fi
+
 changelog_path="docs/changelog.md"
 
 if [ -z "${VERSION_TAG}" ]; then

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -61,7 +61,7 @@ if [ -z "${VERSION_TAG}" ]; then
     sanity_errors=0
 
     printf "Checking that %s has an entry for %s... " "${changelog_path}" "${VERSION_FULL_NOTAG}"
-    if grep "## ${VERSION_FULL_NOTAG}" "${changelog_path}"; then
+    if grep "## ${REGEX_VERSION_FULL_NOTAG}" "${changelog_path}"; then
         echo "OK"
     else
         echo "Missing"


### PR DESCRIPTION
Pulls in many of the release script improvements that were made in DLA-Future.
- Adds checks for `CITATION.cff`
- Uses regexes instead of just the version number to check that the version is set correctly.
- Check for today's date in the changelog and `CITATION.cff`.

Also adds a note in the release procedure to update the `CITATION.cff` file.

I also did not update the `CITATION.cff` file for 0.30.0 and 0.30.1. I've updated the entries manually on zenodo.org, and updated the file here for 0.30.1.

I obviously haven't tested the updated release script on a full release, but testing until the tagging phase seems work to catch errors e.g. in the `CITATION.cff` file.