### PR TITLE
Enable clang-tidy checks on CSCS CI clang pipelines

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -17,7 +17,12 @@ COPY . ${SOURCE_DIR}
 RUN spack -e pika_ci spec -lI $spack_spec
 
 # Configure & Build
+# Make sure clang-tidy etc. binaries are in PATH when using clang.
+ARG COMPILER
 RUN spack -e pika_ci config add "config:flags:keep_werror:all" && \
+    if [[ $COMPILER =~ clang ]]; then \
+        export PATH="$(spack location --install-dir llvm)/bin:$PATH"; \
+    fi && \
     spack -e pika_ci build-env $spack_spec -- \
     bash -c " \
     cmake -B${BUILD_DIR} ${SOURCE_DIR} -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_COMMON_FLAGS $CMAKE_FLAGS && \
@@ -34,7 +39,6 @@ ARG CI_COMMIT_SHA
 ARG CI_COMMIT_SHORT_SHA
 ARG CI_COMMIT_TIMESTAMP
 ARG CI_COMMIT_TITLE
-ARG COMPILER
 ARG CSCS_LOGSTASH_URL
 ARG SPACK_COMMIT
 ARG SPACK_SPEC
@@ -43,6 +47,9 @@ RUN CTEST_XML=$PWD/ctest.xml; \
         "${SOURCE_DIR}/.gitlab/scripts/collect_ctest_metrics.sh ${CTEST_XML}; \
          ${SOURCE_DIR}/.gitlab/scripts/collect_file_sizes.sh ${BUILD_DIR}" \
         EXIT; \
+    if [[ $COMPILER =~ clang ]]; then \
+        export PATH="$(spack location --install-dir llvm)/bin:$PATH"; \
+    fi && \
     spack -e pika_ci build-env $spack_spec -- \
         bash -c "ctest \
             --output-junit ${CTEST_XML} \

--- a/.gitlab/includes/clang14_cuda11_pipeline.yml
+++ b/.gitlab/includes/clang14_cuda11_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: '60'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +cuda cuda_arch=${GPU_TARGET} malloc=system
       cxxstd=$CXXSTD +valgrind ^boost@1.79.0 ^cuda@11.5.0 +allow-unsupported-compilers ^hwloc@2.7.0 ^valgrind ~mpi"
-    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=20 -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
+    CMAKE_FLAGS: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy -DPIKA_WITH_CXX_STANDARD=20 -DPIKA_WITH_CUDA=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON -DCMAKE_CUDA_COMPILER=c++ \
                   -DCMAKE_CUDA_ARCHITECTURES=${GPU_TARGET} \
                   -DPIKA_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE=OFF \

--- a/.gitlab/includes/clang19_pipeline.yml
+++ b/.gitlab/includes/clang19_pipeline.yml
@@ -20,7 +20,7 @@ include:
                  ^fmt cxxflags=-stdlib=libc++ cxxflags=-DLIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
                  ^spdlog cxxflags=-stdlib=libc++ cxxflags=-DLIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG \
                  ^stdexec@24.09"
-    CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD \
+    CMAKE_FLAGS: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy -DPIKA_WITH_CXX_STANDARD=$CXXSTD \
                   -DCMAKE_CXX_FLAGS='-stdlib=libc++ -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG' \
                   -DPIKA_WITH_MALLOC=system -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON \
                   -DPIKA_WITH_STDEXEC=ON"

--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler_bulk.hpp
@@ -133,7 +133,7 @@ namespace pika::cuda::experimental {
             std::decay_t<T> operator()(T&& t, whip::stream_t stream) const
             {
                 launch_bulk_function(f, shape, t, stream);
-                return std::move(t);
+                return std::forward<T>(t);
             }
         };
     }    // namespace detail

--- a/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/pika/async_cuda/tests/unit/cublas_matmul.cpp
@@ -287,7 +287,7 @@ int pika_main(pika::program_options::variables_map& vm)
     sizeMult = (std::min)(sizeMult, std::size_t(100));
     sizeMult = (std::max)(sizeMult, std::size_t(1));
     //
-    int block_size = 32;
+    std::size_t block_size = 32;
 
     sMatrixSize matrix_size;
     matrix_size.uiWA = 2 * block_size * sizeMult;

--- a/libs/pika/async_cuda_base/include/pika/async_cuda_base/cuda_stream.hpp
+++ b/libs/pika/async_cuda_base/include/pika/async_cuda_base/cuda_stream.hpp
@@ -34,7 +34,7 @@ namespace pika::cuda::experimental {
         int device;
         pika::execution::thread_priority priority;
         unsigned int flags;
-        whip::stream_t stream = 0;
+        whip::stream_t stream{};
 
         struct priorities
         {


### PR DESCRIPTION
Enabling on the clang/CUDA pipeline and the latest clang (19 at the time of the PR) pipeline.