### PR TITLE
Minor `transform_mpi` refactoring

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -158,18 +158,8 @@ namespace pika::mpi::experimental::detail {
                                         mpi::exception(status, "dispatch mpi")));
                                 return;
                             }
-                            // early poll just in case the request completed immediately
-                            if (poll_request(request))
-                            {
-#ifdef PIKA_HAVE_APEX
-                                apex::scoped_timer apex_invoke("pika::mpi::trigger");
-#endif
-                                PIKA_DETAIL_DP(mpi_tran<7>,
-                                    debug(
-                                        str<>("dispatch_mpi_recv"), "eager poll ok", ptr(request)));
-                                ex::set_value(std::move(r.op_state.receiver), MPI_REQUEST_NULL);
-                            }
-                            else { ex::set_value(std::move(r.op_state.receiver), request); }
+
+                            ex::set_value(std::move(r.op_state.receiver), request);
                         },
                         [&](std::exception_ptr ep) {
                             ex::set_error(std::move(r.op_state.receiver), std::move(ep));

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -67,14 +67,9 @@ namespace pika::mpi::experimental {
             auto completion_snd = [=](MPI_Request request) -> unique_any_sender<> {
                 if (!completions_inline)    // not inline : a transfer is required
                 {
-                    if (request == MPI_REQUEST_NULL)
-                    {
-                        return ex::schedule(default_pool_scheduler(p));
-                    }
                     return just(request) | trigger_mpi(mode) |
                         ex::continues_on(default_pool_scheduler(p));
                 }
-                if (request == MPI_REQUEST_NULL) { return just(); }
                 return just(request) | trigger_mpi(mode);
             };
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -65,7 +65,7 @@ namespace pika::mpi::experimental {
 
             if (completions_inline)
             {
-                auto f_completion = [mode, p, f = std::forward<F>(f)](auto&... args) mutable {
+                auto f_completion = [mode, f = std::forward<F>(f)](auto&... args) mutable {
                     return just(std::forward_as_tuple(args...)) | unpack() |
                         dispatch_mpi(std::move(f)) | trigger_mpi(mode);
                 };

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -65,7 +65,7 @@ namespace pika::mpi::experimental {
 
             if (completions_inline)
             {
-                auto f_completion = [=, f = std::forward<F>(f)](auto&... args) mutable {
+                auto f_completion = [mode, p, f = std::forward<F>(f)](auto&... args) mutable {
                     return just(std::forward_as_tuple(args...)) | unpack() |
                         dispatch_mpi(std::move(f)) | trigger_mpi(mode);
                 };
@@ -82,7 +82,7 @@ namespace pika::mpi::experimental {
             }
             else
             {
-                auto f_completion = [=, f = std::forward<F>(f)](auto&... args) mutable {
+                auto f_completion = [mode, p, f = std::forward<F>(f)](auto&... args) mutable {
                     return just(std::forward_as_tuple(args...)) | unpack() |
                         dispatch_mpi(std::move(f)) | trigger_mpi(mode) |
                         continues_on(default_pool_scheduler(p));

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -52,7 +52,6 @@ namespace pika::mpi::experimental {
             using pika::execution::experimental::continues_on;
             using pika::execution::experimental::just;
             using pika::execution::experimental::let_value;
-            using pika::execution::experimental::unique_any_sender;
             using pika::execution::experimental::unpack;
 
             // get mpi completion mode settings
@@ -67,7 +66,7 @@ namespace pika::mpi::experimental {
             if (completions_inline)
             {
                 auto f_completion = [=, f = std::forward<F>(f)](auto&... args) mutable {
-                    return just(std::forward_as_tuple(args...)) | ex::unpack() |
+                    return just(std::forward_as_tuple(args...)) | unpack() |
                         dispatch_mpi(std::move(f)) | trigger_mpi(mode);
                 };
 
@@ -84,9 +83,9 @@ namespace pika::mpi::experimental {
             else
             {
                 auto f_completion = [=, f = std::forward<F>(f)](auto&... args) mutable {
-                    return just(std::forward_as_tuple(args...)) | ex::unpack() |
+                    return just(std::forward_as_tuple(args...)) | unpack() |
                         dispatch_mpi(std::move(f)) | trigger_mpi(mode) |
-                        ex::continues_on(default_pool_scheduler(p));
+                        continues_on(default_pool_scheduler(p));
                 };
 
                 if (requests_inline)

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -119,9 +119,14 @@ namespace pika::mpi::experimental::detail {
                 {
                     auto r = std::move(*this);
 
-                    // early exit check
-                    if (request == MPI_REQUEST_NULL)
+                    // early poll just in case the request completed immediately
+                    if (poll_request(request))
                     {
+#ifdef PIKA_HAVE_APEX
+                        apex::scoped_timer apex_ invoke("pika::mpi::trigger");
+#endif
+                        PIKA_DETAIL_DP(mpi_tran<7>,
+                            debug(str<>("trigger_mpi_recv"), "eager poll ok", ptr(request)));
                         ex::set_value(std::move(r.op_state.receiver));
                         return;
                     }


### PR DESCRIPTION
This PR is a proposal for some small refactorings of how the `transform_mpi` adaptor is composed of `dispatch_mpi` and `trigger_mpi`.

There are two goals with the changes:
- handle the "early polling" in one place and one place only: the `trigger_mpi` receiver
- remove nesting of `let_value` and extra type-erasure with `unique_any_sender`

The early check for `MPI_REQUEST_NULL` was done in at least two places, and the early polling was done in `dispatch_mpi`. I've moved the early poll to `trigger_mpi` where I think it fits semantically.