### PR TITLE
Allow failure on test stage of APEX CI configuration

### DIFF
--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -45,7 +45,9 @@ gcc10_apex_build:
 gcc10_apex_test_release:
   extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
+  allow_failure: true
 
 gcc10_apex_test_debug:
   extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG
+  allow_failure: true


### PR DESCRIPTION
I believe https://github.com/UO-OACISS/apex/issues/182 is what has been causing occasional test failures on the APEX CI configuration. In the hope that the issue is resolved quite quickly upstream, I'm going to use the very large hammer of allowing anything in the test stage to fail at the moment, for simplicity.

https://github.com/pika-org/pika/issues/1353 tracks disallowing failures again.