### PR TITLE
Install GDB in base image for CSCS CI for easier debugging

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_base
+++ b/.gitlab/docker/Dockerfile.spack_base
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get -yqq install --no-install-recommends \
     findutils \
     g++ \
     gcc \
+    gdb \
     git \
     gnupg2 \
     jq \


### PR DESCRIPTION
Since one can't install new packages when running in a container (since it runs as user, not root), e.g. on Alps, add `gdb` to the list of packages available in the image by default.