### PR TITLE
Enable timestamps in CSCS CI output

### DIFF
--- a/.gitlab/includes/common_pipeline.yml
+++ b/.gitlab/includes/common_pipeline.yml
@@ -8,6 +8,7 @@ include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
 variables:
+  FF_TIMESTAMPS: true
   SOURCE_DIR: /pika/source
   BUILD_DIR: /pika/build
 


### PR DESCRIPTION
Adds a timestamp to every line of log output. The raw log has the full timestamp. See https://docs.gitlab.com/runner/configuration/feature-flags.html for details. This feature is only available for gitlab runners 16.11 and newer, which at the time of the PR is not all CSCS CI runners, but I'm enabling the flag globally anyway, so that when they're updated, we'll have the timestamps there.