### PR TITLE
Use apex 2.7.1 in CI which fixes shutdown use-after-free

### DIFF
--- a/.gitlab/includes/gcc10_apex_pipeline.yml
+++ b/.gitlab/includes/gcc10_apex_pipeline.yml
@@ -14,7 +14,7 @@ include:
     COMPILER: gcc@10.3.0
     CXXSTD: 17
     SPACK_SPEC: "pika@main +apex arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD \
-                 ^apex@2.6.5 ~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
+                 ^apex@2.7.1 ~activeharmony~plugins~binutils~openmp~papi ^otf2@2.3"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_APEX=ON -DPIKA_WITH_MALLOC=system \
                   -DPIKA_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
@@ -45,9 +45,7 @@ gcc10_apex_build:
 gcc10_apex_test_release:
   extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_RELEASE
-  allow_failure: true
 
 gcc10_apex_test_debug:
   extends: [.gcc10_apex_test_common]
   image: $PERSIST_IMAGE_NAME_DEBUG
-  allow_failure: true


### PR DESCRIPTION
2.7.1 includes which https://github.com/UO-OACISS/apex/commit/cde877d0b01ded4c4c328c026454bfff6fe1714d should fix https://github.com/UO-OACISS/apex/issues/182.

Fixes #1353.