### PR TITLE
Try reenabling `detect_stack_use_after_return` again on address sanitizer CI workflow

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -83,7 +83,7 @@ jobs:
             export OMPI_ALLOW_RUN_AS_ROOT=1
             export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-            export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
+            export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
             export LSAN_OPTIONS=suppressions=$PWD/tools/lsan.supp
             cd build
@@ -104,7 +104,7 @@ jobs:
             export OMPI_ALLOW_RUN_AS_ROOT=1
             export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-            export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
+            export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:suppressions=$PWD/tools/asan.supp
             export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/tools/ubsan.supp
             export LSAN_OPTIONS=suppressions=$PWD/tools/lsan.supp
             cd build

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -156,20 +156,22 @@ namespace pika::threads::coroutines {
                 x86_linux_context_impl_base const& to, yield_hint);
 
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
-            void start_switch_fiber(void** fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void start_switch_fiber(void** fake_stack)
             {
                 __sanitizer_start_switch_fiber(fake_stack, asan_stack_bottom, asan_stack_size);
             }
-            void start_yield_fiber(void** fake_stack, x86_linux_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void start_yield_fiber(
+                void** fake_stack, x86_linux_context_impl_base& caller)
             {
                 __sanitizer_start_switch_fiber(
                     fake_stack, caller.asan_stack_bottom, caller.asan_stack_size);
             }
-            void finish_yield_fiber(void* fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void finish_yield_fiber(void* fake_stack)
             {
                 __sanitizer_finish_switch_fiber(fake_stack, &asan_stack_bottom, &asan_stack_size);
             }
-            void finish_switch_fiber(void* fake_stack, x86_linux_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void finish_switch_fiber(
+                void* fake_stack, x86_linux_context_impl_base& caller)
             {
                 __sanitizer_finish_switch_fiber(
                     fake_stack, &caller.asan_stack_bottom, &caller.asan_stack_size);

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_posix.hpp
@@ -188,20 +188,22 @@ namespace pika::threads::coroutines {
             ~ucontext_context_impl_base() { PIKA_COROUTINE_DESTROY_CONTEXT(m_ctx); }
 
 # if defined(PIKA_HAVE_ADDRESS_SANITIZER)
-            void start_switch_fiber(void** fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void start_switch_fiber(void** fake_stack)
             {
                 __sanitizer_start_switch_fiber(fake_stack, asan_stack_bottom, asan_stack_size);
             }
-            void start_yield_fiber(void** fake_stack, ucontext_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void start_yield_fiber(
+                void** fake_stack, ucontext_context_impl_base& caller)
             {
                 __sanitizer_start_switch_fiber(
                     fake_stack, caller.asan_stack_bottom, caller.asan_stack_size);
             }
-            void finish_yield_fiber(void* fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void finish_yield_fiber(void* fake_stack)
             {
                 __sanitizer_finish_switch_fiber(fake_stack, &asan_stack_bottom, &asan_stack_size);
             }
-            void finish_switch_fiber(void* fake_stack, ucontext_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void finish_switch_fiber(
+                void* fake_stack, ucontext_context_impl_base& caller)
             {
                 __sanitizer_finish_switch_fiber(
                     fake_stack, &caller.asan_stack_bottom, &caller.asan_stack_size);

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_windows_fibers.hpp
@@ -171,7 +171,7 @@ namespace pika::threads::coroutines {
             ~fibers_context_impl_base() = default;
 
 #if defined(PIKA_HAVE_ADDRESS_SANITIZER)
-            void start_switch_fiber(void** fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void start_switch_fiber(void** fake_stack)
             {
                 if (asan_stack_bottom == nullptr)
                 {
@@ -181,16 +181,18 @@ namespace pika::threads::coroutines {
                 }
                 __sanitizer_start_switch_fiber(fake_stack, asan_stack_bottom, asan_stack_size);
             }
-            void start_yield_fiber(void** fake_stack, fibers_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void start_yield_fiber(
+                void** fake_stack, fibers_context_impl_base& caller)
             {
                 __sanitizer_start_switch_fiber(
                     fake_stack, caller.asan_stack_bottom, caller.asan_stack_size);
             }
-            void finish_yield_fiber(void* fake_stack)
+            PIKA_NO_SANITIZE_ADDRESS void finish_yield_fiber(void* fake_stack)
             {
                 __sanitizer_finish_switch_fiber(fake_stack, &asan_stack_bottom, &asan_stack_size);
             }
-            void finish_switch_fiber(void* fake_stack, fibers_context_impl_base& caller)
+            PIKA_NO_SANITIZE_ADDRESS void finish_switch_fiber(
+                void* fake_stack, fibers_context_impl_base& caller)
             {
                 __sanitizer_finish_switch_fiber(
                     fake_stack, &caller.asan_stack_bottom, &caller.asan_stack_size);


### PR DESCRIPTION
The comments in https://github.com/google/sanitizers/issues/1760 seem to suggest that excluding the `__sanitizer*` functions from asan itself, may help avoiding `WARNING: ASan is ignoring requested __asan_handle_no_return` (but there's more, and it may be that the other changes in that issue are actually required to avoid the warning).