### PR TITLE
Remove unused cmake variable

### DIFF
--- a/cmake/pika_add_config_test.cmake
+++ b/cmake/pika_add_config_test.cmake
@@ -432,11 +432,6 @@ function(pika_check_for_cxx20_trivial_virtual_destructor_gpu)
       set(trivial_virtual_destructor_test_extension "hip")
     endif()
 
-    set(extra_cxxflags)
-    if(PIKA_WITH_CUDA AND CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
-      set(extra_cxxflags "-x cu")
-    endif()
-
     pika_add_config_test(
       PIKA_WITH_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR_GPU
       SOURCE


### PR DESCRIPTION
I thought I had already remove it in #1259 but looks like it's back