### PR TITLE
Call `spack spec` without an explicit spec in CI

### DIFF
--- a/.gitlab/docker/Dockerfile.spack_build
+++ b/.gitlab/docker/Dockerfile.spack_build
@@ -14,7 +14,7 @@ ARG CMAKE_FLAGS
 COPY . ${SOURCE_DIR}
 
 # Print spack spec since not printed if the compiler image is found on jfrog
-RUN spack -e pika_ci spec -lI $spack_spec
+RUN spack -e pika_ci spec -lI
 
 # Configure & Build
 RUN spack -e pika_ci config add "config:flags:keep_werror:all" && \


### PR DESCRIPTION
Since the environment is already concretized, calling it without an explicit spec simply prints the spec of anything that is in the environment. Calling it with an explicit spec will reconcretize. It will concretize to the right thing, unless something very strange happens, since all the dependencies are installed, but it takes significantly longer to print the spec with an explicit spec.