### PR TITLE
Restore some type-erasure to `transform_mpi` to avoid debug bloat

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -66,7 +66,7 @@ namespace pika::mpi::experimental {
 
             auto f_completion = [f = std::forward<F>(f), mode, completions_inline, p](
                                     auto&... args) mutable -> unique_any_sender<> {
-                auto s = just(std::forward_as_tuple(args...)) | unpack() |
+                unique_any_sender<> s = just(std::forward_as_tuple(args...)) | unpack() |
                     dispatch_mpi(std::move(f)) | trigger_mpi(mode);
                 if (completions_inline) { return s; }
                 else { return std::move(s) | continues_on(default_pool_scheduler(p)); }


### PR DESCRIPTION
#1346 simplified `transform_mpi`, but at the same time it removed almost all type-erasure of senders. This increased the debug symbol sizes caused by `transform_mpi` quite significantly. This PR proposes to restore some of the type-erasure, which further simplifies the implementation a bit and reduces debug bloat.

For reference, here are the binary sizes of the `transform_mpi` test (with build type `Debug`) at different points in history starting from just before #1321:
- https://github.com/pika-org/pika/commit/22d5654bd575bb66e3750c2bf5b4dc5e90e3a04c (just before #1321 was merged): 10,910,456 bytes
- https://github.com/pika-org/pika/commit/6c9fdf1b6 (merge commit of #1321): 18,794,288 bytes
- https://github.com/pika-org/pika/commit/2df06f72dd804e32396d3acda59059c2a1e158ac (merge commit of #1295): 19,029,672 bytes
- https://github.com/pika-org/pika/commit/015302ca235992a01a08f6424215401c42aa0e23 (merge commit of #1325): 20,175,936 bytes
- https://github.com/pika-org/pika/commit/1e5ce1dcc (merge commit of #1346): 35,766,456 bytes
- https://github.com/pika-org/pika/commit/152cb750d (merge commit of #1354): 40,082,936 bytes
- https://github.com/pika-org/pika/commit/aae604699f58f1925a786432158940ab2d6a07ea (first commit of this PR): 27,778,176 bytes
- https://github.com/pika-org/pika/commit/243c3601a717ba6bb1d9bcd2d737bbd658177e80 (second commit of this PR): 18,843,520 bytes

I've included a few selected commits above that also affect the binary size. #1321 is a bugfix, so the big increase from that PR we can't directly fix/revert. A few other PRs also increase the binary size, but not as much as #1346, so I'm targeting that first. With the changes in this PR we get back to the same size we had after #1321.