### PR TITLE
Change operation state `start` CPO to use member functions

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -113,13 +113,12 @@ namespace pika::cuda::experimental {
                 operation_state& operator=(operation_state&&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                friend void tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
+                void start() & noexcept
                 {
                     // This currently only acts as an inline scheduler to signal
                     // downstream senders that they should use the
                     // cuda_scheduler.
-                    pika::execution::experimental::set_value(std::move(os.receiver));
+                    pika::execution::experimental::set_value(std::move(receiver));
                 }
             };
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -474,11 +474,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             {
             }
 
-            friend constexpr void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::start(os.op_state);
-            }
+            void start() & noexcept { pika::execution::experimental::start(op_state); }
         };
 
         template <typename Receiver>

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -53,9 +53,9 @@ struct const_reference_cuda_sender
         std::reference_wrapper<std::decay_t<T>> const x;
         std::decay_t<R> r;
 
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
-            pika::execution::experimental::set_value(std::move(os.r), os.x.get());
+            pika::execution::experimental::set_value(std::move(r), x.get());
         };
     };
 
@@ -111,10 +111,10 @@ struct const_reference_error_cuda_sender
     struct operation_state
     {
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
             auto const e = std::make_exception_ptr(std::runtime_error("error"));
-            pika::execution::experimental::set_error(std::move(os.r), e);
+            pika::execution::experimental::set_error(std::move(r), e);
         }
     };
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -192,10 +192,7 @@ namespace pika::mpi::experimental::detail {
                 PIKA_DETAIL_DP(mpi_tran<5>, debug(str<>("operation_state")));
             }
 
-            friend constexpr auto tag_invoke(ex::start_t, operation_state& os) noexcept
-            {
-                return ex::start(os.op_state);
-            }
+            void start() & noexcept { return ex::start(op_state); }
         };
 
         template <typename Receiver>

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -243,10 +243,7 @@ namespace pika::mpi::experimental::detail {
             {
             }
 
-            friend constexpr auto tag_invoke(ex::start_t, operation_state& os) noexcept
-            {
-                return ex::start(os.op_state);
-            }
+            void start() & noexcept { return ex::start(op_state); }
         };
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -143,12 +143,11 @@ namespace pika::drop_op_state_detail {
         drop_op_state_op_state_type(drop_op_state_op_state_type const&) = delete;
         drop_op_state_op_state_type& operator=(drop_op_state_op_state_type const&) = delete;
 
-        friend void tag_invoke(
-            pika::execution::experimental::start_t, drop_op_state_op_state_type& os) noexcept
+        void start() & noexcept
         {
-            PIKA_ASSERT(os.op_state.has_value());
+            PIKA_ASSERT(op_state.has_value());
             // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            pika::execution::experimental::start(*(os.op_state));
+            pika::execution::experimental::start(*(op_state));
         }
     };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -463,11 +463,7 @@ namespace pika::ensure_started_detail {
             operation_state(operation_state const&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                os.state->add_continuation(os.receiver);
-            }
+            void start() & noexcept { state->add_continuation(receiver); }
         };
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -81,17 +81,16 @@ namespace pika::just_detail {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                friend void tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
+                void start() & noexcept
                 {
                     pika::detail::try_catch_exception_ptr(
                         [&]() {
                             pika::execution::experimental::set_value(
-                                std::move(os.receiver), std::move(os.ts).template get<Is>()...);
+                                std::move(receiver), std::move(ts).template get<Is>()...);
                         },
                         [&](std::exception_ptr ep) {
                             pika::execution::experimental::set_error(
-                                std::move(os.receiver), std::move(ep));
+                                std::move(receiver), std::move(ep));
                         });
                 }
             };

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -249,10 +249,9 @@ namespace pika::let_error_detail {
             operation_state(operation_state const&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
-                pika::execution::experimental::start(os.predecessor_operation_state);
+                pika::execution::experimental::start(predecessor_operation_state);
             }
         };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -261,11 +261,7 @@ namespace pika::let_value_detail {
             operation_state(operation_state const&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::start(os.predecessor_op_state);
-            }
+            void start() & noexcept { pika::execution::experimental::start(predecessor_op_state); }
         };
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -199,15 +199,14 @@ namespace pika {
             require_started_op_state_type(require_started_op_state_type const&) = delete;
             require_started_op_state_type& operator=(require_started_op_state_type const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, require_started_op_state_type& os) noexcept
+            void start() & noexcept
             {
-                PIKA_ASSERT(os.op_state.has_value());
+                PIKA_ASSERT(op_state.has_value());
 
-                os.started = true;
+                started = true;
 
                 // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                pika::execution::experimental::start(*(os.op_state));
+                pika::execution::experimental::start(*(op_state));
             }
         };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -290,11 +290,7 @@ namespace pika::schedule_from_detail {
                     scheduler_sender_value_visitor{std::move(receiver)}, std::move(ts));
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::start(os.sender_os);
-            }
+            void start() & noexcept { pika::execution::experimental::start(sender_os); }
         };
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -410,11 +410,10 @@ namespace pika::split_detail {
             operation_state(operation_state const&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
-                os.state->start();
-                os.state->add_continuation(os.receiver);
+                state->start();
+                state->add_continuation(receiver);
             }
         };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -449,11 +449,10 @@ namespace pika::split_tuple_detail {
             operation_state(operation_state const&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
-                os.state->start();
-                os.state->template add_continuation<Index>(os.receiver);
+                state->start();
+                state->template add_continuation<Index>(receiver);
             }
         };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -333,13 +333,6 @@ namespace pika::when_all_impl {
             }
         };
 
-        template <typename Receiver, typename SendersPack>
-        friend void tag_invoke(pika::execution::experimental::start_t,
-            operation_state<Receiver, SendersPack, num_predecessors - 1>& os) noexcept
-        {
-            os.start();
-        }
-
         template <typename Receiver>
         friend auto tag_invoke(
             pika::execution::experimental::connect_t, when_all_sender_type&& s, Receiver&& receiver)

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -318,25 +318,24 @@ namespace pika::when_all_vector_detail {
                 }
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
                 // If there are no predecessors we can signal the
                 // continuation as soon as start is called.
-                if (os.num_predecessors == 0)
+                if (num_predecessors == 0)
                 {
                     // If the predecessor sender type sends nothing, we also
                     // send nothing to the continuation.
                     if constexpr (is_void_value_type)
                     {
-                        pika::execution::experimental::set_value(std::move(os.receiver));
+                        pika::execution::experimental::set_value(std::move(receiver));
                     }
                     // If the predecessor sender type sends something we
                     // send an empty vector of that type to the continuation.
                     else
                     {
                         pika::execution::experimental::set_value(
-                            std::move(os.receiver), std::vector<element_value_type>{});
+                            std::move(receiver), std::vector<element_value_type>{});
                     }
                 }
                 // Otherwise we start all the operation states and wait for
@@ -347,12 +346,12 @@ namespace pika::when_all_vector_detail {
                     // when_all_vector operation state may already have been released. We read the
                     // number of predecessors from the operation state into a stack-local variable
                     // so that the loop can end without reading freed memory.
-                    auto const num_predecessors = os.num_predecessors;
-                    for (std::size_t i = 0; i < num_predecessors; ++i)
+                    std::size_t const num_predecessors_local = num_predecessors;
+                    for (std::size_t i = 0; i < num_predecessors_local; ++i)
                     {
-                        PIKA_ASSERT(os.op_states[i].has_value());
+                        PIKA_ASSERT(op_states[i].has_value());
                         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                        pika::execution::experimental::start(*(os.op_states.get()[i]));
+                        pika::execution::experimental::start(*(op_states.get()[i]));
                     }
                 }
             }

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -37,10 +37,7 @@ struct sender
     {
         std::decay_t<R> receiver;
 
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
-        {
-            pika::execution::experimental::set_value(std::move(os.receiver));
-        };
+        void start() & noexcept { pika::execution::experimental::set_value(std::move(receiver)); };
     };
 
     template <typename R>

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -58,11 +58,7 @@ struct scheduler_schedule_from
         {
             std::decay_t<R> r;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::set_value(std::move(os.r));
-            };
+            void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); };
         };
 
         template <typename R>
@@ -155,11 +151,7 @@ struct scheduler_transfer
         {
             std::decay_t<R> r;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::set_value(std::move(os.r));
-            };
+            void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); };
         };
 
         template <typename R>

--- a/libs/pika/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all.cpp
@@ -39,7 +39,7 @@ int main()
         auto f = [](int x) { PIKA_TEST_EQ(x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 

--- a/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -31,7 +31,7 @@ int main()
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 
@@ -41,7 +41,7 @@ int main()
         auto f = [](std::vector<int> v) { PIKA_TEST_EQ(v.size(), std::size_t(0)); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 
@@ -54,7 +54,7 @@ int main()
         };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 
@@ -68,7 +68,7 @@ int main()
         };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 
@@ -131,7 +131,7 @@ int main()
         auto f = []() {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        tag_invoke(ex::start, os);
+        ex::start(os);
         PIKA_TEST(set_value_called);
     }
 

--- a/libs/pika/execution/tests/unit/scheduler_queries.cpp
+++ b/libs/pika/execution/tests/unit/scheduler_queries.cpp
@@ -29,10 +29,7 @@ struct uncustomized_scheduler
         {
             std::decay_t<R> r;
 
-            friend void tag_invoke(ex::start_t, operation_state& os) noexcept
-            {
-                ex::set_value(std::move(os.r));
-            };
+            void start() & noexcept { ex::set_value(std::move(r)); };
         };
 
         template <typename R>

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -565,11 +565,7 @@ namespace pika::execution::experimental::detail {
         any_operation_state& operator=(any_operation_state&&) = delete;
         any_operation_state& operator=(any_operation_state const&) = delete;
 
-        friend void tag_invoke(
-            pika::execution::experimental::start_t, any_operation_state& os) noexcept
-        {
-            os.op_state.start();
-        }
+        void start() & noexcept { op_state.start(); }
     };
 
     [[noreturn]] PIKA_EXPORT void throw_bad_any_call(

--- a/libs/pika/execution_base/include/pika/execution_base/operation_state.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/operation_state.hpp
@@ -54,8 +54,16 @@ namespace pika::execution::experimental {
     struct is_operation_state;
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct start_t : pika::functional::detail::tag_noexcept<start_t>
+    struct start_t
     {
+        template <typename OperationState>
+        PIKA_FORCEINLINE constexpr auto
+        PIKA_STATIC_CALL_OPERATOR(OperationState& os) noexcept -> decltype(os.start())
+        {
+            static_assert(noexcept(os.start()),
+                "std::execution operation state start member function must be noexcept");
+            os.start();
+        }
     } start{};
 
     namespace detail {

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -37,10 +37,7 @@ struct void_sender
     struct operation_state
     {
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
-        {
-            pika::execution::experimental::set_value(std::move(os.r));
-        }
+        void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); }
     };
 
     template <typename R>
@@ -72,7 +69,7 @@ struct error_sender
     struct operation_state
     {
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
             try
             {
@@ -80,7 +77,7 @@ struct error_sender
             }
             catch (...)
             {
-                pika::execution::experimental::set_error(std::move(os.r), std::current_exception());
+                pika::execution::experimental::set_error(std::move(r), std::current_exception());
             }
         }
     };
@@ -114,10 +111,10 @@ struct const_reference_error_sender
     struct operation_state
     {
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
             auto const e = std::make_exception_ptr(std::runtime_error("error"));
-            pika::execution::experimental::set_error(std::move(os.r), e);
+            pika::execution::experimental::set_error(std::move(r), e);
         }
     };
 
@@ -287,10 +284,10 @@ struct custom_sender
     {
         std::atomic<bool>& start_called;
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
-            os.start_called = true;
-            pika::execution::experimental::set_value(std::move(os.r));
+            start_called = true;
+            pika::execution::experimental::set_value(std::move(r));
         };
     };
 
@@ -331,10 +328,10 @@ struct custom_typed_sender
         std::decay_t<T> x;
         std::atomic<bool>& start_called;
         std::decay_t<R> r;
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
-            os.start_called = true;
-            pika::execution::experimental::set_value(std::move(os.r), std::move(os.x));
+            start_called = true;
+            pika::execution::experimental::set_value(std::move(r), std::move(x));
         };
     };
 
@@ -379,9 +376,9 @@ struct const_reference_sender
         std::reference_wrapper<std::decay_t<T>> const x;
         std::decay_t<R> r;
 
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
-            pika::execution::experimental::set_value(std::move(os.r), os.x.get());
+            pika::execution::experimental::set_value(std::move(r), x.get());
         };
     };
 
@@ -474,11 +471,7 @@ struct scheduler
         {
             std::decay_t<R> r;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::set_value(std::move(os.r));
-            };
+            void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); };
         };
 
         template <typename R>
@@ -555,11 +548,7 @@ struct scheduler2
         {
             std::decay_t<R> r;
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::set_value(std::move(os.r));
-            };
+            void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); };
         };
 
         template <typename R>
@@ -665,11 +654,7 @@ namespace my_namespace {
             {
                 std::decay_t<R> r;
 
-                friend void tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
-                {
-                    pika::execution::experimental::set_value(std::move(os.r));
-                };
+                void start() & noexcept { pika::execution::experimental::set_value(std::move(r)); };
             };
 
             template <typename R>
@@ -733,10 +718,9 @@ namespace my_namespace {
         struct operation_state
         {
             std::decay_t<R> r;
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
-                pika::execution::experimental::set_value(std::move(os.r), Ts{}...);
+                pika::execution::experimental::set_value(std::move(r), Ts{}...);
             }
         };
 

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -80,11 +80,11 @@ struct non_copyable_sender
         std::decay_t<R> r;
         std::tuple<std::decay_t<Ts>...> ts;
 
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
             std::apply(pika::util::detail::bind_front(
-                           pika::execution::experimental::set_value, std::move(os.r)),
-                std::move(os.ts));
+                           pika::execution::experimental::set_value, std::move(r)),
+                std::move(ts));
         };
     };
 
@@ -137,11 +137,11 @@ struct sender
         std::decay_t<R> r;
         std::tuple<std::decay_t<Ts>...> ts;
 
-        friend void tag_invoke(pika::execution::experimental::start_t, operation_state& os) noexcept
+        void start() & noexcept
         {
             std::apply(pika::util::detail::bind_front(
-                           pika::execution::experimental::set_value, std::move(os.r)),
-                std::move(os.ts));
+                           pika::execution::experimental::set_value, std::move(r)),
+                std::move(ts));
         };
     };
 

--- a/libs/pika/execution_base/tests/unit/basic_operation_state.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_operation_state.cpp
@@ -21,65 +21,26 @@ namespace mylib {
 
     struct state_2
     {
-        friend void tag_invoke(pika::execution::experimental::start_t, state_2&) {}
+        void start() & {}
     };
 
     struct state_3
     {
-        friend void tag_invoke(pika::execution::experimental::start_t, state_3&) noexcept
-        {
-            start_called = true;
-        }
+        void start() & noexcept { start_called = true; }
     };
-
-    struct state_4
-    {
-    };
-
-    void tag_invoke(pika::execution::experimental::start_t, state_4&) {}
-
-    struct state_5
-    {
-    };
-
-    void tag_invoke(pika::execution::experimental::start_t, state_5&) noexcept
-    {
-        start_called = true;
-    }
 }    // namespace mylib
 
 int main()
 {
     static_assert(!pika::execution::experimental::is_operation_state_v<mylib::state_1>,
         "mylib::state_1 is not an operation state");
-#if defined(PIKA_HAVE_STDEXEC)
     static_assert(pika::execution::experimental::is_operation_state_v<mylib::state_2>,
         "mylib::state_2 is an operation state");
-#else
-    static_assert(!pika::execution::experimental::is_operation_state_v<mylib::state_2>,
-        "mylib::state_2 is not an operation state");
-#endif
     static_assert(pika::execution::experimental::is_operation_state_v<mylib::state_3>,
         "mylib::state_3 is an operation state");
-#if defined(PIKA_HAVE_STDEXEC)
-    static_assert(pika::execution::experimental::is_operation_state_v<mylib::state_4>,
-        "mylib::state_4 is an operation state");
-#else
-    static_assert(!pika::execution::experimental::is_operation_state_v<mylib::state_4>,
-        "mylib::state_4 is not an operation state");
-#endif
-    static_assert(pika::execution::experimental::is_operation_state_v<mylib::state_5>,
-        "mylib::state_5 is an operation state");
 
     {
         mylib::state_3 state;
-
-        pika::execution::experimental::start(state);
-        PIKA_TEST(start_called);
-        start_called = false;
-    }
-    {
-        mylib::state_5 state;
 
         pika::execution::experimental::start(state);
         PIKA_TEST(start_called);

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -35,7 +35,7 @@ struct sender
 
     struct operation_state
     {
-        friend operation_state tag_invoke(ex::start_t, operation_state&) noexcept { return {}; }
+        void start() & noexcept {}
     };
 
     template <typename R>

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -102,10 +102,7 @@ struct sender_1
     struct operation_state
     {
         receiver r;
-        friend void tag_invoke(ex::start_t, operation_state& os) noexcept
-        {
-            ex::set_value(std::move(os.r), 4711);
-        };
+        void start() & noexcept { ex::set_value(std::move(r), 4711); };
     };
 
     friend operation_state tag_invoke(ex::connect_t, sender_1&&, receiver r)
@@ -133,10 +130,7 @@ struct sender_2
     struct operation_state
     {
         receiver r;
-        friend void tag_invoke(ex::start_t, operation_state& os) noexcept
-        {
-            ex::set_value(std::move(os.r), 4711);
-        };
+        void start() & noexcept { ex::set_value(std::move(r), 4711); };
     };
 };
 

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -52,18 +52,18 @@ namespace pika::execution::experimental {
             operation_state& operator=(operation_state&&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
                 pika::detail::try_catch_exception_ptr(
                     [&]() {
-                        std::thread t{[&os]() mutable {
-                            pika::execution::experimental::set_value(std::move(os.receiver));
+                        std::thread t{[&]() mutable {
+                            pika::execution::experimental::set_value(std::move(receiver));
                         }};
                         t.detach();
                     },
                     [&](std::exception_ptr ep) {
                         pika::execution::experimental::set_error(
-                            std::move(os.receiver), std::move(ep));
+                            std::move(receiver), std::move(ep));
                     });
             }
         };

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -159,19 +159,19 @@ namespace pika::execution::experimental {
             operation_state& operator=(operation_state&&) = delete;
             operation_state& operator=(operation_state const&) = delete;
 
-            friend void tag_invoke(start_t, operation_state& os) noexcept
+            void start() & noexcept
             {
                 pika::detail::try_catch_exception_ptr(
                     [&]() {
-                        os.scheduler.execute(
-                            [&os]() mutable {
-                                pika::execution::experimental::set_value(std::move(os.receiver));
+                        scheduler.execute(
+                            [&]() mutable {
+                                pika::execution::experimental::set_value(std::move(receiver));
                             },
-                            os.fallback_annotation);
+                            fallback_annotation);
                     },
                     [&](std::exception_ptr ep) {
                         pika::execution::experimental::set_error(
-                            std::move(os.receiver), std::move(ep));
+                            std::move(receiver), std::move(ep));
                     });
             }
         };

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -473,11 +473,7 @@ namespace pika::thread_pool_bulk_detail {
             {
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::start_t, operation_state& os) noexcept
-            {
-                pika::execution::experimental::start(os.op_state);
-            }
+            void start() & noexcept { pika::execution::experimental::start(op_state); }
         };
 
     public:

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -473,41 +473,40 @@ namespace pika::execution::experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                friend void tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
+                void start() & noexcept
                 {
-                    PIKA_ASSERT_MSG(os.state,
+                    PIKA_ASSERT_MSG(state,
                         "async_rw_lock::sender::operation_state state is empty, was the sender "
                         "already started?");
 
-                    auto continuation = [&os](shared_state_ptr_type state) mutable {
+                    auto continuation = [&](shared_state_ptr_type state) mutable {
                         try
                         {
                             pika::execution::experimental::set_value(
-                                std::move(os.r), access_type{std::move(state)});
+                                std::move(r), access_type{std::move(state)});
                         }
                         catch (...)
                         {
                             pika::execution::experimental::set_error(
-                                std::move(os.r), std::current_exception());
+                                std::move(r), std::current_exception());
                         }
                     };
 
-                    if (auto p = os.prev_state.lock())
+                    if (auto p = prev_state.lock())
                     {
                         // If the previous state is set and it's still alive,
                         // add a continuation to be triggered when the previous
                         // state is released.
                         p->add_continuation(std::move(continuation));
-                        os.state.reset();
-                        os.prev_state.reset();
+                        state.reset();
+                        prev_state.reset();
                     }
                     else
                     {
                         // There is no previous state on the first access or the
                         // previous state has already been released. We can run
                         // the continuation immediately.
-                        continuation(std::move(os.state));
+                        continuation(std::move(state));
                     }
                 }
             };
@@ -681,41 +680,40 @@ namespace pika::execution::experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                friend void tag_invoke(
-                    pika::execution::experimental::start_t, operation_state& os) noexcept
+                void start() & noexcept
                 {
-                    PIKA_ASSERT_MSG(os.state,
+                    PIKA_ASSERT_MSG(state,
                         "async_rw_lock::sender::operation_state state is empty, was the sender "
                         "already started?");
 
-                    auto continuation = [&os](shared_state_ptr_type state) mutable {
+                    auto continuation = [&](shared_state_ptr_type state) mutable {
                         try
                         {
                             pika::execution::experimental::set_value(
-                                std::move(os.r), access_type{std::move(state)});
+                                std::move(r), access_type{std::move(state)});
                         }
                         catch (...)
                         {
                             pika::execution::experimental::set_error(
-                                std::move(os.r), std::current_exception());
+                                std::move(r), std::current_exception());
                         }
                     };
 
-                    if (auto p = os.prev_state.lock())
+                    if (auto p = prev_state.lock())
                     {
                         // If the previous state is set and it's still alive,
                         // add a continuation to be triggered when the previous
                         // state is released.
                         p->add_continuation(std::move(continuation));
-                        os.state.reset();
-                        os.prev_state.reset();
+                        state.reset();
+                        prev_state.reset();
                     }
                     else
                     {
                         // There is no previous state on the first access or the
                         // previous state has already been released. We can run
                         // the continuation immediately.
-                        continuation(std::move(os.state));
+                        continuation(std::move(state));
                     }
                 }
             };


### PR DESCRIPTION
Part of #1204. A step towards reducing debug bloat as well.