### PR TITLE
Change sender `connect` CPO to use member functions

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -145,17 +145,15 @@ namespace pika::cuda::experimental {
 #endif
 
             template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-                cuda_scheduler_sender&& s, Receiver&& receiver)
+            operation_state<Receiver> connect(Receiver&& receiver) &&
             {
-                return {std::move(s.scheduler), std::forward<Receiver>(receiver)};
+                return {std::move(scheduler), std::forward<Receiver>(receiver)};
             }
 
             template <typename Receiver>
-            friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-                cuda_scheduler_sender const& s, Receiver&& receiver)
+            operation_state<Receiver> connect(Receiver&& receiver) const&
             {
-                return {s.scheduler, std::forward<Receiver>(receiver)};
+                return {scheduler, std::forward<Receiver>(receiver)};
             }
 
             struct env

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -478,19 +478,16 @@ namespace pika::cuda::experimental::then_with_stream_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            then_with_cuda_stream_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return operation_state<Receiver>(std::forward<Receiver>(receiver), std::move(s.f),
-                std::move(s.sched), std::move(s.sender));
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), std::move(f),
+                std::move(sched), std::move(sender));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            then_with_cuda_stream_sender_type const& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
-            return operation_state<Receiver>(
-                std::forward<Receiver>(receiver), s.f, s.sched, s.sender);
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), f, sched, sender);
         }
 
         friend auto tag_invoke(pika::execution::experimental::get_env_t,

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -60,10 +60,9 @@ struct const_reference_cuda_sender
     };
 
     template <typename R>
-    friend auto
-    tag_invoke(pika::execution::experimental::connect_t, const_reference_cuda_sender&& s, R&& r)
+    auto connect(R&& r) &&
     {
-        return operation_state<R>{std::move(s.x), std::forward<R>(r)};
+        return operation_state<R>{std::move(x), std::forward<R>(r)};
     }
 
     struct env
@@ -119,8 +118,7 @@ struct const_reference_error_cuda_sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, const_reference_error_cuda_sender, R&& r)
+    operation_state<R> connect(R&& r)
     {
         return {std::forward<R>(r)};
     }

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -196,18 +196,16 @@ namespace pika::mpi::experimental::detail {
         };
 
         template <typename Receiver>
-        friend constexpr auto
-        tag_invoke(ex::connect_t, dispatch_mpi_sender_type const& s, Receiver&& receiver)
+        constexpr auto connect(Receiver&& receiver) const&
         {
-            return operation_state<Receiver>(std::forward<Receiver>(receiver), s.f, s.sender);
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), f, sender);
         }
 
         template <typename Receiver>
-        friend constexpr auto
-        tag_invoke(ex::connect_t, dispatch_mpi_sender_type&& s, Receiver&& receiver)
+        constexpr auto connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver>(
-                std::forward<Receiver>(receiver), std::move(s.f), std::move(s.sender));
+                std::forward<Receiver>(receiver), std::move(f), std::move(sender));
         }
     };
 

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -247,18 +247,16 @@ namespace pika::mpi::experimental::detail {
         };
 
         template <typename Receiver>
-        friend constexpr auto
-        tag_invoke(ex::connect_t, trigger_mpi_sender_type const& s, Receiver&& receiver)
+        constexpr auto connect(Receiver&& receiver) const&
         {
-            return operation_state<Receiver>(std::forward<Receiver>(receiver), s.sender);
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), sender);
         }
 
         template <typename Receiver>
-        friend constexpr auto
-        tag_invoke(ex::connect_t, trigger_mpi_sender_type&& s, Receiver&& receiver)
+        constexpr auto connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver>(
-                std::forward<Receiver>(receiver), std::move(s.sender), s.completion_mode_flags_);
+                std::forward<Receiver>(receiver), std::move(sender), completion_mode_flags_);
         }
     };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -112,20 +112,18 @@ namespace pika::bulk_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, bulk_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return pika::execution::experimental::connect(std::move(s.sender),
+            return pika::execution::experimental::connect(std::move(sender),
                 bulk_receiver<Receiver>(
-                    std::forward<Receiver>(receiver), std::move(s.shape), std::move(s.f)));
+                    std::forward<Receiver>(receiver), std::move(shape), std::move(f)));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, bulk_sender_type const& s,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return pika::execution::experimental::connect(
-                s.sender, bulk_receiver<Receiver>(std::forward<Receiver>(receiver), s.shape, s.f));
+                sender, bulk_receiver<Receiver>(std::forward<Receiver>(receiver), shape, f));
         }
     };
 }    // namespace pika::bulk_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -218,19 +218,15 @@ namespace pika::drop_op_state_detail {
         drop_op_state_sender_type& operator=(drop_op_state_sender_type&&) = default;
 
         template <typename Receiver>
-        friend drop_op_state_op_state<Sender, Receiver>
-        tag_invoke(pika::execution::experimental::connect_t, drop_op_state_sender_type&& s,
-            Receiver&& receiver)
+        drop_op_state_op_state<Sender, Receiver> connect(Receiver&& receiver) &&
         {
-            return {std::move(s.sender), std::forward<Receiver>(receiver)};
+            return {std::move(sender), std::forward<Receiver>(receiver)};
         }
 
         template <typename Receiver>
-        friend drop_op_state_op_state<Sender, Receiver>
-        tag_invoke(pika::execution::experimental::connect_t, drop_op_state_sender_type const& s,
-            Receiver&& receiver)
+        drop_op_state_op_state<Sender, Receiver> connect(Receiver&& receiver) const&
         {
-            return {s.sender, std::forward<Receiver>(receiver)};
+            return {sender, std::forward<Receiver>(receiver)};
         }
     };
 }    // namespace pika::drop_op_state_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -105,19 +105,17 @@ namespace pika::drop_value_detail {
 #endif
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, drop_value_sender_type&& s,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return pika::execution::experimental::connect(std::move(s.sender),
-                drop_value_receiver<Receiver>{std::forward<Receiver>(receiver)});
+            return pika::execution::experimental::connect(
+                std::move(sender), drop_value_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            drop_value_sender_type const& r, Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return pika::execution::experimental::connect(
-                r.sender, drop_value_receiver<Receiver>{std::forward<Receiver>(receiver)});
+                sender, drop_value_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
         friend decltype(auto) tag_invoke(

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -467,15 +467,13 @@ namespace pika::ensure_started_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-            ensure_started_sender_type&& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &&
         {
-            return {std::forward<Receiver>(receiver), std::move(s.state)};
+            return {std::forward<Receiver>(receiver), std::move(state)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t, ensure_started_sender_type const&, Receiver&&)
+        operation_state<Receiver> connect(Receiver&&) const&
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The ensure_started sender is not copyable and thus "

--- a/libs/pika/execution/include/pika/execution/algorithms/just.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/just.hpp
@@ -96,17 +96,15 @@ namespace pika::just_detail {
             };
 
             template <typename Receiver>
-            friend auto tag_invoke(
-                pika::execution::experimental::connect_t, just_sender_type&& s, Receiver&& receiver)
+            auto connect(Receiver&& receiver) &&
             {
-                return operation_state<Receiver>{std::forward<Receiver>(receiver), std::move(s.ts)};
+                return operation_state<Receiver>{std::forward<Receiver>(receiver), std::move(ts)};
             }
 
             template <typename Receiver>
-            friend auto tag_invoke(pika::execution::experimental::connect_t,
-                just_sender_type const& s, Receiver&& receiver)
+            auto connect(Receiver&& receiver) const&
             {
-                return operation_state<Receiver>{std::forward<Receiver>(receiver), s.ts};
+                return operation_state<Receiver>{std::forward<Receiver>(receiver), ts};
             }
         };
     };

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -256,16 +256,14 @@ namespace pika::let_error_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, let_error_sender_type&& s,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver>(
-                std::move(s.predecessor_sender), std::forward<Receiver>(receiver), std::move(s.f));
+                std::move(predecessor_sender), std::forward<Receiver>(receiver), std::move(f));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, let_error_sender_type const&, Receiver&&)
+        auto connect(Receiver&&) const&
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The let_error sender is not copyable and thus not "

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -265,16 +265,14 @@ namespace pika::let_value_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, let_value_sender_type&& s,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver>(
-                std::move(s.predecessor_sender), std::forward<Receiver>(receiver), std::move(s.f));
+                std::move(predecessor_sender), std::forward<Receiver>(receiver), std::move(f));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, let_value_sender_type const&, Receiver&&)
+        auto connect(Receiver&&) const&
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The let_value sender is not copyable and thus not "

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -361,14 +361,12 @@ namespace pika {
             }
 
             template <typename Receiver>
-            friend require_started_op_state<Sender, Receiver>
-            tag_invoke(pika::execution::experimental::connect_t, require_started_sender_type&& s,
-                Receiver&& receiver)
+            require_started_op_state<Sender, Receiver> connect(Receiver&& receiver) &&
             {
-                if (!s.sender.has_value())
+                if (!sender.has_value())
                 {
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
-                    PIKA_DETAIL_HANDLE_UNSTARTED_REQUIRE_STARTED_SENDER(s.mode,
+                    PIKA_DETAIL_HANDLE_UNSTARTED_REQUIRE_STARTED_SENDER(mode,
                         "pika::execution::experimental::connect(require_started_sender&&)",
                         "Trying to connect an empty require_started sender");
 #else
@@ -378,25 +376,23 @@ namespace pika {
 #endif
                 }
 
-                s.connected = true;
+                connected = true;
                 return {// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                    *std::exchange(s.sender, std::nullopt), std::forward<Receiver>(receiver)
+                    *std::exchange(sender, std::nullopt), std::forward<Receiver>(receiver)
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
-                                                                ,
-                    s.mode
+                                                              ,
+                    mode
 #endif
                 };
             }
 
             template <typename Receiver>
-            friend require_started_op_state<Sender, Receiver>
-            tag_invoke(pika::execution::experimental::connect_t,
-                require_started_sender_type const& s, Receiver&& receiver)
+            require_started_op_state<Sender, Receiver> connect(Receiver&& receiver) const&
             {
-                if (!s.sender.has_value())
+                if (!sender.has_value())
                 {
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
-                    PIKA_DETAIL_HANDLE_UNSTARTED_REQUIRE_STARTED_SENDER(s.mode,
+                    PIKA_DETAIL_HANDLE_UNSTARTED_REQUIRE_STARTED_SENDER(mode,
                         "pika::execution::experimental::connect(require_started_sender const&)",
                         "Trying to connect an empty require_started sender");
 #else
@@ -406,11 +402,11 @@ namespace pika {
 #endif
                 }
 
-                s.connected = true;
-                return {*s.sender, std::forward<Receiver>(receiver)
+                connected = true;
+                return {*sender, std::forward<Receiver>(receiver)
 #if defined(PIKA_DETAIL_HAVE_REQUIRE_STARTED_MODE)
-                                       ,
-                    s.mode
+                                     ,
+                    mode
 #endif
                 };
             }

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -294,18 +294,16 @@ namespace pika::schedule_from_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-            schedule_from_sender_type&& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &&
         {
-            return {std::move(s.predecessor_sender), std::move(s.scheduler),
+            return {std::move(predecessor_sender), std::move(scheduler),
                 std::forward<Receiver>(receiver)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-            schedule_from_sender_type const& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) const&
         {
-            return {s.predecessor_sender, s.scheduler, std::forward<Receiver>(receiver)};
+            return {predecessor_sender, scheduler, std::forward<Receiver>(receiver)};
         }
     };
 }    // namespace pika::schedule_from_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -418,17 +418,15 @@ namespace pika::split_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t, split_sender_type&& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &&
         {
-            return {std::forward<Receiver>(receiver), std::move(s.state)};
+            return {std::forward<Receiver>(receiver), std::move(state)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-            split_sender_type const& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) const&
         {
-            return {std::forward<Receiver>(receiver), s.state};
+            return {std::forward<Receiver>(receiver), state};
         }
     };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -457,15 +457,13 @@ namespace pika::split_tuple_detail {
         };
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(pika::execution::experimental::connect_t,
-            split_tuple_sender_type&& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &&
         {
-            return {std::forward<Receiver>(receiver), std::move(s.state)};
+            return {std::forward<Receiver>(receiver), std::move(state)};
         }
 
         template <typename Receiver>
-        friend operation_state<Receiver> tag_invoke(
-            pika::execution::experimental::connect_t, split_tuple_sender_type const&, Receiver&&)
+        operation_state<Receiver> connect(Receiver&&) const&
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? The split_tuple sender is not copyable and thus not "

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -132,19 +132,17 @@ namespace pika::then_detail {
         static constexpr bool sends_done = false;
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, then_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return pika::execution::experimental::connect(std::move(s.sender),
-                then_receiver<Receiver, F>{std::forward<Receiver>(receiver), std::move(s.f)});
+            return pika::execution::experimental::connect(std::move(sender),
+                then_receiver<Receiver, F>{std::forward<Receiver>(receiver), std::move(f)});
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, then_sender_type const& r,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return pika::execution::experimental::connect(
-                r.sender, then_receiver<Receiver, F>{std::forward<Receiver>(receiver), r.f});
+                sender, then_receiver<Receiver, F>{std::forward<Receiver>(receiver), f});
         }
 
         friend decltype(auto) tag_invoke(

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -174,19 +174,17 @@ namespace pika::unpack_detail {
 #endif
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, unpack_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
             return pika::execution::experimental::connect(
-                std::move(s.sender), unpack_receiver<Receiver>{std::forward<Receiver>(receiver)});
+                std::move(sender), unpack_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            unpack_sender_type const& r, Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return pika::execution::experimental::connect(
-                r.sender, unpack_receiver<Receiver>{std::forward<Receiver>(receiver)});
+                sender, unpack_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
         friend decltype(auto) tag_invoke(

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -334,19 +334,17 @@ namespace pika::when_all_impl {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            pika::execution::experimental::connect_t, when_all_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver, senders_type&&, num_predecessors - 1>(
-                std::forward<Receiver>(receiver), std::move(s.senders));
+                std::forward<Receiver>(receiver), std::move(senders));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            when_all_sender_type const& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return operation_state<Receiver, senders_type&, num_predecessors - 1>(
-                std::forward<Receiver>(receiver), s.senders);
+                std::forward<Receiver>(receiver), senders);
         }
     };
 }    // namespace pika::when_all_impl

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -358,18 +358,15 @@ namespace pika::when_all_vector_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            when_all_vector_sender_type&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return operation_state<Receiver>(
-                std::forward<Receiver>(receiver), std::move(s.senders));
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), std::move(senders));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            when_all_vector_sender_type const& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
-            return operation_state<Receiver>(std::forward<Receiver>(receiver), s.senders);
+            return operation_state<Receiver>(std::forward<Receiver>(receiver), senders);
         }
     };
 }    // namespace pika::when_all_vector_detail

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -41,8 +41,7 @@ struct sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& receiver) noexcept
+    operation_state<R> connect(R&& receiver) && noexcept
     {
         return {std::forward<R>(receiver)};
     }

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -62,7 +62,7 @@ struct scheduler_schedule_from
         };
 
         template <typename R>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
+        auto connect(R&& r) &&
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -155,7 +155,7 @@ struct scheduler_transfer
         };
 
         template <typename R>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
+        auto connect(R&& r) &&
         {
             return operation_state<R>{std::forward<R>(r)};
         }

--- a/libs/pika/execution/tests/unit/scheduler_queries.cpp
+++ b/libs/pika/execution/tests/unit/scheduler_queries.cpp
@@ -33,7 +33,7 @@ struct uncustomized_scheduler
         };
 
         template <typename R>
-        friend auto tag_invoke(ex::connect_t, sender&&, R&& r)
+        auto connect(R&& r) &&
         {
             return operation_state<R>{std::forward<R>(r)};
         }

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -797,20 +797,18 @@ namespace pika::execution::experimental {
             pika::execution::experimental::set_stopped_t()>;
 
         template <typename Receiver>
-        friend detail::any_operation_state<Receiver, Ts...> tag_invoke(
-            pika::execution::experimental::connect_t, unique_any_sender&& s, Receiver&& receiver)
+        detail::any_operation_state<Receiver, Ts...> connect(Receiver&& receiver) &&
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
             // std::move(storage.get()).connect(...) would leave us with a
             // non-empty any_sender holding a moved-from sender.
-            auto moved_storage = std::move(s.storage);
+            auto moved_storage = std::move(storage);
             return {std::move(moved_storage.get()), std::forward<Receiver>(receiver)};
         }
 
         template <typename Receiver>
-        friend detail::any_operation_state<Receiver, Ts...>
-        tag_invoke(pika::execution::experimental::connect_t, unique_any_sender const&, Receiver&&)
+        detail::any_operation_state<Receiver, Ts...> connect(Receiver&&) const&
         {
             static_assert(sizeof(Receiver) == 0,
                 "Are you missing a std::move? unique_any_sender is not copyable and thus not "
@@ -923,21 +921,19 @@ namespace pika::execution::experimental {
             pika::execution::experimental::set_stopped_t()>;
 
         template <typename Receiver>
-        friend detail::any_operation_state<Receiver, Ts...> tag_invoke(
-            pika::execution::experimental::connect_t, any_sender const& s, Receiver&& receiver)
+        detail::any_operation_state<Receiver, Ts...> connect(Receiver&& receiver) const&
         {
-            return {s.storage.get(), std::forward<Receiver>(receiver)};
+            return {storage.get(), std::forward<Receiver>(receiver)};
         }
 
         template <typename Receiver>
-        friend detail::any_operation_state<Receiver, Ts...>
-        tag_invoke(pika::execution::experimental::connect_t, any_sender&& s, Receiver&& receiver)
+        detail::any_operation_state<Receiver, Ts...> connect(Receiver&& receiver) &&
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
             // std::move(storage.get()).connect(...) would leave us with a
             // non-empty any_sender holding a moved-from sender.
-            auto moved_storage = std::move(s.storage);
+            auto moved_storage = std::move(storage);
             return {std::move(moved_storage.get()), std::forward<Receiver>(receiver)};
         }
 

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -210,8 +210,16 @@ namespace pika::execution::experimental {
     }    // namespace detail
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct connect_t : pika::functional::detail::tag<connect_t>
+    struct connect_t
     {
+        template <typename Sender, typename Receiver>
+        PIKA_FORCEINLINE constexpr auto
+        PIKA_STATIC_CALL_OPERATOR(Sender&& sender, Receiver&& receiver) noexcept(
+            noexcept(std::forward<Sender>(sender).connect(std::forward<Receiver>(receiver))))
+            -> decltype(std::forward<Sender>(sender).connect(std::forward<Receiver>(receiver)))
+        {
+            return std::forward<Sender>(sender).connect(std::forward<Receiver>(receiver));
+        }
     } connect{};
 
     namespace detail {

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -41,8 +41,7 @@ struct void_sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, void_sender, R&& r)
+    operation_state<R> connect(R&& r) const
     {
         return {std::forward<R>(r)};
     }
@@ -83,8 +82,7 @@ struct error_sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, error_sender, R&& r)
+    operation_state<R> connect(R&& r) const
     {
         return {std::forward<R>(r)};
     }
@@ -119,8 +117,7 @@ struct const_reference_error_sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, const_reference_error_sender, R&& r)
+    operation_state<R> connect(R&& r) const
     {
         return {std::forward<R>(r)};
     }
@@ -253,7 +250,7 @@ struct custom_sender_tag_invoke
     };
 
     template <typename R>
-    operation_state<R> connect(R&& r)
+    operation_state<R> connect(R&& r) const
     {
         return {std::forward<R>(r)};
     }
@@ -292,10 +289,10 @@ struct custom_sender
     };
 
     template <typename R>
-    friend auto tag_invoke(pika::execution::experimental::connect_t, custom_sender&& s, R&& r)
+    auto connect(R&& r) &&
     {
-        s.connect_called = true;
-        return operation_state<R>{s.start_called, std::forward<R>(r)};
+        connect_called = true;
+        return operation_state<R>{start_called, std::forward<R>(r)};
     }
 };
 
@@ -336,10 +333,10 @@ struct custom_typed_sender
     };
 
     template <typename R>
-    friend auto tag_invoke(pika::execution::experimental::connect_t, custom_typed_sender&& s, R&& r)
+    auto connect(R&& r) &&
     {
-        s.connect_called = true;
-        return operation_state<R>{std::move(s.x), s.start_called, std::forward<R>(r)};
+        connect_called = true;
+        return operation_state<R>{std::move(x), start_called, std::forward<R>(r)};
     }
 };
 
@@ -383,17 +380,15 @@ struct const_reference_sender
     };
 
     template <typename R>
-    friend auto
-    tag_invoke(pika::execution::experimental::connect_t, const_reference_sender&& s, R&& r)
+    auto connect(R&& r) &&
     {
-        return operation_state<R>{std::move(s.x), std::forward<R>(r)};
+        return operation_state<R>{std::move(x), std::forward<R>(r)};
     }
 
     template <typename R>
-    friend auto
-    tag_invoke(pika::execution::experimental::connect_t, const_reference_sender const& s, R&& r)
+    auto connect(R&& r) const&
     {
-        return operation_state<R>{s.x, std::forward<R>(r)};
+        return operation_state<R>{x, std::forward<R>(r)};
     }
 };
 
@@ -475,7 +470,7 @@ struct scheduler
         };
 
         template <typename R>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
+        auto connect(R&& r) &&
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -552,7 +547,7 @@ struct scheduler2
         };
 
         template <typename R>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
+        auto connect(R&& r) &&
         {
             return operation_state<R>{std::forward<R>(r)};
         }
@@ -658,7 +653,7 @@ namespace my_namespace {
             };
 
             template <typename R>
-            friend auto tag_invoke(pika::execution::experimental::connect_t, sender&&, R&& r)
+            auto connect(R&& r) &&
             {
                 return operation_state<R>{std::forward<R>(r)};
             }
@@ -725,8 +720,7 @@ namespace my_namespace {
         };
 
         template <typename R>
-        friend operation_state<R>
-        tag_invoke(pika::execution::experimental::connect_t, my_sender, R&& r)
+        operation_state<R> connect(R&& r) &&
         {
             return {std::forward<R>(r)};
         }

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -89,10 +89,9 @@ struct non_copyable_sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, non_copyable_sender&& s, R&& r) noexcept
+    operation_state<R> connect(R&& r) && noexcept
     {
-        return {std::forward<R>(r), std::move(s.ts)};
+        return {std::forward<R>(r), std::move(ts)};
     }
 };
 
@@ -146,17 +145,15 @@ struct sender
     };
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, sender&& s, R&& r)
+    operation_state<R> connect(R&& r) &&
     {
-        return {std::forward<R>(r), std::move(s.ts)};
+        return {std::forward<R>(r), std::move(ts)};
     }
 
     template <typename R>
-    friend operation_state<R>
-    tag_invoke(pika::execution::experimental::connect_t, sender const& s, R&& r)
+    operation_state<R> connect(R&& r) const&
     {
-        return {std::forward<R>(r), s.ts};
+        return {std::forward<R>(r), ts};
     }
 };
 

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -39,7 +39,7 @@ struct sender
     };
 
     template <typename R>
-    friend operation_state tag_invoke(ex::connect_t, sender, R&&) noexcept
+    operation_state connect(R&&) noexcept
     {
         return {};
     }

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -17,8 +17,7 @@
 
 namespace ex = pika::execution::experimental;
 
-static std::size_t friend_tag_invoke_connect_calls = 0;
-static std::size_t tag_invoke_connect_calls = 0;
+static std::size_t connect_calls = 0;
 
 struct non_sender_1
 {
@@ -105,40 +104,12 @@ struct sender_1
         void start() & noexcept { ex::set_value(std::move(r), 4711); };
     };
 
-    friend operation_state tag_invoke(ex::connect_t, sender_1&&, receiver r)
+    operation_state connect(receiver r) &&
     {
-        ++friend_tag_invoke_connect_calls;
+        ++connect_calls;
         return {r};
     }
 };
-
-struct sender_2
-{
-    PIKA_STDEXEC_SENDER_CONCEPT
-
-    template <template <class...> class Tuple, template <class...> class Variant>
-    using value_types = Variant<Tuple<int>>;
-
-    template <template <class...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = false;
-
-    using completion_signatures =
-        ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
-
-    struct operation_state
-    {
-        receiver r;
-        void start() & noexcept { ex::set_value(std::move(r), 4711); };
-    };
-};
-
-sender_2::operation_state tag_invoke(ex::connect_t, sender_2, receiver r)
-{
-    ++tag_invoke_connect_calls;
-    return {r};
-}
 
 static std::size_t void_receiver_set_value_calls = 0;
 
@@ -195,7 +166,6 @@ int main()
     static_assert(
         unspecialized<non_sender_7>(nullptr), "non_sender_7 should not have sender_traits");
     static_assert(!unspecialized<sender_1>(nullptr), "sender_1 should have sender_traits");
-    static_assert(!unspecialized<sender_2>(nullptr), "sender_2 should have sender_traits");
 #endif
 
     static_assert(!ex::is_sender_v<void>, "void is not a sender");
@@ -210,17 +180,12 @@ int main()
     static_assert(!ex::is_sender_v<non_sender_6>, "non_sender_6 is not a sender");
     static_assert(!ex::is_sender_v<non_sender_7>, "non_sender_7 is not a sender");
     static_assert(ex::is_sender_v<sender_1>, "sender_1 is a sender");
-    static_assert(ex::is_sender_v<sender_2>, "sender_2 is a sender");
 
     static_assert(ex::is_sender_to_v<sender_1, receiver>, "sender_1 is a sender to receiver");
     static_assert(ex::is_sender_to_v<sender_1, receiver>, "sender_1 is a sender to receiver");
     static_assert(
         !ex::is_sender_to_v<sender_1, non_sender_1>, "sender_1 is not a sender to non_sender_1");
     static_assert(!ex::is_sender_to_v<sender_1, sender_1>, "sender_1 is not a sender to sender_1");
-    static_assert(ex::is_sender_to_v<sender_2, receiver>, "sender_2 is a sender to receiver");
-    static_assert(
-        !ex::is_sender_to_v<sender_2, non_sender_2>, "sender_2 is not a sender to non_sender_2");
-    static_assert(!ex::is_sender_to_v<sender_2, sender_2>, "sender_2 is not a sender to sender_2");
 
     {
         int i = 1;
@@ -228,18 +193,7 @@ int main()
         auto os = ex::connect(sender_1{}, std::move(r1));
         ex::start(os);
         PIKA_TEST_EQ(i, 4711);
-        PIKA_TEST_EQ(friend_tag_invoke_connect_calls, std::size_t(1));
-        PIKA_TEST_EQ(tag_invoke_connect_calls, std::size_t(0));
-    }
-
-    {
-        int i = 1;
-        receiver r2{i};
-        auto os = ex::connect(sender_2{}, std::move(r2));
-        ex::start(os);
-        PIKA_TEST_EQ(i, 4711);
-        PIKA_TEST_EQ(friend_tag_invoke_connect_calls, std::size_t(1));
-        PIKA_TEST_EQ(tag_invoke_connect_calls, std::size_t(1));
+        PIKA_TEST_EQ(connect_calls, std::size_t(1));
     }
 
     return 0;

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -85,8 +85,7 @@ namespace pika::execution::experimental {
                 pika::execution::experimental::set_error_t(std::exception_ptr)>;
 
             template <typename Receiver>
-            friend operation_state<Receiver>
-            tag_invoke(connect_t, sender const&, Receiver&& receiver)
+            operation_state<Receiver> connect(Receiver&& receiver) const&
             {
                 return {std::forward<Receiver>(receiver)};
             }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -202,18 +202,16 @@ namespace pika::execution::experimental {
                 pika::execution::experimental::set_error_t(std::exception_ptr)>;
 
             template <typename Receiver>
-            friend operation_state<Scheduler, Receiver>
-            tag_invoke(connect_t, sender&& s, Receiver&& receiver)
+            operation_state<Scheduler, Receiver> connect(Receiver&& receiver) &&
             {
-                return {std::move(s.scheduler), std::forward<Receiver>(receiver),
-                    s.fallback_annotation};
+                return {
+                    std::move(scheduler), std::forward<Receiver>(receiver), fallback_annotation};
             }
 
             template <typename Receiver>
-            friend operation_state<Scheduler, Receiver>
-            tag_invoke(connect_t, sender const& s, Receiver&& receiver)
+            operation_state<Scheduler, Receiver> connect(Receiver&& receiver) const&
             {
-                return {s.scheduler, std::forward<Receiver>(receiver), s.fallback_annotation};
+                return {scheduler, std::forward<Receiver>(receiver), fallback_annotation};
             }
 
             struct env

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -478,20 +478,17 @@ namespace pika::thread_pool_bulk_detail {
 
     public:
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t,
-            thread_pool_bulk_sender&& s, Receiver&& receiver)
+        auto connect(Receiver&& receiver) &&
         {
-            return operation_state<std::decay_t<Receiver>>{std::move(s.scheduler),
-                std::move(s.sender), std::move(s.shape), std::move(s.f),
-                std::forward<Receiver>(receiver)};
+            return operation_state<std::decay_t<Receiver>>{std::move(scheduler), std::move(sender),
+                std::move(shape), std::move(f), std::forward<Receiver>(receiver)};
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(pika::execution::experimental::connect_t, thread_pool_bulk_sender& s,
-            Receiver&& receiver)
+        auto connect(Receiver&& receiver) const&
         {
             return operation_state<std::decay_t<Receiver>>{
-                s.scheduler, s.sender, s.shape, s.f, std::forward<Receiver>(receiver)};
+                scheduler, sender, shape, f, std::forward<Receiver>(receiver)};
         }
 
         friend auto tag_invoke(

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -512,10 +512,10 @@ namespace pika::execution::experimental {
             };
 
             template <typename R>
-            friend auto tag_invoke(pika::execution::experimental::connect_t, sender&& s, R&& r)
+            auto connect(R&& r) &&
             {
                 return operation_state<R>{
-                    std::forward<R>(r), std::move(s.prev_state), std::move(s.state)};
+                    std::forward<R>(r), std::move(prev_state), std::move(state)};
             }
         };
 
@@ -719,14 +719,14 @@ namespace pika::execution::experimental {
             };
 
             template <typename R>
-            friend auto tag_invoke(pika::execution::experimental::connect_t, sender&& s, R&& r)
+            auto connect(R&& r) &&
             {
                 return operation_state<R>{
-                    std::forward<R>(r), std::move(s.prev_state), std::move(s.state)};
+                    std::forward<R>(r), std::move(prev_state), std::move(state)};
             }
 
             template <typename R>
-            friend auto tag_invoke(pika::execution::experimental::connect_t, sender const& s, R&& r)
+            auto connect(R&& r) const&
             {
                 if constexpr (AccessType == async_rw_mutex_access_type::readwrite)
                 {
@@ -735,7 +735,7 @@ namespace pika::execution::experimental {
                         "connectable");
                 }
 
-                return operation_state<R>{std::forward<R>(r), s.prev_state, s.state};
+                return operation_state<R>{std::forward<R>(r), prev_state, state};
             }
         };
 


### PR DESCRIPTION
Part of #1204. A step towards reducing debug bloat.