### PR TITLE
Change `get_env` CPO to use member functions

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/cuda_scheduler.hpp
@@ -169,11 +169,7 @@ namespace pika::cuda::experimental {
                 }
             };
 
-            friend env tag_invoke(
-                pika::execution::experimental::get_env_t, cuda_scheduler_sender const& s) noexcept
-            {
-                return {s.scheduler};
-            }
+            env get_env() const& noexcept { return {scheduler}; }
         };
     }    // namespace detail
 

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -379,9 +379,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                         });
                 }
 
-                friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                    pika::execution::experimental::get_env_t,
-                    then_with_cuda_stream_receiver const&) noexcept
+                constexpr pika::execution::experimental::empty_env get_env() const& noexcept
                 {
                     return {};
                 }
@@ -490,11 +488,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             return operation_state<Receiver>(std::forward<Receiver>(receiver), f, sched, sender);
         }
 
-        friend auto tag_invoke(pika::execution::experimental::get_env_t,
-            then_with_cuda_stream_sender_type const& s) noexcept
-        {
-            return pika::execution::experimental::get_env(s.sender);
-        }
+        auto get_env() const& noexcept { return pika::execution::experimental::get_env(sender); }
     };
 
     /// This is a helper that calls f with the values sent by sender and a

--- a/libs/pika/async_cuda/tests/unit/then_with_stream.cu
+++ b/libs/pika/async_cuda/tests/unit/then_with_stream.cu
@@ -78,11 +78,7 @@ struct const_reference_cuda_sender
         }
     };
 
-    friend env tag_invoke(
-        pika::execution::experimental::get_env_t, const_reference_cuda_sender const& s) noexcept
-    {
-        return {s.sched};
-    }
+    env get_env() const& noexcept { return {sched}; }
 };
 
 struct const_reference_error_cuda_sender
@@ -136,11 +132,7 @@ struct const_reference_error_cuda_sender
         }
     };
 
-    friend env tag_invoke(pika::execution::experimental::get_env_t,
-        const_reference_error_cuda_sender const& s) noexcept
-    {
-        return {s.sched};
-    }
+    env get_env() const& noexcept { return {sched}; }
 };
 
 struct dummy

--- a/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/dispatch_mpi.hpp
@@ -166,11 +166,7 @@ namespace pika::mpi::experimental::detail {
                         });
                 }
 
-                friend constexpr ex::empty_env tag_invoke(
-                    ex::get_env_t, dispatch_mpi_receiver const&) noexcept
-                {
-                    return {};
-                }
+                constexpr ex::empty_env get_env() const& noexcept { return {}; }
             };
 
             using operation_state_type =

--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -223,11 +223,7 @@ namespace pika::mpi::experimental::detail {
                         });
                 }
 
-                friend constexpr ex::empty_env tag_invoke(
-                    ex::get_env_t, trigger_mpi_receiver const&) noexcept
-                {
-                    return {};
-                }
+                constexpr ex::empty_env get_env() const& noexcept { return {}; }
             };
 
             using operation_state_type =

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -59,10 +59,9 @@ namespace pika::bulk_detail {
 
         static constexpr bool sends_done = false;
 
-        friend constexpr decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, bulk_sender_type const& s) noexcept
+        constexpr decltype(auto) get_env() const& noexcept
         {
-            return pika::execution::experimental::get_env(s.sender);
+            return pika::execution::experimental::get_env(sender);
         }
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -104,11 +104,7 @@ namespace pika::drop_op_state_detail {
             }
         }
 
-        friend constexpr pika::execution::experimental::empty_env tag_invoke(
-            pika::execution::experimental::get_env_t, drop_op_state_receiver_type const&) noexcept
-        {
-            return {};
-        }
+        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender, typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -59,11 +59,7 @@ namespace pika::drop_value_detail {
             pika::execution::experimental::set_value(std::move(r.receiver));
         }
 
-        friend constexpr pika::execution::experimental::empty_env tag_invoke(
-            pika::execution::experimental::get_env_t, drop_value_receiver_type const&) noexcept
-        {
-            return {};
-        }
+        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender>
@@ -118,10 +114,9 @@ namespace pika::drop_value_detail {
                 sender, drop_value_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
-        friend decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, drop_value_sender_type const& s) noexcept
+        decltype(auto) get_env() const& noexcept
         {
-            return pika::execution::experimental::get_env(s.sender);
+            return pika::execution::experimental::get_env(sender);
         }
     };
 }    // namespace pika::drop_value_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -128,9 +128,7 @@ namespace pika {
                     std::move(r.op_state->receiver), std::forward<Ts>(ts)...);
             }
 
-            friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                pika::execution::experimental::get_env_t,
-                require_started_receiver_type const&) noexcept
+            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
             {
                 return {};
             }

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -91,11 +91,10 @@ namespace pika::schedule_from_detail {
             }
         };
 
-        friend auto tag_invoke(
-            pika::execution::experimental::get_env_t, schedule_from_sender_type const& s) noexcept
+        auto get_env() const& noexcept
         {
-            auto e = pika::execution::experimental::get_env(s.predecessor_sender);
-            return env<std::decay_t<decltype(e)>>{std::move(e), s.scheduler};
+            auto e = pika::execution::experimental::get_env(predecessor_sender);
+            return env<std::decay_t<decltype(e)>>{std::move(e), scheduler};
         }
 
         template <typename Receiver>

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -159,8 +159,7 @@ namespace pika::split_tuple_detail {
                 r.state.set_predecessor_done();
             }
 
-            friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                pika::execution::experimental::get_env_t, split_tuple_receiver const&) noexcept
+            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
             {
                 return {};
             }

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -184,11 +184,7 @@ namespace pika::sync_wait_detail {
             r.signal_set_called();
         }
 
-        friend constexpr pika::execution::experimental::empty_env tag_invoke(
-            pika::execution::experimental::get_env_t, sync_wait_receiver_type const&) noexcept
-        {
-            return {};
-        }
+        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
     };
 }    // namespace pika::sync_wait_detail
 

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -145,10 +145,9 @@ namespace pika::then_detail {
                 sender, then_receiver<Receiver, F>{std::forward<Receiver>(receiver), f});
         }
 
-        friend decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, then_sender_type const& s) noexcept
+        decltype(auto) get_env() const& noexcept
         {
-            return pika::execution::experimental::get_env(s.sender);
+            return pika::execution::experimental::get_env(sender);
         }
     };
 }    // namespace pika::then_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -64,11 +64,7 @@ namespace pika::unpack_detail {
                 std::forward<Ts>(ts));
         }
 
-        friend constexpr pika::execution::experimental::empty_env tag_invoke(
-            pika::execution::experimental::get_env_t, unpack_receiver_type const&) noexcept
-        {
-            return {};
-        }
+        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
     };
 
 #if defined(PIKA_HAVE_STDEXEC)
@@ -187,10 +183,9 @@ namespace pika::unpack_detail {
                 sender, unpack_receiver<Receiver>{std::forward<Receiver>(receiver)});
         }
 
-        friend decltype(auto) tag_invoke(
-            pika::execution::experimental::get_env_t, unpack_sender_type const& s) noexcept
+        decltype(auto) get_env() const& noexcept
         {
-            return pika::execution::experimental::get_env(s.sender);
+            return pika::execution::experimental::get_env(sender);
         }
     };
 }    // namespace pika::unpack_detail

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -205,9 +205,7 @@ namespace pika::when_all_vector_detail {
                     r.op_state.finish();
                 }
 
-                friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                    pika::execution::experimental::get_env_t,
-                    when_all_vector_receiver const&) noexcept
+                constexpr pika::execution::experimental::empty_env get_env() const& noexcept
                 {
                     return {};
                 }

--- a/libs/pika/execution/tests/unit/algorithm_execute.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_execute.cpp
@@ -56,10 +56,7 @@ struct sender
         }
     };
 
-    friend env tag_invoke(pika::execution::experimental::get_env_t, sender const&) noexcept
-    {
-        return {};
-    }
+    env get_env() const& noexcept { return {}; }
 };
 
 struct scheduler_1

--- a/libs/pika/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_transfer.cpp
@@ -88,9 +88,9 @@ struct scheduler_schedule_from
             }
         };
 
-        friend env tag_invoke(ex::get_env_t, sender const& s) noexcept
+        env get_env() const& noexcept
         {
-            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+            return {schedule_called, execute_called, tag_invoke_overload_called};
         }
     };
 
@@ -181,9 +181,9 @@ struct scheduler_transfer
             }
         };
 
-        friend env tag_invoke(ex::get_env_t, sender const& s) noexcept
+        env get_env() const& noexcept
         {
-            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+            return {schedule_called, execute_called, tag_invoke_overload_called};
         }
     };
 
@@ -226,10 +226,7 @@ struct sender_with_completion_scheduler : void_sender
         }
     };
 
-    friend env tag_invoke(ex::get_env_t, sender_with_completion_scheduler const& s) noexcept
-    {
-        return {s.sched};
-    }
+    env get_env() const& noexcept { return {sched}; }
 };
 
 int main()

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -486,11 +486,7 @@ namespace pika::execution::experimental::detail {
             r.receiver->set_stopped();
         }
 
-        friend constexpr pika::execution::experimental::empty_env tag_invoke(
-            pika::execution::experimental::get_env_t, any_receiver const&) noexcept
-        {
-            return {};
-        }
+        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender, typename... Ts>

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -423,13 +423,34 @@ namespace pika::execution::experimental {
     {
     };
 
-    inline constexpr struct get_env_t final : pika::functional::detail::tag_fallback<get_env_t>
+    template <typename T, typename Enable = void>
+    struct has_get_env : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct has_get_env<T, std::void_t<decltype(std::declval<T const&>().get_env())>>
+      : std::true_type
+    {
+    };
+
+    inline constexpr struct get_env_t
     {
         template <typename T>
-        friend constexpr auto tag_fallback_invoke(get_env_t const&, T const&) noexcept
+        constexpr auto PIKA_STATIC_CALL_OPERATOR(T const& t) noexcept
         {
-            if constexpr (is_sender_v<T>) { return empty_env{}; }
-            else { static_assert(sizeof(T) == 0, "No environment for type T"); }
+            if constexpr (has_get_env<T>::value)
+            {
+                static_assert(noexcept(t.get_env()),
+                    "std::execution get_env member function must be noexcept");
+                return t.get_env();
+            }
+            else if constexpr (is_sender_v<T>) { return empty_env{}; }
+            else
+            {
+                static_assert(sizeof(T) == 0, "No environment for type T");
+                return empty_env{};
+            }
         }
     } get_env{};
 }    // namespace pika::execution::experimental

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -153,11 +153,7 @@ struct callback_receiver
         r.set_value_called = true;
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, callback_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 template <typename F>
@@ -190,11 +186,7 @@ struct error_callback_receiver
         PIKA_TEST(r.expect_set_value);
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, error_callback_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 template <typename F>
@@ -489,9 +481,9 @@ struct scheduler
             }
         };
 
-        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s) noexcept
+        env get_env() const& noexcept
         {
-            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+            return {schedule_called, execute_called, tag_invoke_overload_called};
         }
     };
 
@@ -566,9 +558,9 @@ struct scheduler2
             }
         };
 
-        friend env tag_invoke(pika::execution::experimental::get_env_t, sender const& s) noexcept
+        env get_env() const& noexcept
         {
-            return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
+            return {schedule_called, execute_called, tag_invoke_overload_called};
         }
     };
 
@@ -677,10 +669,7 @@ namespace my_namespace {
                 }
             };
 
-            friend env tag_invoke(pika::execution::experimental::get_env_t, sender const&) noexcept
-            {
-                return {};
-            }
+            env get_env() const& noexcept { return {}; }
         };
 
         friend sender tag_invoke(pika::execution::experimental::schedule_t, my_scheduler)

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -243,11 +243,7 @@ struct error_receiver
         PIKA_TEST(false);
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, error_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 template <template <typename...> typename Sender, typename... Ts, typename F>

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -33,10 +33,7 @@ namespace mylib {
 
         void set_value(int) && noexcept { value_called = true; }
 
-        friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_1 const&) noexcept
-        {
-            return {};
-        }
+        constexpr ex::empty_env get_env() const& noexcept { return {}; }
     };
 
     struct receiver_2
@@ -47,10 +44,7 @@ namespace mylib {
 
         friend void tag_invoke(ex::set_error_t, receiver_2&&, int) noexcept { error_called = true; }
 
-        friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_2 const&) noexcept
-        {
-            return {};
-        }
+        constexpr ex::empty_env get_env() const& noexcept { return {}; }
     };
 
     struct receiver_3
@@ -66,10 +60,7 @@ namespace mylib {
 
         void set_value(int) && noexcept { value_called = true; }
 
-        friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver_3 const&) noexcept
-        {
-            return {};
-        }
+        constexpr ex::empty_env get_env() const& noexcept { return {}; }
     };
 
     struct non_receiver_1
@@ -121,10 +112,7 @@ namespace mylib {
 
         void set_value(int) & noexcept { value_called = true; }
 
-        friend constexpr ex::empty_env tag_invoke(ex::get_env_t, non_receiver_4 const&) noexcept
-        {
-            return {};
-        }
+        constexpr ex::empty_env get_env() const& noexcept { return {}; }
     };
 
     struct non_receiver_5

--- a/libs/pika/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_schedule.cpp
@@ -53,7 +53,7 @@ struct sender
         }
     };
 
-    friend env tag_invoke(ex::get_env_t, sender const&) noexcept { return {}; }
+    env get_env() const& noexcept { return {}; }
 };
 
 struct non_scheduler_1

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -75,10 +75,7 @@ struct receiver
 
     void set_value(int v) && noexcept { i.get() = v; }
 
-    friend constexpr ex::empty_env tag_invoke(ex::get_env_t, receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr ex::empty_env get_env() const& noexcept { return {}; }
 
     std::reference_wrapper<int> i;
 };
@@ -123,10 +120,7 @@ struct void_receiver
 
     void set_value() && noexcept { ++void_receiver_set_value_calls; }
 
-    friend constexpr ex::empty_env tag_invoke(ex::get_env_t, void_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr ex::empty_env get_env() const& noexcept { return {}; }
 };
 
 #if !defined(PIKA_HAVE_STDEXEC)

--- a/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/std_thread_scheduler.hpp
@@ -101,11 +101,7 @@ namespace pika::execution::experimental {
                 }
             };
 
-            friend constexpr env tag_invoke(
-                pika::execution::experimental::get_env_t, sender const&) noexcept
-            {
-                return {};
-            }
+            constexpr env get_env() const& noexcept { return {}; }
         };
 
         friend sender tag_invoke(schedule_t, std_thread_scheduler const&) { return {}; }

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler.hpp
@@ -227,11 +227,7 @@ namespace pika::execution::experimental {
                 }
             };
 
-            friend env tag_invoke(
-                pika::execution::experimental::get_env_t, sender const& s) noexcept
-            {
-                return {s.scheduler};
-            }
+            env get_env() const& noexcept { return {scheduler}; }
         };
 
         friend sender<thread_pool_scheduler> tag_invoke(schedule_t, thread_pool_scheduler&& sched)

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -434,8 +434,7 @@ namespace pika::thread_pool_bulk_detail {
                     r.do_work_local(r.op_state->shape, chunk_size, local_worker_thread);
                 }
 
-                friend constexpr pika::execution::experimental::empty_env tag_invoke(
-                    pika::execution::experimental::get_env_t, bulk_receiver const&) noexcept
+                constexpr pika::execution::experimental::empty_env get_env() const& noexcept
                 {
                     return {};
                 }
@@ -491,11 +490,7 @@ namespace pika::thread_pool_bulk_detail {
                 scheduler, sender, shape, f, std::forward<Receiver>(receiver)};
         }
 
-        friend auto tag_invoke(
-            pika::execution::experimental::get_env_t, thread_pool_bulk_sender const& s) noexcept
-        {
-            return pika::execution::experimental::get_env(s.sender);
-        }
+        auto get_env() const& noexcept { return pika::execution::experimental::get_env(sender); }
     };
 }    // namespace pika::thread_pool_bulk_detail
 

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -77,11 +77,7 @@ struct check_context_receiver
         cond.notify_one();
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, check_context_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 void test_sender_receiver_basic()
@@ -235,11 +231,7 @@ struct callback_receiver
         r.cond.notify_one();
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, callback_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 void test_transfer_basic()

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -85,11 +85,7 @@ struct check_context_receiver
         cond.notify_one();
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, check_context_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 void test_sender_receiver_basic()
@@ -242,11 +238,7 @@ struct callback_receiver
         cond.notify_one();
     }
 
-    friend constexpr pika::execution::experimental::empty_env tag_invoke(
-        pika::execution::experimental::get_env_t, callback_receiver const&) noexcept
-    {
-        return {};
-    }
+    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
 };
 
 void test_properties()


### PR DESCRIPTION
Part of #1204. Also a step towards reducing debug bloat.