### PR TITLE
Add start-stop and resume-suspend performance benchmarks to performance CI runs

### DIFF
--- a/.gitlab/scripts/run_performance_benchmarks.sh
+++ b/.gitlab/scripts/run_performance_benchmarks.sh
@@ -38,6 +38,8 @@ pika_targets=(
     "task_yield_test"
     "condition_variable_overhead_test"
     "async_rw_mutex_scheduling_test"
+    "start_stop_test"
+    "resume_suspend_test"
 )
 pika_test_options=(
     "--pika:ini=pika.thread_queue.init_threads_count=100 \
@@ -112,6 +114,14 @@ pika_test_options=(
 --num-rw-accesses=5
 --num-ro-accesses=5
 --repetitions=100
+--pika:threads=4
+--perftest-json"
+
+    "--repetitions=100
+--pika:threads=4
+--perftest-json"
+
+    "--repetitions=100
 --pika:threads=4
 --perftest-json"
 )

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -44,8 +44,6 @@ int main(int argc, char** argv)
 
     std::uint64_t threads = pika::resource::get_num_threads("default");
 
-    auto sched = ex::thread_pool_scheduler{};
-
     std::cout << "threads, resume [s], execute [s], suspend [s]" << std::endl;
 
     double suspend_time = 0;
@@ -59,11 +57,6 @@ int main(int argc, char** argv)
         pika::resume();
         auto t_resume = timer.elapsed();
         resume_time += t_resume;
-
-        for (std::size_t thread = 0; thread < threads; ++thread)
-        {
-            ex::execute(sched, [] {});
-        }
 
         auto t_execute = timer.elapsed();
 

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -47,7 +47,6 @@ int main(int argc, char** argv)
     std::cout << "threads, resume [s], execute [s], suspend [s]" << std::endl;
 
     double suspend_time = 0;
-    double resume_time = 0;
     pika::chrono::detail::high_resolution_timer timer;
 
     for (std::size_t i = 0; i < repetitions; ++i)
@@ -56,7 +55,6 @@ int main(int argc, char** argv)
 
         pika::resume();
         auto t_resume = timer.elapsed();
-        resume_time += t_resume;
 
         auto t_execute = timer.elapsed();
 
@@ -67,9 +65,6 @@ int main(int argc, char** argv)
         std::cout << threads << ", " << t_resume << ", " << t_execute << ", " << t_suspend
                   << std::endl;
     }
-
-    pika::util::print_cdash_timing("ResumeTime", resume_time);
-    pika::util::print_cdash_timing("SuspendTime", suspend_time);
 
     pika::resume();
     pika::finalize();

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -51,7 +51,6 @@ int main(int argc, char** argv)
 
     std::cout << "threads, resume [s], execute [s], suspend [s]" << std::endl;
 
-    double start_time = 0;
     double stop_time = 0;
     pika::chrono::detail::high_resolution_timer timer;
 
@@ -64,7 +63,6 @@ int main(int argc, char** argv)
 
         pika::start(pika_main, argc, argv, init_args);
         auto t_start = timer.elapsed();
-        start_time += t_start;
 
         auto t_execute = timer.elapsed();
 
@@ -74,6 +72,4 @@ int main(int argc, char** argv)
 
         std::cout << threads << ", " << t_start << ", " << t_execute << ", " << t_stop << std::endl;
     }
-    pika::util::print_cdash_timing("StartTime", start_time);
-    pika::util::print_cdash_timing("StopTime", stop_time);
 }

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -66,12 +66,6 @@ int main(int argc, char** argv)
         auto t_start = timer.elapsed();
         start_time += t_start;
 
-        auto sched = ex::thread_pool_scheduler{};
-        for (std::size_t thread = 0; thread < threads; ++thread)
-        {
-            ex::execute(sched, [] {});
-        }
-
         auto t_execute = timer.elapsed();
 
         pika::stop();

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -14,6 +14,8 @@
 #include <pika/testing/performance.hpp>
 #include <pika/thread.hpp>
 
+#include <fmt/format.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -29,18 +31,19 @@ int pika_main()
 
 int main(int argc, char** argv)
 {
-    pika::program_options::options_description desc_commandline;
-    desc_commandline.add_options()("repetitions",
-        pika::program_options::value<std::uint64_t>()->default_value(100), "Number of repetitions");
+    using namespace pika::program_options;
+    options_description desc_commandline;
+    // clang-format off
+    desc_commandline.add_options()
+        ("repetitions", value<std::uint64_t>()->default_value(100), "Number of repetitions")
+        ("perftest-json", bool_switch(), "Print average start-stop time in json format for use with performance CI");
+    // clang-format on
 
-    pika::program_options::variables_map vm;
-    pika::program_options::store(pika::program_options::command_line_parser(argc, argv)
-                                     .allow_unregistered()
-                                     .options(desc_commandline)
-                                     .run(),
-        vm);
+    variables_map vm;
+    store(command_line_parser(argc, argv).allow_unregistered().options(desc_commandline).run(), vm);
 
-    std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
+    auto const repetitions = vm["repetitions"].as<std::uint64_t>();
+    auto const perftest_json = vm["perftest-json"].as<bool>();
 
     pika::init_params init_args;
     init_args.desc_cmdline = desc_commandline;
@@ -49,7 +52,7 @@ int main(int argc, char** argv)
     std::uint64_t threads = pika::resource::get_num_threads("default");
     pika::stop();
 
-    std::cout << "threads, resume [s], execute [s], suspend [s]" << std::endl;
+    if (!perftest_json) { std::cout << "threads, resume [s], suspend [s]" << std::endl; }
 
     double stop_time = 0;
     pika::chrono::detail::high_resolution_timer timer;
@@ -64,12 +67,20 @@ int main(int argc, char** argv)
         pika::start(pika_main, argc, argv, init_args);
         auto t_start = timer.elapsed();
 
-        auto t_execute = timer.elapsed();
-
         pika::stop();
         auto t_stop = timer.elapsed();
         stop_time += t_stop;
 
-        std::cout << threads << ", " << t_start << ", " << t_execute << ", " << t_stop << std::endl;
+        if (!perftest_json)
+        {
+            std::cout << threads << ", " << t_start << ", " << t_stop << std::endl;
+        }
+    }
+
+    if (perftest_json)
+    {
+        pika::util::detail::json_perf_times t;
+        t.add(fmt::format("start_stop - {} threads", threads), stop_time / repetitions);
+        std::cout << t;
     }
 }


### PR DESCRIPTION
This adds support to the two tests for printing the json used in elastic. This also removes the scheduling of tasks from the two tests, as that's somewhat orthogonal to starting/stopping/resuming/suspending. We have other tests for benchmarking the time to schedule a task.