### PR TITLE
Store ctest JUnit XML files as artifacts in GitLab CI pipelines

### DIFF
--- a/.gitlab/includes/common_spack_pipeline.yml
+++ b/.gitlab/includes/common_spack_pipeline.yml
@@ -120,6 +120,12 @@ base_spack_image_x86_64:
     - .cmake_variables_common
   variables:
     TEST_TIMEOUT: 300
+  artifacts:
+    when: always
+    paths:
+      - ctest.xml
+    reports:
+      junit: ctest.xml
   script:
     - spack arch
     - export CTEST_XML=$PWD/ctest.xml


### PR DESCRIPTION
Using https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html for more test statistics on GitLab.