### PR TITLE
Add non-nullptr labels to all `yield_while` calls

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -112,7 +112,8 @@ namespace pika::trigger_mpi_detail {
                             // yield/while is invalid on a non pika thread
                             PIKA_ASSERT(pika::threads::detail::get_self_id());
                             pika::util::yield_while(
-                                [&r]() { return !mpi::detail::poll_request(r.op_state.request); });
+                                [&r]() { return !mpi::detail::poll_request(r.op_state.request); },
+                                "trigger_mpi wait for request");
 #ifdef PIKA_HAVE_APEX
                             apex::scoped_timer apex_invoke("pika::mpi::trigger");
 #endif

--- a/libs/pika/async_mpi/src/mpi_polling.cpp
+++ b/libs/pika/async_mpi/src/mpi_polling.cpp
@@ -626,7 +626,8 @@ namespace pika::mpi::experimental {
         {
             // try to ensure that no (other) threads are still polling elsewhere
             // before we allow polling to commence on this/another pool
-            pika::util::yield_while([&] { return detail::mpi_data_.all_in_flight_ > 0; });
+            pika::util::yield_while(
+                [&] { return detail::mpi_data_.all_in_flight_ > 0; }, "mpi::register_polling");
 
 #if defined(PIKA_DEBUG)
             ++get_register_polling_count();
@@ -975,7 +976,8 @@ namespace pika::mpi::experimental {
 
         // try to ensure that no (other) threads are still polling
         // before we exit and allow polling to commence on another pool
-        pika::util::yield_while([&] { return detail::mpi_data_.all_in_flight_ > 0; });
+        pika::util::yield_while(
+            [&] { return detail::mpi_data_.all_in_flight_ > 0; }, "mpi::stop_polling");
 
         // remove error handler if we installed it
         if (detail::mpi_data_.error_handler_initialized_)

--- a/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
+++ b/libs/pika/async_mpi/tests/unit/mpi_ring_async_sender_receiver.cpp
@@ -441,7 +441,7 @@ int pika_main(pika::program_options::variables_map& vm)
         }
 
         // don't exit until all messages are drained
-        pika::util::yield_while([&] { return counter > 0; });
+        pika::util::yield_while([&] { return counter > 0; }, "wait counter");
         if (output)
         {
             // clang-format off

--- a/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/pika/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -114,7 +114,7 @@ int pika_main()
                 --counter;
             }));
     }
-    pika::util::yield_while([&]() { return counter > 0; });
+    pika::util::yield_while([&]() { return counter > 0; }, "wait counter 1");
 
     std::cout << "2: Starting NP " << loops << std::endl;
     counter = loops;
@@ -131,7 +131,7 @@ int pika_main()
                 --counter;
             }));
     }
-    pika::util::yield_while([&]() { return counter > 0; });
+    pika::util::yield_while([&]() { return counter > 0; }, "wait counter 2");
 
     std::cout << "3: Starting HP->NP " << loops << std::endl;
     counter = loops;
@@ -148,7 +148,7 @@ int pika_main()
                 --counter;
             }));
     }
-    pika::util::yield_while([&]() { return counter > 0; });
+    pika::util::yield_while([&]() { return counter > 0; }, "wait counter 3");
 
     std::cout << "4: Starting NP->HP " << loops << std::endl;
     counter = loops;
@@ -165,7 +165,7 @@ int pika_main()
                 --counter;
             }));
     }
-    pika::util::yield_while([&]() { return counter > 0; });
+    pika::util::yield_while([&]() { return counter > 0; }, "wait counter 4");
 
     std::cout << "5: Starting suspending " << loops << std::endl;
     counter = loops;
@@ -187,7 +187,7 @@ int pika_main()
             --counter;
         }));
     }
-    pika::util::yield_while([&]() { return counter > 0; });
+    pika::util::yield_while([&]() { return counter > 0; }, "wait counter 5");
 
     pika::finalize();
     return EXIT_SUCCESS;

--- a/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
+++ b/libs/pika/synchronization/include/pika/synchronization/async_rw_mutex.hpp
@@ -96,7 +96,8 @@ namespace pika::execution::experimental {
             T& get_value()
             {
                 pika::util::yield_while(
-                    [this]() { return !value_set.load(std::memory_order_acquire); });
+                    [this]() { return !value_set.load(std::memory_order_acquire); },
+                    "async_rw_mutex_shared_state::get_value");
                 PIKA_ASSERT(value);
                 // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                 return *value;

--- a/libs/pika/thread_manager/src/thread_manager.cpp
+++ b/libs/pika/thread_manager/src/thread_manager.cpp
@@ -870,10 +870,12 @@ namespace pika::threads::detail {
 
     void thread_manager::wait()
     {
-        pika::util::yield_while([]() {
-            return pika::threads::detail::get_global_activity_count() >
-                (threads::detail::get_self_ptr() != nullptr ? 1 : 0);
-        });
+        pika::util::yield_while(
+            []() {
+                return pika::threads::detail::get_global_activity_count() >
+                    (threads::detail::get_self_ptr() != nullptr ? 1 : 0);
+            },
+            "thread_manager::wait");
     }
 
     void thread_manager::suspend()

--- a/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/pika/thread_pools/include/pika/thread_pools/scheduled_thread_pool_impl.hpp
@@ -196,7 +196,7 @@ namespace pika::threads::detail {
     void scheduled_thread_pool<Scheduler>::wait()
     {
         pika::util::detail::yield_while_count(
-            [this]() { return is_busy(); }, shutdown_check_count_);
+            [this]() { return is_busy(); }, shutdown_check_count_, "scheduled_thread_pool::wait");
     }
 
     template <typename Scheduler>

--- a/libs/pika/threading/tests/unit/jthread1.cpp
+++ b/libs/pika/threading/tests/unit/jthread1.cpp
@@ -211,10 +211,12 @@ void test_detach()
     PIKA_TEST(ssource.stop_requested());
 
     auto t0 = std::chrono::high_resolution_clock::now();
-    pika::util::yield_while([&]() {
-        return !finally_interrupted.load() &&
-            (std::chrono::high_resolution_clock::now() - t0 < std::chrono::seconds(1));
-    });
+    pika::util::yield_while(
+        [&]() {
+            return !finally_interrupted.load() &&
+                (std::chrono::high_resolution_clock::now() - t0 < std::chrono::seconds(1));
+        },
+        "wait finally_interrupted");
 
     PIKA_TEST(finally_interrupted.load());
 }

--- a/tests/performance/local/task_size.cpp
+++ b/tests/performance/local/task_size.cpp
@@ -48,7 +48,7 @@ namespace tt = pika::this_thread::experimental;
 void task(double task_size_s) noexcept
 {
     high_resolution_timer t;
-    pika::util::yield_while([&]() { return t.elapsed() < task_size_s; }, nullptr, false);
+    pika::util::yield_while([&]() { return t.elapsed() < task_size_s; }, "task", false);
 }
 
 // The "task" method simply spawns total_tasks independent tasks without any special consideration

--- a/tests/regressions/threads/thread_rescheduling.cpp
+++ b/tests/regressions/threads/thread_rescheduling.cpp
@@ -153,12 +153,14 @@ int pika_main(variables_map& vm)
         // state. Even though we wait for the tasks above to finish, the target task may not be
         // active or suspended yet. Since we want to guarantee that the task terminates, we may have
         // to retry multiple times until the restart state actually becomes terminate.
-        pika::util::yield_while([&] {
-            auto prev_state = set_thread_state(thread_id.noref(),
-                pika::threads::detail::thread_schedule_state::pending,
-                pika::threads::detail::thread_restart_state::terminate);
-            return prev_state.state() == pika::threads::detail::thread_schedule_state::pending;
-        });
+        pika::util::yield_while(
+            [&] {
+                auto prev_state = set_thread_state(thread_id.noref(),
+                    pika::threads::detail::thread_schedule_state::pending,
+                    pika::threads::detail::thread_restart_state::terminate);
+                return prev_state.state() == pika::threads::detail::thread_schedule_state::pending;
+            },
+            "wait not pending");
     }
 
     pika::finalize();


### PR DESCRIPTION
This makes the spinlock deadlock detection much more useful when it reports a failure, since the label will be printed on failure.