### PR TITLE
Refactor stack size checks

### DIFF
--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -193,7 +193,7 @@ namespace pika::threads::coroutines {
         public:
             enum
             {
-                default_stack_size = 4 * EXEC_PAGESIZE
+                default_stack_size = 4 * PIKA_EXEC_PAGESIZE
             };
 
             using context_impl_base = x86_linux_context_impl_base;

--- a/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/context_linux_x86.hpp
@@ -213,19 +213,6 @@ namespace pika::threads::coroutines {
             {
                 if (m_stack != nullptr) return;
 
-                if (0 != (m_stack_size % EXEC_PAGESIZE))
-                {
-                    throw std::runtime_error(
-                        fmt::format("stack size of {} is not page aligned, page size is {}",
-                            m_stack_size, EXEC_PAGESIZE));
-                }
-
-                if (0 >= m_stack_size)
-                {
-                    throw std::runtime_error(
-                        fmt::format("stack size of {} is invalid", m_stack_size));
-                }
-
                 m_stack = posix::alloc_stack(static_cast<std::size_t>(m_stack_size));
                 if (m_stack == nullptr)
                 {

--- a/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
+++ b/libs/pika/coroutines/include/pika/coroutines/detail/posix_utility.hpp
@@ -173,7 +173,7 @@ namespace pika::threads::coroutines::detail::posix {
 
     inline void watermark_stack(void* stack, std::size_t size)
     {
-        PIKA_ASSERT(size > EXEC_PAGESIZE);
+        PIKA_ASSERT(size >= EXEC_PAGESIZE);
 
         // Fill the bottom 8 bytes of the first page with 1s.
         void** watermark = static_cast<void**>(stack) + ((size - EXEC_PAGESIZE) / sizeof(void*));

--- a/libs/pika/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/pika/runtime_configuration/src/runtime_configuration.cpp
@@ -414,12 +414,9 @@ namespace pika::util {
         pre_initialize_ini();
 
         // set global config options
-        PIKA_ASSERT(init_small_stack_size() >= PIKA_SMALL_STACK_SIZE);
-
         small_stacksize = init_small_stack_size();
         medium_stacksize = init_medium_stack_size();
         large_stacksize = init_large_stack_size();
-        PIKA_ASSERT(init_huge_stack_size() <= PIKA_HUGE_STACK_SIZE);
         huge_stacksize = init_huge_stack_size();
     }
 
@@ -443,8 +440,6 @@ namespace pika::util {
         post_initialize_ini(pika_ini_file, cmdline_ini_defs);
 
         // set global config options
-        PIKA_ASSERT(init_small_stack_size() >= PIKA_SMALL_STACK_SIZE);
-
         small_stacksize = init_small_stack_size();
         medium_stacksize = init_medium_stack_size();
         large_stacksize = init_large_stack_size();

--- a/tests/regressions/stack_size_config_4543.cpp
+++ b/tests/regressions/stack_size_config_4543.cpp
@@ -29,10 +29,15 @@ int pika_main()
 int main(int argc, char** argv)
 {
     pika::init_params p;
-    p.cfg = {"pika.stacks.small_size=" + std::to_string(PIKA_SMALL_STACK_SIZE + 0x1000),
-        "pika.stacks.medium_size=" + std::to_string(PIKA_MEDIUM_STACK_SIZE + 0x1000),
-        "pika.stacks.large_size=" + std::to_string(PIKA_LARGE_STACK_SIZE + 0x1000),
-        "pika.stacks.huge_size=" + std::to_string(PIKA_HUGE_STACK_SIZE + 0x1000)};
+    p.cfg = {
+#if defined(__linux) || defined(linux) || defined(__linux__) || defined(__FreeBSD__) ||            \
+    defined(__APPLE__)
+        "pika.stacks.small_size=" + std::to_string(PIKA_SMALL_STACK_SIZE + PIKA_EXEC_PAGESIZE),
+        "pika.stacks.medium_size=" + std::to_string(PIKA_MEDIUM_STACK_SIZE + PIKA_EXEC_PAGESIZE),
+        "pika.stacks.large_size=" + std::to_string(PIKA_LARGE_STACK_SIZE + PIKA_EXEC_PAGESIZE),
+        "pika.stacks.huge_size=" + std::to_string(PIKA_HUGE_STACK_SIZE + PIKA_EXEC_PAGESIZE)
+#endif
+    };
 
     // This test should just run without crashing
     PIKA_TEST(true);


### PR DESCRIPTION
- Removes unnecessarily strict stack size restrictions (e.g. small stack size has to be smaller than `PIKA_SMALL_STACK_SIZE`)
- Adjusts the assertion when watermarking stacks to allow stack size == page size
- Refactor "stack-size-is-multiple-of-page-size` checks to be used for both the x86 and posix context implementations