### PR TITLE
Pin sphinx version for documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # noinshpect
-sphinx
+sphinx <8.2.0
 breathe
 recommonmark
 # https://github.com/jbms/sphinx-immaterial/pull/338


### PR DESCRIPTION
sphinx 8.2.0 is currently incompatible with breathe: https://github.com/breathe-doc/breathe/pull/1010. breathe main branch already has a fix, but a new version is required: https://github.com/breathe-doc/breathe/issues/1022.