### PR TITLE
Stop pinning sphinx for documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # noinshpect
-sphinx <8.2.0
+sphinx
 breathe
 recommonmark
 # https://github.com/jbms/sphinx-immaterial/pull/338


### PR DESCRIPTION
The compatibility issue has been fixed in https://github.com/breathe-doc/breathe/pull/1010. Effectively reverts #1413 and fixes #1414.