### PR TITLE
Use newer stdexec commit in CI

### DIFF
--- a/.gitlab/includes/gcc12_hip6_pipeline.yml
+++ b/.gitlab/includes/gcc12_hip6_pipeline.yml
@@ -16,7 +16,7 @@ include:
     GPU_TARGET: 'gfx90a'
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} +rocm +stdexec amdgpu_target=${GPU_TARGET} \
                  malloc=system cxxstd=$CXXSTD ^boost@1.85.0 ^hwloc@2.9.1 ^hip@6.1.0 ^llvm~gold \
-                 ^fmt@10.2.1 ^stdexec@24.09"
+                 ^fmt@10.2.1 ^stdexec@git.f7308ea245b896a76c6fd9a58a097ae23579e489=main"
     CMAKE_FLAGS: "-DPIKA_WITH_CXX_STANDARD=$CXXSTD -DPIKA_WITH_HIP=ON -DPIKA_WITH_MALLOC=system \
                   -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGET -DPIKA_WITH_STDEXEC=ON"
 

--- a/.gitlab/includes/gcc13_pipeline.yml
+++ b/.gitlab/includes/gcc13_pipeline.yml
@@ -14,7 +14,7 @@ include:
     COMPILER: gcc@13.1.0
     CXXSTD: 20
     SPACK_SPEC: "pika@main arch=$SPACK_ARCH %${COMPILER} malloc=system cxxstd=$CXXSTD +stdexec \
-                 ^boost@1.82.0 ^hwloc@2.9.1 ^stdexec@24.09 \
+                 ^boost@1.82.0 ^hwloc@2.9.1 ^stdexec@git.nvhpc-25.03.rc1=main \
                  ^spdlog cxxflags=-D_GLIBCXX_DEBUG cxxflags=-D_GLIBCXX_DEBUG_PEDANTIC \
                  cxxflags=-D_GLIBCXX_DEBUG_BACKTRACE cxxflags=-D_GLIBCXX_ASSERTIONS' \
                  ^fmt@11.0.1"

--- a/cmake/pika_add_config_test.cmake
+++ b/cmake/pika_add_config_test.cmake
@@ -497,6 +497,15 @@ function(pika_check_for_stdexec_continues_on)
 endfunction()
 
 # ##################################################################################################
+function(pika_check_for_stdexec_env)
+  pika_add_config_test(
+    PIKA_WITH_STDEXEC_ENV
+    SOURCE cmake/tests/stdexec_env.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##################################################################################################
 function(pika_check_for_mpix_continuations)
   pika_add_config_test(
     PIKA_WITH_MPIX_CONTINUATIONS

--- a/cmake/pika_perform_cxx_feature_tests.cmake
+++ b/cmake/pika_perform_cxx_feature_tests.cmake
@@ -62,5 +62,7 @@ function(pika_perform_cxx_feature_tests)
 
   pika_check_for_stdexec_continues_on(DEFINITIONS PIKA_HAVE_STDEXEC_CONTINUES_ON)
 
+  pika_check_for_stdexec_env(DEFINITIONS PIKA_HAVE_STDEXEC_ENV)
+
   pika_check_for_pthread_setname_np(DEFINITIONS PIKA_HAVE_PTHREAD_SETNAME_NP)
 endfunction()

--- a/cmake/tests/stdexec_env.cpp
+++ b/cmake/tests/stdexec_env.cpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2024 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdexec/execution.hpp>
+
+int main()
+{
+    // Earlier versions of stdexec only have empty_env, not env. We want to use env if it's
+    // available.
+    using stdexec::env;
+}

--- a/libs/pika/execution/tests/unit/CMakeLists.txt
+++ b/libs/pika/execution/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     algorithm_bulk
+    algorithm_continues_on
     algorithm_drop_operation_state
     algorithm_drop_value
     algorithm_ensure_started
@@ -20,7 +21,6 @@ set(tests
     algorithm_start_detached
     algorithm_sync_wait
     algorithm_then
-    algorithm_transfer
     algorithm_transfer_just
     algorithm_unpack
     algorithm_when_all

--- a/libs/pika/execution/tests/unit/algorithm_continues_on.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_continues_on.cpp
@@ -113,15 +113,16 @@ auto tag_invoke(ex::schedule_from_t, scheduler_schedule_from sched, Sender&&)
         sched.schedule_called, sched.execute_called, sched.tag_invoke_overload_called};
 }
 
-// transfer customization
-struct scheduler_transfer
+// continues_on customization
+struct scheduler_continues_on
 {
     std::reference_wrapper<std::atomic<bool>> schedule_called;
     std::reference_wrapper<std::atomic<bool>> execute_called;
     std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
 
     template <typename F>
-    friend void tag_invoke(pika::execution::experimental::execute_t, scheduler_transfer s, F&& f)
+    friend void
+    tag_invoke(pika::execution::experimental::execute_t, scheduler_continues_on s, F&& f)
     {
         s.execute_called.get() = true;
         PIKA_INVOKE(std::forward<F>(f), );
@@ -160,7 +161,7 @@ struct scheduler_transfer
             return operation_state<R>{std::forward<R>(r)};
         }
 
-        friend scheduler_transfer tag_invoke(
+        friend scheduler_continues_on tag_invoke(
             pika::execution::experimental::get_completion_scheduler_t<
                 pika::execution::experimental::set_value_t>,
             sender const& s) noexcept
@@ -174,7 +175,7 @@ struct scheduler_transfer
             std::reference_wrapper<std::atomic<bool>> execute_called;
             std::reference_wrapper<std::atomic<bool>> tag_invoke_overload_called;
 
-            friend scheduler_transfer tag_invoke(
+            friend scheduler_continues_on tag_invoke(
                 ex::get_completion_scheduler_t<ex::set_value_t>, env const& e) noexcept
             {
                 return {e.schedule_called, e.execute_called, e.tag_invoke_overload_called};
@@ -187,20 +188,20 @@ struct scheduler_transfer
         }
     };
 
-    friend sender tag_invoke(pika::execution::experimental::schedule_t, scheduler_transfer s)
+    friend sender tag_invoke(pika::execution::experimental::schedule_t, scheduler_continues_on s)
     {
         s.schedule_called.get() = true;
         return {s.schedule_called, s.execute_called, s.tag_invoke_overload_called};
     }
 
-    bool operator==(scheduler_transfer const&) const noexcept { return true; }
+    bool operator==(scheduler_continues_on const&) const noexcept { return true; }
 
-    bool operator!=(scheduler_transfer const&) const noexcept { return false; }
+    bool operator!=(scheduler_continues_on const&) const noexcept { return false; }
 };
 
 template <typename Sender, typename Scheduler>
-decltype(auto)
-tag_invoke(ex::transfer_t, scheduler_transfer completion_sched, Sender&& sender, Scheduler&& sched)
+decltype(auto) tag_invoke(
+    ex::continues_on_t, scheduler_continues_on completion_sched, Sender&& sender, Scheduler&& sched)
 {
     completion_sched.tag_invoke_overload_called.get() = true;
     return ex::schedule_from(std::forward<Scheduler>(sched), std::forward<Sender>(sender));
@@ -208,18 +209,18 @@ tag_invoke(ex::transfer_t, scheduler_transfer completion_sched, Sender&& sender,
 
 struct sender_with_completion_scheduler : void_sender
 {
-    scheduler_transfer sched;
+    scheduler_continues_on sched;
 
-    explicit sender_with_completion_scheduler(scheduler_transfer sched)
+    explicit sender_with_completion_scheduler(scheduler_continues_on sched)
       : sched(std::move(sched))
     {
     }
 
     struct env
     {
-        scheduler_transfer scheduler;
+        scheduler_continues_on scheduler;
 
-        friend scheduler_transfer tag_invoke(
+        friend scheduler_continues_on tag_invoke(
             ex::get_completion_scheduler_t<ex::set_value_t>, env const& e) noexcept
         {
             return e.scheduler;
@@ -237,7 +238,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = ex::transfer(ex::just(),
+        auto s = ex::continues_on(ex::just(),
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [] {};
@@ -255,7 +256,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = ex::transfer(ex::just(3),
+        auto s = ex::continues_on(ex::just(3),
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](int x) { PIKA_TEST_EQ(x, 3); };
@@ -274,7 +275,7 @@ int main()
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         int x = 3;
-        auto s = ex::transfer(const_reference_sender<decltype(x)>{x},
+        auto s = ex::continues_on(const_reference_sender<decltype(x)>{x},
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](int x) { PIKA_TEST_EQ(x, 3); };
@@ -292,7 +293,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = ex::transfer(ex::just(custom_type_non_default_constructible{42}),
+        auto s = ex::continues_on(ex::just(custom_type_non_default_constructible{42}),
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](auto x) { PIKA_TEST_EQ(x.x, 42); };
@@ -310,7 +311,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = ex::transfer(ex::just(custom_type_non_default_constructible_non_copyable{42}),
+        auto s = ex::continues_on(ex::just(custom_type_non_default_constructible_non_copyable{42}),
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](auto x) { PIKA_TEST_EQ(x.x, 42); };
@@ -328,7 +329,7 @@ int main()
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = ex::transfer(ex::just(std::string("hello"), 3),
+        auto s = ex::continues_on(ex::just(std::string("hello"), 3),
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](std::string s, int x) {
@@ -350,7 +351,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         int x = 3;
-        auto s = ex::transfer(const_reference_sender<int>{x},
+        auto s = ex::continues_on(const_reference_sender<int>{x},
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](int x) { PIKA_TEST_EQ(x, 3); };
@@ -370,7 +371,7 @@ int main()
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just(std::string("hello"), 3) |
-            ex::transfer(scheduler{
+            ex::continues_on(scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](std::string s, int x) {
             PIKA_TEST_EQ(s, std::string("hello"));
@@ -391,7 +392,7 @@ int main()
         std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::transfer(ex::just(),
+        auto s = ex::continues_on(ex::just(),
             scheduler_schedule_from{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto f = [] {};
@@ -413,13 +414,13 @@ int main()
         std::atomic<bool> destination_scheduler_schedule_called{false};
         std::atomic<bool> destination_scheduler_execute_called{false};
 
-        scheduler_transfer source_scheduler{source_scheduler_schedule_called,
+        scheduler_continues_on source_scheduler{source_scheduler_schedule_called,
             source_scheduler_execute_called, source_scheduler_tag_invoke_overload_called};
         scheduler destination_scheduler{
             scheduler{destination_scheduler_schedule_called, destination_scheduler_execute_called,
                 destination_scheduler_tag_invoke_overload_called}};
 
-        auto s = ex::transfer(
+        auto s = ex::continues_on(
             sender_with_completion_scheduler{std::move(source_scheduler)}, destination_scheduler);
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -443,12 +444,12 @@ int main()
         std::atomic<bool> destination_scheduler_schedule_called{false};
         std::atomic<bool> destination_scheduler_execute_called{false};
 
-        scheduler_transfer source_scheduler{source_scheduler_schedule_called,
+        scheduler_continues_on source_scheduler{source_scheduler_schedule_called,
             source_scheduler_execute_called, source_scheduler_tag_invoke_overload_called};
         scheduler_schedule_from destination_scheduler{destination_scheduler_schedule_called,
             destination_scheduler_execute_called, destination_scheduler_tag_invoke_overload_called};
 
-        auto s = ex::transfer(
+        auto s = ex::continues_on(
             sender_with_completion_scheduler{std::move(source_scheduler)}, destination_scheduler);
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -469,7 +470,7 @@ int main()
         std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::transfer(error_sender{},
+        auto s = ex::continues_on(error_sender{},
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
@@ -478,12 +479,11 @@ int main()
         ex::start(os);
         PIKA_TEST(set_error_called);
         PIKA_TEST(!tag_invoke_overload_called);
-        // The reference implementation transfers to the given scheduler no
-        // matter the signal from the predecessor sender. Our implementation
-        // only transfers on set_value. In this particular case the reference
-        // implementation puts in more effort call set_error on the scheduler's
-        // context, but it can't be guaranteed in all cases which is why
-        // transfer doesn't provide a completion scheduler for set_error.
+        // The reference implementation transfers to the given scheduler no matter the signal from
+        // the predecessor sender. Our implementation only transfers on set_value. In this
+        // particular case the reference implementation puts in more effort call set_error on the
+        // scheduler's context, but it can't be guaranteed in all cases which is why continues_on
+        // doesn't provide a completion scheduler for set_error.
 #if defined(PIKA_HAVE_STDEXEC)
         PIKA_TEST(scheduler_schedule_called);
 #else
@@ -497,7 +497,7 @@ int main()
         std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::transfer(const_reference_error_sender{},
+        auto s = ex::continues_on(const_reference_error_sender{},
             scheduler{
                 scheduler_schedule_called, scheduler_execute_called, tag_invoke_overload_called});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
@@ -506,12 +506,12 @@ int main()
         ex::start(os);
         PIKA_TEST(set_error_called);
         PIKA_TEST(!tag_invoke_overload_called);
-        // The reference implementation transfers to the given scheduler no
+        // The reference implementation continues_on to the given scheduler no
         // matter the signal from the predecessor sender. Our implementation
-        // only transfers on set_value. In this particular case the reference
+        // only continues_on on set_value. In this particular case the reference
         // implementation puts in more effort call set_error on the scheduler's
         // context, but it can't be guaranteed in all cases which is why
-        // transfer doesn't provide a completion scheduler for set_error.
+        // continues_on doesn't provide a completion scheduler for set_error.
 #if defined(PIKA_HAVE_STDEXEC)
         PIKA_TEST(scheduler_schedule_called);
 #else

--- a/libs/pika/execution_base/include/pika/execution_base/stdexec_forward.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/stdexec_forward.hpp
@@ -17,5 +17,9 @@ namespace pika::execution::experimental {
     using continues_on_t = stdexec::continue_on_t;
     inline constexpr continues_on_t continues_on{};
 # endif
+
+# if defined(PIKA_HAVE_STDEXEC_ENV)
+    using empty_env = stdexec::env<>;
+# endif
 }    // namespace pika::execution::experimental
 #endif


### PR DESCRIPTION
Updates one CI configuration to use latest stdexec main, another to use the `nvhpc-25.03.rc1` tag, and leaves the rest on 24.09 (available in spack).