### PR TITLE
Add missing `completion_mode_flags` in l-value reference connect overload of `trigger_mpi`

### DIFF
--- a/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/trigger_mpi.hpp
@@ -238,7 +238,7 @@ namespace pika::trigger_mpi_detail {
         constexpr auto connect(Receiver&& r) const&
         {
             return operation_state<std::decay_t<Receiver>, Sender>(
-                std::forward<Receiver>(r), sender);
+                std::forward<Receiver>(r), sender, completion_mode_flags_);
         }
 
         template <typename Receiver>


### PR DESCRIPTION
This overload is currently unused, so this would not so far have caused any known bugs, but the flags should still be propagated.