### PR TITLE
Refer to environment variables in warning about starting runtime with only one worker thread

### DIFF
--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Test
         shell: bash
         run: |
+            # Don't use the gds/shmem component with valgrind. Without the following, PMIX will
+            # report:
+            #
+            # The gds/shmem component attempted to attach to a shared-memory segment at a
+            # particular base address, but was given a different one. Your job will now likely
+            # abort.
+            #   Requested Address: 0x2aba44000000
+            #   Acquired Address:  0x7fed0431c000
+            # If this problem persists, please consider disabling the gds/shmem component by
+            # setting in your environment the following: PMIX_MCA_gds=hash
+            export PMIX_MCA_gds=hash
+
             # We are certain that we want to run mpiexec as root despite warnings as that is the
             # only user available in the container. Mistakes will only affect the current step.
             export OMPI_ALLOW_RUN_AS_ROOT=1

--- a/libs/pika/command_line_handling/src/command_line_handling.cpp
+++ b/libs/pika/command_line_handling/src/command_line_handling.cpp
@@ -895,9 +895,13 @@ namespace pika::detail {
                 PIKA_LOG(warn,
                     "The pika runtime will be started with only one worker thread because the "
                     "process mask has restricted the available resources to only one thread. If "
-                    "this is unintentional make sure the process mask contains the resources "
-                    "you need or use --pika:ignore-process-mask to use all resources. Use "
-                    "--pika:print-bind to print the thread bindings used by pika.");
+                    "this is unintentional make sure the process mask contains the resources you "
+                    "need or use the environment variable PIKA_IGNORE_PROCESS_MASK=1 to use all "
+                    "resources. Set PIKA_PRINT_BIND to any value to print the thread bindings used "
+                    "by pika. See "
+                    "https://pikacpp.org/"
+                    "usage.html#controlling-the-number-of-threads-and-thread-bindings for more "
+                    "information.");
             }
             else if (num_cores_ == 1 && get_number_of_default_cores(false) != 1 &&
                 !command_line_arguments_given)
@@ -906,8 +910,12 @@ namespace pika::detail {
                     "The pika runtime will be started on only one core with {} worker threads "
                     "because the process mask has restricted the available resources to only one "
                     "core. If this is unintentional make sure the process mask contains the "
-                    "resources you need or use --pika:ignore-process-mask to use all resources. "
-                    "Use --pika:print-bind to print the thread bindings used by pika.",
+                    "resources you need or use the environment variable PIKA_IGNORE_PROCESS_MASK=1 "
+                    "to use all resources. Set PIKA_PRINT_BIND to any value to print the thread "
+                    "bindings used by pika. See "
+                    "https://pikacpp.org/"
+                    "usage.html#controlling-the-number-of-threads-and-thread-bindings for more "
+                    "information.",
                     num_threads_);
             }
         }


### PR DESCRIPTION
Prefer environment variables over command line options.