### PR TITLE
Only set `-Wl,-z,defs` in CI for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
                 -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=On \
                 -DPIKA_WITH_GIT_COMMIT=${CIRCLE_SHA1} \
                 -DPIKA_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
@@ -529,6 +530,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_CXX_COMPILER=clang++ \
                 -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DPIKA_WITH_GIT_COMMIT=${CIRCLE_SHA1} \
                 -DPIKA_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
                 -DPIKA_WITH_GIT_TAG="${CIRCLE_TAG}" \

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -37,6 +37,7 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_EXAMPLES=ON \

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -37,6 +37,7 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_HIP=ON \

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -38,6 +38,7 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DPIKA_REPOSITORY="file:////$(pwd)" \
                 -DPIKA_TAG="$GITHUB_SHA" \

--- a/.github/workflows/linux_tracy.yml
+++ b/.github/workflows/linux_tracy.yml
@@ -67,6 +67,7 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_TRACY=ON \

--- a/.github/workflows/linux_valgrind.yml
+++ b/.github/workflows/linux_valgrind.yml
@@ -44,6 +44,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 -DCMAKE_CXX_FLAGS="-gdwarf-4" \
+                -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,defs" \
                 -DPIKA_WITH_MALLOC=system \
                 -DPIKA_WITH_MPI=ON \
                 -DPIKA_WITH_EXAMPLES=ON \

--- a/.gitlab/includes/common_pipeline.yml
+++ b/.gitlab/includes/common_pipeline.yml
@@ -18,7 +18,8 @@ variables:
                          -DPIKA_WITH_COMPILER_WARNINGS_AS_ERRORS=ON \
                          -DPIKA_WITH_CHECK_MODULE_DEPENDENCIES=ON \
                          -DPIKA_WITH_EXAMPLES=ON -DPIKA_WITH_TESTS=ON \
-                         -DPIKA_WITH_PARALLEL_TESTS_BIND_NONE=ON"
+                         -DPIKA_WITH_PARALLEL_TESTS_BIND_NONE=ON \
+                         -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,defs"
 .build_variables_common:
   variables:
     DOCKERFILE: .gitlab/docker/Dockerfile.spack_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1152,13 +1152,6 @@ else()
     pika_add_compile_flag_if_available(-Wno-delete-non-virtual-dtor)
   endif()
 
-  # Check if our libraries have unresolved symbols
-  if(NOT APPLE
-     AND NOT WIN32
-     AND NOT PIKA_WITH_SANITIZERS
-  )
-    pika_add_link_flag_if_available(-Wl,-z,defs)
-  endif()
   if(WIN32)
     target_link_libraries(pika_base_libraries INTERFACE psapi WS2_32 mswsock)
   endif()


### PR DESCRIPTION
Don't set it always when available, and especially not for consumers of pika.