### PR TITLE
Use member functions instead of `tag_invoke` for `set_stopped`

### DIFF
--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -231,9 +231,9 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                         std::move(r.op_state.receiver), std::forward<Error>(error));
                 }
 
-                friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                    then_with_cuda_stream_receiver&& r) noexcept
+                void set_stopped() && noexcept
                 {
+                    auto r = std::move(*this);
                     pika::execution::experimental::set_stopped(std::move(r.op_state.receiver));
                 }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/bulk.hpp
@@ -78,9 +78,9 @@ namespace pika::bulk_detail {
                     std::move(r.receiver), std::forward<Error>(error));
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, bulk_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 pika::execution::experimental::set_stopped(std::move(r.receiver));
             }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -67,9 +67,9 @@ namespace pika::drop_op_state_detail {
             }
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, drop_op_state_receiver_type r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             PIKA_ASSERT(r.op_state != nullptr);
             PIKA_ASSERT(r.op_state->op_state.has_value());
 

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -46,9 +46,9 @@ namespace pika::drop_value_detail {
                 std::move(r.receiver), std::forward<Error>(error));
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, drop_value_receiver_type&& r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             pika::execution::experimental::set_stopped(std::move(r.receiver));
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -193,9 +193,9 @@ namespace pika::ensure_started_detail {
                     r.state->set_predecessor_done();
                 }
 
-                friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                    ensure_started_receiver r) noexcept
+                void set_stopped() && noexcept
                 {
+                    auto r = std::move(*this);
                     r.state->v.template emplace<pika::execution::detail::stopped_type>();
                     r.state->set_predecessor_done();
                 };

--- a/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_error.hpp
@@ -145,9 +145,9 @@ namespace pika::let_error_detail {
                     });
             }
 
-            friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                let_error_predecessor_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 pika::execution::experimental::set_stopped(std::move(r.op_state.receiver));
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/let_value.hpp
@@ -174,9 +174,9 @@ namespace pika::let_value_detail {
                     std::move(r.op_state.receiver), std::forward<Error>(error));
             }
 
-            friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                let_value_predecessor_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 pika::execution::experimental::set_stopped(std::move(r.op_state.receiver));
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -112,9 +112,9 @@ namespace pika {
                     std::move(r.op_state->receiver), std::forward<Error>(error));
             }
 
-            friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                require_started_receiver_type r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 PIKA_ASSERT(r.op_state != nullptr);
                 pika::execution::experimental::set_stopped(std::move(r.op_state->receiver));
             };

--- a/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/schedule_from.hpp
@@ -106,9 +106,9 @@ namespace pika::schedule_from_detail {
                 r.op_state.set_error_predecessor_sender(std::forward<Error>(error));
             }
 
-            friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                predecessor_sender_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.op_state.set_stopped_predecessor_sender();
             }
 
@@ -187,9 +187,9 @@ namespace pika::schedule_from_detail {
                 r.op_state.set_error_scheduler_sender(std::forward<Error>(error));
             }
 
-            friend void tag_invoke(pika::execution::experimental::set_stopped_t,
-                scheduler_sender_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.op_state.set_stopped_scheduler_sender();
             }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split.hpp
@@ -126,9 +126,9 @@ namespace pika::split_detail {
                 r.state->set_predecessor_done();
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, split_receiver r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.state->set_predecessor_done();
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -123,9 +123,9 @@ namespace pika::split_tuple_detail {
                 r.state.set_predecessor_done();
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, split_tuple_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.state.set_predecessor_done();
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/start_detached.hpp
@@ -60,9 +60,9 @@ namespace pika::start_detached_detail {
                 std::terminate();
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, start_detached_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.op_state.release();
             };
 

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -168,9 +168,9 @@ namespace pika::sync_wait_detail {
             r.signal_set_called();
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, sync_wait_receiver_type&& r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             r.signal_set_called();
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/then.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/then.hpp
@@ -49,9 +49,9 @@ namespace pika::then_detail {
                 std::move(r.receiver), std::forward<Error>(error));
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, then_receiver_type&& r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             pika::execution::experimental::set_stopped(std::move(r.receiver));
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -49,9 +49,9 @@ namespace pika::unpack_detail {
                 std::move(r.receiver), std::forward<Error>(error));
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, unpack_receiver_type&& r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             pika::execution::experimental::set_stopped(std::move(r.receiver));
         }
 

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all.hpp
@@ -75,9 +75,9 @@ namespace pika::when_all_impl {
             r.op_state.finish();
         }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, when_all_receiver_type&& r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             r.op_state.set_stopped_error_called = true;
             r.op_state.finish();
         };

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -107,9 +107,9 @@ namespace pika::when_all_vector_detail {
                 r.op_state.finish();
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, when_all_vector_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 r.op_state.set_stopped_error_called = true;
                 r.op_state.finish();
             };

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -464,21 +464,22 @@ namespace pika::execution::experimental::detail {
         auto set_value(
             Ts_&&... ts) && noexcept -> decltype(receiver->set_value(std::forward<Ts_>(ts)...))
         {
+            auto r = std::move(*this);
             try
             {
-                receiver->set_value(std::forward<Ts_>(ts)...);
+                r.receiver->set_value(std::forward<Ts_>(ts)...);
             }
             catch (...)
             {
-                receiver->set_error(std::current_exception());
+                r.receiver->set_error(std::current_exception());
             }
         }
 
         void set_error(std::exception_ptr ep) && noexcept { receiver->set_error(std::move(ep)); }
 
-        friend void tag_invoke(
-            pika::execution::experimental::set_stopped_t, any_receiver r) noexcept
+        void set_stopped() && noexcept
         {
+            auto r = std::move(*this);
             r.receiver->set_stopped();
         }
 

--- a/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/receiver.hpp
@@ -148,8 +148,16 @@ namespace pika::execution::experimental {
     } set_error{};
 
     PIKA_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_stopped_t : pika::functional::detail::tag_noexcept<set_stopped_t>
+    struct set_stopped_t
     {
+        template <typename Receiver, typename... Ts>
+        PIKA_FORCEINLINE constexpr auto PIKA_STATIC_CALL_OPERATOR(Receiver&& receiver) noexcept
+            -> decltype(std::forward<Receiver>(receiver).set_stopped())
+        {
+            static_assert(noexcept(std::forward<Receiver>(receiver).set_stopped()),
+                "std::execution receiver set_stopped member function must be noexcept");
+            return std::forward<Receiver>(receiver).set_stopped();
+        }
     } set_stopped{};
 
     ///////////////////////////////////////////////////////////////////////

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -137,9 +137,9 @@ struct callback_receiver
         PIKA_TEST(false);
     }
 
-    friend void tag_invoke(
-        pika::execution::experimental::set_stopped_t, callback_receiver&&) noexcept
+    void set_stopped() && noexcept
     {
+        [[maybe_unused]] auto r = std::move(*this);
         PIKA_TEST(false);
     };
 
@@ -172,9 +172,9 @@ struct error_callback_receiver
         r.set_error_called = true;
     }
 
-    friend void tag_invoke(
-        pika::execution::experimental::set_stopped_t, error_callback_receiver&&) noexcept
+    void set_stopped() && noexcept
     {
+        [[maybe_unused]] auto r = std::move(*this);
         PIKA_TEST(false);
     };
 

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -232,10 +232,7 @@ struct error_receiver
         r.set_error_called = true;
     }
 
-    friend void tag_invoke(pika::execution::experimental::set_stopped_t, error_receiver&&) noexcept
-    {
-        PIKA_TEST(false);
-    };
+    void set_stopped() && noexcept { PIKA_TEST(false); };
 
     template <typename... Ts>
     void set_value(Ts&&...) && noexcept

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -24,7 +24,7 @@ namespace mylib {
     {
         PIKA_STDEXEC_RECEIVER_CONCEPT
 
-        friend void tag_invoke(ex::set_stopped_t, receiver_1&&) noexcept { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) && noexcept { error_called = true; }
 
@@ -37,7 +37,7 @@ namespace mylib {
     {
         PIKA_STDEXEC_RECEIVER_CONCEPT
 
-        friend void tag_invoke(ex::set_stopped_t, receiver_2&&) noexcept { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
         void set_error(int) && noexcept { error_called = true; }
 
@@ -48,7 +48,7 @@ namespace mylib {
     {
         PIKA_STDEXEC_RECEIVER_CONCEPT
 
-        friend void tag_invoke(ex::set_stopped_t, receiver_3&&) noexcept { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) && noexcept { error_called = true; }
 
@@ -59,7 +59,7 @@ namespace mylib {
 
     struct non_receiver_1
     {
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_1&) noexcept { done_called = true; }
+        void set_stopped() & noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) && noexcept { error_called = true; }
 
@@ -68,7 +68,7 @@ namespace mylib {
 
     struct non_receiver_2
     {
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_2&&) noexcept { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) & noexcept { error_called = true; }
 
@@ -77,7 +77,7 @@ namespace mylib {
 
     struct non_receiver_3
     {
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_3&) noexcept { done_called = true; }
+        void set_stopped() & noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) & noexcept { error_called = true; }
 
@@ -88,7 +88,7 @@ namespace mylib {
     {
         PIKA_STDEXEC_RECEIVER_CONCEPT
 
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_4&&) noexcept { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
         void set_error(std::exception_ptr) && noexcept { error_called = true; }
 
@@ -99,19 +99,9 @@ namespace mylib {
 
     struct non_receiver_5
     {
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_5&&) { done_called = true; }
+        void set_stopped() && noexcept { done_called = true; }
 
-        friend void tag_invoke(ex::set_error_t, non_receiver_5&&, std::exception_ptr) noexcept
-        {
-            error_called = true;
-        }
-    };
-
-    struct non_receiver_6
-    {
-        friend void tag_invoke(ex::set_stopped_t, non_receiver_6&&) { done_called = true; }
-
-        friend void tag_invoke(ex::set_error_t, non_receiver_6&&, std::exception_ptr)
+        friend void tag_invoke(ex::set_error_t, non_receiver_5&&, std::exception_ptr)
         {
             error_called = true;
         }
@@ -200,8 +190,6 @@ int main()
         ex::is_receiver_v<mylib::non_receiver_4>, "mylib::non_receiver_4 should be a receiver");
     static_assert(!ex::is_receiver_v<mylib::non_receiver_5>,
         "mylib::non_receiver_5 should not be a receiver");
-    static_assert(!ex::is_receiver_v<mylib::non_receiver_6>,
-        "mylib::non_receiver_6 should not be a receiver");
 
 #if !defined(PIKA_NVHPC_VERSION) || !defined(PIKA_HAVE_STDEXEC)
     static_assert(!receiver_of_helper_v<mylib::non_receiver_1, int>,
@@ -214,8 +202,6 @@ int main()
         "mylib::non_receiver_4 should not be a receiver of int");
     static_assert(!receiver_of_helper_v<mylib::non_receiver_5, int>,
         "mylib::non_receiver_5 should not be a receiver of int");
-    static_assert(!receiver_of_helper_v<mylib::non_receiver_6, int>,
-        "mylib::non_receiver_6 should not be a receiver of int");
 #endif
 
     {

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -70,11 +70,8 @@ struct receiver
     PIKA_STDEXEC_RECEIVER_CONCEPT
 
     void set_error(std::exception_ptr) && noexcept {}
-
-    friend void tag_invoke(ex::set_stopped_t, receiver&&) noexcept {}
-
+    void set_stopped() && noexcept {}
     void set_value(int v) && noexcept { i.get() = v; }
-
     constexpr ex::empty_env get_env() const& noexcept { return {}; }
 
     std::reference_wrapper<int> i;
@@ -115,11 +112,8 @@ struct void_receiver
     PIKA_STDEXEC_RECEIVER_CONCEPT
 
     void set_error(std::exception_ptr) && noexcept {}
-
-    friend void tag_invoke(ex::set_stopped_t, void_receiver&&) noexcept {}
-
+    void set_stopped() && noexcept {}
     void set_value() && noexcept { ++void_receiver_set_value_calls; }
-
     constexpr ex::empty_env get_env() const& noexcept { return {}; }
 };
 

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -89,9 +89,9 @@ namespace pika::thread_pool_bulk_detail {
                     std::move(r.op_state->receiver), std::forward<E>(e));
             }
 
-            friend void tag_invoke(
-                pika::execution::experimental::set_stopped_t, bulk_receiver&& r) noexcept
+            void set_stopped() && noexcept
             {
+                auto r = std::move(*this);
                 pika::execution::experimental::set_stopped(std::move(r.op_state->receiver));
             };
 

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -62,10 +62,7 @@ struct check_context_receiver
         PIKA_TEST(false);
     }
 
-    friend void tag_invoke(ex::set_stopped_t, check_context_receiver&&) noexcept
-    {
-        PIKA_TEST(false);
-    }
+    void set_stopped() && noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
     void set_value(Ts&&...) && noexcept
@@ -219,7 +216,7 @@ struct callback_receiver
         PIKA_TEST(false);
     }
 
-    friend void tag_invoke(ex::set_stopped_t, callback_receiver&&) noexcept { PIKA_TEST(false); }
+    void set_stopped() && noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
     void set_value(Ts&&...) && noexcept

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -69,10 +69,7 @@ struct check_context_receiver
         PIKA_TEST(false);
     }
 
-    friend void tag_invoke(ex::set_stopped_t, check_context_receiver&&) noexcept
-    {
-        PIKA_TEST(false);
-    }
+    void set_stopped() && noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
     void set_value(Ts&&...) && noexcept
@@ -227,7 +224,7 @@ struct callback_receiver
         PIKA_TEST(false);
     }
 
-    friend void tag_invoke(ex::set_stopped_t, callback_receiver&&) noexcept { PIKA_TEST(false); }
+    void set_stopped() && noexcept { PIKA_TEST(false); }
 
     template <typename... Ts>
     void set_value(Ts&&...) && noexcept


### PR DESCRIPTION
Like in #1369, one of the `basic_receiver` tests was removed because noexceptness is `static_assert`ed rather than SFINAEd out.