### PR TITLE
Fix warnings about non virtual destructors

### DIFF
--- a/libs/pika/execution/include/pika/execution/async_rw_mutex.hpp
+++ b/libs/pika/execution/include/pika/execution/async_rw_mutex.hpp
@@ -143,6 +143,7 @@ namespace pika::execution::experimental {
 
         struct async_rw_mutex_operation_state_base
         {
+            virtual ~async_rw_mutex_operation_state_base() = default;
             // This is most of the time an async_rw_mutex_operation_state_base*, but can also
             // contain the special value of the address of the shared state, hence this is a void*.
             void* next{nullptr};

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -404,6 +404,7 @@ namespace pika::execution::experimental::detail {
         any_receiver_ref_base& operator=(any_receiver_ref_base&&) noexcept = default;
         any_receiver_ref_base(any_receiver_ref_base const&) = delete;
         any_receiver_ref_base& operator=(any_receiver_ref_base const&) = delete;
+        virtual ~any_receiver_ref_base() = default;
 
         virtual void set_value(Ts...) noexcept = 0;
         virtual void set_error(std::exception_ptr) noexcept = 0;


### PR DESCRIPTION
This fixes warnings such as 
```
pika/libs/pika/execution/include/pika/execution/async_rw_mutex.hpp:144:16: warning: 'struct pika::execution::experimental::detail::async_rw_mutex_operation_state_base' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  144 |         struct async_rw_mutex_operation_state_base
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
and
```
pika/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp:394:12: warning: 'struct pika::execution::experimental::detail::any_receiver_ref_base<>' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  394 |     struct any_receiver_ref_base
      |            ^~~~~~~~~~~~~~~~~~~~~
```