### PR TITLE
Restrict sphinx to lower than version 9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # noinshpect
-sphinx
+sphinx < 9
 breathe
 recommonmark
 sphinx_immaterial


### PR DESCRIPTION
Sphinx 9 seems to break search in sphinx-immaterial.