### PR TITLE
Fix deprecation warning about empty_env

### DIFF
--- a/cmake/tests/stdexec_env.cpp
+++ b/cmake/tests/stdexec_env.cpp
@@ -8,7 +8,7 @@
 
 int main()
 {
-    // Earlier versions of stdexec only have empty_env, not env. We want to use env if it's
+    // Earlier versions of stdexec only have env<>, not env. We want to use env if it's
     // available.
     using stdexec::env;
 }

--- a/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
+++ b/libs/pika/async_cuda/include/pika/async_cuda/then_with_stream.hpp
@@ -149,7 +149,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
                 invoke_result_helper>;
@@ -368,7 +368,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                         });
                 }
 
-                constexpr pika::execution::experimental::empty_env get_env() const& noexcept
+                constexpr pika::execution::experimental::env<> get_env() const& noexcept
                 {
                     return {};
                 }
@@ -389,7 +389,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
             using ts_type = pika::util::detail::prepend_t<
                 pika::util::detail::transform_t<
                     pika::execution::experimental::value_types_of_t<std::decay_t<Sender>,
-                        pika::execution::experimental::empty_env, std::tuple,
+                        pika::execution::experimental::env<>, std::tuple,
                         pika::detail::variant>,
                     value_types_helper>,
                 pika::detail::monostate>;
@@ -435,7 +435,7 @@ namespace pika::cuda::experimental::then_with_stream_detail {
                 pika::util::detail::unique_t<pika::util::detail::prepend_t<
                     pika::util::detail::transform_t<
                         pika::execution::experimental::value_types_of_t<
-                            then_with_cuda_stream_sender, pika::execution::experimental::empty_env,
+                            then_with_cuda_stream_sender, pika::execution::experimental::env<>,
                             pika::util::detail::pack, pika::util::detail::pack>,
                         result_types_helper>,
                     pika::detail::monostate>>>;

--- a/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
+++ b/libs/pika/async_mpi/include/pika/async_mpi/transform_mpi.hpp
@@ -65,7 +65,7 @@ namespace pika::transform_mpi_detail {
         using ts_type = pika::util::detail::prepend_t<
             pika::util::detail::transform_t<
                 pika::execution::experimental::value_types_of_t<std::decay_t<Sender>,
-                    pika::execution::experimental::empty_env, std::tuple, pika::detail::variant>,
+                    pika::execution::experimental::env<>, std::tuple, pika::detail::variant>,
                 value_types_helper>,
             pika::detail::monostate>;
 #else
@@ -269,7 +269,7 @@ namespace pika::transform_mpi_detail {
                     });
             }
 
-            constexpr ex::empty_env get_env() const& noexcept { return {}; }
+            constexpr ex::env<> get_env() const& noexcept { return {}; }
         };
 
         using operation_state_type = ex::connect_result_t<Sender, receiver>;
@@ -304,7 +304,7 @@ namespace pika::transform_mpi_detail {
         using no_value_completion = pika::execution::experimental::completion_signatures<>;
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_value_t(),
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_operation_state.hpp
@@ -104,7 +104,7 @@ namespace pika::drop_op_state_detail {
             }
         }
 
-        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+        constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender, typename Receiver>
@@ -151,7 +151,7 @@ namespace pika::drop_op_state_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
                 value_types_helper>;

--- a/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/drop_value.hpp
@@ -59,7 +59,7 @@ namespace pika::drop_value_detail {
             pika::execution::experimental::set_value(std::move(r.receiver));
         }
 
-        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+        constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender>
@@ -76,7 +76,7 @@ namespace pika::drop_value_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<>, empty_set_value>;
 #else
         template <template <typename...> class Tuple, template <typename...> class Variant>

--- a/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/ensure_started.hpp
@@ -94,7 +94,7 @@ namespace pika::ensure_started_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_stopped_t(),
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
@@ -152,14 +152,14 @@ namespace pika::ensure_started_detail {
             using value_type = pika::util::detail::prepend_t<
                 pika::util::detail::transform_t<
                     typename pika::execution::experimental::value_types_of_t<Sender,
-                        pika::execution::experimental::empty_env, std::tuple,
+                        pika::execution::experimental::env<>, std::tuple,
                         pika::detail::variant>,
                     value_types_helper>,
                 pika::detail::monostate>;
             using error_type = pika::util::detail::unique_t<pika::util::detail::prepend_t<
                 pika::util::detail::transform_t<
                     pika::execution::experimental::error_types_of_t<Sender,
-                        pika::execution::experimental::empty_env, pika::detail::variant>,
+                        pika::execution::experimental::env<>, pika::detail::variant>,
                     std::decay>,
                 std::exception_ptr>>;
 #else
@@ -212,7 +212,7 @@ namespace pika::ensure_started_detail {
                 using value_type = pika::util::detail::prepend_t<
                     pika::util::detail::transform_t<
                         typename pika::execution::experimental::value_types_of_t<Sender,
-                            pika::execution::experimental::empty_env, std::tuple,
+                            pika::execution::experimental::env<>, std::tuple,
                             pika::detail::variant>,
                         value_types_helper>,
                     pika::detail::monostate>;

--- a/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/require_started.hpp
@@ -128,7 +128,7 @@ namespace pika {
                     std::move(r.op_state->receiver), std::forward<Ts>(ts)...);
             }
 
-            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
+            constexpr pika::execution::experimental::env<> get_env() const& noexcept
             {
                 return {};
             }
@@ -212,7 +212,7 @@ namespace pika {
 #if defined(PIKA_HAVE_STDEXEC)
             using completion_signatures =
                 pika::execution::experimental::transform_completion_signatures_of<
-                    std::decay_t<Sender>, pika::execution::experimental::empty_env>;
+                    std::decay_t<Sender>, pika::execution::experimental::env<>>;
 #else
             template <template <typename...> class Tuple, template <typename...> class Variant>
             using value_types = typename pika::execution::experimental::sender_traits<

--- a/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/split_tuple.hpp
@@ -77,7 +77,7 @@ namespace pika::split_tuple_detail {
 #if defined(PIKA_HAVE_STDEXEC)
         using value_type = typename std::decay<
             pika::execution::experimental::detail::single_result_t<typename pika::execution::
-                    experimental::value_types_of_t<Sender, pika::execution::experimental::empty_env,
+                    experimental::value_types_of_t<Sender, pika::execution::experimental::env<>,
                         pika::util::detail::pack, pika::util::detail::pack>>>::type;
 #else
         using value_type =
@@ -90,7 +90,7 @@ namespace pika::split_tuple_detail {
         using error_type = pika::util::detail::unique_t<pika::util::detail::prepend_t<
             pika::util::detail::transform_t<
                 typename pika::execution::experimental::error_types_of_t<Sender,
-                    pika::execution::experimental::empty_env, pika::detail::variant>,
+                    pika::execution::experimental::env<>, pika::detail::variant>,
                 std::decay>,
             std::exception_ptr>>;
 #else
@@ -136,7 +136,7 @@ namespace pika::split_tuple_detail {
             using value_type =
                 typename std::decay<pika::execution::experimental::detail::single_result_t<
                     typename pika::execution::experimental::value_types_of_t<Sender,
-                        pika::execution::experimental::empty_env, pika::util::detail::pack,
+                        pika::execution::experimental::env<>, pika::util::detail::pack,
                         pika::util::detail::pack>>>::type;
 #else
             using value_type =
@@ -159,7 +159,7 @@ namespace pika::split_tuple_detail {
                 r.state.set_predecessor_done();
             }
 
-            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
+            constexpr pika::execution::experimental::env<> get_env() const& noexcept
             {
                 return {};
             }
@@ -195,7 +195,7 @@ namespace pika::split_tuple_detail {
                 constexpr bool sends_stopped =
 #if defined(PIKA_HAVE_STDEXEC)
                     pika::execution::experimental::sends_stopped<Sender,
-                        pika::execution::experimental::empty_env>
+                        pika::execution::experimental::env<>>
 #else
                     pika::execution::experimental::sender_traits<Sender>::sends_done
 #endif
@@ -359,7 +359,7 @@ namespace pika::split_tuple_detail {
 #if defined(PIKA_HAVE_STDEXEC)
         using value_type = typename std::decay<
             pika::execution::experimental::detail::single_result_t<typename pika::execution::
-                    experimental::value_types_of_t<Sender, pika::execution::experimental::empty_env,
+                    experimental::value_types_of_t<Sender, pika::execution::experimental::env<>,
                         pika::util::detail::pack, pika::util::detail::pack>>>::type;
 #else
         using value_type =
@@ -389,7 +389,7 @@ namespace pika::split_tuple_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
                 set_value_helper, set_error_helper>;
@@ -491,7 +491,7 @@ namespace pika::split_tuple_detail {
 #if defined(PIKA_HAVE_STDEXEC)
         using value_type = typename std::decay<
             pika::execution::experimental::detail::single_result_t<typename pika::execution::
-                    experimental::value_types_of_t<Sender, pika::execution::experimental::empty_env,
+                    experimental::value_types_of_t<Sender, pika::execution::experimental::env<>,
                         pika::util::detail::pack, pika::util::detail::pack>>>::type;
 #else
         using value_type =

--- a/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/sync_wait.hpp
@@ -59,11 +59,11 @@ namespace pika::sync_wait_detail {
         template <template <typename...> class Tuple, template <typename...> class Variant>
         using predecessor_value_types =
             pika::util::detail::unique_t<pika::execution::experimental::value_types_of_t<Sender,
-                pika::execution::experimental::empty_env, Tuple, Variant>>;
+                pika::execution::experimental::env<>, Tuple, Variant>>;
 
         template <template <typename...> class Variant>
         using predecessor_error_types = pika::execution::experimental::error_types_of_t<Sender,
-            pika::execution::experimental::empty_env, Variant>;
+            pika::execution::experimental::env<>, Variant>;
 
         // The type of the single void or non-void result that we store. If
         // there are multiple variants or multiple values sync_wait will
@@ -184,7 +184,7 @@ namespace pika::sync_wait_detail {
             r.signal_set_called();
         }
 
-        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+        constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
     };
 }    // namespace pika::sync_wait_detail
 

--- a/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/unpack.hpp
@@ -64,7 +64,7 @@ namespace pika::unpack_detail {
                 std::forward<Ts>(ts));
         }
 
-        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+        constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
     };
 
 #if defined(PIKA_HAVE_STDEXEC)
@@ -142,7 +142,7 @@ namespace pika::unpack_detail {
 #if defined(PIKA_HAVE_STDEXEC)
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<std::decay_t<Sender>,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
                 invoke_result_helper_t>;

--- a/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
+++ b/libs/pika/execution/include/pika/execution/algorithms/when_all_vector.hpp
@@ -48,7 +48,7 @@ namespace pika::when_all_vector_detail {
 #if defined(PIKA_HAVE_STDEXEC)
         using element_value_type =
             std::decay_t<pika::execution::experimental::detail::single_result_t<pika::execution::
-                    experimental::value_types_of_t<Sender, pika::execution::experimental::empty_env,
+                    experimental::value_types_of_t<Sender, pika::execution::experimental::env<>,
                         pika::util::detail::pack, pika::util::detail::pack>>>;
 
         // This sender sends any error types sent by the predecessor senders
@@ -56,7 +56,7 @@ namespace pika::when_all_vector_detail {
         template <template <typename...> class Variant>
         using error_types = pika::util::detail::unique_concat_t<
             pika::util::detail::transform_t<pika::execution::experimental::error_types_of_t<Sender,
-                                                pika::execution::experimental::empty_env, Variant>,
+                                                pika::execution::experimental::env<>, Variant>,
                 std::decay>,
             Variant<std::exception_ptr>>;
 #else
@@ -144,7 +144,7 @@ namespace pika::when_all_vector_detail {
                 r.op_state.finish();
             }
 
-            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
+            constexpr pika::execution::experimental::env<> get_env() const& noexcept
             {
                 return {};
             }
@@ -343,7 +343,7 @@ namespace pika::when_all_vector_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>,
                 set_value_helper>;

--- a/libs/pika/execution/tests/unit/algorithm_unpack.cpp
+++ b/libs/pika/execution/tests/unit/algorithm_unpack.cpp
@@ -40,23 +40,23 @@ int main()
 {
 #if defined(PIKA_HAVE_STDEXEC)
     static_assert(std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple()))),
-                                   ex::empty_env, std::tuple, std::variant>,
+                                   ex::env<>, std::tuple, std::variant>,
         std::variant<std::tuple<>>>);
     static_assert(std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple(42)))),
-                                   ex::empty_env, std::tuple, std::variant>,
+                                   ex::env<>, std::tuple, std::variant>,
         std::variant<std::tuple<int&&>>>);
     static_assert(
         std::same_as<ex::value_types_of_t<decltype(ex::unpack(std::declval<
                                               const_reference_sender<std::tuple<int>>>())),
-                         ex::empty_env, std::tuple, std::variant>,
+                         ex::env<>, std::tuple, std::variant>,
             std::variant<std::tuple<int const&>>>);
     static_assert(std::same_as<
         ex::value_types_of_t<decltype(ex::unpack(ex::just(std::declval<std::tuple<int&>>()))),
-            ex::empty_env, std::tuple, std::variant>,
+            ex::env<>, std::tuple, std::variant>,
         std::variant<std::tuple<int&>>>);
     static_assert(
         std::same_as<ex::value_types_of_t<decltype(ex::unpack(ex::just(std::tuple(42, 3.14f)))),
-                         ex::empty_env, std::tuple, std::variant>,
+                         ex::env<>, std::tuple, std::variant>,
             std::variant<std::tuple<int&&, float&&>>>);
 #else
     static_assert(

--- a/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/any_sender.hpp
@@ -484,7 +484,7 @@ namespace pika::execution::experimental::detail {
             r.receiver->set_stopped();
         }
 
-        constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+        constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
     };
 
     template <typename Sender, typename... Ts>
@@ -970,7 +970,7 @@ namespace pika::execution::experimental {
         {
 #if defined(PIKA_HAVE_STDEXEC)
             using value_types_pack = pika::execution::experimental::value_types_of_t<Sender,
-                pika::execution::experimental::empty_env, pika::util::detail::pack,
+                pika::execution::experimental::env<>, pika::util::detail::pack,
                 pika::util::detail::pack>;
 #else
             using value_types_pack =

--- a/libs/pika/execution_base/include/pika/execution_base/sender.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/sender.hpp
@@ -419,7 +419,7 @@ namespace pika::execution::experimental {
     template <typename S, typename R>
     using connect_result_t = pika::detail::invoke_result_plain_function_t<connect_t, S, R>;
 
-    struct empty_env
+    struct env<>
     {
     };
 
@@ -445,11 +445,11 @@ namespace pika::execution::experimental {
                     "std::execution get_env member function must be noexcept");
                 return t.get_env();
             }
-            else if constexpr (is_sender_v<T>) { return empty_env{}; }
+            else if constexpr (is_sender_v<T>) { return env<>{}; }
             else
             {
                 static_assert(sizeof(T) == 0, "No environment for type T");
-                return empty_env{};
+                return env<>{};
             }
         }
     } get_env{};

--- a/libs/pika/execution_base/include/pika/execution_base/stdexec_forward.hpp
+++ b/libs/pika/execution_base/include/pika/execution_base/stdexec_forward.hpp
@@ -19,7 +19,7 @@ namespace pika::execution::experimental {
 # endif
 
 # if defined(PIKA_HAVE_STDEXEC_ENV)
-    using empty_env = stdexec::env<>;
+    using env<> = stdexec::env<>;
 # endif
 }    // namespace pika::execution::experimental
 #endif

--- a/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
+++ b/libs/pika/execution_base/tests/include/pika/execution_base/tests/algorithm_test_utils.hpp
@@ -152,7 +152,7 @@ struct callback_receiver
         r.set_value_called = true;
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 template <typename F>
@@ -185,7 +185,7 @@ struct error_callback_receiver
         PIKA_TEST(r.expect_set_value);
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 template <typename F>

--- a/libs/pika/execution_base/tests/unit/any_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/any_sender.cpp
@@ -240,7 +240,7 @@ struct error_receiver
         PIKA_TEST(false);
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 template <template <typename...> typename Sender, typename... Ts, typename F>

--- a/libs/pika/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_receiver.cpp
@@ -30,7 +30,7 @@ namespace mylib {
 
         void set_value(int) && noexcept { value_called = true; }
 
-        constexpr ex::empty_env get_env() const& noexcept { return {}; }
+        constexpr ex::env<> get_env() const& noexcept { return {}; }
     };
 
     struct receiver_2
@@ -41,7 +41,7 @@ namespace mylib {
 
         void set_error(int) && noexcept { error_called = true; }
 
-        constexpr ex::empty_env get_env() const& noexcept { return {}; }
+        constexpr ex::env<> get_env() const& noexcept { return {}; }
     };
 
     struct receiver_3
@@ -54,7 +54,7 @@ namespace mylib {
 
         void set_value(int) && noexcept { value_called = true; }
 
-        constexpr ex::empty_env get_env() const& noexcept { return {}; }
+        constexpr ex::env<> get_env() const& noexcept { return {}; }
     };
 
     struct non_receiver_1
@@ -94,7 +94,7 @@ namespace mylib {
 
         void set_value(int) & noexcept { value_called = true; }
 
-        constexpr ex::empty_env get_env() const& noexcept { return {}; }
+        constexpr ex::env<> get_env() const& noexcept { return {}; }
     };
 
     struct non_receiver_5

--- a/libs/pika/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/pika/execution_base/tests/unit/basic_sender.cpp
@@ -72,7 +72,7 @@ struct receiver
     void set_error(std::exception_ptr) && noexcept {}
     void set_stopped() && noexcept {}
     void set_value(int v) && noexcept { i.get() = v; }
-    constexpr ex::empty_env get_env() const& noexcept { return {}; }
+    constexpr ex::env<> get_env() const& noexcept { return {}; }
 
     std::reference_wrapper<int> i;
 };
@@ -114,7 +114,7 @@ struct void_receiver
     void set_error(std::exception_ptr) && noexcept {}
     void set_stopped() && noexcept {}
     void set_value() && noexcept { ++void_receiver_set_value_calls; }
-    constexpr ex::empty_env get_env() const& noexcept { return {}; }
+    constexpr ex::env<> get_env() const& noexcept { return {}; }
 };
 
 #if !defined(PIKA_HAVE_STDEXEC)

--- a/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/pika/executors/include/pika/executors/thread_pool_scheduler_bulk.hpp
@@ -55,7 +55,7 @@ namespace pika::thread_pool_bulk_detail {
         template <template <typename...> class Tuple, template <typename...> class Variant>
         using value_types = pika::util::detail::transform_t<
             pika::execution::experimental::value_types_of_t<Sender,
-                pika::execution::experimental::empty_env, Tuple, Variant>,
+                pika::execution::experimental::env<>, Tuple, Variant>,
             value_types_helper>;
 #else
         template <template <typename...> class Tuple, template <typename...> class Variant>
@@ -376,7 +376,7 @@ namespace pika::thread_pool_bulk_detail {
                 r.do_work_local(r.op_state->shape, chunk_size, local_worker_thread);
             }
 
-            constexpr pika::execution::experimental::empty_env get_env() const& noexcept
+            constexpr pika::execution::experimental::env<> get_env() const& noexcept
             {
                 return {};
             }
@@ -461,7 +461,7 @@ namespace pika::thread_pool_bulk_detail {
 
         using completion_signatures =
             pika::execution::experimental::transform_completion_signatures_of<Sender,
-                pika::execution::experimental::empty_env,
+                pika::execution::experimental::env<>,
                 pika::execution::experimental::completion_signatures<
                     pika::execution::experimental::set_error_t(std::exception_ptr)>>;
 #else

--- a/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/std_thread_scheduler.cpp
@@ -74,7 +74,7 @@ struct check_context_receiver
         cond.notify_one();
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 void test_sender_receiver_basic()
@@ -228,7 +228,7 @@ struct callback_receiver
         r.cond.notify_one();
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 void test_transfer_basic()

--- a/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/pika/executors/tests/unit/thread_pool_scheduler.cpp
@@ -82,7 +82,7 @@ struct check_context_receiver
         cond.notify_one();
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 void test_sender_receiver_basic()
@@ -235,7 +235,7 @@ struct callback_receiver
         cond.notify_one();
     }
 
-    constexpr pika::execution::experimental::empty_env get_env() const& noexcept { return {}; }
+    constexpr pika::execution::experimental::env<> get_env() const& noexcept { return {}; }
 };
 
 void test_properties()


### PR DESCRIPTION
I get a lot of empty_env warnings on my builds. This PR fixes them, but I didn't check if there should be a version  requirement etc