### PR TITLE
Fix formatting errors

### DIFF
--- a/tools/perftests_ci/pyutils/__init__.py
+++ b/tools/perftests_ci/pyutils/__init__.py
@@ -13,6 +13,5 @@ It includes argument parsing, logging and test packages
 
 import sys
 
-
 if sys.version_info < (3, 6):
     raise Exception("Python 3.6 or newer is required")

--- a/tools/perftests_ci/pyutils/log.py
+++ b/tools/perftests_ci/pyutils/log.py
@@ -12,7 +12,6 @@ import logging
 import sys
 import textwrap
 
-
 _logger = logging.getLogger("pyutils")
 _logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
black version changed recently, those 2 workflow have different versions that could be due to the bump of actions in pika-ci-image that actually rebuild and push the image with the same tag
- old black 25.11.0: https://app.circleci.com/pipelines/github/pika-org/pika/12811/workflows/21359624-7ef0-48d0-bef0-7618e74ebcf1/jobs/148805
- new black 26.3.1: https://app.circleci.com/pipelines/github/pika-org/pika/12831/workflows/51fa650f-45d7-4828-85de-629104dee9d5/jobs/149175/steps