### PR TITLE
Add a timeout on blacklisted tests, they seem to hang forever otherwise

### DIFF
--- a/.github/workflows/linux_asan_ubsan_lsan.yml
+++ b/.github/workflows/linux_asan_ubsan_lsan.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Test blacklisted tests
         if: always()
         continue-on-error: true
+        timeout-minutes: 120
         shell: bash
         run: |
             # See above.

--- a/.github/workflows/linux_tsan.yml
+++ b/.github/workflows/linux_tsan.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Test blacklisted tests
         if: always()
         continue-on-error: true
+        timeout-minutes: 120
         shell: bash
         run: |
             # See above.


### PR DESCRIPTION
When one of the blacklisted test hangs, github automatically marks the job as failed after 6 hours but the test itself still seem to be indefinitely running, this adds a timeout at the job step level